### PR TITLE
Fix yang validation failure when table contains empty value

### DIFF
--- a/src/sonic-yang-mgmt/sonic_yang_ext.py
+++ b/src/sonic-yang-mgmt/sonic_yang_ext.py
@@ -591,22 +591,22 @@ class SonicYangExtMixin:
     """
     def _xlateContainerInContainer(self, model, yang, configC, table):
         ccontainer = model
-        #print(ccontainer['@name'])
-        yang[ccontainer['@name']] = dict()
-        if configC.get(ccontainer['@name']) is None:
+        ccName = ccontainer['@name']
+        yang[ccName] = dict()
+        if ccName not in configC:
             return
-        if len(ccontainer['@name']) == 0:
+        if len(ccName) == 0:
             # Empty container, clean config and return
-            del configC[ccontainer['@name']]
+            del configC[ccName]
             return
-        self.sysLog(msg="xlateProcessListOfContainer: {}".format(ccontainer['@name']))
-        self._xlateContainer(ccontainer, yang[ccontainer['@name']], \
-        configC[ccontainer['@name']], table)
+        self.sysLog(msg="xlateProcessListOfContainer: {}".format(ccName))
+        self._xlateContainer(ccontainer, yang[ccName], \
+        configC[ccName], table)
         # clean empty container
-        if len(yang[ccontainer['@name']]) == 0:
-            del yang[ccontainer['@name']]
+        if len(yang[ccName]) == 0:
+            del yang[ccName]
         # remove copy after processing
-        del configC[ccontainer['@name']]
+        del configC[ccName]
 
         return
 

--- a/src/sonic-yang-mgmt/sonic_yang_ext.py
+++ b/src/sonic-yang-mgmt/sonic_yang_ext.py
@@ -594,8 +594,9 @@ class SonicYangExtMixin:
         ccName = ccontainer['@name']
         yang[ccName] = dict()
         if ccName not in configC:
+            # Inner container doesn't exist in config
             return
-        if len(ccName) == 0:
+        if len(configC[ccName]) == 0:
             # Empty container, clean config and return
             del configC[ccName]
             return

--- a/src/sonic-yang-mgmt/sonic_yang_ext.py
+++ b/src/sonic-yang-mgmt/sonic_yang_ext.py
@@ -593,7 +593,11 @@ class SonicYangExtMixin:
         ccontainer = model
         #print(ccontainer['@name'])
         yang[ccontainer['@name']] = dict()
-        if not configC.get(ccontainer['@name']):
+        if configC.get(ccontainer['@name']) is None:
+            return
+        if len(ccontainer['@name']) == 0:
+            # Empty container, clean config and return
+            del configC[ccontainer['@name']]
             return
         self.sysLog(msg="xlateProcessListOfContainer: {}".format(ccontainer['@name']))
         self._xlateContainer(ccontainer, yang[ccontainer['@name']], \

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/test_sonic_yang.py
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/test_sonic_yang.py
@@ -364,5 +364,20 @@ class Test_SonicYang(object):
 
         return
 
+    def test_special_json_with_yang(self, sonic_yang_data):
+        # in this test, we validate unusual json config and check if
+        # loadData works successfully
+        test_file = sonic_yang_data['test_file']
+        syc = sonic_yang_data['syc']
+
+        # read config
+        jIn = self.readIjsonInput(test_file, 'SAMPLE_CONFIG_DB_SPECIAL_CASE')
+        jIn = json.loads(jIn)
+
+        # load config and create Data tree
+        syc.loadData(jIn)
+
+        return
+
     def teardown_class(self):
         pass

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -304,7 +304,7 @@
                 "switch_id": "2",
                 "switch_type": "voq",
                 "max_cores": "8",
-                "sub_role": "FrondEnd",
+                "sub_role": "FrontEnd",
                 "dhcp_server": "disabled"
             }
         },

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1694,5 +1694,11 @@
         "UNKNOWN_TABLE": {
             "Error": "This Table is for testing, This Table does not have YANG models."
         }
+    },
+    "SAMPLE_CONFIG_DB_SPECIAL_CASE": {
+        "TACPLUS": {
+            "global": {
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/tacacs.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/tacacs.json
@@ -4,18 +4,21 @@
     },
     "TACPLUS_INVALID_TIMEOUT_TEST": {
         "desc": "Tacplus global configuration with invalid timeout value in TACPLUS table.",
-	"eStr": "TACACS timeout must be 1..60"
+        "eStr": "TACACS timeout must be 1..60"
     },
     "TACPLUS_NOT_PRESENT_SRC_INTF_TEST": {
         "desc": "Tacplus global configuration with a non existent port in TACPLUS table.",
         "eStrKey": "InvalidValue"
+    },
+    "TACPLUS_VERIFY_VALID_EMPTY_GLOBAL": {
+        "desc": "Tacplus valid empty global configuration in TACPLUS table."
     },
     "TACPLUS_SERVER_TEST" : {
         "desc": "Tacplus server configuration in TACPLUS_SERVER table."
     },
     "TACPLUS_SERVER_INVALID_PRIORITY_TEST": {
         "desc": "Tacplus server configuration with invalid priority value in TACPLUS_SERVER table.",
-	"eStr": "TACACS server priority must be 1..64"
+        "eStr": "TACACS server priority must be 1..64"
     },
     "TACPLUS_SERVER_INVALID_TIMEOUT_TEST" : {
         "desc": "Tacplus server configuration with invalid timeout value in TACPLUS_SERVER table.",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/tacacs.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/tacacs.json
@@ -10,9 +10,6 @@
         "desc": "Tacplus global configuration with a non existent port in TACPLUS table.",
         "eStrKey": "InvalidValue"
     },
-    "TACPLUS_VERIFY_VALID_EMPTY_GLOBAL": {
-        "desc": "Tacplus valid empty global configuration in TACPLUS table."
-    },
     "TACPLUS_SERVER_TEST" : {
         "desc": "Tacplus server configuration in TACPLUS_SERVER table."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/tacacs.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/tacacs.json
@@ -52,16 +52,6 @@
         }
     },
 
-    "TACPLUS_VERIFY_VALID_EMPTY_GLOBAL": {
-        "sonic-system-tacacs:sonic-system-tacacs": {
-            "sonic-system-tacacs:TACPLUS": {
-                "global": {
-                }
-            }
-        }
-
-    },
-
     "TACPLUS_SERVER_TEST": {
         "sonic-system-tacacs:sonic-system-tacacs": {
             "sonic-system-tacacs:TACPLUS_SERVER": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/tacacs.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/tacacs.json
@@ -52,6 +52,16 @@
         }
     },
 
+    "TACPLUS_VERIFY_VALID_EMPTY_GLOBAL": {
+        "sonic-system-tacacs:sonic-system-tacacs": {
+            "sonic-system-tacacs:TACPLUS": {
+                "global": {
+                }
+            }
+        }
+
+    },
+
     "TACPLUS_SERVER_TEST": {
         "sonic-system-tacacs:sonic-system-tacacs": {
             "sonic-system-tacacs:TACPLUS_SERVER": {

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -129,7 +129,7 @@ module sonic-device_metadata {
 
                 leaf sub_role {
                     type string;
-                    description "sub_role indicates if ASIC is FrondEnd or BackEnd.";
+                    description "sub_role indicates if ASIC is FrontEnd or BackEnd.";
                 }
 
                 leaf downstream_subrole {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix https://github.com/Azure/sonic-buildimage/issues/9746
#### How I did it
Split the check condition based on non-exist and zero length.
#### How to verify it
Run verification script when table contains empty value
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

