### PR TITLE
Run tune2fs during initramfs instead of image install

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -355,9 +355,6 @@ extract_image() {
     local rootdev="$(echo $mountstr | cut -f1 -d' ')"
     rootfs_type="$(echo $mountstr | cut -d' ' -f3)"
 
-    ## Don't reserve any blocks just for root
-    tune2fs -m 0 -r 0 $rootdev
-
     info "Extracting $dockerfs from swi"
     ## Unpacking dockerfs delayed
     ## 1. when disk is vfat as it does not support symbolic link

--- a/files/initramfs-tools/mke2fs
+++ b/files/initramfs-tools/mke2fs
@@ -21,6 +21,7 @@ copy_exec /usr/sbin/mke2fs /usr/local/sbin/
 copy_exec /sbin/sfdisk
 copy_exec /sbin/fdisk
 copy_exec /sbin/resize2fs
+copy_exec /sbin/tune2fs
 copy_exec /sbin/findfs
 
 fstypes="ext4 ext3"

--- a/files/initramfs-tools/union-mount.j2
+++ b/files/initramfs-tools/union-mount.j2
@@ -133,6 +133,7 @@ case "${ROOT}" in
     *)
         ## Mount the raw partition again
         mount -t ext4 ${ROOT} ${rootmnt}/host
+        tune2fs -m 0 -r 0 ${ROOT}
         ;;
 esac
 

--- a/installer/arm64/install.sh
+++ b/installer/arm64/install.sh
@@ -139,11 +139,6 @@ elif [ "$install_env" = "sonic" ]; then
             rm -rf $f
         fi
     done
-
-    demo_dev=$(findmnt -n -o SOURCE --target /host)
-
-    # Don't reserve any blocks just for root
-    tune2fs -m 0 -r 0 $demo_dev
 fi
 
 # Create target directory or clean it up if exists

--- a/installer/armhf/install.sh
+++ b/installer/armhf/install.sh
@@ -139,11 +139,6 @@ elif [ "$install_env" = "sonic" ]; then
             rm -rf $f
         fi
     done
-
-    demo_dev=$(findmnt -n -o SOURCE --target /host)
-
-    # Don't reserve any blocks just for root
-    tune2fs -m 0 -r 0 $demo_dev
 fi
 
 # Create target directory or clean it up if exists

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -477,9 +477,6 @@ if [ "$install_env" = "onie" ]; then
     # Make filesystem
     mkfs.ext4 -L $demo_volume_label $demo_dev
 
-    # Don't reserve any blocks just for root
-    tune2fs -m 0 -r 0 $demo_dev
-
     # Mount demo filesystem
     demo_mnt=$(${onie_bin} mktemp -d) || {
         echo "Error: Unable to create file system mount point"
@@ -512,19 +509,11 @@ elif [ "$install_env" = "sonic" ]; then
             rm -rf $f
         fi
     done
-
-    demo_dev=$(findmnt -n -o SOURCE --target /host)
-
-    # Don't reserve any blocks just for root
-    tune2fs -m 0 -r 0 $demo_dev
 else
     demo_mnt="build_raw_image_mnt"
     demo_dev=$cur_wd/"%%OUTPUT_RAW_IMAGE%%"
 
     mkfs.ext4 -L $demo_volume_label $demo_dev
-
-    # Don't reserve any blocks just for root
-    tune2fs -m 0 -r 0 $demo_dev
 
     echo "Mounting $demo_dev on $demo_mnt..."
     mkdir $demo_mnt


### PR DESCRIPTION


Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

If it is run during image install, it's not guaranteed that the
installation environment will have tune2fs available. Therefore, run it
during initramfs instead.

#### How I did it

Remove the tune2fs command from the image installation files, and add
it into initramfs, just after the filesystem gets mounted. 

#### How to verify it

Tested on a Arista 7060 running 201911 image, and was able to install and
boot a 202012 branch image with 5% reserved blocks.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

