### PR TITLE
[gbsyncd] Support multiple gbsyncd containers in the same SWI

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -233,6 +233,20 @@ start() {
         source $ASIC_CONF
     fi
 
+    {%- if docker_container_name == "gbsyncd" %}
+    GBSYNCD_CONF=/usr/share/sonic/device/$PLATFORM/gbsyncd.ini
+    GBSYNCD_PLATFORM=gbsyncd-vs
+    if [ -f "$GBSYNCD_CONF" ]; then
+        while IFS="=" read -r key value; do
+            case "$key" in
+                platform)
+                    GBSYNCD_PLATFORM="$value"
+                    ;;
+            esac
+        done < "$GBSYNCD_CONF"
+    fi
+    {%- endif %}
+
     {%- if docker_container_name == "database" %}
     # Don't mount HWSKU in {{docker_container_name}} container.
     HWSKU=""
@@ -457,7 +471,9 @@ start() {
         --env "NAMESPACE_PREFIX"="$NAMESPACE_PREFIX" \
         --env "NAMESPACE_COUNT"=$NUM_ASIC \
         --name=$DOCKERNAME \
-{%- if docker_image_name is defined %}
+{%- if docker_container_name == "gbsyncd" %}
+        "docker-$GBSYNCD_PLATFORM":latest \
+{%- elif docker_image_name is defined %}
         {{docker_image_name}}:latest \
 {%- else %}
         {{docker_image_id}} \


### PR DESCRIPTION
Currently the only supported gbsyncd container is docker-gbsyncd-credo.
This change will allow docker_image_ctl to check the platform gbsyncd
configuration file and run the correct version of gbsyncd for that
platform. This will enable the support of docker-gbsyncd-broncos in the
future.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Some new platforms will require docker-gbsyncd-broncos for their external PHYs. This change will allow non-Credo gbsyncd to be supported.

#### How I did it
Add a check for gbsyncd.ini to see which gbsyncd the platform needs.

#### How to verify it
The existing functionalities for gbsyncd-credo are unaffected.
To test adding a new gbsyncd, one can add the build under platform/components.
The method to verify is not included in this change.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

