### PR TITLE
Fix AS7726 not showing serial number in 'show platform summary' (#10489)

### DIFF
--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_chassis.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_chassis.py
@@ -96,11 +96,11 @@ class PddfChassis(ChassisBase):
         """
         return self._eeprom.part_number_str()
 
-    def get_serial(self):
+    def get_service_tag(self):
         """
-        Retrieves the serial number of the chassis (Service tag)
+        Retrieves the service tag of the chassis
         Returns:
-            string: Serial number of chassis
+            string: Sevice tag of chassis
         """
         return self._eeprom.serial_str()
 
@@ -123,7 +123,7 @@ class PddfChassis(ChassisBase):
         """
         return self._eeprom.base_mac_addr()
 
-    def get_serial_number(self):
+    def get_serial(self):
         """
         Retrieves the hardware serial number for the chassis
 

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_fan.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_fan.py
@@ -150,7 +150,7 @@ class PddfFan(FanBase):
             if output['status'].isalpha():
                 return 0
             else:
-                speed = int(output['status'])
+                speed = int(float(output['status']))
 
             max_speed = int(self.plugin_data['PSU']['PSU_FAN_MAX_SPEED'])
             speed_percentage = round((speed*100)/max_speed)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
AS7726 platform was not showing serial number in the output of
 - show platform summary
 - show version
 
Issue #10489 

#### How I did it
Th root cause was that thePDDF chassis common class was reading the 'service_tag' upon invoking get_serial(). However, Accton platform AS7726 did not have service tag programmed in the EEPROM. Hence throwing 'N/A'. I changed the 'get_serial()' method to fetch the serial number of the board.

#### How to verify it
- show platform summary
- show platform version

```
root@sonic:/sys/bus/i2c/devices# show ver

SONiC Software Version: SONiC.master.0-dirty-20220408.025810
Distribution: Debian 11.3
Kernel: 5.10.0-8-2-amd64
Build commit: 50067c8e4
Build date: Fri Apr  8 10:03:36 UTC 2022
Built by: fk410167@sonic-lvn-csg-004

Platform: x86_64-accton_as7726_32x-r0
HwSKU: Accton-AS7726-32X
ASIC: broadcom
ASIC Count: 1
Serial Number: 772632X1911067
Model Number: FP3ZZ7632074A
Hardware Revision: N/A
Uptime: 10:54:30 up 17 min,  1 user,  load average: 0.87, 0.91, 0.82
Date: Fri 08 Apr 2022 10:54:30

Docker images:
REPOSITORY                    TAG                              IMAGE ID       SIZE
docker-platform-monitor       latest                           6d11a86a79be   519MB
docker-platform-monitor       master.0-dirty-20220408.025810   6d11a86a79be   519MB
docker-dhcp-relay             latest                           6134df8859e5   427MB
docker-sonic-telemetry        latest                           02f2bdff3ca6   506MB
docker-sonic-telemetry        master.0-dirty-20220408.025810   02f2bdff3ca6   506MB
docker-router-advertiser      latest                           4186dc554e53   417MB
docker-router-advertiser      master.0-dirty-20220408.025810   4186dc554e53   417MB
docker-database               latest                           f3ff7e7a38f5   417MB
docker-database               master.0-dirty-20220408.025810   f3ff7e7a38f5   417MB
docker-orchagent              latest                           38289831c04a   437MB
docker-orchagent              master.0-dirty-20220408.025810   38289831c04a   437MB
docker-fpm-frr                latest                           6c146abbc4f3   438MB
docker-fpm-frr                master.0-dirty-20220408.025810   6c146abbc4f3   438MB
docker-nat                    latest                           3a07c488cbc5   423MB
docker-nat                    master.0-dirty-20220408.025810   3a07c488cbc5   423MB
docker-sflow                  latest                           58c97022daf1   421MB
docker-sflow                  master.0-dirty-20220408.025810   58c97022daf1   421MB
docker-teamd                  latest                           77b13fe63153   420MB
docker-teamd                  master.0-dirty-20220408.025810   77b13fe63153   420MB
docker-macsec                 latest                           d3f757f29037   423MB
docker-macsec                 master.0-dirty-20220408.025810   d3f757f29037   423MB
docker-snmp                   latest                           87255f532f0b   449MB
docker-snmp                   master.0-dirty-20220408.025810   87255f532f0b   449MB
docker-syncd-brcm             latest                           0c1f4caa79f1   784MB
docker-syncd-brcm             master.0-dirty-20220408.025810   0c1f4caa79f1   784MB
docker-gbsyncd-credo          latest                           d2585339145a   422MB
docker-gbsyncd-credo          master.0-dirty-20220408.025810   d2585339145a   422MB
docker-lldp                   latest                           d4a5b441d5e6   445MB
docker-lldp                   master.0-dirty-20220408.025810   d4a5b441d5e6   445MB
docker-sonic-mgmt-framework   latest                           dc235a4f16fd   549MB
docker-sonic-mgmt-framework   master.0-dirty-20220408.025810   dc235a4f16fd   549MB
docker-mux                    latest                           dbcc3675685e   458MB
docker-mux                    master.0-dirty-20220408.025810   dbcc3675685e   458MB

root@sonic:/sys/bus/i2c/devices# show platform summary
Platform: x86_64-accton_as7726_32x-r0
HwSKU: Accton-AS7726-32X
ASIC: broadcom
ASIC Count: 1
Serial Number: 772632X1911067
Model Number: FP3ZZ7632074A
Hardware Revision: N/A
root@sonic:/sys/bus/i2c/devices#
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

