### PR TITLE
[build]: Fix marvell-armhf build hung issue (#10156)

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -652,6 +652,11 @@ fi
 {% if installer_images.strip() -%}
 ## ensure proc is mounted
 sudo mount proc /proc -t proc || true
+if [[ $CONFIGURED_ARCH == armhf ]]; then
+    # A workaround to fix the armhf build hung issue, caused by sonic-platform-nokia-7215_1.0_armhf.deb post installation script 
+    ps -eo pid,cmd | grep python | grep "/etc/entropy.py" | awk '{print $1}' | xargs sudo kill -9 2>/dev/null || true
+fi
+
 sudo mkdir $FILESYSTEM_ROOT/target
 sudo mount --bind target $FILESYSTEM_ROOT/target
 sudo LANG=C DOCKER_HOST="$DOCKER_HOST" chroot $FILESYSTEM_ROOT docker info


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The marvel-armhf build is hung, it does not exit after waiting for a long time.
It is caused by the process /etc/entropy.py which is started by the postinst script in target/debs/buster/sonic-platform-nokia-7215_1.0_armhf.deb

$ cat postinst
sh /usr/sbin/nokia-7215_plt_setup.sh
...

$ cat usr/sbin/nokia-7215_plt_setup.sh | tail

    python /etc/entropy.py &

$ cat etc/entropy.py
if path.exists("/proc/sys/kernel/random/entropy_avail"):
    while 1:
        while avail() < 2048:
            with open('/dev/urandom', 'rb') as urnd, open("/dev/random", mode='wb') as rnd:
                d = urnd.read(512)
                t = struct.pack('ii', 4 * len(d), len(d)) + d
                fcntl.ioctl(rnd, RNDADDENTROPY, t)
        time.sleep(30)

It is a workaround to fix the build issue, need to fix debian package, and revert the change.

#### How I did it
Kill the hung installation process.

#### How to verify it
Master build hung: https://dev.azure.com/mssonic/build/_build/results?buildId=80864&view=results
Feature branch succeeded: https://dev.azure.com/mssonic/build/_build/results?buildId=80863&view=results



#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

