### PR TITLE
[YANG] Update YANG model for `pfcwd_sw_enable`

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1604,7 +1604,7 @@
 	          "pfc_to_queue_map": "pfc_prio_to_q_map1",
 	          "pfc_to_pg_map"   : "pfc_prio_to_pg_map1",
 	          "pfc_enable"      : "3,4",
-              "pfcwd_sw_enable" : "3,4"
+	          "pfcwd_sw_enable" : "3,4"
             },
             "Ethernet4": {
               "dot1p_to_tc_map" : "Dot1p_to_tc_map2",
@@ -1614,7 +1614,7 @@
 	          "pfc_to_queue_map": "pfc_prio_to_q_map2",
 	          "pfc_to_pg_map"   : "pfc_prio_to_pg_map2",
 	          "pfc_enable"      : "3,4",
-              "pfcwd_sw_enable" : "3,4"
+	          "pfcwd_sw_enable" : "3,4"
             }
         },
 

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1603,7 +1603,8 @@
 	          "tc_to_pg_map": "tc_to_pg_map1",
 	          "pfc_to_queue_map": "pfc_prio_to_q_map1",
 	          "pfc_to_pg_map"   : "pfc_prio_to_pg_map1",
-	          "pfc_enable"      : "3,4"
+	          "pfc_enable"      : "3,4",
+              "pfcwd_sw_enable" : "3,4"
             },
             "Ethernet4": {
               "dot1p_to_tc_map" : "Dot1p_to_tc_map2",
@@ -1612,7 +1613,8 @@
 	          "tc_to_pg_map": "tc_to_pg_map2",
 	          "pfc_to_queue_map": "pfc_prio_to_q_map2",
 	          "pfc_to_pg_map"   : "pfc_prio_to_pg_map2",
-	          "pfc_enable"      : "3,4"
+	          "pfc_enable"      : "3,4",
+              "pfcwd_sw_enable" : "3,4"
             }
         },
 

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/qosmaps.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/qosmaps.json
@@ -621,7 +621,8 @@
                         "pfc_to_pg_map": "map1",
                         "dscp_to_tc_map": "map1",
                         "dot1p_to_tc_map": "map1",
-                        "pfc_enable": "3,4"
+                        "pfc_enable": "3,4",
+                        "pfcwd_sw_enable" : "3,4"
                     }
                 ]
             }
@@ -657,7 +658,8 @@
                         "pfc_to_pg_map": "map2",
                         "dscp_to_tc_map": "map2",
                         "dot1p_to_tc_map": "map2",
-                        "pfc_enable": "3,4"
+                        "pfc_enable": "3,4",
+                        "pfcwd_sw_enable" : "3,4"
                     }
                 ]
             }
@@ -714,7 +716,8 @@
                 "PORT_QOS_MAP_LIST": [
                     {
                         "ifname": "Ethernet4",
-                        "pfc_enable": "8"
+                        "pfc_enable": "8",
+                        "pfcwd_sw_enable" : "8"
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-port-qos-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port-qos-map.yang
@@ -81,6 +81,12 @@ module sonic-port-qos-map {
                     }
                 }
 
+                leaf pfcwd_sw_enable {
+                    type string {
+                        pattern "[0-7](,[0-7])?";
+                    }
+                }
+
                 leaf pfc_to_queue_map {
                     type leafref {
                         path "/ppqm:sonic-pfc-priority-queue-map/ppqm:MAP_PFC_PRIORITY_TO_QUEUE/ppqm:MAP_PFC_PRIORITY_TO_QUEUE_LIST/ppqm:name";

--- a/src/sonic-yang-models/yang-models/sonic-port-qos-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port-qos-map.yang
@@ -85,6 +85,8 @@ module sonic-port-qos-map {
                     type string {
                         pattern "[0-7](,[0-7])?";
                     }
+                    description
+                        "Specify the queue(s) on which software pfc watchdog are enabled.";
                 }
 
                 leaf pfc_to_queue_map {


### PR DESCRIPTION
Signed-off-by: bingwang <wang.bing@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR is to update YANG model `sonic-port-qos-map.yang` to support new table `pfcwd_sw_enable`.
HLD https://github.com/Azure/SONiC/pull/950
Related PR https://github.com/Azure/sonic-buildimage/pull/10176

#### How I did it
Update `pfcwd_sw_enable`.

#### How to verify it
Verified by UT
```
collected 3 items                                                                                                                                                                                     

tests/test_sonic_yang_models.py ..                                                                                                                                                              [ 66%]
tests/yang_model_tests/test_yang_model.py .                                                                                                                                                     [100%]

========================================================================================== 3 passed in 2.62s ==========================================================================================
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Update YANG model `sonic-port-qos-map.yang` to support new table `pfcwd_sw_enable`.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->
https://github.com/Azure/SONiC/wiki/Configuration#port-qos-map
#### A picture of a cute animal (not mandatory but encouraged)

