### PR TITLE
[201811][dhcp_relay] Check payload size to prevent buffer overflow in dhcpv6 option

### DIFF
--- a/src/dhcp6relay/src/relay.cpp
+++ b/src/dhcp6relay/src/relay.cpp
@@ -490,15 +490,18 @@ void relay_client(int sock, const uint8_t *msg, int32_t len, const ip6_hdr *ip_h
 
     auto position = current_position + sizeof(struct dhcpv6_option);
     auto dhcpv6msg = parse_dhcpv6_hdr(position);
-    
-    while ((current_position - msg) != len) {
+
+    while ((current_position - msg) < len) {
         auto option = parse_dhcpv6_opt(current_position, &tmp);
         current_position = tmp;
+        if (current_position - msg > len || ntohs(option->option_length) > sizeof(buffer) - (current_buffer_position - buffer)) {
+            break;
+        }
         switch (ntohs(option->option_code)) {
             case OPTION_RELAY_MSG:
                 memcpy(current_buffer_position, ((uint8_t *)option) + sizeof(struct dhcpv6_option), ntohs(option->option_length));
                 current_buffer_position += ntohs(option->option_length);
-                type = dhcpv6msg->msg_type;;
+                type = dhcpv6msg->msg_type;
                 break;
             default:
                 break;


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
This is a cherry-pick of https://github.com/Azure/sonic-buildimage/pull/9740

#### Why I did it
When parsing through relay reply packets, parse_dhcpv6_option introduces vulnerability in buffer overflow, allowing up to 2 byte/65535 copied into a fixed buffer of size 4096.

#### How I did it
Add bound checks to before and after option parsing

#### How to verify it
Send a dummy packet with option length greater than 4096. dhcp6relay should not perform memcpy on invalid option length.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

