### PR TITLE
[BFN] Fix exception when fwutil run without sudo

### DIFF
--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/chassis.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/chassis.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python
 
 try:
+    import os
     import time
     import syslog
+    import logging
+    import logging.config
+    import yaml
 
     from sonic_platform_base.chassis_base import ChassisBase
     from sonic_platform.sfp import Sfp
     from sonic_platform.psu import psu_list_get
     from sonic_platform.fan_drawer import fan_drawer_list_get
     from sonic_platform.thermal import thermal_list_get
-    from eeprom import Eeprom
+    from eeprom import Eeprom, logfile_create
 
     from sonic_platform.platform_thrift_client import pltfm_mgr_ready
     from sonic_platform.platform_thrift_client import thrift_try
@@ -46,6 +50,11 @@ class Chassis(ChassisBase):
         self.phy_port_cur_state = {}
         self.qsfp_interval = self.QSFP_CHECK_INTERVAL
         self.__initialize_components()
+
+        with open(os.path.dirname(__file__) + "/logging.conf", 'r') as f:
+            config_dict = yaml.load(f, yaml.SafeLoader)
+            logfile_create(config_dict['handlers']['file']['filename'])
+            logging.config.dictConfig(config_dict)
 
     @property
     def _eeprom(self):

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/chassis.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/chassis.py
@@ -13,7 +13,8 @@ try:
     from sonic_platform.psu import psu_list_get
     from sonic_platform.fan_drawer import fan_drawer_list_get
     from sonic_platform.thermal import thermal_list_get
-    from eeprom import Eeprom, logfile_create
+    from eeprom import Eeprom
+    from platform_utils import file_create
 
     from sonic_platform.platform_thrift_client import pltfm_mgr_ready
     from sonic_platform.platform_thrift_client import thrift_try
@@ -53,7 +54,7 @@ class Chassis(ChassisBase):
 
         with open(os.path.dirname(__file__) + "/logging.conf", 'r') as f:
             config_dict = yaml.load(f, yaml.SafeLoader)
-            logfile_create(config_dict['handlers']['file']['filename'])
+            file_create(config_dict['handlers']['file']['filename'], '646')
             logging.config.dictConfig(config_dict)
 
     @property

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/component.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/component.py
@@ -1,4 +1,5 @@
 try:
+    import os
     import subprocess
     from sonic_platform_base.component_base import ComponentBase
     from platform_thrift_client import thrift_try
@@ -16,7 +17,10 @@ def get_bios_version():
     A string containing the firmware version of the BIOS
     """
     try:
-        return subprocess.check_output(['sudo', 'dmidecode', '-s', 'bios-version']).strip().decode()
+        if os.geteuid() != 0:
+            return subprocess.check_output(['sudo', 'dmidecode', '-s', 'bios-version']).strip().decode()
+        else:
+            return subprocess.check_output(['dmidecode', '-s', 'bios-version']).strip().decode()
     except subprocess.CalledProcessError as e:
         raise RuntimeError("Failed to get BIOS version")
 

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/component.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/component.py
@@ -16,9 +16,9 @@ def get_bios_version():
     A string containing the firmware version of the BIOS
     """
     try:
-        return subprocess.check_output(['dmidecode', '-s', 'bios-version']).strip().decode()
+        return subprocess.check_output(['sudo', 'dmidecode', '-s', 'bios-version']).strip().decode()
     except subprocess.CalledProcessError as e:
-        raise RuntimeError("Failed to getget BIOS version")
+        raise RuntimeError("Failed to get BIOS version")
 
 def get_bmc_version():
     """

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/component.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/component.py
@@ -17,10 +17,10 @@ def get_bios_version():
     A string containing the firmware version of the BIOS
     """
     try:
+        cmd = ['dmidecode', '-s', 'bios-version']
         if os.geteuid() != 0:
-            return subprocess.check_output(['sudo', 'dmidecode', '-s', 'bios-version']).strip().decode()
-        else:
-            return subprocess.check_output(['dmidecode', '-s', 'bios-version']).strip().decode()
+            cmd.insert(0, 'sudo')
+        return subprocess.check_output(cmd).strip().decode()
     except subprocess.CalledProcessError as e:
         raise RuntimeError("Failed to get BIOS version")
 

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/eeprom.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/eeprom.py
@@ -3,7 +3,6 @@ try:
     import sys
     import datetime
     import re
-    import subprocess
 
     sys.path.append(os.path.dirname(__file__))
 
@@ -14,6 +13,7 @@ try:
 
     from sonic_platform_base.sonic_eeprom import eeprom_base
     from sonic_platform_base.sonic_eeprom import eeprom_tlvinfo
+    from platform_utils import file_create
 
     from platform_thrift_client import thrift_try
 except ImportError as e:
@@ -42,8 +42,8 @@ _EEPROM_STATUS = "/var/run/platform/eeprom/status"
 
 class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
     def __init__(self):
