### PR TITLE
Fix issue of partially parsing syseeprom value (#10020)

### DIFF
--- a/device/celestica/x86_64-cel_e1031-r0/sonic_platform/eeprom.py
+++ b/device/celestica/x86_64-cel_e1031-r0/sonic_platform/eeprom.py
@@ -45,7 +45,7 @@ class Tlv(eeprom_tlvinfo.TlvInfoDecoder):
         for line in lines:
             try:
                 match = re.search(
-                    '(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)([\S]+)', line)
+                    '(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)(.*$)', line)
                 if match is not None:
                     idx = match.group(1)
                     value = match.group(3).rstrip('\0')

--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/eeprom.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/eeprom.py
@@ -44,7 +44,7 @@ class Tlv(eeprom_tlvinfo.TlvInfoDecoder):
         for line in lines:
             try:
                 match = re.search(
-                    '(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)([\S]+)', line)
+                    '(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)(.*$)', line)
                 if match is not None:
                     idx = match.group(1)
                     value = match.group(3).rstrip('\0')


### PR DESCRIPTION
  * fix issue #10020 for celestica e1031 device
  * fix issue #10020 for celestica seastone device

Signed-off-by: Eric Zhu <erzhu@celestica.com>

Fix #10020 

#### Why I did it
The current code assumes that the value part does not have whitespace. So everything after the whitespace will be ignored. The syseeprom values returned from platform API do not match the output of "show platform syseeprom" on dx010 and e1031 device.

#### How I did it
This change improved the regular expression for parsing syseeprom values to accommodate whitespaces in the value.
PR 10021 provides the solution, but committed to the wrong place for dx010 and e1031.

#### How to verify it
Compile the sonic_platform wheel for dx010, then upload to device and install the wheel, verify the platform eeprom API.
```
>>> import sonic_platform
>>> platform = sonic_platform.platform.Platform()
>>> chassis = platform.get_chassis()
>>> chassis.get_system_eeprom_info()
{'0x21': 'DX010', '0x22': 'R0872-F0010-01', '0x23': 'DX010B2F108711LK100031', '0x24': '00:E0:EC:B9:28:10', '0x25': '10/23/2018 17:33:54', '0x26': '10', '0x27': 'Seastone', '0x28': 'RANGELEY', '0x29': '2014.08', '0x2A': '131', '0x2B': 'CELESTICA', '0x2C': 'CHN', '0x2D': 'Celestica', '0x2E': '1.1.1', '0x2F': 'LB', '0xFD': '', '0xFE': '0xA7CD2590'}
>>>
```

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)
