### PR TITLE
Add scapy support for python3 virtual environment in the sonic-mgmt docker container

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -245,7 +245,8 @@ RUN python3 -m pip install setuptools-rust \
                             allure-pytest==2.8.22 \
                             retry \
                             thrift==0.11.0 \
-                            ptf
+                            ptf \
+                            scapy==2.4.5
 
 # Deactivating a virtualenv.
 ENV PATH="$BACKUP_OF_PATH"


### PR DESCRIPTION
Add scapy support for python3 virtual environment in the sonic-mgmt docker container

Signed-off-by: Oleksandr Kozodoi <oleksandrx.kozodoi@intel.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Migration of sonic-mgmt codebase from Python 2 to Python 3
#### How I did it
Added scapy dependencies to the env-python3 virtual environment.
#### How to verify it
Run test case
```
py.test --testbed=testbed-t0 --inventory=../ansible/lab --testbed_file=../ansible/testbed.csv --host-pattern=testbed-t0 -- module-path=../ansible/library lldp
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

