### PR TITLE
[202111][Cherry-pick]Correct the pkg name for thrift.0.13.0 (#9688)

### DIFF
--- a/rules/thrift_0_13_0.mk
+++ b/rules/thrift_0_13_0.mk
@@ -11,7 +11,7 @@ LIBTHRIFT_DEV_0_13_0 = libthrift-dev_$(THRIFT_VERSION_0_13_0_FULL)_$(CONFIGURED_
 $(eval $(call add_derived_package,$(LIBTHRIFT_0_13_0),$(LIBTHRIFT_DEV_0_13_0)))
 
 PYTHON3_THRIFT_0_13_0 = python3-thrift_$(THRIFT_VERSION_0_13_0_FULL)_$(CONFIGURED_ARCH).deb
-$(eval $(call add_derived_package,$(LIBTHRIFT_0_13_0),$(PYTHON_THRIFT_0_13_0)))
+$(eval $(call add_derived_package,$(LIBTHRIFT_0_13_0),$(PYTHON3_THRIFT_0_13_0)))
 
 THRIFT_COMPILER_0_13_0 = thrift-compiler_$(THRIFT_VERSION_0_13_0_FULL)_$(CONFIGURED_ARCH).deb
 $(eval $(call add_derived_package,$(LIBTHRIFT_0_13_0),$(THRIFT_COMPILER_0_13_0)))


### PR DESCRIPTION
Correct thrift.0.13.0 dependent package name.
In previous code, the buildout target was named as PYTHON3_THRIFT_0_13_0
But when add the prackage to LIBTHRIFT_0_13_0, it typo as PYTHON_THRIFT_0_13_0

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

