### PR TITLE
[Arista] Fix arista-net initramfs hook

### DIFF
--- a/files/initramfs-tools/arista-net
+++ b/files/initramfs-tools/arista-net
@@ -47,7 +47,9 @@ arista_net_rename() {
     local new_name="$2"
     local from_name="$3"
     devname=$(arista_net_devname "$device_path" "$from_name")
-    [ -n "$devname" ] && ip link set "$devname" name "$new_name"
+    if [ -n "$devname" ]; then
+        ip link set "$devname" name "$new_name"
+    fi
 }
 
 # Sets the MAC address to the value passed by Aboot through /proc/cmdline


### PR DESCRIPTION
#### Why I did it

The `arista-net` initramfs hook exits early when a mgmt NIC is missing.
This leads to mgmt interfaces not properly renamed and possibly `eth0` missing.

#### How I did it

Fixed the line in `arista-net` that fails when one NIC is missing.
The error is tied to the syntax which is incompatible with `set -e`

#### How to verify it

Tested on products where one of the management NIC is missing.

#### Which release branch to backport (provide reason below if selected)

Backport will be made manually to 202111 and 202012 as `arista-net`
has changed since.

#### Description for the changelog
Fix `arista-net` initramfs hook when a mgmt NIC is missing

