### PR TITLE
[sonic-cfggen] make minigraph parser fail when speed and lanes are not in PORT table

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -349,7 +349,7 @@ def main():
         else:
             deep_update(data, parse_xml(minigraph, port_config_file=args.port_config, asic_name=asic_name, hwsku_config_file=args.hwsku_config))
         # check if minigraph parser has speed and lanes in PORT table
-        _must_field_by_yang(data, 'PORT', ['speed', 'lanes']):
+        _must_field_by_yang(data, 'PORT', ['speed', 'lanes'])
 
     if args.device_description is not None:
         deep_update(data, parse_device_desc_xml(args.device_description))

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -249,7 +249,7 @@ def _get_jinja2_env(paths):
 
 def _must_field_by_yang(data, table, must_fields):
     """
-    Check if table contians must field based on yang defination
+    Check if table contains must field based on yang definition
     """
     if table not in data:
         return

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -348,6 +348,8 @@ def main():
                 deep_update(data, parse_xml(minigraph, platform, asic_name=asic_name))
         else:
             deep_update(data, parse_xml(minigraph, port_config_file=args.port_config, asic_name=asic_name, hwsku_config_file=args.hwsku_config))
+        # check if minigraph parser has speed and lanes in PORT table
+        _must_field_by_yang(data, 'PORT', ['speed', 'lanes']):
 
     if args.device_description is not None:
         deep_update(data, parse_device_desc_xml(args.device_description))

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -247,6 +247,19 @@ def _get_jinja2_env(paths):
 
     return env
 
+def _must_field_by_yang(data, table, must_fields):
+    """
+    Check if table contians must field based on yang defination
+    """
+    if table not in data:
+        return
+
+    for must_field in must_fields:
+        for _, fields in data[table].items():
+            if must_field not in fields:
+                print(must_field, 'is a must field in', table, file=sys.stderr)
+                sys.exit(1)
+
 def main():
     parser=argparse.ArgumentParser(description="Render configuration file from minigraph data and jinja2 template.")
     group = parser.add_mutually_exclusive_group()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Fix https://github.com/Azure/sonic-buildimage/issues/9676
[Done] Lanes is fixed by https://github.com/Azure/sonic-buildimage/pull/10362
[Done]Wait for UT speed update
#### Why I did it
Config db schema generated by minigraph can’t pass yang validation, PORT table does not have 'lanes' field.
#### How I did it
cfggen command fail when 'lanes' and 'speed' are not provided
#### How to verify it
Run 'sonic-cfggen -m xxx.xml --print-data' to make sure command fail when 'lanes' not in PORT table
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

