### PR TITLE
[dhcp6relay] Add transaction id check

### DIFF
--- a/src/dhcp6relay/src/relay.h
+++ b/src/dhcp6relay/src/relay.h
@@ -58,6 +58,7 @@ struct relay_config {
 
 struct dhcpv6_msg {
     uint8_t msg_type;
+    uint8_t xid[3];
 };
 
 struct PACKED dhcpv6_relay_msg {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Prevent forwarding DHCPv6 packets with malformed payload

#### How I did it
Check if transaction id is present

#### How to verify it
Such packet should not be forwarded by dhcp6relay
```
pkt = Ether(dst="33:33:00:01:00:02")/IPv6(src="fe80::e42:a1ff:fec0:993e", dst="ff02::1:2")/UDP(sport=546, dport=547)/DHCP6_Request()/Raw("test string here")
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