-        logfile_create(_EEPROM_SYMLINK)
-        logfile_create(_EEPROM_STATUS)
+        file_create(_EEPROM_SYMLINK, '646')
+        file_create(_EEPROM_STATUS, '646')
         with open(_EEPROM_STATUS, 'w') as f:
             f.write("initializing..")
 
@@ -140,15 +140,3 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
     def revision_str(self):
         return self.__tlv_get(self._TLV_CODE_LABEL_REVISION)
 
-def logfile_create(path):
-    def run_cmd(cmd):
-        if os.geteuid() != 0:
-            cmd.insert(0, 'sudo')
-        subprocess.check_output(cmd)
-
-    file_path = os.path.dirname(path)
-    if not os.path.exists(file_path):
-        run_cmd(['mkdir', '-p', file_path])
-    if not os.path.isfile(path):
-        run_cmd(['touch', path])
-    run_cmd(['chmod', '646', path])

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/eeprom.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/eeprom.py
@@ -1,7 +1,6 @@
 try:
     import os
     import sys
-    import errno
     import datetime
     import logging
     import logging.config

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/eeprom.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/eeprom.py
@@ -7,6 +7,7 @@ try:
     import logging.config
     import yaml
     import re
+    import subprocess
 
     sys.path.append(os.path.dirname(__file__))
 
@@ -45,6 +46,11 @@ _EEPROM_STATUS = "/var/run/platform/eeprom/status"
 
 class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
     def __init__(self):
