### PR TITLE
[202012][Arista] Fix arista-net initramfs hook

### DIFF
--- a/files/initramfs-tools/arista-net
+++ b/files/initramfs-tools/arista-net
@@ -47,7 +47,9 @@ arista_net_rename() {
     local new_name="$2"
     local from_name="$3"
     devname=$(arista_net_devname "$device_path" "$from_name")
-    [ -n "$devname" ] && ip link set "$devname" name "$new_name"
+    if [ -n "$devname" ]; then
+        ip link set "$devname" name "$new_name"
+    fi
 }
 
 # Sets the MAC address to the value passed by Aboot through /proc/cmdline


### PR DESCRIPTION
#### Why I did it

Backport from #10624 

#### Description for the changelog

Fix `arista-net` management interface rename logic in initramfs
