### PR TITLE
[Nokia][device] Update the BCM config with recycle ports info for Nokia IXR7250E platform

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/jr2cp-nokia-18x400g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/jr2cp-nokia-18x400g-config.bcm
@@ -1553,7 +1553,9 @@ ucode_port_18.BCM8885X=CDGE0:core_0.18
 
 
 ucode_port_19.BCM8885X=RCY0:core_0.19
-ucode_port_20.BCM8885X=OLP:core_1.20
+ucode_port_20.BCM8885X=RCY1:core_1.20
+ucode_port_21.BCM8885X=OLP:core_1.21
+
 
 
 serdes_lane_config_dfe_1.BCM8885X=on

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/jr2cp-nokia-18x400g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/jr2cp-nokia-18x400g-config.bcm
@@ -1553,7 +1553,9 @@ ucode_port_18.BCM8885X=CDGE0:core_0.18
 
 
 ucode_port_19.BCM8885X=RCY0:core_0.19
-ucode_port_20.BCM8885X=OLP:core_1.20
+ucode_port_20.BCM8885X=RCY1:core_1.20
+ucode_port_21.BCM8885X=OLP:core_1.21
+
 
 
 serdes_lane_config_dfe_1.BCM8885X=on


### PR DESCRIPTION
#### Why I did it
Update the the BCM config file with the recycle ports info for Nokia IXR7250E platform

#### How I did it
Modify the the BCM configuration file with the recycle ports configuration 

#### How to verify it
Boot up image with the config_db#.json files which contain recycle ports.  Using the "docker ps -a"  to verify the containers  swss/syncd.  They should be up and running.
```
admin@ixre-egl-board1:~$ docker ps -a
CONTAINER ID   IMAGE                                COMMAND                  CREATED             STATUS                      PORTS     NAMES
...
e49cb5fbd2aa   docker-syncd-brcm-dnx:latest         "/usr/local/bin/sup.."   About an hour ago   Up 24 minutes                 syncd0
31123572b3bf   docker-syncd-brcm-dnx:latest         "/usr/local/bin/sup.."   About an hour ago   Up 24 minutes                 syncd1
e6a47dba14b5   docker-orchagent:latest              "/usr/bin/docker-ini..."   About an hour ago   Up 24 minutes                    swss1     
7e491d4dd656   docker-orchagent:latest              "/usr/bin/docker-ini..."   About an hour ago   Up 24 minutes                    swss0
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

