### PR TITLE
Fix race condition between networking service and interface-config service

### DIFF
--- a/files/image_config/interfaces/interfaces-config.sh
+++ b/files/image_config/interfaces/interfaces-config.sh
@@ -9,7 +9,7 @@ function wait_networking_service_done() {
     while [[ "${_WDOG_CNT}" -le "${_WDOG_MAX}" ]]; do
         networking_status="$(systemctl is-active networking 2>&1)"
 
-        if [ "${networking_status}" == active ] || [ "${networking_status}" == inactive ] || [ "${networking_status}" == failed ] ; then
+        if [[ "${networking_status}" == active || "${networking_status}" == inactive || "${networking_status}" == failed ]] ; then
             return
         fi
 
@@ -29,11 +29,11 @@ if [[ $(ifquery --running eth0) ]]; then
 fi
 
 # Check if ZTP DHCP policy has been installed
-if [ -e /etc/network/ifupdown2/policy.d/ztp_dhcp.json ]; then
+if [[ -e /etc/network/ifupdown2/policy.d/ztp_dhcp.json ]]; then
     # Obtain port operational state information
     redis-dump -d 0 -k "PORT_TABLE:Ethernet*"  -y > /tmp/ztp_port_data.json
 
-    if [ $? -ne 0 ] || [ ! -e /tmp/ztp_port_data.json ] || [ "$(cat /tmp/ztp_port_data.json)" = "" ]; then
+    if [[ $? -ne 0 || ! -e /tmp/ztp_port_data.json || "$(cat /tmp/ztp_port_data.json)" = "" ]]; then
         echo "{}" > /tmp/ztp_port_data.json
     fi
 
@@ -53,28 +53,28 @@ CFGGEN_PARAMS=" \
 "
 sonic-cfggen $CFGGEN_PARAMS
 
-[ -f /var/run/dhclient.eth0.pid ] && kill `cat /var/run/dhclient.eth0.pid` && rm -f /var/run/dhclient.eth0.pid
-[ -f /var/run/dhclient6.eth0.pid ] && kill `cat /var/run/dhclient6.eth0.pid` && rm -f /var/run/dhclient6.eth0.pid
+[[ -f /var/run/dhclient.eth0.pid ]] && kill `cat /var/run/dhclient.eth0.pid` && rm -f /var/run/dhclient.eth0.pid
+[[ -f /var/run/dhclient6.eth0.pid ]] && kill `cat /var/run/dhclient6.eth0.pid` && rm -f /var/run/dhclient6.eth0.pid
 
 for intf_pid in $(ls -1 /var/run/dhclient*.Ethernet*.pid 2> /dev/null); do
-    [ -f ${intf_pid} ] && kill `cat ${intf_pid}` && rm -f ${intf_pid}
+    [[ -f ${intf_pid} ]] && kill `cat ${intf_pid}` && rm -f ${intf_pid}
 done
 
 
 # Setup eth1 if we connect to a remote chassis DB.
 PLATFORM=${PLATFORM:-`sonic-cfggen -H -v DEVICE_METADATA.localhost.platform`}
 CHASSISDB_CONF="/usr/share/sonic/device/$PLATFORM/chassisdb.conf"
-[ -f $CHASSISDB_CONF ] && source $CHASSISDB_CONF
+[[ -f $CHASSISDB_CONF ]] && source $CHASSISDB_CONF
 
 ASIC_CONF="/usr/share/sonic/device/$PLATFORM/asic.conf"
-[ -f $ASIC_CONF ] && source $ASIC_CONF
+[[ -f $ASIC_CONF ]] && source $ASIC_CONF
 
 if [[ -n "$midplane_subnet" && ($NUM_ASIC -gt 1) ]]; then
     for asic_id in `seq 0 $((NUM_ASIC - 1))`; do
        NET_NS="asic$asic_id"
 
        PIDS=`ip netns pids "$NET_NS" 2>/dev/null`
-       if [ "$?" -ne "0" ]; then # namespace doesn't exist
+       if [[ "$?" -ne "0" ]]; then # namespace doesn't exist
           continue
        fi
 

--- a/files/image_config/interfaces/interfaces-config.sh
+++ b/files/image_config/interfaces/interfaces-config.sh
@@ -9,7 +9,7 @@ function wait_networking_service_done() {
     while [[ "${_WDOG_CNT}" -le "${_WDOG_MAX}" ]]; do
         networking_status="$(systemctl is-active networking 2>&1)"
 
-        if [[ "${networking_status}" == active ]]; then
+        if [ "${networking_status}" == active ] || [ "${networking_status}" == inactive ] || [ "${networking_status}" == failed ] ; then
             return
         fi
 

--- a/files/image_config/interfaces/interfaces-config.sh
+++ b/files/image_config/interfaces/interfaces-config.sh
@@ -1,6 +1,30 @@
 #!/bin/bash
 
+function wait_networking_service_done() {
+    local -i _WDOG_CNT="1"
+    local -ir _WDOG_MAX="30"
+
+    local -r _TIMEOUT="1s"
+
+    while [[ "${_WDOG_CNT}" -le "${_WDOG_MAX}" ]]; do
+        networking_status="$(systemctl is-active networking 2>&1)"
+
+        if [[ "${networking_status}" == active ]]; then
+            return
+        fi
+
+        echo "interfaces-config: networking service is running, wait for it done"
+
+        let "_WDOG_CNT++"
+        sleep "${_TIMEOUT}"
+    done
+
+    echo "interfaces-config: networking service is still running after 30 seconds, killing it"
+    systemctl kill networking 2>&1
+}
+
 if [[ $(ifquery --running eth0) ]]; then
+    wait_networking_service_done
     ifdown --force eth0
 fi
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The PR is aimed to fix a bug that mgmt port eth0 may loss IP even if user configured static IP of eth0. This is not a always reproduceable issue, the reproducing flow is like:

1.	Systemd starts networking service, which runs a dhcp based configuration and assigned an ip from dhcp.
2.	Systemd starts interface-config service who depends on networking service
3.	Interface-config service runs command  “ifdown –force eth0”, check [line](https://github.com/Azure/sonic-buildimage/blob/16717d2dc51f74fa711ed7b4392ce5e4f7e71c29/files/image_config/interfaces/interfaces-config.sh#L4). but networking service is still running so that this [line](https://github.com/CumulusNetworks/ifupdown2/blob/ac32bec0e24d64c583778f387050a7b6f4269db0/ifupdown2/ifupdown/main.py#L74) failed with error: “error: Another instance of this program is already running.”. This error is printed by ifupdown2 lib who is the main process of networking service. So, ifdown actually does not work here, the ip of eth0 is not down.
4.	Interface-config service updates /etc/networking/interface to static configuration.
5.	Interface-config service runs command “systemctl restart networking”. This command kills the previous networking related processes (log: networking.service: Main process exited, code=killed, status=15/TERM), and try to reconfigure the ip address with static configuration. But it detects that the configured IP and the existing IP are the same, and it does not really configure the ip to kernel. Hence, the ip is still getting from dhcp. (this could be a bug of ifupdown2: previous ip is from dhcp, new ip is a static ip, it treats them as same instead of re-configuring the IP)
6.	When the lease of the ip expires, the ip of eth0 is removed by kernel and the issue reproduces.

The issue is not always reproduceable because networking service usually runs fast so that it won't hit step#3.

#### How I did it

Check networking service state before running "ifdown –force eth0", wait for it done if it is activating.

#### How to verify it

Manual test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)
