### PR TITLE
[Nokia ixs7215] Fixes to support Debian bullseye

### DIFF
--- a/device/nokia/armhf-nokia_ixs7215_52x-r0/plugins/led_control.py
+++ b/device/nokia/armhf-nokia_ixs7215_52x-r0/plugins/led_control.py
@@ -60,8 +60,8 @@ class LedControl(LedControlBase):
 
     def _initSystemLed(self):
         # Front Panel System LEDs setting
-        oldfan = 0xf
-        oldpsu = 0xf
+        oldfan = 0xf    # 0=amber, 1=green
+        oldpsu = 0xf    # 0=amber, 1=green
 
         # Write sys led
         if smbus_present == 0:
@@ -73,18 +73,19 @@ class LedControl(LedControlBase):
             bus.write_byte_data(DEVICE_ADDRESS, DEVICEREG, 0x02)
             DBG_PRINT(" System LED set O.K. ")
 
+        # Timer loop to monitor and set front panel Status, Fan, and PSU LEDs
         while True:
-            # Front Panel FAN Panel LED setting in register 0x08
+            # Front Panel FAN Panel LED setting
             if (self.chassis.get_fan(0).get_status() == self.chassis.get_fan(1).get_status() == True):
-                if (os.path.isfile("/sys/class/gpio/fanLedAmber/value")):
+                if (os.path.isfile("/sys/class/gpio/fanLedGreen/value")):
                     if oldfan != 0x1:
                         self._set_i2c_register("/sys/class/gpio/fanLedAmber/value", 0)
                         self._set_i2c_register("/sys/class/gpio/fanLedGreen/value", 1)
                         oldfan = 0x1
                 else:
-                        oldfan = 0xf
+                    oldfan = 0xf
             else:
-                if (os.path.isfile("/sys/class/gpio/fanLedGreen/value")):
+                if (os.path.isfile("/sys/class/gpio/fanLedAmber/value")):
                     if oldfan != 0x0:
                         self._set_i2c_register("/sys/class/gpio/fanLedGreen/value", 0)
                         self._set_i2c_register("/sys/class/gpio/fanLedAmber/value", 1)
@@ -92,9 +93,9 @@ class LedControl(LedControlBase):
                 else:
                     oldfan = 0xf
 
-            # Front Panel PSU Panel LED setting in register 0x09
+            # Front Panel PSU Panel LED setting
             if (self.chassis.get_psu(0).get_status() == self.chassis.get_psu(1).get_status() == True):
-                if (os.path.isfile("/sys/class/gpio/psuLedAmber/value")):
+                if (os.path.isfile("/sys/class/gpio/psuLedGreen/value")):
                     if oldpsu != 0x1:
                         self._set_i2c_register("/sys/class/gpio/psuLedAmber/value", 0)
                         self._set_i2c_register("/sys/class/gpio/psuLedGreen/value", 1)
@@ -102,13 +103,14 @@ class LedControl(LedControlBase):
                 else:
                     oldpsu = 0xf
             else:
-                if (os.path.isfile("/sys/class/gpio/psuLedGreen/value")):
+                if (os.path.isfile("/sys/class/gpio/psuLedAmber/value")):
                     if oldpsu != 0x0:
                         self._set_i2c_register("/sys/class/gpio/psuLedGreen/value", 0)
                         self._set_i2c_register("/sys/class/gpio/psuLedAmber/value", 1)
                         oldpsu = 0x0
                 else:
                     oldpsu = 0xf
+
             time.sleep(6)
 
     # Helper method to map SONiC port name to index

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/chassis.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/chassis.py
@@ -201,6 +201,22 @@ class Chassis(ChassisBase):
         """
         return self._eeprom.serial_number_str()
 
+    def get_revision(self):
+        """
+        Retrieves the hardware revision of the chassis
+
+        Returns:
+            string: Revision value of chassis
+        """
+        if smbus_present == 0:  # called from host
+            cmdstatus, value = cmd.getstatusoutput('sudo i2cget -y 0 0x41 0x0')
+        else:
+            bus = smbus.SMBus(0)
+            DEVICE_ADDRESS = 0x41
+            DEVICE_REG = 0x0
+            value = bus.read_byte_data(DEVICE_ADDRESS, DEVICE_REG)
+        return str(value)
+
     def get_system_eeprom_info(self):
         """
         Retrieves the full content of system EEPROM information for the

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/fan.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/fan.py
@@ -33,7 +33,7 @@ class Fan(FanBase):
 
     def __init__(self, fan_index, fan_drawer, psu_fan=False, dependency=None):
         self.is_psu_fan = psu_fan
-        ADT7473_DIR = "/sys/bus/i2c/devices/0-002e/"
+        ADT7473_DIR = "/sys/bus/i2c/devices/0-002e/hwmon/hwmon1/"
 
         if not self.is_psu_fan:
             # Fan is 1-based in Nokia platforms

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/psu.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/psu.py
@@ -114,7 +114,6 @@ class Psu(PsuBase):
         """
         return self.eeprom.modelstr()
 
-
     def get_serial(self):
         """
         Retrieves the serial number of the PSU
@@ -124,6 +123,14 @@ class Psu(PsuBase):
         """
         return self.eeprom.serial_number_str()
 
+    def get_revision(self):
+        """
+        Retrieves the HW revision of the PSU
+
+        Returns:
+            string: HW revision of PSU
+        """
+        return self.eeprom.part_number_str()
 
     def get_part_number(self):
         """

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/test/test-chassis.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/test/test-chassis.py
@@ -21,6 +21,8 @@ def main():
 
     print("  Chassis serial: {}".format(chassis.get_serial()))
 
+    print("  Chassis revision: {}".format(chassis.get_revision()))
+
     print("  Chassis status: {}".format(chassis.get_status()))
 
     print("  Chassis base_mac: {}".format(chassis.get_base_mac()))

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/thermal.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/thermal.py
@@ -22,9 +22,9 @@ class Thermal(ThermalBase):
     I2C_CLASS_DIR = "/sys/class/i2c-adapter/"
     I2C_DEV_MAPPING = (['i2c-0/0-004a/hwmon/', 1],
                        ['i2c-0/0-004b/hwmon/', 1],
-                       ['i2c-0/0-002e/', 1],
-                       ['i2c-0/0-002e/', 2],
-                       ['i2c-0/0-002e/', 3])
+                       ['i2c-0/0-002e/hwmon/', 1],
+                       ['i2c-0/0-002e/hwmon/', 2],
+                       ['i2c-0/0-002e/hwmon/', 3])
 
     HWMON_CLASS_DIR = "/sys/class/hwmon/"
 
@@ -55,7 +55,8 @@ class Thermal(ThermalBase):
             sensor_index = self.I2C_DEV_MAPPING[self.index - 1][1]
             sensor_max_suffix = "max"
             sensor_crit_suffix = "crit"
-            self.SENSOR_DIR = i2c_path
+            hwmon_node = os.listdir(i2c_path)[0]
+            self.SENSOR_DIR = i2c_path + hwmon_node + '/'
 
         # Armada 38x SOC temperature sensor
         else:


### PR DESCRIPTION
The following changes are provided to support bullseye and the latest master
branch content.
    - Accommodate relocated fan and thermal sysfs entries in bullseye
    - Add support for chassis and PSU HW revision

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix platform issues introduced by the bullseye kernel upgrade.

#### How I did it
Minor fixes to Nokia ixs7215 platform code

#### How to verify it
Execute the following CLI commands
    show platform summary
    show platform fan
    show platform temperature

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

