### PR TITLE
[tun_pkt]: Wait for AsyncSniffer to init fully

### DIFF
--- a/dockers/docker-orchagent/tunnel_packet_handler.py
+++ b/dockers/docker-orchagent/tunnel_packet_handler.py
@@ -51,6 +51,10 @@ class TunnelPacketHandler(object):
         self._portchannel_intfs = None
         self.up_portchannels = None
         self.netlink_api = IPRoute()
+        self.sniffer = None
+        self.self_ip = ''
+        self.packet_filter = ''
+        self.sniff_intfs = []
 
     @property
     def portchannel_intfs(self):
@@ -270,6 +274,39 @@ class TunnelPacketHandler(object):
                     return True
         return False
 
+    def start_sniffer(self):
+        """
+        Starts an AsyncSniffer and waits for it to inititalize fully
+        """
+        self.sniffer = AsyncSniffer(
+            iface=self.sniff_intfs,
+            filter=self.packet_filter,
+            prn=self.ping_inner_dst,
+            store=0
+        )
+        self.sniffer.start()
+
+        while not hasattr(self.sniffer, 'stop_cb'):
+            time.sleep(0.1)
+
+    def ping_inner_dst(self, packet):
+        """
+        Pings the inner destination IP for an encapsulated packet
+
+        Args:
+            packet: The encapsulated packet received
+        """
+        inner_packet_type = self.get_inner_pkt_type(packet)
+        if inner_packet_type and packet[IP].dst == self.self_ip:
+            cmds = ['timeout', '0.2', 'ping', '-c1',
+                    '-W1', '-i0', '-n', '-q']
+            if inner_packet_type == IPv6:
+                cmds.append('-6')
+            dst_ip = packet[IP].payload[inner_packet_type].dst
+            cmds.append(dst_ip)
+            logger.log_info("Running command '{}'".format(' '.join(cmds)))
+            subprocess.run(cmds, stdout=subprocess.DEVNULL)
+
     def listen_for_tunnel_pkts(self):
         """
         Listens for tunnel packets that are trapped to CPU
@@ -277,59 +314,28 @@ class TunnelPacketHandler(object):
         These packets may be trapped if there is no neighbor info for the
         inner packet destination IP in the hardware.
         """
-
-        def _ping_inner_dst(packet):
-            """
-            Pings the inner destination IP for an encapsulated packet
-
-            Args:
-                packet: The encapsulated packet received
-            """
-            inner_packet_type = self.get_inner_pkt_type(packet)
-            if inner_packet_type and packet[IP].dst == self_ip:
-                cmds = ['timeout', '0.2', 'ping', '-c1',
-                        '-W1', '-i0', '-n', '-q']
-                if inner_packet_type == IPv6:
-                    cmds.append('-6')
-                dst_ip = packet[IP].payload[inner_packet_type].dst
-                cmds.append(dst_ip)
-                logger.log_info("Running command '{}'".format(' '.join(cmds)))
-                subprocess.run(cmds, stdout=subprocess.DEVNULL)
-
-        self_ip, peer_ip = self.get_ipinip_tunnel_addrs()
-        if self_ip is None or peer_ip is None:
+        self.self_ip, peer_ip = self.get_ipinip_tunnel_addrs()
+        if self.self_ip is None or peer_ip is None:
             logger.log_notice('Could not get tunnel addresses from '
                               'config DB, exiting...')
             return None
 
-        packet_filter = 'host {} and host {}'.format(self_ip, peer_ip)
+        self.packet_filter = 'host {} and host {}'.format(self.self_ip, peer_ip)
         logger.log_notice('Starting tunnel packet handler for {}'
-                          .format(packet_filter))
+                          .format(self.packet_filter))
 
-        sniff_intfs = self.get_up_portchannels()
-        logger.log_info("Listening on interfaces {}".format(sniff_intfs))
+        self.sniff_intfs = self.get_up_portchannels()
+        logger.log_info("Listening on interfaces {}".format(self.sniff_intfs))
 
-        sniffer = AsyncSniffer(
-            iface=sniff_intfs,
-            filter=packet_filter,
-            prn=_ping_inner_dst,
-            store=0
-        )
-        sniffer.start()
+        self.start_sniffer()
         while True:
             msgs = self.wait_for_netlink_msgs()
             if self.sniffer_restart_required(msgs):
-                sniffer.stop()
+                self.sniffer.stop()
                 sniff_intfs = self.get_up_portchannels()
                 logger.log_notice('Restarting tunnel packet handler on '
                                   'interfaces {}'.format(sniff_intfs))
