### PR TITLE
[Build]: Fix armhf mirrors not existing issue

### DIFF
--- a/files/apt/sources.list.armhf
+++ b/files/apt/sources.list.armhf
@@ -1,11 +1,16 @@
 ## Debian mirror for ARM
 ## Not the repo mirror site can change in future, and needs to be updated to be in sync
 
-deb [arch=armhf] http://debian-archive.trafficmanager.net/debian/ bullseye main contrib non-free
-deb-src [arch=armhf] http://debian-archive.trafficmanager.net/debian/ bullseye main contrib non-free
-deb [arch=armhf] http://debian-archive.trafficmanager.net/debian-security/ bullseye-security main contrib non-free
-deb-src [arch=armhf] http://debian-archive.trafficmanager.net/debian-security/ bullseye-security main contrib non-free
-deb [arch=armhf] http://debian-archive.trafficmanager.net/debian/ bullseye-backports main contrib non-free
+deb [arch=armhf] http://deb.debian.org/debian bullseye main contrib non-free
+deb-src [arch=armhf] http://deb.debian.org/debian bullseye main contrib non-free
+deb [arch=armhf] http://security.debian.org bullseye-security main contrib non-free
+deb-src [arch=armhf] http://security.debian.org bullseye-security main contrib non-free
+deb [arch=armhf] http://deb.debian.org/debian bullseye-backports main contrib non-free
+#deb [arch=armhf] http://debian-archive.trafficmanager.net/debian/ bullseye main contrib non-free
+#deb-src [arch=armhf] http://debian-archive.trafficmanager.net/debian/ bullseye main contrib non-free
+#deb [arch=armhf] http://debian-archive.trafficmanager.net/debian-security/ bullseye-security main contrib non-free
+#deb-src [arch=armhf] http://debian-archive.trafficmanager.net/debian-security/ bullseye-security main contrib non-free
+#deb [arch=armhf] http://debian-archive.trafficmanager.net/debian/ bullseye-backports main contrib non-free
 deb [arch=armhf] http://packages.trafficmanager.net/debian/debian bullseye main contrib non-free
 deb-src [arch=armhf] http://packages.trafficmanager.net/debian/debian bullseye main contrib non-free
 deb [arch=armhf] http://packages.trafficmanager.net/debian/debian-security/ bullseye-security main contrib non-free


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
[Build]: Fix armhf mirrors not existing issue
The mirror endpoint debian-archive.trafficmanager.net does not support armhf, change to use deb.debian.org and security.debian.org.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

