### PR TITLE
[Build]: Fix host image debian package version issue

### DIFF
--- a/scripts/prepare_slave_container_buildinfo.sh
+++ b/scripts/prepare_slave_container_buildinfo.sh
@@ -10,6 +10,10 @@ sudo dpkg -i --force-overwrite $SLAVE_DIR/buildinfo/sonic-build-hooks_*.deb > /d
 # Enable the build hooks
 symlink_build_hooks
 
+# Enable reproducible mirrors
+set_reproducible_mirrors
+apt-get update > /dev/null 2>&1
+
 # Build the slave running config
 cp -rf $SLAVE_DIR/buildinfo/* /usr/local/share/buildinfo/
 . /usr/local/share/buildinfo/scripts/buildinfo_base.sh

--- a/scripts/versions_manager.py
+++ b/scripts/versions_manager.py
@@ -180,11 +180,12 @@ class VersionModule:
         default_module_path = VersionModule.get_module_path_by_name(source_path, DEFAULT_MODULE)
         default_module = VersionModule()
         default_module.load(default_module_path, filter_dist=dist, filter_arch=arch)
-        module = default_module.clone(exclude_ctypes=DEFAULT_OVERWRITE_COMPONENTS)
+        module = default_module
         if self.name == 'host-image':
             base_module_path = VersionModule.get_module_path_by_name(source_path, 'host-base-image')
             base_module = VersionModule()
             base_module.load(base_module_path, filter_dist=dist, filter_arch=arch)
+            module = default_module.clone(exclude_ctypes=DEFAULT_OVERWRITE_COMPONENTS)
             module.overwrite(base_module, True, True)
         elif not self.is_aggregatable_module(self.name):
             module = default_module.clone(exclude_ctypes=DEFAULT_OVERWRITE_COMPONENTS)

--- a/scripts/versions_manager.py
+++ b/scripts/versions_manager.py
@@ -174,24 +174,19 @@ class VersionModule:
                 self.components.append(tmp_component)
         self.adjust()
 
-    def get_config_module_from_source(self, source_path, dist, arch):
+    def get_config_module(self, source_path, dist, arch):
         if self.is_individule_version():
             return self
         default_module_path = VersionModule.get_module_path_by_name(source_path, DEFAULT_MODULE)
         default_module = VersionModule()
         default_module.load(default_module_path, filter_dist=dist, filter_arch=arch)
+        module = default_module.clone(exclude_ctypes=DEFAULT_OVERWRITE_COMPONENTS)
         if self.name == 'host-image':
             base_module_path = VersionModule.get_module_path_by_name(source_path, 'host-base-image')
             base_module = VersionModule()
             base_module.load(base_module_path, filter_dist=dist, filter_arch=arch)
-            default_module.overwrite(base_module, True, True)
-        return self.get_config_module(default_module, dist, arch)
-
-    def get_config_module(self, default_module, dist, arch):
-        if self.is_individule_version():
-            return self
-        module = default_module
-        if not self.is_aggregatable_module(self.name):
+            module.overwrite(base_module, True, True)
+        elif not self.is_aggregatable_module(self.name):
             module = default_module.clone(exclude_ctypes=DEFAULT_OVERWRITE_COMPONENTS)
         return self._get_config_module(module, dist, arch)
 
@@ -674,7 +669,7 @@ class VersionManagerCommands:
             os.makedirs(args.target_path)
         module = VersionModule()
         module.load(module_path, filter_dist=args.distribution, filter_arch=args.architecture)
-        config = module.get_config_module_from_source(args.source_path, args.distribution, args.architecture)
+        config = module.get_config_module(args.source_path, args.distribution, args.architecture)
         config.clean_info(force=True)
         config.dump(args.target_path, config=True, priority=args.priority)
 

--- a/scripts/versions_manager.py
+++ b/scripts/versions_manager.py
@@ -174,6 +174,19 @@ class VersionModule:
                 self.components.append(tmp_component)
         self.adjust()
 
+    def get_config_module_from_source(self, source_path, dist, arch):
+        if self.is_individule_version():
+            return self
+        default_module_path = VersionModule.get_module_path_by_name(source_path, DEFAULT_MODULE)
+        default_module = VersionModule()
+        default_module.load(default_module_path, filter_dist=dist, filter_arch=arch)
+        if self.name == 'host-image':
+            base_module_path = VersionModule.get_module_path_by_name(source_path, 'host-base-image')
+            base_module = VersionModule()
+            base_module.load(base_module_path, filter_dist=args.distribution, filter_arch=args.architecture)
+            default_module.overwrite(base_module, True, True)
+        return self.get_config_module(default_module, dist, arch)
+
     def get_config_module(self, default_module, dist, arch):
         if self.is_individule_version():
             return self
@@ -661,10 +674,7 @@ class VersionManagerCommands:
             os.makedirs(args.target_path)
         module = VersionModule()
         module.load(module_path, filter_dist=args.distribution, filter_arch=args.architecture)
-        default_module_path = VersionModule.get_module_path_by_name(args.source_path, DEFAULT_MODULE)
-        default_module = VersionModule()
-        default_module.load(default_module_path, filter_dist=args.distribution, filter_arch=args.architecture)
-        config = module.get_config_module(default_module, args.distribution, args.architecture)
+        config = module.get_config_module_from_source(args.source_path, args.distribution, args.architecture)
         config.clean_info(force=True)
         config.dump(args.target_path, config=True, priority=args.priority)
 

--- a/scripts/versions_manager.py
+++ b/scripts/versions_manager.py
@@ -183,7 +183,7 @@ class VersionModule:
         if self.name == 'host-image':
             base_module_path = VersionModule.get_module_path_by_name(source_path, 'host-base-image')
             base_module = VersionModule()
-            base_module.load(base_module_path, filter_dist=args.distribution, filter_arch=args.architecture)
+            base_module.load(base_module_path, filter_dist=dist, filter_arch=arch)
             default_module.overwrite(base_module, True, True)
         return self.get_config_module(default_module, dist, arch)
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix host image debian package version issue.
The package dependencies may have issue, when some of debian packages of the base image are upgraded. For example, libc is installed in base image, but if the mirror has new version, when running "apt-get upgrade", the package will be upgraded unexpected. To avoid such issue, need to add the versions when building the host image.

#### How I did it
The package versions of host-image should contain host-base-image.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