-                sniffer = AsyncSniffer(
-                    iface=sniff_intfs,
-                    filter=packet_filter,
-                    prn=_ping_inner_dst,
-                    store=0
-                )
-                sniffer.start()
+                self.start_sniffer()
 
     def run(self):
         """


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Tunnel packet handler can crash at system startup:
```
Mar 19 13:11:07.240465 str2-8102-03 INFO swss#/supervisord: tunnel_packet_handler Traceback (most recent call last):
Mar 19 13:11:07.240465 str2-8102-03 INFO swss#/supervisord: tunnel_packet_handler   File "/usr/local/lib/python3.7/dist-packages/scapy/sendrecv.py", line 1017, in stop
Mar 19 13:11:07.240465 str2-8102-03 INFO swss#/supervisord: tunnel_packet_handler     self.stop_cb()
Mar 19 13:11:07.240529 str2-8102-03 INFO swss#/supervisord: tunnel_packet_handler AttributeError: 'AsyncSniffer' object has no attribute 'stop_cb'
Mar 19 13:11:07.240529 str2-8102-03 INFO swss#/supervisord: tunnel_packet_handler 
Mar 19 13:11:07.240529 str2-8102-03 INFO swss#/supervisord: tunnel_packet_handler During handling of the above exception, another exception occurred:
Mar 19 13:11:07.240529 str2-8102-03 INFO swss#/supervisord: tunnel_packet_handler 
Mar 19 13:11:07.240560 str2-8102-03 INFO swss#/supervisord: tunnel_packet_handler Traceback (most recent call last):
Mar 19 13:11:07.240560 str2-8102-03 INFO swss#/supervisord: tunnel_packet_handler   File "/usr/bin/tunnel_packet_handler.py", line 349, in <module>
Mar 19 13:11:07.240560 str2-8102-03 INFO swss#/supervisord: tunnel_packet_handler     main()
Mar 19 13:11:07.240587 str2-8102-03 INFO swss#/supervisord: tunnel_packet_handler   File "/usr/bin/tunnel_packet_handler.py", line 345, in main
Mar 19 13:11:07.240587 str2-8102-03 INFO swss#/supervisord: tunnel_packet_handler     handler.run()
Mar 19 13:11:07.240632 str2-8102-03 INFO swss#/supervisord: tunnel_packet_handler   File "/usr/bin/tunnel_packet_handler.py", line 339, in run
Mar 19 13:11:07.240632 str2-8102-03 INFO swss#/supervisord: tunnel_packet_handler     self.listen_for_tunnel_pkts()
Mar 19 13:11:07.240652 str2-8102-03 INFO swss#/supervisord: tunnel_packet_handler   File "/usr/bin/tunnel_packet_handler.py", line 322, in listen_for_tunnel_pkts
Mar 19 13:11:07.240667 str2-8102-03 INFO swss#/supervisord: tunnel_packet_handler     sniffer.stop()
Mar 19 13:11:07.240680 str2-8102-03 INFO swss#/supervisord: tunnel_packet_handler   File "/usr/local/lib/python3.7/dist-packages/scapy/sendrecv.py", line 1020, in stop
Mar 19 13:11:07.240680 str2-8102-03 INFO swss#/supervisord: tunnel_packet_handler     "Unsupported (offline or unsupported socket)"
Mar 19 13:11:07.240718 str2-8102-03 INFO swss#/supervisord: tunnel_packet_handler scapy.error.Scapy_Exception: Unsupported (offline or unsupported socket)
Mar 19 13:11:07.310724 str2-8102-03 INFO swss#supervisord 2022-03-19 13:11:07,310 INFO exited: tunnel_packet_handler (exit status 1; not expected)
```
This is due to a race condition between netlink messages being sent by the kernel and the `AsyncSniffer` object inititalizing fully. It is possible for a netlink message to arrive and trigger a sniffer restart prior to the sniffer [initializing its `self.stop_cb` variable](https://github.com/secdev/scapy/blob/d48733db4efe411999daaac01daf90cf79ea90ca/scapy/sendrecv.py#L1205), since the variable creation happens during the sniffer startup rather than during the creation of the sniffer object. If this occurs, the tunnel_packet_handler attempts to stop the sniffer, but this operation fails because `self.stop_cb` doesn't exist yet.

#### How I did it
After creating the sniffer object, block until the `self.stop_cb` attribute has been created.

#### How to verify it
Run `sudo systemctl restart swss` and verify the tunnel packet handler does not crash

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

