### PR TITLE
[yang] In ACL_RULE PRIORITY is mandatory and also PACKET_ACTION for CTRLPLANE ACLs

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
@@ -4,6 +4,16 @@
         "eStrKey" : "InvalidValue",
         "eStr": ["PACKET_ACTION"]
     },
+    "ACL_RULE_FOR_CTRLPLANE_ACL_REQUIRES_PACKET_ACTION": {
+        "desc": "ACL_RULE for CTRLPLANE ACLs require PACKET_ACTION.",
+        "eStrKey" : "Must",
+        "eStr": ["CTRLPLANE", "PACKET_ACTION"]
+    },
+    "ACL_RULE_MANDATORY_PRIORITY": {
+        "desc": "ACL_RULE MANDATORY PRIORITY field.",
+        "eStrKey" : "Mandatory",
+        "eStr": ["ACL_RULE", "PRIORITY"]
+    },
     "ACL_TABLE_EMPTY_PORTS": {
         "desc": "Configure ACL_TABLE with empty ports."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
@@ -211,6 +211,63 @@
             }
         }
     },
+    "ACL_RULE_FOR_CTRLPLANE_ACL_REQUIRES_PACKET_ACTION": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "MGMT_ONLY",
+                        "DST_IP": "10.186.72.0/26",
+                        "IP_TYPE": "IPv4ANY",
+                        "PRIORITY": 999980,
+                        "RULE_NAME": "Rule_20",
+                        "SRC_IP": "10.176.0.0/15"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "MGMT_ONLY",
+                        "policy_desc": "Filter IPv4",
+                        "services": [
+                            "SNMP"
+                        ],
+                        "stage": "EGRESS",
+                        "type": "CTRLPLANE"
+                    }
+                ]
+            }
+        }
+    },
+    "ACL_RULE_MANDATORY_PRIORITY": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "EVERFLOW",
+                        "DST_IP": "10.186.72.0/26",
+                        "IP_TYPE": "IPv4ANY",
+                        "RULE_NAME": "Rule_20",
+                        "SRC_IP": "10.176.0.0/15"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "EVERFLOW",
+                        "policy_desc": "Filter IPv4",
+                        "services": [
+                            "SNMP"
+                        ],
+                        "stage": "EGRESS",
+                        "type": "MIRROR"
+                    }
+                ]
+            }
+        }
+    },
     "ACL_RULE_WITH_NON_EXIST_ACL_TABLE": {
         "sonic-acl:sonic-acl": {
             "sonic-acl:ACL_RULE": {

--- a/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
@@ -69,6 +69,9 @@ module sonic-acl {
 					type stypes:packet_action;
 				}
 
+				/* Validating 'PACKET_ACTION' exist if ACL type is 'CTRLPLANE' */
+				must "(not(../../ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME=current()/ACL_TABLE_NAME]/type = 'CTRLPLANE')) or (boolean(PACKET_ACTION))";
+
 				leaf MIRROR_INGRESS_ACTION {
 					type leafref {
 						path "/sms:sonic-mirror-session/sms:MIRROR_SESSION/sms:MIRROR_SESSION_LIST/sms:name";
@@ -86,6 +89,7 @@ module sonic-acl {
 				}
 
 				leaf PRIORITY {
+					mandatory true;
 					type uint32 {
 						range 0..999999;
 					}


### PR DESCRIPTION
#### Why I did it
Fixes https://github.com/Azure/sonic-utilities/issues/2049

from caclmgr:
- PRIORITY is a required field [code](https://github.com/Azure/sonic-buildimage/blob/3fa18d18d4c06fe38164ebfefdc3187820fc7496/src/sonic-host-services/scripts/caclmgrd#L548)
- PACKET_ACTION is a required field [code](https://github.com/Azure/sonic-buildimage/blob/3fa18d18d4c06fe38164ebfefdc3187820fc7496/src/sonic-host-services/scripts/caclmgrd#L581)

I think PRIORITY is a required field for ACLs not only CTRLPLANE ACLs

#### How I did it
Check code.

#### How to verify it
Unit-test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

