### PR TITLE
[dhcp6relay] Add interface-id option

### DIFF
--- a/src/dhcp6relay/src/configInterface.cpp
+++ b/src/dhcp6relay/src/configInterface.cpp
@@ -118,6 +118,7 @@ void processRelayNotification(std::deque<swss::KeyOpFieldsValuesTuple> &entries,
 
         relay_config intf;
         intf.is_option_79 = true;
+        intf.is_interface_id = false;
         intf.interface = vlan;
         intf.db = nullptr;
         for (auto &fieldValue: fieldValues) {
@@ -134,6 +135,9 @@ void processRelayNotification(std::deque<swss::KeyOpFieldsValuesTuple> &entries,
             }
             if(f == "dhcpv6_option|rfc6939_support" && v == "false") {
                 intf.is_option_79 = false;
+            }
+            if(f == "dhcpv6_option|interface_id" && v == "true") { // interface-id is off by default on non-Dual-ToR, unless specified in config db
+                intf.is_interface_id = true;
             }
         }
         vlans->push_back(intf);

--- a/src/dhcp6relay/src/relay.cpp
+++ b/src/dhcp6relay/src/relay.cpp
@@ -12,7 +12,6 @@
 #include "dbconnector.h" 
 #include "configInterface.h"
 
-
 struct event *listen_event;
 struct event *server_listen_event;
 struct event_base *base;
@@ -457,6 +456,16 @@ void relay_client(int sock, const uint8_t *msg, int32_t len, const ip6_hdr *ip_h
 
         memcpy(current_buffer_position, &ether_hdr->ether_shost, sizeof(ether_hdr->ether_shost));
         current_buffer_position += sizeof(ether_hdr->ether_shost);
+    }
+
+    if(config->is_interface_id) {
+        interface_id_option intf_id;
+        intf_id.option_code = htons(OPTION_INTERFACE_ID);
+        intf_id.option_length = htons(sizeof(in6_addr));
+        intf_id.interface_id = config->link_address.sin6_addr;
+
+        memcpy(current_buffer_position, &intf_id, sizeof(interface_id_option));
+        current_buffer_position += sizeof(interface_id_option);
     }
 
     auto dhcp_message_length = len;

--- a/src/dhcp6relay/src/relay.h
+++ b/src/dhcp6relay/src/relay.h
@@ -20,6 +20,7 @@
 #define lengthof(A) (sizeof (A) / sizeof (A)[0])
 
 #define OPTION_RELAY_MSG 9
+#define OPTION_INTERFACE_ID 18
 #define OPTION_CLIENT_LINKLAYER_ADDR 79
 
 /* DHCPv6 message types */
@@ -51,6 +52,7 @@ struct relay_config {
     std::vector<std::string> servers;
     std::vector<sockaddr_in6> servers_sock;
     bool is_option_79;
+    bool is_interface_id;
 };
 
 
@@ -77,6 +79,12 @@ struct linklayer_addr_option  {
     uint16_t option_code;
     uint16_t option_length;
     uint16_t link_layer_type;
+};
+
+struct interface_id_option  {
+    uint16_t option_code;
+    uint16_t option_length;
+    in6_addr interface_id;  // to accomodate dual-tor, this opaque value is set to carry relay interface's global ipv6 address
 };
 
 /**


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Support interface-id option with opaque value carrying link-address which will be used in dual-tor

#### How I did it
Add interface-id option in DHCP_RELAY configuration table, copy link-address to interface-id value

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

