### PR TITLE
[fast-reboot] Optimize PMON and LLDP services start up CPU consumption

### DIFF
--- a/dockers/docker-lldp/docker-lldp-init.sh
+++ b/dockers/docker-lldp/docker-lldp-init.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+. /usr/bin/start.sh
+
 #Generate supervisord.conf based on device metadata
 mkdir -p /etc/supervisor/conf.d/
 sonic-cfggen -d -t /usr/share/sonic/templates/supervisord.conf.j2 > /etc/supervisor/conf.d/supervisord.conf

--- a/dockers/docker-lldp/supervisord.conf.j2
+++ b/dockers/docker-lldp/supervisord.conf.j2
@@ -28,17 +28,6 @@ stdout_logfile=syslog
 stderr_logfile=syslog
 dependent_startup=true
 
-[program:start]
-command=/usr/bin/start.sh
-priority=2
-autostart=false
-autorestart=false
-startsecs=0
-stdout_logfile=syslog
-stderr_logfile=syslog
-dependent_startup=true
-dependent_startup_wait_for=rsyslogd:running
-
 [program:lldpd]
 # https://github.com/vincentbernat/lldpd/commit/9856f2792c301116cc4a3fcfba91b9672ee5db1f
 # - `-d` means to stay in foreground, log to syslog

--- a/dockers/docker-platform-monitor/docker_init.j2
+++ b/dockers/docker-platform-monitor/docker_init.j2
@@ -42,8 +42,8 @@ if [ -e /usr/share/sonic/platform/platform_wait ]; then
 fi
 
 # If the Python 2 sonic-platform package is not installed, try to install it
-python2 -c "import sonic_platform" > /dev/null 2>&1 || pip2 show sonic-platform > /dev/null 2>&1
-if [ $? -ne 0 ]; then
+PYTHON2_PLATFORM_PACKAGE=/usr/local/lib/python2.7/dist-packages/sonic_platform
+if [ ! -d "$PYTHON2_PLATFORM_PACKAGE" ]; then
     SONIC_PLATFORM_WHEEL="/usr/share/sonic/platform/sonic_platform-1.0-py2-none-any.whl"
     echo "sonic-platform package not installed, attempting to install..."
     if [ -e ${SONIC_PLATFORM_WHEEL} ]; then
@@ -59,8 +59,8 @@ if [ $? -ne 0 ]; then
 fi
 
 # If the Python 3 sonic-platform package is not installed, try to install it
-python3 -c "import sonic_platform" > /dev/null 2>&1 || pip3 show sonic-platform > /dev/null 2>&1
-if [ $? -ne 0 ]; then
+PYTHON3_PLATFORM_PACKAGE=/usr/local/lib/python3.7/dist-packages/sonic_platform
+if [ ! -d "$PYTHON3_PLATFORM_PACKAGE" ]; then
     SONIC_PLATFORM_WHEEL="/usr/share/sonic/platform/sonic_platform-1.0-py3-none-any.whl"
     echo "sonic-platform package not installed, attempting to install..."
     if [ -e ${SONIC_PLATFORM_WHEEL} ]; then


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Profiling the system state on init after fast-reboot during create_switch function execution, it is possible to see few python scripts running at the same time.
This parallel execution consume CPU time and the duration of create_switch is longer than it should be.
Following this finding, some adaptations to init of PMON and LLDP ae required to off load the CPU consumption during create_switch execution.

#### How I did it

- Change the way PMON init bash script validate the existence of python2 and python3 platform packages to a more efficient way.
- On LLDP, move the sonic-cfggen call by "start.sh" script triggered by supervisord to the init bash script of this docker.

By doing this 2 adaptations PMON is not consuming a lot of CPU during init and LLDP consume the CPU before create_switch is executed and not interfering it.

#### How to verify it

Run fast-reboot on MLNX platform and observe ~2 seconds less in create_switch execution time.
Attached to this PR, bootchart outputs with the different utilizations

**With no optimizations:**

![bootchart_no_optimizations](https://user-images.githubusercontent.com/60430976/158380853-69fc4e7a-27a3-4caa-84d2-3c463bfb19ab.png)

**After PMON optimizations:**

![bootchart_202111_pmon_optimized_sonic_db_cli_optimized](https://user-images.githubusercontent.com/60430976/158380909-0f476ff9-9fe0-427f-a7a7-f22f31fbceb4.png)

**After PMON and LLDP optimizations:**

![bootchart_202111_pmon_optimized_sonic_db_cli_optimized_lldp_optimized](https://user-images.githubusercontent.com/60430976/158380924-3bd4b40f-8a43-4b96-9030-d13100be188c.png)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)


