### PR TITLE
[202012] Use unix socket path in ConfigDBConnector for some components

### DIFF
--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -389,7 +389,7 @@ class HostConfigDaemon:
     def __init__(self):
         # Just a sanity check to verify if the CONFIG_DB has been initialized
         # before moving forward
-        self.config_db = ConfigDBConnector()
+        self.config_db = ConfigDBConnector(use_unix_socket_path=True)
         self.config_db.connect(wait_for_init=True, retry_on=True)
         self.dbconn = DBConnector(CFG_DB, 0)
         self.selector = Select()

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -35,7 +35,7 @@ BACKEND_ASIC_SUB_ROLE = "BackEnd"
 
 def get_localhost_info(field):
     try:
-        config_db = ConfigDBConnector()
+        config_db = ConfigDBConnector(use_unix_socket_path=True)
         config_db.connect()
 
         metadata = config_db.get_table('DEVICE_METADATA')

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -27,7 +27,7 @@ DEFAULT_NAMESPACE = ''
 PORT_ROLE = 'role'
 
 
-def connect_config_db_for_ns(namespace=DEFAULT_NAMESPACE):
+def connect_config_db_for_ns(namespace=DEFAULT_NAMESPACE, use_unix_socket_path=False):
     """
     The function connects to the config DB for a given namespace and
     returns the handle
@@ -40,12 +40,12 @@ def connect_config_db_for_ns(namespace=DEFAULT_NAMESPACE):
       handle to the config_db for a namespace
     """
     SonicDBConfig.load_sonic_global_db_config()
-    config_db = ConfigDBConnector(namespace=namespace)
+    config_db = ConfigDBConnector(namespace=namespace, use_unix_socket_path=use_unix_socket_path)
     config_db.connect()
     return config_db
 
 
-def connect_to_all_dbs_for_ns(namespace=DEFAULT_NAMESPACE):
+def connect_to_all_dbs_for_ns(namespace=DEFAULT_NAMESPACE, use_unix_socket_path=False):
     """
     The function connects to the DBs for a given namespace and
     returns the handle
@@ -59,7 +59,7 @@ def connect_to_all_dbs_for_ns(namespace=DEFAULT_NAMESPACE):
         handle to all the dbs for a namespaces
     """
     SonicDBConfig.load_sonic_global_db_config()
-    db = SonicV2Connector(namespace=namespace)
+    db = SonicV2Connector(namespace=namespace, use_unix_socket_path=use_unix_socket_path)
     for db_id in db.get_db_list():
         db.connect(db_id)
     return db
@@ -227,7 +227,7 @@ def get_all_namespaces():
     if is_multi_asic():
         for asic in range(num_asics):
             namespace = "{}{}".format(ASIC_NAME_PREFIX, asic)
-            config_db = connect_config_db_for_ns(namespace)
+            config_db = connect_config_db_for_ns(namespace, use_unix_socket_path=True)
 
             metadata = config_db.get_table('DEVICE_METADATA')
             if metadata['localhost']['sub_role'] == FRONTEND_ASIC_SUB_ROLE:
@@ -296,7 +296,7 @@ def get_port_entry_for_asic(port, namespace):
 
 def get_port_table_for_asic(namespace):
 
-    config_db = connect_config_db_for_ns(namespace)
+    config_db = connect_config_db_for_ns(namespace, use_unix_socket_path=True)
     ports = config_db.get_table(PORT_CFG_DB_TABLE)
     return ports
 


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Using TCP connection might be interrupted when restaring interfaces-config.service. Unix socket does not have this issue.

#### How I did it

Use unix socket.

#### How to verify it

Restart interfaces-config.service with hostcfgd.


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

