### PR TITLE
[202012][CoPP] Fix the issue that trap entry can not be installed for DHCP and DHCPv6

### DIFF
--- a/files/image_config/copp/copp_cfg.j2
+++ b/files/image_config/copp/copp_cfg.j2
@@ -82,7 +82,7 @@
 		    "trap_group": "queue4_group3"
 	    },
 {% if not (DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] != "ToRRouter") %}
-	    "dhcp": {
+	    "dhcp_relay": {
 		    "trap_ids": "dhcp,dhcpv6",
 		    "trap_group": "queue4_group3"
 	    },


### PR DESCRIPTION
Fix the issue that TRAP entry can not be installed via aligning the entry names of DHCP in copp_cfg.j2 with the feature name
There is a logic in CoPP manager which loads CoPP items only if the feature is enabled.
It requires the feature name to align with CoPP item name otherwise the CoPP item can not be loaded.
Currently, DHCP CoPP item is used by feature dhcp_relay but the name doesn't align, which prevents DHCP CoPP entries from being installed.
This is to fix it.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

