### PR TITLE
Check to see that the py2 and py3 version files exist before trying to sort them

### DIFF
--- a/src/sonic-build-hooks/scripts/collect_version_files
+++ b/src/sonic-build-hooks/scripts/collect_version_files
@@ -20,7 +20,11 @@ dpkg-query -W -f '${Package}==${Version}\n' >> "${TARGET_PATH}/versions-deb-${DI
 
 ## Print the unique and sorted result
 sort -u "${TARGET_PATH}/versions-deb-${DIST}-${ARCH}" -o "${TARGET_PATH}/versions-deb-${DIST}-${ARCH}"
-sort -u "${TARGET_PATH}/versions-py2-${DIST}-${ARCH}" -o "${TARGET_PATH}/versions-py2-${DIST}-${ARCH}"
-sort -u "${TARGET_PATH}/versions-py3-${DIST}-${ARCH}" -o "${TARGET_PATH}/versions-py3-${DIST}-${ARCH}"
+if [ -e "${TARGET_PATH}/versions-py2-${DIST}-${ARCH}" ]; then
+    sort -u "${TARGET_PATH}/versions-py2-${DIST}-${ARCH}" -o "${TARGET_PATH}/versions-py2-${DIST}-${ARCH}"
+fi
+if [ -e "${TARGET_PATH}/versions-py3-${DIST}-${ARCH}" ]; then
+    sort -u "${TARGET_PATH}/versions-py3-${DIST}-${ARCH}" -o "${TARGET_PATH}/versions-py3-${DIST}-${ARCH}"
+fi
 
 exit 0


### PR DESCRIPTION
For Bullseye, Python 2 isn't present at all. This means that in certain
build cases (such as building something only for Bullseye), the version
file may not exist, and so the sort command would fail.

For most normal build commands, this probably won't be an issue, because
the SONiC build will start with Buster (which has both Python 2 and
Python 3 wheels built), and so the py2 and py3 files will be present
even during the Bullseye builds.

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

