### PR TITLE
sonic-platform-modules-cel dx010: speed up dx010 platform init script

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.init
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.init
@@ -61,19 +61,19 @@ start)
         [ $found -eq 0 ] && echo "cannot find iSMT" && exit 1
 
         i2cset -y ${devnum} 0x70 0x10 0x00 0x01 i
-        sleep 1
+        sleep 0.1
 
         # Attach PCA9548 0x71 Channel Extender for Main Board
         echo pca9548 0x71 > /sys/bus/i2c/devices/i2c-${devnum}/new_device
-        sleep 1
+        sleep 0.1
 
         # Attach PCA9548 0x73 Channel Extender for CPU Board
         echo pca9548 0x73 > /sys/bus/i2c/devices/i2c-${devnum}/new_device
-        sleep 1
+        sleep 0.1
 
         # Attach PCA9548 0x77 Channel Extender for Fan's EEPROMs
         echo pca9548 0x77 > /sys/bus/i2c/devices/i2c-${devnum}/new_device
-        sleep 1
+        sleep 0.1
 
         # Attach syseeprom
         echo 24lc64t 0x50 > /sys/bus/i2c/devices/i2c-12/new_device
@@ -106,7 +106,7 @@ start)
         echo pca9505 0x20 > /sys/bus/i2c/devices/i2c-17/new_device
 
         modprobe dx010_cpld
-        sleep 2
+        sleep 1
 
         # Export platform gpio sysfs
         export_gpio 10 "in" # Fan 1 present
@@ -148,15 +148,14 @@ start)
         done
 
 	bus_en=8
-	sleep 1
 	cfg_r=`i2cget -y -f 8 0x60 0xD1`
 	((cfg_w=$cfg_r+$bus_en))	
 	i2cset -y -f 8 0x60 0xD1 $cfg_w
-	sleep 1
+	sleep 0.1
 	cfg_r=`i2cget -y -f 9 0x20 0xD1`
 	((cfg_w=$cfg_r+$bus_en))	
 	i2cset -y -f 9 0x20 0xD1 $cfg_w
-	sleep 1
+	sleep 0.1
 
 	/bin/sh /usr/local/bin/platform_api_mgnt.sh init
 

--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.install
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.install
@@ -4,6 +4,5 @@ dx010/systemd/platform-modules-dx010.service lib/systemd/system
 dx010/scripts/fancontrol.sh etc/init.d
 dx010/scripts/fancontrol.service lib/systemd/system
 services/fancontrol/fancontrol  usr/local/bin
-dx010/modules/sonic_platform-1.0-py2-none-any.whl usr/share/sonic/device/x86_64-cel_seastone-r0
 dx010/modules/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-cel_seastone-r0
 services/platform_api/platform_api_mgnt.sh usr/local/bin


### PR DESCRIPTION
* Remove installing of python2 sonic platform wheel for dx010
* Optimize dx010 sonic platform init script to speed up init process
* Fix issue #10152: [warm-upgrade][202012] Slow Celestica platform init
in rc.local causes lacp-teardown

Signed-off-by: Eric Zhu <erzhu@celestica.com>

#### Why I did it
To fix issue #10152 for dx010.
202012 Warm upgrade causes lacp-teardown on Dx010 TOR. platform code initialize slow causing lacp timeout.

#### How I did it
1. Remove the python2 sonic platform wheel which is deprecated.
2. Optimize the dx010 sonic platform script to speed up the init process.

