### PR TITLE
[minigraph] change device type

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -43,7 +43,7 @@ VLAN_SUB_INTERFACE_VLAN_ID = '10'
 FRONTEND_ASIC_SUB_ROLE = 'FrontEnd'
 BACKEND_ASIC_SUB_ROLE = 'BackEnd'
 
-# Default Virtual Network Index (VNI) 
+# Default Virtual Network Index (VNI)
 vni_default = 8000
 
 ###############################################################################
@@ -400,7 +400,7 @@ def parse_dpg(dpg, hname):
     subintfs = None
     tunnelintfs = defaultdict(dict)
     for child in dpg:
-        """ 
+        """
             In Multi-NPU platforms the acl intfs are defined only for the host not for individual asic.
             There is just one aclintf node in the minigraph
             Get the aclintfs node first.
@@ -424,7 +424,7 @@ def parse_dpg(dpg, hname):
             if vni_element.text.isdigit():
                 vni = int(vni_element.text)
             else:
-                print("VNI must be an integer (use default VNI %d instead)" % vni_default, file=sys.stderr) 
+                print("VNI must be an integer (use default VNI %d instead)" % vni_default, file=sys.stderr)
 
         ipintfs = child.find(str(QName(ns, "IPInterfaces")))
         intfs = {}
@@ -478,7 +478,7 @@ def parse_dpg(dpg, hname):
         pc_intfs = []
         pcs = {}
         pc_members = {}
-        intfs_inpc = [] # List to hold all the LAG member interfaces 
+        intfs_inpc = [] # List to hold all the LAG member interfaces
         for pcintf in pcintfs.findall(str(QName(ns, "PortChannel"))):
             pcintfname = pcintf.find(str(QName(ns, "Name"))).text
             pcintfmbr = pcintf.find(str(QName(ns, "AttachTo"))).text
@@ -643,7 +643,7 @@ def parse_dpg(dpg, hname):
                         if panel_port not in intfs_inpc and panel_port not in acl_intfs:
                             acl_intfs.append(panel_port)
                     break
-            # if acl is classified as mirror (erpsan) or acl interface 
+            # if acl is classified as mirror (erpsan) or acl interface
             # are binded then do not classify as Control plane.
             # For multi-asic platforms it's possible there is no
             # interface are binded to everflow in host namespace.
@@ -690,9 +690,9 @@ def parse_dpg(dpg, hname):
 
         mg_tunnels = child.find(str(QName(ns, "TunnelInterfaces")))
         if mg_tunnels is not None:
-            table_key_to_mg_key_map = {"encap_ecn_mode": "EcnEncapsulationMode", 
-                                       "ecn_mode": "EcnDecapsulationMode", 
-                                       "dscp_mode": "DifferentiatedServicesCodePointMode", 
+            table_key_to_mg_key_map = {"encap_ecn_mode": "EcnEncapsulationMode",
+                                       "ecn_mode": "EcnDecapsulationMode",
+                                       "dscp_mode": "DifferentiatedServicesCodePointMode",
                                        "ttl_mode": "TtlMode"}
             for mg_tunnel in mg_tunnels.findall(str(QName(ns, "TunnelInterface"))):
                 tunnel_type = mg_tunnel.attrib["Type"]
@@ -998,12 +998,12 @@ def parse_deviceinfo(meta, hwsku):
 
     return port_speeds, port_descriptions, sys_ports
 
-# Function to check if IP address is present in the key. 
+# Function to check if IP address is present in the key.
 # If it is present, then the key would be a tuple.
 def is_ip_prefix_in_key(key):
     return (isinstance(key, tuple))
 
-# Special parsing for spine chassis frontend 
+# Special parsing for spine chassis frontend
 def parse_spine_chassis_fe(results, vni, lo_intfs, phyport_intfs, pc_intfs, pc_members, devices):
     chassis_vnet ='VnetFE'
     chassis_vxlan_tunnel = 'TunnelInt'
@@ -1028,29 +1028,29 @@ def parse_spine_chassis_fe(results, vni, lo_intfs, phyport_intfs, pc_intfs, pc_m
 
     # For each IP interface
     for intf in phyport_intfs:
-        # A IP interface may have multiple entries. 
+        # A IP interface may have multiple entries.
         # For example, "Ethernet0": {}", "Ethernet0|192.168.1.1": {}"
         # We only care about the one without IP information
         if is_ip_prefix_in_key(intf) == True:
-            continue 
-            
+            continue
+
         neighbor_router = results['DEVICE_NEIGHBOR'][intf]['name']
-            
-        # If the neighbor router is an external router 
+
+        # If the neighbor router is an external router
         if devices[neighbor_router]['type'] != chassis_backend_role:
             # Enslave the interface to a Vnet
             phyport_intfs[intf] = {'vnet_name': chassis_vnet}
-           
+
     # For each port channel IP interface
     for pc_intf in pc_intfs:
-        # A port channel IP interface may have multiple entries. 
+        # A port channel IP interface may have multiple entries.
         # For example, "Portchannel0": {}", "Portchannel0|192.168.1.1": {}"
         # We only care about the one without IP information
         if is_ip_prefix_in_key(pc_intf) == True:
-            continue 
+            continue
 
-        intf_name = None 
-        # Get a physical interface that belongs to this port channel         
+        intf_name = None
+        # Get a physical interface that belongs to this port channel
         for pc_member in pc_members:
             if pc_member[0] == pc_intf:
                 intf_name = pc_member[1]
@@ -1063,10 +1063,10 @@ def parse_spine_chassis_fe(results, vni, lo_intfs, phyport_intfs, pc_intfs, pc_m
         # Get the neighbor router of this port channel interface
         neighbor_router = results['DEVICE_NEIGHBOR'][intf_name]['name']
 
-        # If the neighbor router is an external router 
+        # If the neighbor router is an external router
         if devices[neighbor_router]['type'] != chassis_backend_role:
             # Enslave the port channel interface to a Vnet
-            pc_intfs[pc_intf] = {'vnet_name': chassis_vnet}        
+            pc_intfs[pc_intf] = {'vnet_name': chassis_vnet}
 
 ###############################################################################
 #
@@ -1076,10 +1076,10 @@ def parse_spine_chassis_fe(results, vni, lo_intfs, phyport_intfs, pc_intfs, pc_m
 
 def filter_acl_table_bindings(acls, neighbors, port_channels, sub_role):
     filter_acls = {}
-    
+
     # If the asic role is BackEnd no ACL Table (Ctrl/Data/Everflow) is binded.
     # This will be applicable in Multi-NPU Platforms.
-    
+
     if sub_role == BACKEND_ASIC_SUB_ROLE:
         return filter_acls
 
@@ -1087,7 +1087,7 @@ def filter_acl_table_bindings(acls, neighbors, port_channels, sub_role):
 
     # List of Backplane ports
     backplane_port_list = [v for k,v in port_alias_map.items() if v.startswith(backplane_prefix())]
-   
+
     # Get the front panel port channel.
     for port_channel_intf in port_channels:
         backend_port_channel = any(lag_member in backplane_port_list \
@@ -1119,12 +1119,12 @@ def filter_acl_table_bindings(acls, neighbors, port_channels, sub_role):
             if port in port_channels and port not in front_port_channel_intf:
                 continue
             front_panel_ports.append(port)
-        
+
         # Filters out inactive front-panel ports from the binding list for mirror
         # ACL tables. We define an "active" port as one that is a member of a
         # front pannel port channel or one that is connected to a neighboring device via front panel port.
         active_ports = [port for port in front_panel_ports if port in neighbors.keys() or port in front_port_channel_intf]
-        
+
         if not active_ports:
             print('Warning: mirror table {} in ACL_TABLE does not have any ports bound to it'.format(acl_table), file=sys.stderr)
 
@@ -1159,7 +1159,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     filename -- minigraph file name
     platform -- device platform
     port_config_file -- port config file name
-    asic_name -- asic name; to parse multi-asic device minigraph to 
+    asic_name -- asic name; to parse multi-asic device minigraph to
     generate asic specific configuration.
      """
 
@@ -1268,11 +1268,14 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
                 (port_speeds_default, port_descriptions, sys_ports) = parse_deviceinfo(child, hwsku)
 
     # set the host device type in asic metadata also
-    device_type = [devices[key]['type'] for key in devices if key.lower() == hostname.lower()][0]
     if asic_name is None:
         current_device = [devices[key] for key in devices if key.lower() == hostname.lower()][0]
     else:
         current_device = [devices[key] for key in devices if key.lower() == asic_name.lower()][0]
+    # if type is mgmttstor, change to mgmttstorrouter so hardcoded rule can be applied
+    if current_device['type'] == 'MgmtTsToR':
+        current_device['type'] = 'MgmtTsToRRouter'
+    device_type = current_device['type']
 
     results = {}
     results['DEVICE_METADATA'] = {'localhost': {
@@ -1309,7 +1312,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
 
         results['DEVICE_METADATA']['localhost']['peer_switch'] = list(results['PEER_SWITCH'].keys())[0]
 
-    # for this hostname, if sub_role is defined, add sub_role in 
+    # for this hostname, if sub_role is defined, add sub_role in
     # device_metadata
     if sub_role is not None:
         current_device['sub_role'] = sub_role
@@ -1711,7 +1714,7 @@ def get_mux_cable_entries(mux_cable_ports, neighbors, devices):
                     server_ipv6_lo_addr = devices[neighbor]['lo_addr_v6'].split('/')[0]
                     server_ipv6_lo_prefix = ipaddress.ip_network(UNICODE_TYPE(server_ipv6_lo_addr))
                     entry['server_ipv6'] = str(server_ipv6_lo_prefix)
-                mux_cable_table[intf] = entry 
+                mux_cable_table[intf] = entry
             else:
                 print("Warning: no server IPv4 loopback found for {}, skipping mux cable table entry".format(neighbor))
 


### PR DESCRIPTION
In the minigraph parser, if encounter MgmtTsToR, change to
MgmtTsToRRouter

Signed-off-by: Xichen Lin <xichenlin@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Starting radvd container depends on the device type ending in ToRRouter, which MgmtTsToR is but does not end with. Modifying the name allows the MgmtTsToR to be treated like a ToRRouter.

#### How I did it
Change name from MgmtTsToR to MgmtTsToRRouter

#### How to verify it
unit test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

