### PR TITLE
Revert "[ci] Set default ACR in UpgrateVersion/PR/official pipeline. …

### DIFF
--- a/.azure-pipelines/azure-pipelines-UpgrateVersion.yml
+++ b/.azure-pipelines/azure-pipelines-UpgrateVersion.yml
@@ -42,11 +42,8 @@ parameters:
 stages:
 - stage: Build
   variables:
-    - name: CACHE_MODE
-      value: none
-    - name: VERSION_CONTROL_OPTIONS
-      value: 'SONIC_VERSION_CONTROL_COMPONENTS='
-    - template: .azure-pipelines/template-variables.yml@buildimage
+    CACHE_MODE: none
+    VERSION_CONTROL_OPTIONS: 'SONIC_VERSION_CONTROL_COMPONENTS='
   jobs:
   - template: azure-pipelines-build.yml
     parameters:

--- a/.azure-pipelines/docker-sonic-slave-template.yml
+++ b/.azure-pipelines/docker-sonic-slave-template.yml
@@ -45,10 +45,7 @@ jobs:
   pool: ${{ parameters.pool }}
   steps:
   - template: cleanup.yml
-  - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-    - template: template-clean-sonic-slave.yml
-  - ${{ else }}:
-    - template: .azure-pipelines/template-variables.yml@buildimage
+  - template: .azure-pipelines/template-clean-sonic-slave.yml@buildimage
   - checkout: self
     clean: true
     submodules: recursive

--- a/.azure-pipelines/official-build.yml
+++ b/.azure-pipelines/official-build.yml
@@ -12,19 +12,8 @@ schedules:
     - 202012
   always: true
 
-resources:
-  repositories:
-  - repository: buildimage
-    type: github
-    name: Azure/sonic-buildimage
-    ref: master
-    endpoint: build
-
 trigger: none
 pr: none
-
-variables:
-- template: .azure-pipelines/template-variables.yml@buildimage
 
 stages:
 - stage: Build

--- a/.azure-pipelines/template-clean-sonic-slave.yml
+++ b/.azure-pipelines/template-clean-sonic-slave.yml
@@ -1,10 +1,8 @@
 steps:
 - script: |
-    set -x
-    containers=$(docker container ls -aq)
+    containers=$(docker container ls -a | grep "sonic-slave" | awk '{ print $1 }')
     [ -n "$containers" ] && docker container rm -f $containers
     docker images | grep "^<none>" | awk '{print$3}' | xargs -i docker rmi {}
     images=$(docker images 'sonic-slave-*' -a -q)
     [ -n "$images" ] && docker rmi -f $images
-    exit 0
   displayName: 'Cleanup sonic slave'

--- a/.azure-pipelines/template-variables.yml
+++ b/.azure-pipelines/template-variables.yml
@@ -1,2 +1,0 @@
-variables:
-  DEFAULT_CONTAINER_REGISTRY: 'publicmirror.azurecr.io'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,20 +29,6 @@ resources:
     type: github
     name: Azure/sonic-mgmt
     endpoint: build
-  - repository: buildimage
-    type: github
-    name: Azure/sonic-buildimage
-    endpoint: build
-    ref: master
-
-variables:
-- template: .azure-pipelines/azure-pipelines-repd-build-variables.yml
-- ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-  - template: .azure-pipelines/template-variables.yml
-- ${{ else }}:
-  - template: .azure-pipelines/template-variables.yml@buildimage
-- name: CACHE_MODE
-  value: rcache 
 
 stages:
 - stage: BuildVS


### PR DESCRIPTION
…(#10341)"

#### Why I did it
This reverts commit f4bbcd1cf106f5e19c2eb69bdaaa8cfc13937b47. The original one was missing one file ".azure-pipelines/azure-pipelines-repd-build-variables.yml" and break the Azure pipeline.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

