### PR TITLE
[Nokia ixs7215] Platform API temperature threshold value fixes

### DIFF
--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/test/test-thermal.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/test/test-thermal.py
@@ -30,7 +30,7 @@ def main():
                 high_thresh = "NA"
 
             print("        Low Threshold(C): {}, High Threshold(C): {}".format(low_thresh,
-                                                                                 high_thresh))
+                                                                               high_thresh))
 
             try:
                 crit_low_thresh = thermal.get_low_critical_threshold()

--- a/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/thermal.py
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/sonic_platform/thermal.py
@@ -44,8 +44,8 @@ class Thermal(ThermalBase):
         if self.index < 3:
             i2c_path = self.I2C_CLASS_DIR + self.I2C_DEV_MAPPING[self.index - 1][0]
             sensor_index = self.I2C_DEV_MAPPING[self.index - 1][1]
-            sensor_max_suffix = "max"
-            sensor_crit_suffix = None
+            sensor_high_suffix = "max"
+            sensor_high_crit_suffix = None
             hwmon_node = os.listdir(i2c_path)[0]
             self.SENSOR_DIR = i2c_path + hwmon_node + '/'
 
@@ -53,8 +53,8 @@ class Thermal(ThermalBase):
         elif self.index < 6:
             i2c_path = self.I2C_CLASS_DIR + self.I2C_DEV_MAPPING[self.index - 1][0]
             sensor_index = self.I2C_DEV_MAPPING[self.index - 1][1]
-            sensor_max_suffix = "max"
-            sensor_crit_suffix = "crit"
+            sensor_high_suffix = "crit"
+            sensor_high_crit_suffix = None
             hwmon_node = os.listdir(i2c_path)[0]
             self.SENSOR_DIR = i2c_path + hwmon_node + '/'
 
@@ -62,8 +62,8 @@ class Thermal(ThermalBase):
         else:
             dev_path = self.HWMON_CLASS_DIR
             sensor_index = 1
-            sensor_max_suffix = None
-            sensor_crit_suffix = None
+            sensor_high_suffix = None
+            sensor_high_crit_suffix = None
             hwmon_node = os.listdir(dev_path)[0]
             self.SENSOR_DIR = dev_path + hwmon_node + '/'
 
@@ -72,16 +72,16 @@ class Thermal(ThermalBase):
             + "temp{}_input".format(sensor_index)
 
         # sysfs file for high threshold value if supported for this sensor
-        if sensor_max_suffix:
+        if sensor_high_suffix:
             self.thermal_high_threshold_file = self.SENSOR_DIR \
-                + "temp{}_{}".format(sensor_index, sensor_max_suffix)
+                + "temp{}_{}".format(sensor_index, sensor_high_suffix)
         else:
             self.thermal_high_threshold_file = None
 
         # sysfs file for crit high threshold value if supported for this sensor
-        if sensor_crit_suffix:
+        if sensor_high_crit_suffix:
             self.thermal_high_crit_threshold_file = self.SENSOR_DIR \
-                + "temp{}_{}".format(sensor_index, sensor_crit_suffix)
+                + "temp{}_{}".format(sensor_index, sensor_high_crit_suffix)
         else:
             self.thermal_high_crit_threshold_file = None
 


### PR DESCRIPTION
Incorrect high-threshold and critical-high-threshold values are displayed for
some of the temperature sensors. This commit fixes that.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Incorrect high-threshold and critical-high-threshold values are displayed for
some of the temperature sensors

#### How I did it
Modify the thermal sensor Platform API 2.0 implementation to return the correct values.

#### How to verify it
Ensure that the 'show platform temperature' command show the correct high-threshold and critical-high-threshold values for each thermal sensor.

Values displayed before the fix.
```
admin@localhost:~$ show platform temperature
     Sensor    Temperature    High TH    Low TH    Crit High TH    Crit Low TH    Warning          Timestamp
-----------  -------------  ---------  --------  --------------  -------------  ---------  -----------------
ADT7473-CPU         23          191.0       N/A           100.0            N/A      False  20220328 16:08:56
ADT7473-LOC         23.5        191.0       N/A           100.0            N/A      False  20220328 16:08:56
ADT7473-MAC         22.5        191.0       N/A           100.0            N/A      False  20220328 16:08:56
   CPU Core         21.5          N/A       N/A             N/A            N/A      False  20220328 16:08:56
    PCB MAC         27.375       80.0       N/A             N/A            N/A      False  20220328 16:08:56
    PCB PHY         21.5         80.0       N/A             N/A            N/A      False  20220328 16:08:56
```

Values displayed after the fix
```
admin@challenger:~$ show platform temperature 
     Sensor    Temperature    High TH    Low TH    Crit High TH    Crit Low TH    Warning          Timestamp
-----------  -------------  ---------  --------  --------------  -------------  ---------  -----------------
ADT7473-CPU         24          100.0       N/A             N/A            N/A      False  20220328 15:49:09
ADT7473-LOC         25          100.0       N/A             N/A            N/A      False  20220328 15:49:09
ADT7473-MAC         23.5        100.0       N/A             N/A            N/A      False  20220328 15:49:09
   CPU Core         22.625        N/A       N/A             N/A            N/A      False  20220328 15:49:09
    PCB MAC         28.75        80.0       N/A             N/A            N/A      False  20220328 15:49:09
    PCB PHY         22.625       80.0       N/A             N/A            N/A      False  20220328 15:49:09
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