+       if os.geteuid() != 0:
+            subprocess.check_output(['sudo', 'chmod', '646', '/var/log/platform.log'])
+            subprocess.check_output(['sudo', 'chmod', '646', '/var/run/platform/eeprom/syseeprom'])
+            subprocess.check_output(['sudo', 'chmod', '646', '/var/run/platform/eeprom/status'])
+
         with open(os.path.dirname(__file__) + "/logging.conf", 'r') as f:
             config_dict = yaml.load(f, yaml.SafeLoader)
             logging.config.dictConfig(config_dict)

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/eeprom.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/eeprom.py
@@ -43,24 +43,19 @@ _product_dict = {
 
 _EEPROM_SYMLINK = "/var/run/platform/eeprom/syseeprom"
 _EEPROM_STATUS = "/var/run/platform/eeprom/status"
+_EEPROM_EEPROM_PATH = "/var/run/platform/eeprom"
 
 class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
     def __init__(self):
-       if os.geteuid() != 0:
-            subprocess.check_output(['sudo', 'chmod', '646', '/var/log/platform.log'])
-            subprocess.check_output(['sudo', 'chmod', '646', '/var/run/platform/eeprom/syseeprom'])
-            subprocess.check_output(['sudo', 'chmod', '646', '/var/run/platform/eeprom/status'])
-
         with open(os.path.dirname(__file__) + "/logging.conf", 'r') as f:
             config_dict = yaml.load(f, yaml.SafeLoader)
+            log_file = config_dict['handlers']['file']['filename']
+            self.file_check(log_file)
             logging.config.dictConfig(config_dict)
 
-        if not os.path.exists(os.path.dirname(_EEPROM_SYMLINK)):
-            try:
-                os.makedirs(os.path.dirname(_EEPROM_SYMLINK))
-            except OSError as e:
-                if e.errno != errno.EEXIST:
-                    raise
+        self.path_check(_EEPROM_EEPROM_PATH)
+        self.file_check(_EEPROM_SYMLINK)
+        self.file_check(_EEPROM_STATUS)
 
         open(_EEPROM_SYMLINK, 'a').close()
         with open(_EEPROM_STATUS, 'w') as f:
@@ -158,3 +153,22 @@ class Eeprom(eeprom_tlvinfo.TlvInfoDecoder):
 
     def revision_str(self):
         return self.__tlv_get(self._TLV_CODE_LABEL_REVISION)
+
+    def file_check(self, file_name):
+        cmd_touch = ['touch', file_name]
+        cmd_chmod = ['chmod', '646', file_name]
+        if os.geteuid() != 0:
+            cmd_touch.insert(0, 'sudo')
+            cmd_chmod.insert(0, 'sudo')
+
+        if not os.path.isfile(file_name):
+            subprocess.check_output(cmd_touch)
+
+        if not os.access(file_name, os.W_OK):
+            subprocess.check_output(cmd_chmod)
+
+    def path_check(self, path):
+        cmd = ['mkdir', '-p', path]
+        if os.geteuid() != 0:
+            cmd.insert(0, 'sudo')
+        subprocess.check_output(cmd)

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/platform_utils.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/platform_utils.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 
 try:
     import os

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/platform_utils.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/platform_utils.py
@@ -1,0 +1,21 @@
+
+try:
+    import os
+    import subprocess
+
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+def file_create(path, mode=None):
+    def run_cmd(cmd):
+        if os.geteuid() != 0:
+            cmd.insert(0, 'sudo')
+        subprocess.check_output(cmd)
+
+    file_path = os.path.dirname(path)
+    if not os.path.exists(file_path):
+        run_cmd(['mkdir', '-p', file_path])
+    if not os.path.isfile(path):
+        run_cmd(['touch', path])
+    if (mode is not None):    
+        run_cmd(['chmod', mode, path])


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Signed-off-by: Taras Keryk <tarasx.keryk@intel.com>
#### Why I did it
The previous implementaion of component.py expect fwutil run with sudo.
When fwutil run without sudo, there is exception:
```
 Traceback (most recent call last):
      File "/usr/local/bin/fwutil", line 5, in <module>
        from fwutil.main import cli
      File "/usr/local/lib/python3.9/dist-packages/fwutil/__init__.py", line 3, in <module>
        from . import main
      File "/usr/local/lib/python3.9/dist-packages/fwutil/main.py", line 40, in <module>
        pdp = PlatformDataProvider()
      File "/usr/local/lib/python3.9/dist-packages/fwutil/lib.py", line 159, in __init__
        self.__platform = Platform()
      File "/usr/local/lib/python3.9/dist-packages/sonic_platform/platform.py", line 21, in __init__
        self._chassis = Chassis()
      File "/usr/local/lib/python3.9/dist-packages/sonic_platform/chassis.py", line 48, in __init__
        self.__initialize_components()
      File "/usr/local/lib/python3.9/dist-packages/sonic_platform/chassis.py", line 136, in __initialize_components
        component = Components(index)
      File "/usr/local/lib/python3.9/dist-packages/sonic_platform/component.py", line 184, in __init__
        self.version = get_bios_version()
      File "/usr/local/lib/python3.9/dist-packages/sonic_platform/component.py", line 19, in get_bios_version
        return subprocess.check_output(['dmidecode', '-s', 'bios-version']).strip().decode()
      File "/usr/lib/python3.9/subprocess.py", line 424, in check_output
        return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
      File "/usr/lib/python3.9/subprocess.py", line 505, in run
        with Popen(*popenargs, **kwargs) as process:
      File "/usr/lib/python3.9/subprocess.py", line 951, in __init__
        self._execute_child(args, executable, preexec_fn, close_fds,
      File "/usr/lib/python3.9/subprocess.py", line 1823, in _execute_child
        raise child_exception_type(errno_num, err_msg, err_filename)
    FileNotFoundError: [Errno 2] No such file or directory: 'dmidecode'
```
The previous implementaion of eeprom.py expect fwutil run with sudo.
When fwutil run without sudo, there is exception:
```
 Traceback (most recent call last):
    File "/usr/lib/python3.9/logging/config.py", line 564, in configure
    handler = self.configure_handler(handlers[name])
    File "/usr/lib/python3.9/logging/config.py", line 745, in configure_handler
    result = factory(**kwargs)
    File "/usr/lib/python3.9/logging/handlers.py", line 153, in init
    BaseRotatingHandler.init(self, filename, mode, encoding=encoding,
    File "/usr/lib/python3.9/logging/handlers.py", line 58, in init
    logging.FileHandler.init(self, filename, mode=mode,
    File "/usr/lib/python3.9/logging/init.py", line 1142, in init
    StreamHandler.init(self, self._open())
    File "/usr/lib/python3.9/logging/init.py", line 1171, in _open
    return open(self.baseFilename, self.mode, encoding=self.encoding,
    PermissionError: [Errno 13] Permission denied: '/var/log/platform.log'
```
 The above exception was the direct cause of the following exception:
```
  Traceback (most recent call last):
    File "/usr/local/bin/fwutil", line 5, in
    from fwutil.main import cli
    File "/usr/local/lib/python3.9/dist-packages/fwutil/init.py", line 3, in
    from . import main
    File "/usr/local/lib/python3.9/dist-packages/fwutil/main.py", line 41, in
    pdp = PlatformDataProvider()
    File "/usr/local/lib/python3.9/dist-packages/fwutil/lib.py", line 162, in init
    self.chassis_component_map = self.__get_chassis_component_map()
    File "/usr/local/lib/python3.9/dist-packages/fwutil/lib.py", line 168, in __get_chassis_component_map
    chassis_name = self.__chassis.get_name()
    File "/usr/local/lib/python3.9/dist-packages/sonic_platform/chassis.py", line 146, in get_name
    return self._eeprom.modelstr()
    File "/usr/local/lib/python3.9/dist-packages/sonic_platform/chassis.py", line 54, in _eeprom
    self.__eeprom = Eeprom()
    File "/usr/local/lib/python3.9/dist-packages/sonic_platform/eeprom.py", line 50, in init
    logging.config.dictConfig(config_dict)
    File "/usr/lib/python3.9/logging/config.py", line 809, in dictConfig
    dictConfigClass(config).configure()
    File "/usr/lib/python3.9/logging/config.py", line 571, in configure
    raise ValueError('Unable to configure handler '
    ValueError: Unable to configure handler 'file'
```
#### How I did it
Modification call of dmidecode command.
Added modification of log files access attributes before file open operations.
#### How to verify it
Run manually 'fwutil' (without sudo)
New command output have no exception.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

