### PR TITLE
[BFN] Fixed SONiC fwutil exec time

### DIFF
--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/component.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/component.py
@@ -6,6 +6,7 @@ try:
     import json
     from collections import OrderedDict
     from sonic_py_common import device_info
+    from platform_utils import limit_execution_time
 
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
@@ -24,6 +25,7 @@ def get_bios_version():
     except subprocess.CalledProcessError as e:
         raise RuntimeError("Failed to get BIOS version")
 
+@limit_execution_time(1)
 def get_bmc_version():
     """
     Retrieves the firmware version of the BMC

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/platform_utils.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/platform_utils.py
@@ -3,6 +3,8 @@
 try:
     import os
     import subprocess
+    import signal
+    from functools import wraps
 
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
@@ -20,3 +22,24 @@ def file_create(path, mode=None):
         run_cmd(['touch', path])
     if (mode is not None):    
         run_cmd(['chmod', mode, path])
+
+def cancel_on_sigterm(func):
+    """
+    Wrapper for a function which has to be cancel on SIGTERM
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        def handler(sig, frame):
+            if sigterm_handler:
+                sigterm_handler(sig, frame)
+            raise Exception("Canceling {}() execution...".format(func.__name__))
+
+        sigterm_handler = signal.getsignal(signal.SIGTERM)
+        signal.signal(signal.SIGTERM, handler)
+        result = None
+        try:
+            result = func(*args, **kwargs)
+        finally:
+            signal.signal(signal.SIGTERM, sigterm_handler)
+        return result
+    return wrapper

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/platform_utils.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/platform_utils.py
@@ -60,16 +60,17 @@ def limit_execution_time(execution_time_secs: int):
     def wrapper(func):
         @wraps(func)
         def execution_func(*args, **kwargs):
-            def handler():
-                raise
+            def handler(sig, frame):
+                if sigalrm_handler:
+                    sigalrm_handler(sig, frame)
+                raise Exception("Canceling {}() execution...".format(func.__name__))
 
+            sigalrm_handler = signal.getsignal(signal.SIGALRM)
             signal.signal(signal.SIGALRM, handler)
             signal.alarm(execution_time_secs)
             result = None
             try:
                 result = func(*args, **kwargs)
-            except Exception:
-                raise
             finally:
                 signal.alarm(0)
 

--- a/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/platform_utils.py
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/sonic_platform/platform_utils.py
@@ -11,7 +11,10 @@ except ImportError as e:
 
 def file_create(path, mode=None):
     """
-    Checks if a file has been created with the appropriate permissions
+    Ensure that file is created with the appropriate permissions
+    Args:
+        path: full path of a file
+        mode: file permission in octal representation  
     """
     def run_cmd(cmd):
         if os.geteuid() != 0:
@@ -23,7 +26,7 @@ def file_create(path, mode=None):
         run_cmd(['mkdir', '-p', file_path])
     if not os.path.isfile(path):
         run_cmd(['touch', path])
-    if (mode is not None):    
+    if (mode is not None):
         run_cmd(['chmod', mode, path])
 
 def cancel_on_sigterm(func):


### PR DESCRIPTION
Signed-off-by: Taras Keryk <tarasx.keryk@intel.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The execution time of the SONiC fwutil command is more than 30s if the BFN SDK is not updated to the latest version
#### How I did it
Added a wrapper to platform_utils to limit function execution time
#### How to verify it
The execution time of the SONiC fwutil command  without  updating SDK to the latest version should be a maximum of a few seconds
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

