### PR TITLE
[gearbox] Add peer gbsyncd for swss if gearbox exists

### DIFF
--- a/files/scripts/gbsyncd.sh
+++ b/files/scripts/gbsyncd.sh
@@ -3,7 +3,11 @@
 . /usr/local/bin/syncd_common.sh
 
 function startplatform() {
-    :
+    # Add gbsyncd to FEATURE table, if not in. It did have same config as syncd.
+    if [ -z $($SONIC_DB_CLI CONFIG_DB HGET 'FEATURE|gbsyncd' state) ]; then
+        local CMD="local r=redis.call('DUMP', KEYS[1]); redis.call('RESTORE', KEYS[2], 0, r)"
+        $SONIC_DB_CLI CONFIG_DB EVAL "$CMD" 2 'FEATURE|syncd' 'FEATURE|gbsyncd'
+    fi
 }
 
 function waitplatform() {

--- a/platform/components/docker-gbsyncd-credo/supervisord.conf.j2
+++ b/platform/components/docker-gbsyncd-credo/supervisord.conf.j2
@@ -10,6 +10,14 @@ autorestart=unexpected
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE
+buffer_size=1024
+
+[eventlistener:supervisor-proc-exit-listener]
+command=/usr/bin/supervisor-proc-exit-listener --container-name gbsyncd
+events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
+autostart=true
+autorestart=unexpected
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix [#10501](https://github.com/Azure/sonic-buildimage/issues/10501)
Fix [#9733](https://github.com/Azure/sonic-buildimage/issues/9733)

If having gearbox, we need
- add gbsyncd as a peer since swss also has dependency on gbsyncd
- add service gbsyncd to FEATURE table if it is missing

#### How I did it

#### How to verify it

- Kill orchagent

```
admin@DUT:~$ docker ps | grep -E 'swss|syncd'
29d108cf328e   docker-gbsyncd-credo:latest          "/usr/bin/docker-ini…"   5 days ago   Up 5 minutes             gbsyncd
0da3a5c5b6b9   docker-syncd-brcm-dnx:latest         "/usr/local/bin/supe…"   5 days ago   Up 5 minutes             syncd
f1e699d0c8fa   docker-orchagent:latest              "/usr/bin/docker-ini…"   5 days ago   Up 5 minutes             swss
admin@DUT:~$ sudo killall orchagent

### Services stopped soon
admin@DUT:~$ docker ps | grep -E 'swss|syncd'
admin@DUT:~$

### Services auto-restart after a while 
admin@DUT:~$ docker ps | grep -E 'swss|syncd'
29d108cf328e   docker-gbsyncd-credo:latest          "/usr/bin/docker-ini…"   5 days ago   Up 17 seconds             gbsyncd
0da3a5c5b6b9   docker-syncd-brcm-dnx:latest         "/usr/local/bin/supe…"   5 days ago   Up 19 seconds             syncd
f1e699d0c8fa   docker-orchagent:latest              "/usr/bin/docker-ini…"   5 days ago   Up 21 seconds             swss
```

- Kill syncd

```
admin@DUT:~$ docker ps | grep -E 'swss|syncd'
29d108cf328e   docker-gbsyncd-credo:latest          "/usr/bin/docker-ini…"   5 days ago   Up 12 hours             gbsyncd
0da3a5c5b6b9   docker-syncd-brcm-dnx:latest         "/usr/local/bin/supe…"   5 days ago   Up 12 hours             syncd
f1e699d0c8fa   docker-orchagent:latest              "/usr/bin/docker-ini…"   5 days ago   Up 12 hours             swss
admin@DUT:~$ ps ax |grep '/usr/bin/syncd'    
  14654 ?        S      0:00 /bin/bash /usr/bin/syncd.sh wait
  15126 pts/0    Sl     0:00 /usr/bin/dsserve /usr/bin/syncd --diag -u -s -p /etc/sai.d/sai.profile -x /usr/share/sonic/hwsku/context_config.json -g 0 -b /tmp/break_before_make_objects
  15181 pts/0    Sl   1490:43 /usr/bin/syncd --diag -u -s -p /etc/sai.d/sai.profile -x /usr/share/sonic/hwsku/context_config.json -g 0 -b /tmp/break_before_make_objects
  15365 pts/0    Sl     5:59 /usr/bin/syncd -s -p /etc/sai.d/psai.profile -x /usr/share/sonic/hwsku/context_config.json -g 1
 342396 pts/0    S+     0:00 grep /usr/bin/syncdps ax
### Kill syncd
admin@DUT:~$ sudo kill 15181
admin@DUT:~$ docker ps | grep -E 'swss|syncd'
admin@DUT:~$
admin@DUT:~$ docker ps | grep -E 'swss|syncd'
29d108cf328e   docker-gbsyncd-credo:latest          "/usr/bin/docker-ini…"   5 days ago   Up 21 seconds             gbsyncd
0da3a5c5b6b9   docker-syncd-brcm-dnx:latest         "/usr/local/bin/supe…"   5 days ago   Up 24 seconds             syncd
f1e699d0c8fa   docker-orchagent:latest              "/usr/bin/docker-ini…"   5 days ago   Up 27 seconds             swss 
```


- Kill gbsyncd

```
admin@str2-a7280cr3-4:~$ docker ps | grep -E 'swss|syncd'
29d108cf328e   docker-gbsyncd-credo:latest          "/usr/bin/docker-ini…"   5 days ago   Up 6 minutes             gbsyncd
0da3a5c5b6b9   docker-syncd-brcm-dnx:latest         "/usr/local/bin/supe…"   5 days ago   Up 6 minutes             syncd
f1e699d0c8fa   docker-orchagent:latest              "/usr/bin/docker-ini…"   5 days ago   Up 6 minutes             swss
admin@DUT:~$ ps ax |grep '/usr/bin/syncd'  
 346899 ?        S      0:00 /bin/bash /usr/bin/syncd.sh wait
 347462 pts/0    Sl     0:00 /usr/bin/dsserve /usr/bin/syncd --diag -u -s -p /etc/sai.d/sai.profile -x /usr/share/sonic/hwsku/context_config.json -g 0 -b /tmp/break_before_make_objects
 347498 pts/0    Sl    12:52 /usr/bin/syncd --diag -u -s -p /etc/sai.d/sai.profile -x /usr/share/sonic/hwsku/context_config.json -g 0 -b /tmp/break_before_make_objects
 347724 pts/0    Sl     0:15 /usr/bin/syncd -s -p /etc/sai.d/psai.profile -x /usr/share/sonic/hwsku/context_config.json -g 1
 356699 pts/0    S+     0:00 grep /usr/bin/syncd
### kill gbsyncd
admin@DUT:~$ sudo kill 347724
admin@DUT:~$ 
admin@DUT:~$ docker ps | grep -E 'swss|syncd'
admin@DUT:~$
admin@DUT:~$ docker ps | grep -E 'swss|syncd'
29d108cf328e   docker-gbsyncd-credo:latest          "/usr/bin/docker-ini…"   5 days ago   Up 48 seconds             gbsyncd
0da3a5c5b6b9   docker-syncd-brcm-dnx:latest         "/usr/local/bin/supe…"   5 days ago   Up 50 seconds             syncd
f1e699d0c8fa   docker-orchagent:latest              "/usr/bin/docker-ini…"   5 days ago   Up 52 seconds             swss
```



#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

