### PR TITLE
[202012] Image disk space reduction (#10172)

### DIFF
--- a/dockers/docker-base-buster/Dockerfile.j2
+++ b/dockers/docker-base-buster/Dockerfile.j2
@@ -121,7 +121,7 @@ RUN apt-get -y purge   \
 RUN apt-get clean -y                     && \
     apt-get autoclean -y                 && \
     apt-get autoremove -y                && \
-    rm -rf /var/lib/apt/lists/* /tmp/*
+    rm -rf /var/lib/apt/lists/* /tmp/* ~/.cache/
 
 COPY ["etc/rsyslog.conf", "/etc/rsyslog.conf"]
 COPY ["etc/rsyslog.d/*", "/etc/rsyslog.d/"]

--- a/dockers/docker-config-engine-buster/Dockerfile.j2
+++ b/dockers/docker-config-engine-buster/Dockerfile.j2
@@ -49,4 +49,4 @@ RUN apt-get purge -y               \
     apt-get clean -y            && \
     apt-get autoclean -y        && \
     apt-get autoremove -y       && \
-    rm -rf /debs /python-wheels
+    rm -rf /debs /python-wheels ~/.cache

--- a/dockers/docker-orchagent/Dockerfile.j2
+++ b/dockers/docker-orchagent/Dockerfile.j2
@@ -63,7 +63,7 @@ RUN apt-get purge -y          \
     apt-get clean -y       && \
     apt-get autoclean -y   && \
     apt-get autoremove -y  && \
-    rm -rf /debs
+    rm -rf /debs ~/.cache
 
 COPY ["files/arp_update", "/usr/bin"]
 COPY ["arp_update.conf", "files/arp_update_vars.j2", "/usr/share/sonic/templates/"]

--- a/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
@@ -51,6 +51,6 @@ RUN apt-get purge -y python-dev
 
 RUN apt-get remove -y g++ python3-dev
 RUN apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y
-RUN rm -rf /debs
+RUN rm -rf /debs ~/.cache
 
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -351,7 +351,12 @@ extract_image() {
     unzip -oq "$swipath" -x boot0 "$dockerfs" -d "$image_path"
 
     ## detect rootfs type
-    rootfs_type=`grep " $target_path " /proc/mounts | cut -d' ' -f3`
+    local mountstr="$(grep " $target_path " /proc/mounts)"
+    local rootdev="$(echo $mountstr | cut -f1 -d' ')"
+    rootfs_type="$(echo $mountstr | cut -d' ' -f3)"
+
+    ## Don't reserve any blocks just for root
+    tune2fs -m 0 -r 0 $rootdev
 
     info "Extracting $dockerfs from swi"
     ## Unpacking dockerfs delayed

--- a/files/initramfs-tools/varlog
+++ b/files/initramfs-tools/varlog
@@ -11,16 +11,26 @@ case $1 in
     ;;
 esac
 
+logs_inram=false
+
 # Extract kernel parameters
 set -- $(cat /proc/cmdline)
 for x in "$@"; do
     case "$x" in
         varlog_size=*)
             varlog_size="${x#varlog_size=}"
+            ;;
+        logs_inram=on)
+            logs_inram=true
+            ;;
     esac
 done
 
 [ -z "$varlog_size" ] && exit 0
+
+# If logs are being stored in memory, then don't bother
+# creating the log file just to have it deleted afterwards.
+$logs_inram && exit 0
 
 # exit when the var_log.ext4 exists and the size matches
 if [ -e "${rootmnt}/host/disk-img/var-log.ext4" ]; then

--- a/installer/arm64/install.sh
+++ b/installer/arm64/install.sh
@@ -117,6 +117,11 @@ elif [ "$install_env" = "sonic" ]; then
             rm -rf $f
         fi
     done
+
+    demo_dev=$(findmnt -n -o SOURCE --target /host)
+
+    # Don't reserve any blocks just for root
+    tune2fs -m 0 -r 0 $demo_dev
 fi
 
 # Create target directory or clean it up if exists

--- a/installer/armhf/install.sh
+++ b/installer/armhf/install.sh
@@ -117,6 +117,11 @@ elif [ "$install_env" = "sonic" ]; then
             rm -rf $f
         fi
     done
+
+    demo_dev=$(findmnt -n -o SOURCE --target /host)
+
+    # Don't reserve any blocks just for root
+    tune2fs -m 0 -r 0 $demo_dev
 fi
 
 # Create target directory or clean it up if exists

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -434,6 +434,9 @@ if [ "$install_env" = "onie" ]; then
     # Make filesystem
     mkfs.ext4 -L $demo_volume_label $demo_dev
 
+    # Don't reserve any blocks just for root
+    tune2fs -m 0 -r 0 $demo_dev
+
     # Mount demo filesystem
     demo_mnt=$(${onie_bin} mktemp -d) || {
         echo "Error: Unable to create file system mount point"
@@ -466,11 +469,19 @@ elif [ "$install_env" = "sonic" ]; then
             rm -rf $f
         fi
     done
+
+    demo_dev=$(findmnt -n -o SOURCE --target /host)
+
+    # Don't reserve any blocks just for root
+    tune2fs -m 0 -r 0 $demo_dev
 else
     demo_mnt="build_raw_image_mnt"
     demo_dev=$cur_wd/"%%OUTPUT_RAW_IMAGE%%"
 
     mkfs.ext4 -L $demo_volume_label $demo_dev
+
+    # Don't reserve any blocks just for root
+    tune2fs -m 0 -r 0 $demo_dev
 
     echo "Mounting $demo_dev on $demo_mnt..."
     mkdir $demo_mnt


### PR DESCRIPTION
* Remove pip2 and pip3 caches from some containers

Only containers which appeared to have a significant pip cache size are
included here.

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>

* Don't create var-log.ext4 if we're storing logs in memory

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>

* Run tune2fs on the device containing /host to not reserve any blocks for just the root user

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>
(cherry picked from commit 5617b1ae3efc6cee52b875651135ada67898ebf0)

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Reduce the disk space taken up during bootup and runtime.

#### How I did it

1. Remove python package cache from the base image and from the containers.
2. During bootup, if logs are to be stored in memory, then don't create the `var-log.ext4` file just to delete it later during bootup.
3. For the partition containing `/host`, don't reserve any blocks for just the root user. This just makes sure all disk space is available for all users, if needed during upgrades (for example).

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

