### PR TITLE
[202111][Arista] Fix arista-net initramfs renaming logic

### DIFF
--- a/files/initramfs-tools/arista-net
+++ b/files/initramfs-tools/arista-net
@@ -47,7 +47,9 @@ arista_net_rename() {
     local new_name="$2"
     local from_name="$3"
     devname=$(arista_net_devname "$device_path" "$from_name")
-    [ -n "$devname" ] && ip link set "$devname" name "$new_name"
+    if [ -n "$devname" ]; then
+        ip link set "$devname" name "$new_name"
+    fi
 }
 
 # Sets the MAC address to the value passed by Aboot through /proc/cmdline

--- a/files/initramfs-tools/arista-net
+++ b/files/initramfs-tools/arista-net
@@ -95,19 +95,33 @@ fi
 # Iterate over all the net_maX items found in the cmdline two times.
 # First time renaming the interfaces to maX.
 # The second time renaming them to their final name ethX.
-if [ -n "$aboot_flag" -a "$platform_flag" == 'rook' ]; then
-    for item in $items; do
-        key="${item%=*}"
-        value="${item#*=}"
-        arista_net_rename "$value" "$key" eth
-    done
-    for item in $items; do
-        key="${item%=*}"
-        value="${item#*=}"
-        index="${key#ma}"
-        index="$(( $index - 1 ))"
-        newKey="eth$index"
-        arista_net_rename "$value" "$newKey" ma
-    done
+if [ -n "$aboot_flag" ]; then
+   if [ "$platform_flag" = 'rook' -o "$platform_flag" = 'lorikeet' ]; then
+      # Rename existing ethX interfaces to tmpX
+      for x in $(ls /sys/class/net/); do
+         case $x in
+            eth*)
+               value="${x#*eth}"
+               newname="tmp$value"
+               ip link set $x down
+               ip link set $x name "$newname"
+               ;;
+            *)
+         esac
+      done
+      for item in $items; do
+         key="${item%=*}"
+         value="${item#*=}"
+         arista_net_rename "$value" "$key" tmp
+      done
+      for item in $items; do
+         key="${item%=*}"
+         value="${item#*=}"
+         index="${key#ma}"
+         index="$(( $index - 1 ))"
+         newKey="eth$index"
+         arista_net_rename "$value" "$newKey" ma
+      done
+   fi
 fi
 


### PR DESCRIPTION
#### Why I did it

Part of this change is a missing backport of #9856 in 202111.
The second part is the fix for `arista-net` renaming logic fixed by #10624 in master.

#### Description for the changelog

Fix `arista-net` management interface rename logic in initramfs 



