### PR TITLE
Revert "[docker-ptf]: Upgrade scapy to 2.4.5 in docker-ptf"

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -119,8 +119,7 @@ RUN rm -rf /debs \
     && pip install pyrasite \
     && mkdir -p /opt       \
     && cd /opt             \
-    && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
-    && pip install --upgrade --ignore-installed scapy==2.4.5
+    && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py
 
 ## Adjust sshd settings
 RUN mkdir /var/run/sshd \


### PR DESCRIPTION
It upgraded scapy to 2.4.5 in docker-ptf container, after this upgrade, all scripts under ansible/roles/test/files/ptftests will import scapy 2.4.5, some test cases will fail because they are not upgraded accordingly. 

Reverts Azure/sonic-buildimage#10507 to avoid breaking regression test.