### PR TITLE
Add linux_ngknet for trident4/tomahawk4 chips

### DIFF
--- a/platform/broadcom/saibcm-modules/debian/opennsl-modules.init
+++ b/platform/broadcom/saibcm-modules/debian/opennsl-modules.init
@@ -14,17 +14,27 @@
 
 function create_devices()
 {
-    rm -f /dev/linux-knet-cb
-    rm -f /dev/linux-bcm-knet
-    rm -f /dev/linux-bcm-bde
-    rm -f /dev/linux-kernel-bde
-    rm -f /dev/linux_ngbde
+    if [[ $is_ltsw_chip -eq 1 ]]; then
+        rm -f /dev/linux_ngbde
+        rm -f /dev/linux_ngknet
+        rm -f /dev/linux_ngknetcb
 
-    mknod /dev/linux_ngbde      c 120 0
-    mknod /dev/linux-knet-cb    c 121 0
-    mknod /dev/linux-bcm-knet   c 122 0
-    mknod /dev/linux-bcm-bde    c 126 0
-    mknod /dev/linux-kernel-bde c 127 0
+        mknod /dev/linux_ngbde       c 120 0
+        mknod /dev/linux_ngknet      c 121 0
+        mknod /dev/linux_ngknetcb    c 122 0
+    else
+        rm -f /dev/linux-knet-cb
+        rm -f /dev/linux-bcm-knet
+        rm -f /dev/linux-bcm-bde
+        rm -f /dev/linux-kernel-bde
+        rm -f /dev/linux_ngbde
+
+        mknod /dev/linux_ngbde      c 120 0
+        mknod /dev/linux-knet-cb    c 121 0
+        mknod /dev/linux-bcm-knet   c 122 0
+        mknod /dev/linux-bcm-bde    c 126 0
+        mknod /dev/linux-kernel-bde c 127 0
+   fi
 }
 
 # linux-kernel-bde debug=4    ==> Verbose level debug
@@ -33,6 +43,44 @@ function create_devices()
 #                                 Events(0x20) and Instance(0x4000)
 #                                 level logs
 function load_kernel_modules()
+{
+    if [[ $is_ltsw_chip -eq 1 ]]; then
+        insmod /lib/modules/$(uname -r)/extra/psample.ko
+        modprobe linux_ngbde
+        modprobe linux_ngknet
+        modprobe linux_ngknetcb
+    else
+        modprobe linux-kernel-bde dmasize=$dmasize maxpayload=128 debug=4 dma_debug=1 usemsi=$usemsi
+        modprobe linux-user-bde
+
+        # Using insmod with absolute path for psample to make sure bcm psample is loaded.
+        # There is a different psample.ko module getting created at net/psample/psample.ko 
+        insmod /lib/modules/$(uname -r)/extra/psample.ko
+
+        modprobe linux-bcm-knet use_rx_skb=1 rx_buffer_size=9238 debug=0x5020 default_mtu=9100
+        modprobe linux-knet-cb
+        modprobe linux_ngbde
+    fi
+}
+
+function remove_kernel_modules()
+{
+    if [[ $is_ltsw_chip -eq 1 ]]; then
+        rmmod linux_ngknetcb
+        rmmod linux_ngknet
+        rmmod linux_ngbde
+        rmmod psample.ko
+    else
+        rmmod psample.ko
+        rmmod linux-knet-cb
+        rmmod linux-bcm-knet
+        rmmod linux-user-bde
+        rmmod linux-kernel-bde
+        rmmod linux_ngbde
+    fi
+}
+
+function load_platform_env()
 {
     . /host/machine.conf
 
@@ -47,37 +95,18 @@ function load_kernel_modules()
     # Set the default configuration for dmasize and usemsi parameters
     dmasize=32M
     usemsi=0
+    is_ltsw_chip=0
 
     # Source the platform env file
     env_file="/usr/share/sonic/device/$platform/platform_env.conf"
     source $env_file
-
-    modprobe linux-kernel-bde dmasize=$dmasize maxpayload=128 debug=4 dma_debug=1 usemsi=$usemsi
-    modprobe linux-user-bde
-
-    # Using insmod with absolute path for psample to make sure bcm psample is loaded.
-    # There is a different psample.ko module getting created at net/psample/psample.ko 
-    insmod /lib/modules/$(uname -r)/extra/psample.ko
-
-    modprobe linux-bcm-knet use_rx_skb=1 rx_buffer_size=9238 debug=0x5020 default_mtu=9100
-    modprobe linux-knet-cb
-    modprobe linux_ngbde
-}
-
-function remove_kernel_modules()
-{
-    rmmod psample.ko
-    rmmod linux-knet-cb
-    rmmod linux-bcm-knet
-    rmmod linux-user-bde
-    rmmod linux-kernel-bde
-    rmmod linux_ngbde
 }
 
 case "$1" in
 start)
     echo -n "Load OpenNSL kernel modules... "
 
+    load_platform_env
     create_devices
     load_kernel_modules
 
@@ -87,6 +116,7 @@ start)
 stop)
     echo -n "Unload OpenNSL kernel modules... "
 
+    load_platform_env
     remove_kernel_modules
 
     echo "done."

--- a/platform/broadcom/saibcm-modules/debian/opennsl-modules.install
+++ b/platform/broadcom/saibcm-modules/debian/opennsl-modules.install
@@ -4,3 +4,5 @@ systems/linux/user/x86-smp_generic_64-2_6/linux-user-bde.ko lib/modules/5.10.0-8
 systems/linux/user/x86-smp_generic_64-2_6/linux-knet-cb.ko lib/modules/5.10.0-8-2-amd64/extra
 systemd/opennsl-modules.service lib/systemd/system
 sdklt/linux/bde/linux_ngbde.ko lib/modules/5.10.0-8-2-amd64/extra
+sdklt/linux/knet/linux_ngknet.ko lib/modules/5.10.0-8-2-amd64/extra
+sdklt/linux/knetcb/linux_ngknetcb.ko lib/modules/5.10.0-8-2-amd64/extra


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
For trident4/tomahawk4, linux_ngknet.ko and linux_ngknetcb.ko have to be installed. Also, the kernel modules to load on such chips are different from existing ones, so we add an option is_ltsw_chip to determine the kernel modules to load. The option is_ltsw_chip is controlled by adding 'is_ltsw_chip=1' to platform_env.conf or not.

#### How I did it

#### How to verify it
We verified that existing platforms still work after this change; and for platforms with trident4/tomahawk4, we can load the different kernel modules as expected after adding 'is_ltsw_chip=1' to platform_env.conf

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