#### How to verify it
1. Check the warm reboot log, warm reboot is 8-9s faster than before.
[945232.436622] kexec_core: Starting new kernel                                                                                                                                                          
[    5.838762] rc.local[461]: + sed -e s/build_version: //g;s/'//g                                                                                                                                       
[    5.863209] rc.local[460]: + grep build_version                                                                                                                                                       
[    5.870373] rc.local[459]: + cat /etc/sonic/sonic_version.yml          
[    5.882392] rc.local[444]: + SONIC_VERSION=CLS-202012-f93d1f64a2_220311_0001                                                                                                                          
[    5.900265] rc.local[444]: + FIRST_BOOT_FILE=/host/image-CLS-202012-f93d1f64a2_220311_0001/platform/firsttime                                                                                         
[    5.919713] rc.local[444]: + SONIC_CONFIG_DIR=/host/image-CLS-202012-f93d1f64a2_220311_0001/sonic-config                                                                                              
[    5.939963] rc.local[444]: + SONIC_ENV_FILE=/host/image-CLS-202012-f93d1f64a2_220311_0001/sonic-config/sonic-environment                                                                              
[    5.959775] rc.local[444]: + [ -d /host/image-CLS-202012-f93d1f64a2_220311_0001/sonic-config -a -f /host/image-CLS-202012-f93d1f64a2_220311_0001/sonic-config/sonic-environment ]                     
[    5.991680] rc.local[444]: + echo moving file /host/image-CLS-202012-f93d1f64a2_220311_0001/sonic-config/sonic-environment to /etc/sonic                                                              
[    6.015772] rc.local[444]: moving file /host/image-CLS-202012-f93d1f64a2_220311_0001/sonic-config/sonic-environment to /etc/sonic                                                                     
[    6.039698] rc.local[444]: + mv /host/image-CLS-202012-f93d1f64a2_220311_0001/sonic-config/sonic-environment /etc/sonic                                                                               
[    6.063968] rc.local[444]: + logger SONiC version CLS-202012-f93d1f64a2_220311_0001 starting up...                                                                                                    
[    6.075689] rc.local[444]: + grub_installation_needed=                                                                                                                                                
[    6.084995] rc.local[444]: + [ ! -e /host/machine.conf ]                                                                                                                                              
[    6.099820] rc.local[444]: + migrate_nos_configuration                                                                                                                                                
[    6.115707] rc.local[444]: + rm -rf /host/migration                                                                                                                                                   
[    6.136062] rc.local[444]: + mkdir -p /host/migration                                                                                                                                                 
[    6.154299] kdump-tools[428]: Starting kdump-tools:                                                                                                                                                   
[    6.169527] rc.local[502]: + cat /proc/cmdline                                                                                                                                                        
[    6.175936] kdump-tools[465]: no crashkernel= parameter in the kernel cmdline ...                                                                                                                     
[    6.199530] kdump-tools[512]:  failed!                                                                                                                                                                
[    6.214259] rc.local[444]: + set -- BOOT_IMAGE=/image-CLS-202012-f93d1f64a2_220311_0001/boot/vmlinuz-4.19.0-12-2-amd64 root=UUID=9695eb38-b94c-46d6-ada1-c2a790617c0e rw console=tty0 console=ttyS0,11
5200n8 quiet intel_idle.max_cstate=0 net.ifnames=0 biosdevname=0 loop=image-CLS-202012-f93d1f64a2_220311_0001/fs.squashfs loopfstype=squashfs systemd.unified_cgroup_hierarchy=0 apparmor=1 security=appa
rmor varlog_size=4096 usbcore.autosuspend=-1 module_blacklist=gpio_ich SONIC_BOOT_TYPE=warm                                                                                                              
[    6.271805] rc.local[444]: + [ -n  ]                                                                                                                                                                  
[    6.283662] rc.local[444]: + . /host/machine.conf                                            
[    6.299681] rc.local[444]: + onie_version=2014.08.0.0.6                                                                                                                                               
[    6.315716] rc.local[444]: + onie_vendor_id=12244                                                                                                                                                     
[    6.332318] rc.local[444]: + onie_platform=x86_64-cel_seastone-r0                                                                                                                                     
[    6.349204] rc.local[444]: + onie_machine=cel_seastone                                                                                                                                                
[    6.363709] rc.local[444]: + onie_machine_rev=0                                                                                                                                                       
[    6.379679] rc.local[444]: + onie_arch=x86_64                                                                                                                                                         
[    6.400461] rc.local[444]: + onie_config_version=1                                                                                                                                                    
[    6.415694] rc.local[444]: + onie_build_date=2016-07-19T12:10-0400                                                                                                                                    
[    6.431697] rc.local[444]: + onie_partition_type=gpt                                                                                                                                                  
[    6.447759] rc.local[444]: + onie_kernel_version=3.2.35                                                                                                                                               
[    6.463741] rc.local[444]: + program_console_speed                                                                                                                                                    
[    6.472723] rc.local[505]: + grep -Eo console=ttyS[0-9]+,[0-9]+                                                                                                                                       
[    6.492563] rc.local[504]: + cat /proc/cmdline                                                                                                                                                        
[    6.508658] rc.local[506]: + cut -d , -f2                                                                                                                                                             
[    6.526088] rc.local[444]: + speed=115200                                                                                                                                                             
[    6.543885] rc.local[444]: + [ -z 115200 ]                                                                                                                                                            
[    6.555790] rc.local[444]: + CONSOLE_SPEED=115200                                                                                                                                                     
[    6.562351] rc.local[507]: + grep agetty /lib/systemd/system/serial-getty@.service                                                                                                                    
[    6.585391] rc.local[508]: + grep keep-baud                                                                                                                                                           
[    6.603647] rc.local[508]: ExecStart=-/sbin/agetty -o '-p -- \\u' --keep-baud 115200,57600,38400,9600 %I $TERM                                                                                        
[    6.624179] rc.local[444]: + [ 0 = 0 ]                                                                                                                                                                
[    6.639718] rc.local[444]: + sed -i s|\-\-keep\-baud .* %I| 115200 %I|g /lib/systemd/system/serial-getty@.service                                                                                     
[    6.659655] rc.local[444]: + systemctl daemon-reload                                                                                                                                                  
[    6.675673] rc.local[444]: + [ -f /host/image-CLS-202012-f93d1f64a2_220311_0001/platform/firsttime ]      
[    6.699699] rc.local[444]: + echo First boot detected. Performing first boot tasks...                                                                                                                 
[    6.719684] rc.local[444]: First boot detected. Performing first boot tasks...                                                                                                                        
[    6.739674] rc.local[444]: + [ -n  ]                                                                                                                                                                  
[    6.751663] rc.local[444]: + [ -n x86_64-cel_seastone-r0 ]                                                                                                                                            
[    6.767624] rc.local[444]: + platform=x86_64-cel_seastone-r0                                                                                                                                          
[    6.783625] rc.local[444]: + [ -d /host/old_config ]                                                                                                                                                  
[    6.799618] rc.local[444]: + mv -f /host/old_config /etc/sonic/                                                                                                                                       
[    6.816864] rc.local[444]: + rm -rf /etc/sonic/old_config/old_config                                                                                                                                  
[    6.835670] rc.local[444]: + touch /tmp/pending_config_migration                                                                                                                                      
[    6.851630] rc.local[444]: + touch /tmp/notify_firstboot_to_platform                                                                                                                                  
[    6.867609] rc.local[444]: + [ ! -d /host/reboot-cause/platform ]                                                                                                                                     
[    6.884516] rc.local[444]: + [ -d /host/image-CLS-202012-f93d1f64a2_220311_0001/platform/x86_64-cel_seastone-r0 ]                                                                                     
[    6.907732] rc.local[444]: + dpkg -i /host/image-CLS-202012-f93d1f64a2_220311_0001/platform/x86_64-cel_seastone-r0/platform-modules-dx010_0.9_amd64.deb                                               
[    6.933086] rc.local[551]: Selecting previously unselected package platform-modules-dx010.                                                                                                            
[    7.518234] rc.local[551]: (Reading database ... 30055 files and directories currently installed.)                                                                                                    
[    7.539760] rc.local[551]: Preparing to unpack .../platform-modules-dx010_0.9_amd64.deb ...                                                                                                           
[    7.563705] rc.local[551]: Unpacking platform-modules-dx010 (0.9) ...                                                                                                                                 
[    8.090707] rc.local[551]: Setting up platform-modules-dx010 (0.9) ...                                                                                                                                
[   12.777431] rc.local[611]: Synchronizing state of platform-modules-dx010.service with SysV service script with /lib/systemd/systemd-sysv-install.                                                     
[   12.807716] rc.local[611]: Executing: /lib/systemd/systemd-sysv-install enable platform-modules-dx010                                                                                                 
[   23.526475] rc.local[993]: Processing /usr/share/sonic/device/x86_64-cel_seastone-r0/sonic_platform-1.0-py3-none-any.whl                                                                              
[   24.213094] rc.local[993]: Installing collected packages: sonic-platform                                                                                                                              
[   24.376318] rc.local[993]: Successfully installed sonic-platform-1.0 
[   24.391815] rc.local[993]: WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv                                                                                                                                                       │
[   26.458719] rc.local[444]: + sync                                                                                                                                                                     
[   27.503835] rc.local[444]: + [ -n x86_64-cel_seastone-r0 ]                                                                                                                                            
[   27.519767] rc.local[444]: + [ -n  ]                                                                                                                                                                  
[   27.531894] rc.local[444]: + mkdir -p /var/platform                                                                                                                                                   
[   27.547755] rc.local[444]: + ebtables_config                                                                                                                                                          
[   27.563785] rc.local[444]: + /usr/sbin/ebtables-restore                                                                                                                                               
[   27.579849] rc.local[444]: + /usr/sbin/ebtables -t filter --atomic-file /etc/ebtables.filter --atomic-save                                                                                            
[   27.599756] rc.local[444]: + sed -i -e s/__PLATFORM__/x86_64-cel_seastone-r0/g /etc/default/kdump-tools                                                                                               
[   27.619761] rc.local[444]: + firsttime_exit                                                                                                                                                           
[   27.635769] rc.local[444]: + rm -rf /host/image-CLS-202012-f93d1f64a2_220311_0001/platform/firsttime                                                                                                  
[   27.655752] rc.local[444]: + exit 0

2. Setup up Port-channel between two DUT, warm upgrade one DUT, and do not see LAG flap in syslog.

#### Which release branch to backport (provide reason below if selected)
No need to backport.

