### PR TITLE
[Marvell] Marvell armhf SAI debian.

### DIFF
--- a/platform/marvell-armhf/sai.mk
+++ b/platform/marvell-armhf/sai.mk
@@ -1,6 +1,6 @@
 # Marvell SAI
 
-export MRVL_SAI_VERSION = 1.7.1-7
+export MRVL_SAI_VERSION = 1.7.1-8
 export MRVL_SAI = mrvllibsai_$(MRVL_SAI_VERSION)_$(PLATFORM_ARCH).deb
 
 $(MRVL_SAI)_SRC_PATH = $(PLATFORM_PATH)/sai


### PR DESCRIPTION
Fixed IPv6 route issue resulting in orchagent crash.

Signed-off-by: Rajkumar Pennadam Ramamoorthy <rpennadamram@marvell.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixed SAI error resulting in orchagent crash in nokia platform.
#### How I did it
Reproduced the issue from sairedis.rec and fixed the bug.
#### How to verify it
Simplified steps to reproduce the issue and validate the fix.
1)	create route "2603:10e2:11:6000::/54"
2)	create route "2603:10e2:11:6000::/64"
3)	delete route  "2603:10e2:11:6000::/64"
4)	set route  "2603:10e2:11:6000::/54" 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fixed IPv6 route issue resulting in orchagent crash in nokia platform.
#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

