### PR TITLE
[Build]: support to collect version when purging debian package

### DIFF
--- a/src/sonic-build-hooks/hooks/apt-get
+++ b/src/sonic-build-hooks/hooks/apt-get
@@ -20,6 +20,11 @@ if [ "$INSTALL" == y ]; then
     [ "$lock_result" == y ] && release_apt_installation_lock
     exit $command_result
 else
+    if [[ "$1" == "purge" || "$@" == *" purge "* ]]; then
+      # When running the purge command, collect the debian versions
+      dpkg-query -W -f '${Package}==${Version}\n' >> $POST_VERSION_PATH/purge-versions-deb
+      chmod a+wr $POST_VERSION_PATH/purge-versions-deb
+    fi
     $REAL_COMMAND "$@"
 fi
 

--- a/src/sonic-build-hooks/scripts/collect_version_files
+++ b/src/sonic-build-hooks/scripts/collect_version_files
@@ -1,14 +1,26 @@
 #!/bin/bash
 
+. /usr/local/share/buildinfo/scripts/buildinfo_base.sh
+
 TARGET_PATH=$1
+[ -z "$TARGET_PATH" ] && TARGET_PATH=$POST_VERSION_PATH
 ARCH=$(dpkg --print-architecture)
 DIST=$(grep VERSION_CODENAME /etc/os-release | cut -d= -f2)
 ([ -z "$DIST" ] && grep -q jessie /etc/os-release) && DIST=jessie
 
 mkdir -p $TARGET_PATH
 chmod a+rw $TARGET_PATH
-dpkg-query -W -f '${Package}==${Version}\n' > "${TARGET_PATH}/versions-deb-${DIST}-${ARCH}"
-([ -x "/usr/local/bin/pip2" ] || [ -x "/usr/bin/pip2" ]) && pip2 freeze > "${TARGET_PATH}/versions-py2-${DIST}-${ARCH}"
-([ -x "/usr/local/bin/pip3" ] || [ -x "/usr/bin/pip3" ]) && pip3 freeze > "${TARGET_PATH}/versions-py3-${DIST}-${ARCH}"
+
+dpkg-query -W -f '${Package}==${Version}\n' >> "${TARGET_PATH}/versions-deb-${DIST}-${ARCH}"
+([ -x "/usr/local/bin/pip2" ] || [ -x "/usr/bin/pip2" ]) && pip2 freeze >> "${TARGET_PATH}/versions-py2-${DIST}-${ARCH}"
+([ -x "/usr/local/bin/pip3" ] || [ -x "/usr/bin/pip3" ]) && pip3 freeze >> "${TARGET_PATH}/versions-py3-${DIST}-${ARCH}"
+
+## Add the the packages purged
+[ -f $POST_VERSION_PATH/purge-versions-deb ] && cat $POST_VERSION_PATH/purge-versions-deb >> "${TARGET_PATH}/versions-deb-${DIST}-${ARCH}"
+
+## Print the unique and sorted result
+sort -u "${TARGET_PATH}/versions-deb-${DIST}-${ARCH}" -o "${TARGET_PATH}/versions-deb-${DIST}-${ARCH}"
+sort -u "${TARGET_PATH}/versions-py2-${DIST}-${ARCH}" -o "${TARGET_PATH}/versions-py2-${DIST}-${ARCH}"
+sort -u "${TARGET_PATH}/versions-py3-${DIST}-${ARCH}" -o "${TARGET_PATH}/versions-py3-${DIST}-${ARCH}"
 
 exit 0

--- a/src/sonic-build-hooks/scripts/post_run_buildinfo
+++ b/src/sonic-build-hooks/scripts/post_run_buildinfo
@@ -2,8 +2,6 @@
 
 . /usr/local/share/buildinfo/scripts/buildinfo_base.sh
 
-[ -d $POST_VERSION_PATH ] && rm -rf $POST_VERSION_PATH
-
 # Collect the version files
 collect_version_files $POST_VERSION_PATH
 

--- a/src/sonic-build-hooks/scripts/pre_run_buildinfo
+++ b/src/sonic-build-hooks/scripts/pre_run_buildinfo
@@ -9,6 +9,7 @@ mkdir -p $LOG_PATH
 
 [ -d $PRE_VERSION_PATH ] && rm -rf $PRE_VERSION_PATH
 [ -d $POST_VERSION_PATH ] && rm -rf $POST_VERSION_PATH
+mkdir -p $POST_VERSION_PATH
 collect_version_files $PRE_VERSION_PATH
 symlink_build_hooks
 set_reproducible_mirrors

--- a/src/sonic-build-hooks/scripts/pre_run_buildinfo
+++ b/src/sonic-build-hooks/scripts/pre_run_buildinfo
@@ -8,6 +8,7 @@ mkdir -p $BUILD_VERSION_PATH
 mkdir -p $LOG_PATH
 
 [ -d $PRE_VERSION_PATH ] && rm -rf $PRE_VERSION_PATH
+[ -d $POST_VERSION_PATH ] && rm -rf $POST_VERSION_PATH
 collect_version_files $PRE_VERSION_PATH
 symlink_build_hooks
 set_reproducible_mirrors


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
support to collect version when purging debian package
Support to collect version multiple times

#### How I did it
Add the collection action before purging.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

