### PR TITLE
[Build][Bug]: fix the warning message not printed as expected issue

### DIFF
--- a/src/sonic-build-hooks/hooks/apt-get
+++ b/src/sonic-build-hooks/hooks/apt-get
@@ -10,10 +10,10 @@ if [ -z "$REAL_COMMAND" ]; then
     exit 1
 fi
 
-INSTALL=$(check_apt_install)
+INSTALL=$(check_apt_install "$@")
 COMMAND_INFO="Locked by command: $REAL_COMMAND $@"
 if [ "$INSTALL" == y ]; then
-    check_apt_version
+    check_apt_version "$@"
     lock_result=$(acquire_apt_installation_lock "$COMMAND_INFO" )
     $REAL_COMMAND "$@"
     command_result=$?

--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -213,6 +213,10 @@ check_apt_version()
                 continue
             fi
 
+            if [ "$para" == "install" ]; then
+                continue
+            fi
+
             if [[ "$para" == *=* ]]; then
                 continue
             else


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the warning message not printed as expected issue

#### How I did it

#### How to verify it

If a version is not specified in the command line, and not in the version control file, then print a warning message as below:
```
apt-get -y install python3-dev
Warning: the version of the package python3-dev is not specified.
Reading package lists... Done
Building dependency tree       
...
```


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

