### PR TITLE
Don't use python/python2 for restapi start scripts

### DIFF
--- a/dockers/docker-sonic-restapi/supervisord.conf
+++ b/dockers/docker-sonic-restapi/supervisord.conf
@@ -4,7 +4,7 @@ logfile_backups=2
 nodaemon=true
 
 [eventlistener:dependent-startup]
-command=python -m supervisord_dependent_startup
+command=python3 -m supervisord_dependent_startup
 autostart=true
 autorestart=unexpected
 startretries=0
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
-command=python2 /usr/bin/supervisor-proc-exit-listener --container-name restapi
+command=/usr/bin/supervisor-proc-exit-listener --container-name restapi
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=false


### PR DESCRIPTION
Python 2 isn't installed by default in Buster and Bullseye containers,
and the scripts/modules can be used with Python 3, so make sure Python 3
is used.

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

After the Buster and Bullseye upgrade for the restapi container, processes will no longer start because supervisord is trying to call `python` and `python2`, both of which are unavailable.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

