### PR TITLE
[Nokia][device] Updated the BCM config file to reduce the CPU usage

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/jr2cp-nokia-18x400g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/jr2cp-nokia-18x400g-config.bcm
@@ -1263,8 +1263,9 @@ phy_tx_polarity_flip_phy143.BCM8885X=0
 
 
 polled_irq_delay.BCM8885X=5
-polled_irq_mode.BCM8885X=1
+polled_irq_mode.BCM8885X=0
 port_fec_fabric.BCM8885X=7
+bcm_stat_interval.BCM8885X=1000000
 
 
 port_init_cl72_1=0

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/jr2cp-nokia-18x400g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/jr2cp-nokia-18x400g-config.bcm
@@ -1263,8 +1263,9 @@ phy_tx_polarity_flip_phy143.BCM8885X=0
 
 
 polled_irq_delay.BCM8885X=5
-polled_irq_mode.BCM8885X=1
+polled_irq_mode.BCM8885X=0
 port_fec_fabric.BCM8885X=7
+bcm_stat_interval.BCM8885X=1000000
 
 
 port_init_cl72_1=0


### PR DESCRIPTION
Signed-off-by: Sakthivadivu Saravanaraj <sakthivadivu.saravanaraj@nokia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
 To reduce CPU usage by syncd dockers
#### How I did it
  Added the .bcm config parameters suggested by BCM
#### How to verify it
  verified that CPU usage by syncd dockers is not high in Nokia-IXR7250E-36x400G 
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

