### PR TITLE
[build][Bug]: Fix the command set_reproducible_mirrors not found issue

### DIFF
--- a/scripts/prepare_slave_container_buildinfo.sh
+++ b/scripts/prepare_slave_container_buildinfo.sh
@@ -10,13 +10,13 @@ sudo dpkg -i --force-overwrite $SLAVE_DIR/buildinfo/sonic-build-hooks_*.deb > /d
 # Enable the build hooks
 symlink_build_hooks
 
-# Enable reproducible mirrors
-set_reproducible_mirrors
-apt-get update > /dev/null 2>&1
-
 # Build the slave running config
 cp -rf $SLAVE_DIR/buildinfo/* /usr/local/share/buildinfo/
 . /usr/local/share/buildinfo/scripts/buildinfo_base.sh
+
+# Enable reproducible mirrors
+set_reproducible_mirrors
+apt-get update > /dev/null 2>&1
 
 # Build the slave version config
 [ -d /usr/local/share/buildinfo/versions ] && rm -rf /usr/local/share/buildinfo/versions


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the command set_reproducible_mirrors not found issue during the build.

#### How I did it
Change to run the command after sourcing the common script.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

