### PR TITLE
[multi-asic]: Skip must field check in config_db for default namespace in multi-asic platform

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -32,7 +32,7 @@ from functools import partial
 from minigraph import minigraph_encoder, parse_xml, parse_device_desc_xml, parse_asic_sub_role, parse_asic_switch_type
 from portconfig import get_port_config, get_breakout_mode
 from redis_bcc import RedisBytecodeCache
-from sonic_py_common.multi_asic import get_asic_id_from_name, get_asic_device_id
+from sonic_py_common.multi_asic import get_asic_id_from_name, get_asic_device_id, is_multi_asic
 from sonic_py_common import device_info
 from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector, SonicDBConfig, ConfigDBPipeConnector
 

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -349,7 +349,10 @@ def main():
         else:
             deep_update(data, parse_xml(minigraph, port_config_file=args.port_config, asic_name=asic_name, hwsku_config_file=args.hwsku_config))
         # check if minigraph parser has speed and lanes in PORT table
-        _must_field_by_yang(data, 'PORT', ['speed', 'lanes'])
+        # speed and lanes will not be present for default namespace for
+        # multi-asic platform.
+        if not is_multi_asic() or asic_name:
+            _must_field_by_yang(data, 'PORT', ['speed', 'lanes'])
 
     if args.device_description is not None:
         deep_update(data, parse_device_desc_xml(args.device_description))


### PR DESCRIPTION
Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
For multi-asic VS testbed bring up, minigraph is copied to DUT and topology service is started.
topology service uses hwsku from minigraph to run the topology script for the right hwsku, using the command below:
```
  HWSKU=`sonic-cfggen -m /etc/sonic/minigraph.xml -v "DEVICE_METADATA['localhost']['hwsku']" 2>&1`
```
The above command fails after PR 10228.
After https://github.com/Azure/sonic-buildimage/pull/10228;   https://github.com/Azure/sonic-buildimage/blob/master/files/image_config/topology/topology.sh#L14 fails to get hwsku as the must-have fields are not present in default namespace for multi-asic platform.

#### How I did it
Check must-have fields only for single asic or only on namespaces in multi-asic platform.

#### How to verify it
Able to generate config_db in multi-asic platform without warning message.
Able to start topology service in multi-asic vs platform.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

