### PR TITLE
[azp]: Fix typo in slave container cleanup

### DIFF
--- a/.azure-pipelines/template-clean-sonic-slave.yml
+++ b/.azure-pipelines/template-clean-sonic-slave.yml
@@ -1,7 +1,7 @@
 steps:
 - script: |
     containers=$(docker container ls -a | grep "sonic-slave" | awk '{ print $1 }')
-    [ -n "$containers" ] && docker container rm -f containers
+    [ -n "$containers" ] && docker container rm -f $containers
     docker images | grep "^<none>" | awk '{print$3}' | xargs -i docker rmi {}
     images=$(docker images 'sonic-slave-*' -a -q)
     [ -n "$images" ] && docker rmi -f $images


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Should unblock failing checks for https://github.com/Azure/sonic-buildimage/pull/10414

#### Why I did it
A typo when cleaning up sonic-slave-* containers is causing build failures

#### How I did it
FIx the typo 

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

