### PR TITLE
[Ci]: Fix an azp template syntax error

### DIFF
--- a/.azure-pipelines/docker-sonic-slave.yml
+++ b/.azure-pipelines/docker-sonic-slave.yml
@@ -66,7 +66,7 @@ stages:
               pool: sonicbld
               arch: ${{ arch }}
               dist: ${{ dist }}
-          ${{ else }}:
+        - ${{ else }}:
           - template: .azure-pipelines/docker-sonic-slave-template.yml@buildimage
             parameters:
               pool: sonicbld

--- a/.azure-pipelines/docker-sonic-slave.yml
+++ b/.azure-pipelines/docker-sonic-slave.yml
@@ -60,15 +60,15 @@ stages:
   - ${{ each dist in parameters.dists }}:
     - ${{ if endswith(variables['Build.DefinitionName'], dist) }}:
       - ${{ each arch in parameters.arches }}:
-        ${{ if eq(variables['System.PullRequest.TargetBranch'], 'master') }}:
-        - template: docker-sonic-slave-template.yml
-          parameters:
-            pool: sonicbld
-            arch: ${{ arch }}
-            dist: ${{ dist }}
-        ${{ else }}:
-        - template: .azure-pipelines/docker-sonic-slave-template.yml@buildimage
-          parameters:
-            pool: sonicbld
-            arch: ${{ arch }}
-            dist: ${{ dist }}
+        - ${{ if eq(variables['System.PullRequest.TargetBranch'], 'master') }}:
+          - template: docker-sonic-slave-template.yml
+            parameters:
+              pool: sonicbld
+              arch: ${{ arch }}
+              dist: ${{ dist }}
+          ${{ else }}:
+          - template: .azure-pipelines/docker-sonic-slave-template.yml@buildimage
+            parameters:
+              pool: sonicbld
+              arch: ${{ arch }}
+              dist: ${{ dist }}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
[Ci]: Fix an azp template syntax error
See https://dev.azure.com/mssonic/build/_build/results?buildId=86535&view=results
```
/.azure-pipelines/docker-sonic-slave.yml (Line: 62, Col: 47): Expected a mapping
```

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

