### PR TITLE
[yang] Update device_metadata to add dhcp_server

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -283,7 +283,8 @@
                 "hwsku": "Stone",
                 "buffer_model": "dynamic",
                 "cloudtype": "Public",
-                "region": "usfoo"
+                "region": "usfoo",
+                "dhcp_server": "disabled"
             }
         },
         "VLAN": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -93,6 +93,13 @@
 	"DEVICE_METADATA_INVALID_STORAGE_DEVICE": {
 		"desc": "Verifying invalid storage device value",
 		"eStrKey": "InvalidValue"
-	}
+    },
+    "DEVICE_METADATA_VALID_DHCP_SERVER": {
+        "desc": "Verifying dhcp_server configuration."
+    },
+    "DEVICE_METADATA_INVALID_DHCP_SERVER": {
+        "desc": "Verifying invalid dhcp_server configuration.",
+        "eStrKey": "InvalidValue"
+    }
 
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
@@ -251,5 +251,23 @@
                 }
             }
         }
+    },
+    "DEVICE_METADATA_VALID_DHCP_SERVER": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "dhcp_server": "enabled"
+                }
+            }
+        }
+    },
+    "DEVICE_METADATA_INVALID_DHCP_SERVER": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "dhcp_server": "invalid"
+                }
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -148,6 +148,11 @@ module sonic-device_metadata {
                 leaf storage_device {
                     type boolean;
                 }
+
+                leaf dhcp_server {
+                    type stypes:admin_mode;
+                    description "Indicate whether enable the embedded DHCP server.";
+                }
             }
             /* end of container localhost */
         }


### PR DESCRIPTION
Signed-off-by: Gang Lv ganglv@microsoft.com

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
dhcp_server is introduced, and need to update yang model.

#### How I did it
Update yang models and add unit test.

#### How to verify it
Run unit test for sonic-yang-models.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
https://github.com/Azure/sonic-buildimage/pull/10382
There is merge conflict in 202111, need a separate PR

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

