### PR TITLE
[Monit] Repeat restarting culprit container if Monit can't reset its counter

### DIFF
--- a/dockers/docker-sonic-telemetry/base_image_files/monit_telemetry
+++ b/dockers/docker-sonic-telemetry/base_image_files/monit_telemetry
@@ -2,4 +2,4 @@
 ## Monit configuration for telemetry container
 ###############################################################################
 check program container_memory_telemetry with path "/usr/bin/memory_checker telemetry 419430400"
-    if status == 3 for 10 times within 20 cycles then exec "/usr/bin/restart_service telemetry"
+    if status == 3 for 10 times within 20 cycles then exec "/usr/bin/restart_service telemetry" repeat every 2 cycles

--- a/files/image_config/monit/memory_checker
+++ b/files/image_config/monit/memory_checker
@@ -85,6 +85,8 @@ def check_memory_usage(container_name, threshold_value):
         if mem_usage_bytes > threshold_value:
             print("[{}]: Memory usage ({} Bytes) is larger than the threshold ({} Bytes)!"
                   .format(container_name, mem_usage_bytes, threshold_value))
+            syslog.syslog(syslog.LOG_INFO, "[{}]: Memory usage ({} Bytes) is larger than the threshold ({} Bytes)!"
+                  .format(container_name, mem_usage_bytes, threshold_value))
             sys.exit(3)
     else:
         syslog.syslog(syslog.LOG_ERR, "[memory_checker] Failed to retrieve memory value from '{}'"


### PR DESCRIPTION
Signed-off-by: Yong Zhao <yozhao@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR aims to fix the Monit issue which shows Monit can't reset its counter when monitoring memory usage of telemetry container.

Specifically the Monit configuration file related to monitoring memory usage of telemetry container is as following:

      check program container_memory_telemetry with path "/usr/bin/memory_checker telemetry 419430400"
          if status == 3 for 10 times within 20 cycles then exec "/usr/bin/restart_service telemetry"
  
If memory usage of telemetry container is larger than 400MB for 10 times within 20 cycles (minutes), then it will be restarted.
Recently we observed, after telemetry container was restarted, its memory usage continuously increased from 400MB to 11GB within 1 hour, but it was not restarted anymore during this 1 hour sliding window.

**The reason is Monit can't reset its counter to count again and Monit can reset its counter if and only if the status of monitored service was changed from `Status failed` to `Status ok`.** However, during this 1 hour sliding window, the status of monitored service was not changed from `Status failed` to `Status ok`.

Currently for each service monitored by Monit, there will be an entry showing the monitoring status, monitoring mode etc. For example, the following output from command `sudo monit status` shows the status of monitored service to monitor memory usage of telemetry:

        Program 'container_memory_telemetry'
             status                             Status ok
             monitoring status          Monitored
             monitoring mode          active
             on reboot                      start
             last exit value                0
             last output                    -
             data collected               Sat, 19 Mar 2022 19:56:26

Every 1 minute, Monit will run the script to check the memory usage of telemetry and update the counter if memory usage is larger than 400MB. If Monit checked the counter and found memory usage of telemetry is larger than 400MB for 10 times 
within 20 minutes, then telemetry container was restarted. Following is an example status of monitored service:

        Program 'container_memory_telemetry'
             status                             Status failed
             monitoring status          Monitored
             monitoring mode          active
             on reboot                      start
             last exit value                0
             last output                    -
             data collected               Tue, 01 Feb 2022 22:52:55

After telemetry container was restarted. we found memory usage of telemetry increased rapidly from around 100MB to more than 400MB during 1 minute and status of monitored service did not have a chance to be changed from `Status failed` to `Status ok`.

#### How I did it
In order to provide a workaround for this issue, Monit recently introduced another syntax format `repeat every <n> cycles` related to `exec`. This new syntax format will enable Monit repeat executing the background script if the error persists for a given number of cycles.

#### How to verify it
I verified this change on lab device `str-s6000-acs-12`. Another pytest PR (https://github.com/Azure/sonic-mgmt/pull/5492) is submitted in sonic-mgmt repo for review.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [x ] 202006
- [x ] 202012
- [x ] 202106
- [x ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

