### PR TITLE
[Mellanox] support newly added reboot cause

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -657,24 +657,23 @@ class Chassis(ChassisBase):
         self.reboot_major_cause_dict = {
             'reset_main_pwr_fail'       :   self.REBOOT_CAUSE_POWER_LOSS,
             'reset_aux_pwr_or_ref'      :   self.REBOOT_CAUSE_POWER_LOSS,
+            'reset_comex_pwr_fail'      :   self.REBOOT_CAUSE_POWER_LOSS,
             'reset_asic_thermal'        :   self.REBOOT_CAUSE_THERMAL_OVERLOAD_ASIC,
+            'reset_comex_thermal'       :   self.REBOOT_CAUSE_THERMAL_OVERLOAD_CPU,
             'reset_hotswap_or_wd'       :   self.REBOOT_CAUSE_WATCHDOG,
+            'reset_comex_wd'            :   self.REBOOT_CAUSE_WATCHDOG,
             'reset_swb_wd'              :   self.REBOOT_CAUSE_WATCHDOG,
-            'reset_sff_wd'              :   self.REBOOT_CAUSE_WATCHDOG
+            'reset_sff_wd'              :   self.REBOOT_CAUSE_WATCHDOG,
+            'reset_hotswap_or_halt'     :   self.REBOOT_CAUSE_HARDWARE_OTHER,
+            'reset_voltmon_upgrade_fail':   self.REBOOT_CAUSE_HARDWARE_OTHER,
+            'reset_reload_bios'         :   self.REBOOT_CAUSE_HARDWARE_BIOS,
+            'reset_from_comex'          :   self.REBOOT_CAUSE_HARDWARE_CPU,
+            'reset_fw_reset'            :   self.REBOOT_CAUSE_HARDWARE_RESET_FROM_ASIC,
+            'reset_from_asic'           :   self.REBOOT_CAUSE_HARDWARE_RESET_FROM_ASIC,
+            'reset_long_pb'             :   self.REBOOT_CAUSE_HARDWARE_BUTTON,
+            'reset_short_pb'            :   self.REBOOT_CAUSE_HARDWARE_BUTTON
         }
-        self.reboot_minor_cause_dict = {
-            'reset_fw_reset'            :   "Reset by ASIC firmware",
-            'reset_long_pb'             :   "Reset by long press on power button",
-            'reset_short_pb'            :   "Reset by short press on power button",
-            'reset_comex_thermal'       :   "ComEx thermal shutdown",
-            'reset_comex_pwr_fail'      :   "ComEx power fail",
-            'reset_comex_wd'            :   "Reset requested from ComEx",
-            'reset_from_asic'           :   "Reset requested from ASIC",
-            'reset_reload_bios'         :   "Reset caused by BIOS reload",
-            'reset_hotswap_or_halt'     :   "Reset caused by hotswap or halt",
-            'reset_from_comex'          :   "Reset from ComEx",
-            'reset_voltmon_upgrade_fail':   "Reset due to voltage monitor devices upgrade failure"
-        }
+        self.reboot_minor_cause_dict = {}
         self.reboot_by_software = 'reset_sw_reset'
         self.reboot_cause_initialized = True
 


### PR DESCRIPTION
Signed-off-by: Kebo Liu <kebol@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Implement newly added reboot causes in PR https://github.com/Azure/sonic-platform-common/pull/277

#### How I did it
Map the reboot cause sysfs to the newly added reboot causes.

#### How to verify it
manual test, check whether the reboot cause is correct after rebooting the switch in various ways.
run the community reboot test to see whether the reboot cause checker is passing.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

