### PR TITLE
[PDDF] Rename temp for as7816/7326/7726

### DIFF
--- a/device/accton/x86_64-accton_as7326_56x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as7326_56x-r0/pddf/pddf-device.json
@@ -303,6 +303,7 @@
      "TEMP1" :
     {
         "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP1", "device_parent":"MUX2"},
+	    "dev_attr": { "display_name":"MB_RearMAC_temp(0x48)"},
         "i2c":
         {
             "topo_info": { "parent_bus":"0xf", "dev_addr":"0x48", "dev_type":"lm75"},
@@ -316,7 +317,8 @@
     },
      "TEMP2" :
     {
-        "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP1", "device_parent":"MUX2"},
+        "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP2", "device_parent":"MUX2"},
+	    "dev_attr": { "display_name":"MB_FrontMAC_temp(0x49)"},
         "i2c":
         {
             "topo_info": { "parent_bus":"0xf", "dev_addr":"0x49", "dev_type":"lm75"},
@@ -330,7 +332,8 @@
     },
      "TEMP3" :
     {
-        "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP1", "device_parent":"MUX2"},
+        "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP3", "device_parent":"MUX2"},
+	    "dev_attr": { "display_name":"MB_LeftCenter_temp(0x4A)"},
         "i2c":
         {
             "topo_info": { "parent_bus":"0xf", "dev_addr":"0x4A", "dev_type":"lm75"},
@@ -344,7 +347,8 @@
     },
     "TEMP4" :
     {
-        "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP1", "device_parent":"MUX2"},
+        "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP4", "device_parent":"MUX2"},
+	    "dev_attr": { "display_name":"CB_temp(0x4B)"},
         "i2c":
         {
             "topo_info": { "parent_bus":"0xf", "dev_addr":"0x4B", "dev_type":"lm75"},

--- a/device/accton/x86_64-accton_as7326_56x-r0/sensors.conf
+++ b/device/accton/x86_64-accton_as7326_56x-r0/sensors.conf
@@ -1,40 +1,36 @@
 # libsensors configuration file for as7326-56x
 # ------------------------------------------------
 #
-
 bus "i2c-11" "i2c-1-mux (chan_id 2)"
 bus "i2c-13" "i2c-1-mux (chan_id 4)"
 bus "i2c-15" "i2c-1-mux (chan_id 6)"
 bus "i2c-17" "i2c-1-mux (chan_id 0)"
 
-
-chip "ym2651-i2c-*-59"
+chip "psu_pmbus-i2c-*-59"
     label in3 "PSU 1 Voltage"
     label fan1 "PSU 1 Fan"
     label temp1 "PSU 1 Temperature"
     label power2 "PSU 1 Power"
     label curr2 "PSU 1 Current"
-
-chip "ym2651-i2c-*-5b"
+chip "psu_pmbus-i2c-*-5b"
     label in3 "PSU 2 Voltage"
     label fan1 "PSU 2 Fan"
     label temp1 "PSU 2 Temperature"
     label power2 "PSU 2 Power"
     label curr2 "PSU 2 Current"
-
-chip "as7326_56x_fan-*"
-    label fan1 "Fan 1 Front"
-    label fan2 "Fan 2 Front"
-    label fan3 "Fan 3 Front"
-    label fan4 "Fan 4 Front"
-    label fan5 "Fan 5 Front"
-    label fan6 "Fan 6 Front"
-    label fan11 "Fan 1 Rear"
-    label fan12 "Fan 2 Rear"
-    label fan13 "Fan 3 Rear"
-    label fan14 "Fan 4 Rear"
-    label fan15 "Fan 5 Rear"
-    label fan16 "Fan 6 Rear"
+chip "fan_ctrl-*"
+    label fan1 "Fantray1 Front"
+    label fan2 "Fantray1 Rear"
+    label fan3 "Fantray2 Front"
+    label fan4 "Fantray2 Rear"
+    label fan5 "Fantray3 Front"
+    label fan6 "Fantray3 Rear"
+    label fan7 "Fantray4 Front"
+    label fan8 "Fantray4 Rear"
+    label fan9 "Fantray5 Front"
+    label fan10 "Fantray5 Rear"
+    label fan11 "Fantray6 Front"
+    label fan12 "Fantray6 Rear"
 
 
 chip "lm75-i2c-*-48"

--- a/device/accton/x86_64-accton_as7326_56x-r0/sensors.conf
+++ b/device/accton/x86_64-accton_as7326_56x-r0/sensors.conf
@@ -38,13 +38,13 @@ chip "as7326_56x_fan-*"
 
 
 chip "lm75-i2c-*-48"
-    label temp1 "Main Board Temperature"
+    label temp1 "MB_RearMAC_temp"
 
 chip "lm75-i2c-*-49"
-    label temp1 "Main Board Temperature"
+    label temp1 "MB_FrontMAC_temp"
 
 chip "lm75-i2c-*-4a"
-    label temp1 "Main Board Temperature"
+    label temp1 "MB_LeftCenter_temp"
 
 chip "lm75-i2c-*-4b"
-    label temp1 "CPU Board Temperature"
+    label temp1 "CB_temp"

--- a/device/accton/x86_64-accton_as7726_32x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as7726_32x-r0/pddf/pddf-device.json
@@ -1789,6 +1789,7 @@
 	"TEMP1" :
 	{
 		"dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP1", "device_parent":"MUX7"},
+		"dev_attr": { "display_name":"FB_temp(0x4C)"},
 		"i2c":
 		{
 			"topo_info": { "parent_bus":"0x36", "dev_addr":"0x4c", "dev_type":"lm75"},
@@ -1804,6 +1805,7 @@
 	"TEMP2" :
 	{
 		"dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP2", "device_parent":"MUX7"},
+		"dev_attr": { "display_name":"MB_RearMAC_temp(0x48)"},
 		"i2c":
 		{
 			"topo_info": { "parent_bus":"0x37", "dev_addr":"0x48", "dev_type":"lm75"},
@@ -1819,6 +1821,7 @@
 	"TEMP3" :
 	{
 		"dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP3", "device_parent":"MUX7"},
+		"dev_attr": { "display_name":"MB_FrontMAC_temp(0x49)"},
 		"i2c":
 		{
 			"topo_info": { "parent_bus":"0x37", "dev_addr":"0x49", "dev_type":"lm75"},
@@ -1834,6 +1837,7 @@
 	"TEMP4" :
 	{
 		"dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP4", "device_parent":"MUX7"},
+		"dev_attr": { "display_name":"MB_LeftCenter_temp(0x4A)"},
 		"i2c":
 		{
 			"topo_info": { "parent_bus":"0x37", "dev_addr":"0x4a", "dev_type":"lm75"},
@@ -1849,6 +1853,7 @@
 	"TEMP5" :
 	{
 		"dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP5", "device_parent":"MUX7"},
+		"dev_attr": { "display_name":"CB_temp(0x4B)"},
 		"i2c":
 		{
 			"topo_info": { "parent_bus":"0x37", "dev_addr":"0x4b", "dev_type":"lm75"},

--- a/device/accton/x86_64-accton_as7726_32x-r0/sensors.conf
+++ b/device/accton/x86_64-accton_as7726_32x-r0/sensors.conf
@@ -34,16 +34,16 @@ chip "as7726_32x_fan-*"
 
 
 chip "lm75-i2c-*-48"
-    label temp1 "Main Board Temperature"
+    label temp1 "MB_RearMAC_temp"
 
 chip "lm75-i2c-*-49"
-    label temp1 "Main Board Temperature"
+    label temp1 "MB_FrontMAC_temp"
 
 chip "lm75-i2c-*-4a"
-    label temp1 "Main Board Temperature"
+    label temp1 "MB_LeftCenter_temp"
 
 chip "lm75-i2c-*-4b"
-    label temp1 "CPU Board Temperature"
+    label temp1 "CB_temp"
 
 chip "lm75-i2c-*-4c"
-    label temp1 "Fan Board Temperature"
+    label temp1 "FB_temp"

--- a/device/accton/x86_64-accton_as7726_32x-r0/sensors.conf
+++ b/device/accton/x86_64-accton_as7726_32x-r0/sensors.conf
@@ -1,36 +1,36 @@
 # libsensors configuration file for as7726-32x
 # ------------------------------------------------
 #
-
 bus "i2c-49" "i2c-2-mux (chan_id 0)"
 bus "i2c-50" "i2c-2-mux (chan_id 1)"
 bus "i2c-54" "i2c-2-mux (chan_id 5)"
 bus "i2c-55" "i2c-2-mux (chan_id 6)"
 
-
-chip "ym2651-i2c-*-5b"
+chip "psu_pmbus-i2c-*-5b"
+    label in3 "PSU 1 Voltage"
     label fan1 "PSU 1 Fan"
     label temp1 "PSU 1 Temperature"
-    label power1 "PSU 1 Power"
-
-chip "ym2651-i2c-*-58"
+    label power2 "PSU 1 Power"
+    label curr2 "PSU 1 Current"
+chip "psu_pmbus-i2c-*-58"
+    label in3 "PSU 2 Voltage"
     label fan1 "PSU 2 Fan"
     label temp1 "PSU 2 Temperature"
-    label power1 "PSU 2 Power"
-
-chip "as7726_32x_fan-*"
-    label fan1 "Fan 1 Front"
-    label fan2 "Fan 2 Front"
-    label fan3 "Fan 3 Front"
-    label fan4 "Fan 4 Front"
-    label fan5 "Fan 5 Front"
-    label fan6 "Fan 6 Front"
-    label fan11 "Fan 1 Rear"
-    label fan12 "Fan 2 Rear"
-    label fan13 "Fan 3 Rear"
-    label fan14 "Fan 4 Rear"
-    label fan15 "Fan 5 Rear"
-    label fan16 "Fan 6 Rear"
+    label power2 "PSU 2 Power"
+    label curr2 "PSU 2 Current"
+chip "fan_ctrl-*"
+    label fan1 "Fantray1 Front"
+    label fan2 "Fantray1 Rear"
+    label fan3 "Fantray2 Front"
+    label fan4 "Fantray2 Rear"
+    label fan5 "Fantray3 Front"
+    label fan6 "Fantray3 Rear"
+    label fan7 "Fantray4 Front"
+    label fan8 "Fantray4 Rear"
+    label fan9 "Fantray5 Front"
+    label fan10 "Fantray5 Rear"
+    label fan11 "Fantray6 Front"
+    label fan12 "Fantray6 Rear"
 
 
 chip "lm75-i2c-*-48"

--- a/device/accton/x86_64-accton_as7816_64x-r0/pddf/pddf-device.json
+++ b/device/accton/x86_64-accton_as7816_64x-r0/pddf/pddf-device.json
@@ -319,7 +319,7 @@
     "TEMP1" :
     {
         "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP1", "device_parent":"MUX3"},
-        "dev_attr": { "display_name":"Temp_1"},
+        "dev_attr": { "display_name":"FB_1_temp(0x4D)"},
         "i2c":
         {
             "topo_info": { "parent_bus":"0x11", "dev_addr":"0x4D", "dev_type":"lm75"},
@@ -334,7 +334,7 @@
     "TEMP2" :
     {
         "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP2", "device_parent":"MUX3"},
-        "dev_attr": { "display_name":"Temp_2"},
+        "dev_attr": { "display_name":"FB_2_temp(0x4E)"},
         "i2c":
         {
             "topo_info": { "parent_bus":"0x11", "dev_addr":"0x4E", "dev_type":"lm75"},
@@ -349,7 +349,7 @@
     "TEMP3" :
     {
         "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP3", "device_parent":"MUX3"},
-        "dev_attr": { "display_name":"Temp_3"},
+        "dev_attr": { "display_name":"MB_MAC_temp(0x48)"},
         "i2c":
         {
             "topo_info": { "parent_bus":"0x12", "dev_addr":"0x48", "dev_type":"lm75"},
@@ -364,7 +364,7 @@
     "TEMP4" :
     {
         "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP4", "device_parent":"MUX3"},
-        "dev_attr": { "display_name":"Temp_4"},
+        "dev_attr": { "display_name":"MB_RearCenter_temp(0x49)"},
         "i2c":
         {
             "topo_info": { "parent_bus":"0x12", "dev_addr":"0x49", "dev_type":"lm75"},
@@ -379,7 +379,7 @@
     "TEMP5" :
     {
         "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP5", "device_parent":"MUX3"},
-        "dev_attr": { "display_name":"Temp_5"},
+        "dev_attr": { "display_name":"MB_RightCenter_temp(0x4A)"},
         "i2c":
         {
             "topo_info": { "parent_bus":"0x12", "dev_addr":"0x4A", "dev_type":"lm75"},
@@ -394,7 +394,7 @@
     "TEMP6" :
     {
         "dev_info": { "device_type":"TEMP_SENSOR", "device_name":"TEMP6", "device_parent":"MUX3"},
-        "dev_attr": { "display_name":"Temp_6"},
+        "dev_attr": { "display_name":"CpuBoard_temp(0x4B)"},
         "i2c":
         {
             "topo_info": { "parent_bus":"0x12", "dev_addr":"0x4B", "dev_type":"lm75"},

--- a/device/accton/x86_64-accton_as7816_64x-r0/sensors.conf
+++ b/device/accton/x86_64-accton_as7816_64x-r0/sensors.conf
@@ -33,19 +33,19 @@ chip "as7816_64x_fan-*"
     label fan14 "Fan 4 Rear"
 
 chip "lm75-i2c-*-48"
-    label temp1 "Main Board Temperature"
+    label temp1 "MB_MAC_temp"
 
 chip "lm75-i2c-*-49"
-    label temp1 "Main Board Temperature"
+    label temp1 "MB_RearCenter_temp"
 
 chip "lm75-i2c-*-4a"
-    label temp1 "Main Board Temperature"
+    label temp1 "MB_RightCenter_temp"
 
 chip "lm75-i2c-*-4b"
-    label temp1 "CPU Board Temperature"
+    label temp1 "CpuBoard_temp"
 
 chip "lm75-i2c-*-4d"
-    label temp1 "Fan Board Temperature"
+    label temp1 "FB_1_temp"
 
 chip "lm75-i2c-*-4e"
-    label temp1 "Fan Board Temperature"
+    label temp1 "FB_2_temp"

--- a/device/accton/x86_64-accton_as7816_64x-r0/sensors.conf
+++ b/device/accton/x86_64-accton_as7816_64x-r0/sensors.conf
@@ -1,36 +1,31 @@
 # libsensors configuration file for as7816-64x
 # ------------------------------------------------
 #
-
 bus "i2c-9" "i2c-1-mux (chan_id 0)"
 bus "i2c-10" "i2c-1-mux (chan_id 1)"
 bus "i2c-17" "i2c-1-mux (chan_id 0)"
 bus "i2c-18" "i2c-1-mux (chan_id 1)"
-
-
-chip "ym2851-i2c-*-5b"
+chip "psu_pmbus-i2c-*-5b"
     label in3 "PSU 1 Voltage"
     label fan1 "PSU 1 Fan"
     label temp1 "PSU 1 Temperature"
     label power2 "PSU 1 Power"
     label curr2 "PSU 1 Current"
-
-chip "ym2851-i2c-*-58"
+chip "psu_pmbus-i2c-*-58"
     label in3 "PSU 2 Voltage"
     label fan1 "PSU 2 Fan"
     label temp1 "PSU 2 Temperature"
     label power2 "PSU 2 Power"
     label curr2 "PSU 2 Current"
-
-chip "as7816_64x_fan-*"
-    label fan1 "Fan 1 Front"
-    label fan2 "Fan 2 Front"
-    label fan3 "Fan 3 Front"
-    label fan4 "Fan 4 Front"
-    label fan11 "Fan 1 Rear"
-    label fan12 "Fan 2 Rear"
-    label fan13 "Fan 3 Rear"
-    label fan14 "Fan 4 Rear"
+chip "fan_ctrl-*"
+    label fan1 "Fantray1 Front"
+    label fan2 "Fantray1 Rear"
+    label fan3 "Fantray2 Front"
+    label fan4 "Fantray2 Rear"
+    label fan5 "Fantray3 Front"
+    label fan6 "Fantray3 Rear"
+    label fan7 "Fantray4 Front"
+    label fan8 "Fantray4 Rear"
 
 chip "lm75-i2c-*-48"
     label temp1 "MB_MAC_temp"


### PR DESCRIPTION
Signed-off-by: Jostar Yang <jostar_yang@accton.com.tw>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Renaming temp for cmd sensors and show platform temp. To let user is easy to know temp location from naming.
#### How I did it
1. Modify name in sensors.conf
2. Modify or add display_name in pddf-device.json
#### How to verify it
Test cmd, sensors, and show platform temp.
For as7816,
root@sonic:/home/admin# show platform temperature
                   Sensor    Temperature    High TH    Low TH    Crit High TH    Crit Low TH    Warning          Timestamp
-------------------------  -------------  ---------  --------  --------------  -------------  ---------  -----------------
      CpuBoard_temp(0x4B)           21.5       80.0       N/A             N/A            N/A      False  20220321 02:51:19
          FB_1_temp(0x4D)           22.5       80.0       N/A             N/A            N/A      False  20220321 02:51:19
          FB_2_temp(0x4E)           22.5       80.0       N/A             N/A            N/A      False  20220321 02:51:19
        MB_MAC_temp(0x48)           25         80.0       N/A             N/A            N/A      False  20220321 02:51:19
 MB_RearCenter_temp(0x49)           29.5       80.0       N/A             N/A            N/A      False  20220321 02:51:19
MB_RightCenter_temp(0x4A)           20.5       80.0       N/A             N/A            N/A      False  20220321 02:51:19
               PSU1_TEMP1           15          N/A       N/A             N/A            N/A      False  20220321 02:51:19
               PSU2_TEMP1            0          N/A       N/A             N/A  

root@sonic:/home/admin# sensors
lm75-i2c-18-48
Adapter: i2c-1-mux (chan_id 1)
MB_MAC_temp:  +25.0 C  (high = +80.0 C, hyst = +75.0 C)

lm75-i2c-17-4e
Adapter: i2c-1-mux (chan_id 0)
FB_2_temp:    +22.0 C  (high = +80.0 C, hyst = +75.0 C)

lm75-i2c-18-4a
Adapter: i2c-1-mux (chan_id 1)
MB_RightCenter_temp:  +20.5 C  (high = +80.0 C, hyst = +75.0 C)

coretemp-isa-0000
Adapter: ISA adapter
Package id 0:  +42.0 C  (high = +82.0 C, crit = +104.0 C)
Core 0:        +42.0 C  (high = +82.0 C, crit = +104.0 C)
Core 1:        +42.0 C  (high = +82.0 C, crit = +104.0 C)
Core 2:        +42.0 C  (high = +82.0 C, crit = +104.0 C)
Core 3:        +42.0 C  (high = +82.0 C, crit = +104.0 C)

lm75-i2c-18-49
Adapter: i2c-1-mux (chan_id 1)
MB_RearCenter_temp:  +29.5 C  (high = +80.0 C, hyst = +75.0 C)

fan_ctrl-i2c-17-68
Adapter: i2c-1-mux (chan_id 0)
fan1:        9897 RPM
fan2:        7791 RPM
fan3:        9637 RPM
fan4:        7961 RPM
fan5:        9897 RPM
fan6:        7791 RPM
fan7:        9637 RPM
fan8:        7961 RPM

lm75-i2c-18-4b
Adapter: i2c-1-mux (chan_id 1)
CpuBoard_temp:  +21.5 C  (high = +80.0 C, hyst = +75.0 C)

lm75-i2c-17-4d
Adapter: i2c-1-mux (chan_id 0)
FB_1_temp:    +22.0 C  (high = +80.0 C, hyst = +75.0 C)

psu_pmbus-i2c-10-5b
Adapter: i2c-1-mux (chan_id 1)
in3:          +0.00 V
fan1:           0 RPM
temp1:         +0.0 C
power2:        0.00 W
curr2:        +0.00 A

psu_pmbus-i2c-9-58
Adapter: i2c-1-mux (chan_id 0)
in3:         +12.00 V
fan1:        11600 RPM
temp1:        +15.0 C
power2:      226.00 W
curr2:       +18.88 A
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

