### PR TITLE
[sonic-cfggen] Fix invalid switch_type

### DIFF
--- a/src/sonic-config-engine/tests/sample-chassis-packet-lc-graph.xml
+++ b/src/sonic-config-engine/tests/sample-chassis-packet-lc-graph.xml
@@ -394,7 +394,7 @@
           <a:DeviceProperty>
             <a:Name>SwitchType</a:Name>
             <a:Reference i:nil="true"/>
-            <a:Value>chassis_packet</a:Value>
+            <a:Value>chassis-packet</a:Value>
           </a:DeviceProperty>
           <a:DeviceProperty>
             <a:Name>DeploymentId</a:Name>
@@ -459,7 +459,7 @@
           <a:DeviceProperty>
             <a:Name>SwitchType</a:Name>
             <a:Reference i:nil="true"/>
-            <a:Value>chassis_packet</a:Value>
+            <a:Value>chassis-packet</a:Value>
           </a:DeviceProperty>
         </a:Properties>
       </a:DeviceMetadata>


### PR DESCRIPTION
Signed-off-by: Gang Lv ganglv@microsoft.com

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
sonic-config-engine unit test is using invalid switch_type

#### How I did it
Update xml with correct switch_type

#### How to verify it
Run UT for sonic-config-engine

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix #10364

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

