### PR TITLE
[hostcfgd] Restart container if `auto_restart` field in `CONFIG_DB` is `enabled` or `always_enabled`

### DIFF
--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -269,7 +269,7 @@ class FeatureHandler(object):
 
         self._cached_config[feature_name].auto_restart = feature.auto_restart # Update Cache
 
-        restart_config = "always" if feature.auto_restart == "enabled" else "no"
+        restart_config = "always" if "enabled" in feature.auto_restart else "no"
         service_conf = "[Service]\nRestart={}\n".format(restart_config)
         feature_names, feature_suffixes = self.get_feature_attribute(feature)
 


### PR DESCRIPTION
Signed-off-by: Yong Zhao <yozhao@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR aims to enable a container to be auto-restarted if `auto_restart` field in `FEATURE` table is set to `enabled` or `always_enabled`.

#### How I did it
This PR determines whether the keyword `enabled` appears in `auto_restart` field or not.

#### How to verify it
This PR is tested on the DuT `str-s6000-on-5`.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

