### PR TITLE
[Ci]: Fix the docker slave azp template issue

### DIFF
--- a/.azure-pipelines/docker-sonic-slave-template.yml
+++ b/.azure-pipelines/docker-sonic-slave-template.yml
@@ -40,7 +40,7 @@ jobs:
   - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
     - template: template-clean-sonic-slave.yml
   - ${{ else }}:
-    - template: .azure-pipelines/template-variables.yml@buildimage
+    - template: .azure-pipelines/template-clean-sonic-slave.yml@buildimage
   - checkout: self
     clean: true
     submodules: recursive

--- a/.azure-pipelines/docker-sonic-slave-template.yml
+++ b/.azure-pipelines/docker-sonic-slave-template.yml
@@ -40,7 +40,7 @@ jobs:
   - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
     - template: template-clean-sonic-slave.yml
   - ${{ else }}:
-    - template: .azure-pipelines/template-clean-sonic-slave.yml@buildimage
+    - template: '/.azure-pipelines/template-clean-sonic-slave.yml@buildimage'
   - checkout: self
     clean: true
     submodules: recursive
@@ -103,7 +103,8 @@ jobs:
       command: push
       tags: |
         $(VARIABLE_SLAVE_BASE_TAG)
-        latest
+        ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
+          latest
   - ${{ if ne(parameters.arch, 'amd64') }}:
     - task: Docker@2
       condition: ne(variables['Build.Reason'], 'PullRequest')

--- a/.azure-pipelines/docker-sonic-slave.yml
+++ b/.azure-pipelines/docker-sonic-slave.yml
@@ -67,7 +67,7 @@ stages:
               arch: ${{ arch }}
               dist: ${{ dist }}
         - ${{ else }}:
-          - template: .azure-pipelines/docker-sonic-slave-template.yml@buildimage
+          - template: '.azure-pipelines/docker-sonic-slave-template.yml@buildimage'
             parameters:
               pool: sonicbld
               arch: ${{ arch }}

--- a/.azure-pipelines/docker-sonic-slave.yml
+++ b/.azure-pipelines/docker-sonic-slave.yml
@@ -67,7 +67,7 @@ stages:
               arch: ${{ arch }}
               dist: ${{ dist }}
         - ${{ else }}:
-          - template: '.azure-pipelines/docker-sonic-slave-template.yml@buildimage'
+          - template: '/.azure-pipelines/docker-sonic-slave-template.yml@buildimage'
             parameters:
               pool: sonicbld
               arch: ${{ arch }}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
[Ci]: Fix the docker slave azp template issue

#### How I did it
1. For multiple repo reference, we need to use the absolute path.
```
template: '/.azure-pipelines/template-clean-sonic-slave.yml@buildimage'
```
2. Fix a usage error, cannot add the variables template in steps.
3. Fix docker slave image publish issue, cannot publish the latest tag in the release branches. It has impacts on the component build, for instance, sonic-swss-common. Some of the required packages are not installed in docker slave images in release branches. See https://github.com/Azure/sonic-swss-common/pull/596#pullrequestreview-929705727

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

