### PR TITLE
[radv] Add new device type in docker-router-advertiser.supervisord.conf.j2

### DIFF
--- a/dockers/docker-router-advertiser/docker-router-advertiser.supervisord.conf.j2
+++ b/dockers/docker-router-advertiser/docker-router-advertiser.supervisord.conf.j2
@@ -45,7 +45,7 @@ dependent_startup_wait_for=rsyslogd:running
 {%- set vlan_v6 = namespace(count=0) -%}
 {%- if DEVICE_METADATA.localhost.deployment_id != "8" -%}
   {%- if DEVICE_METADATA.localhost.type -%}
-    {%- if "ToRRouter" in DEVICE_METADATA.localhost.type or DEVICE_METADATA.localhost.type == "EPMS" -%}
+    {%- if "ToRRouter" in DEVICE_METADATA.localhost.type or DEVICE_METADATA.localhost.type in ["EPMS", "MgmtTsToR"] -%}
       {%- if VLAN_INTERFACE -%}
         {%- for (name, prefix) in VLAN_INTERFACE|pfx_filter -%}
           {# If this VLAN has an IPv6 address... #}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Allow radvd to run on new device type MgmtTsTor

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

