### PR TITLE
[YANG][vlan-sub-intf] Enforce Linux interface name length

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vlan_sub_interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vlan_sub_interface.json
@@ -9,6 +9,10 @@
         "desc": "Configure vlan sub interface must condition false.",
         "eStrKey": "Must"
     },
+    "VLAN_SUB_INTERFACE_NAME_LENGTH_LIMIT_MUST_CONDITION_FALSE_TEST": {
+        "desc": "Configure vlan sub interface name length must condition false.",
+        "eStrKey": "Must"
+    },
     "VLAN_SUB_INTERFACE_SHORT_NAME_FORMAT_MUST_CONDITION_FALSE_TEST": {
         "desc": "Configure short name format vlan sub interface must condition false.",
         "eStrKey": "Must"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vlan_sub_interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vlan_sub_interface.json
@@ -20,6 +20,9 @@
     "VLAN_SUB_INTERFACE_PO_SHORT_NAME_FORMAT_MUST_CONDITION_TRUE_TEST": {
         "desc": "Configure valid portchannel short name format vlan sub interface  must condition true."
     },
+    "VLAN_SUB_INTERFACE_PO_MUST_CONDITION_TRUE_TEST": {
+        "desc": "Configure portchannel long name format vlan sub interface must condition true."
+    },
     "VLAN_SUB_INTERFACE_PO_MUST_CONDITION_FALSE_TEST": {
         "desc": "Configure portchannel long name format vlan sub interface must condition false.",
         "eStrKey": "Must"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan_sub_interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan_sub_interface.json
@@ -95,6 +95,38 @@
             }
         }
     },
+    "VLAN_SUB_INTERFACE_NAME_LENGTH_LIMIT_MUST_CONDITION_FALSE_TEST": {
+        "sonic-vlan-sub-interface:sonic-vlan-sub-interface": {
+            "sonic-vlan-sub-interface:VLAN_SUB_INTERFACE": {
+                "VLAN_SUB_INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet12000.10"
+                    }
+                ],
+                "VLAN_SUB_INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "name": "Ethernet12000.10",
+                        "ip-prefix": "10.0.0.1/30"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet12000",
+                        "admin_status": "up",
+                        "alias": "Ethernet12000/1",
+                        "description": "Ethernet12000",
+                        "lanes": "49,50,51,52",
+                        "mtu": 9000,
+                        "speed": 100000
+                    }
+                ]
+            }
+        }
+    },
     "VLAN_SUB_INTERFACE_SHORT_NAME_FORMAT_MUST_CONDITION_FALSE_TEST": {
         "sonic-vlan-sub-interface:sonic-vlan-sub-interface": {
             "sonic-vlan-sub-interface:VLAN_SUB_INTERFACE": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan_sub_interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan_sub_interface.json
@@ -209,6 +209,56 @@
             }
         }
     },
+    "VLAN_SUB_INTERFACE_PO_MUST_CONDITION_TRUE_TEST": {
+        "sonic-vlan-sub-interface:sonic-vlan-sub-interface": {
+            "sonic-vlan-sub-interface:VLAN_SUB_INTERFACE": {
+                "VLAN_SUB_INTERFACE_LIST": [
+                    {
+                        "name": "PortChannel01.8"
+                    }
+                ],
+                "VLAN_SUB_INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "name": "PortChannel01.8",
+                        "ip-prefix": "10.0.0.1/30"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "tpid": "0x8100",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "members": [
+                            "Ethernet0"
+                        ],
+                        "min_links": "1",
+                        "mtu": "9100",
+                        "tpid": "0x8100",
+                        "lacp_key": "auto",
+                        "name": "PortChannel01"
+                    }
+                ]
+            }
+        }
+    },
     "VLAN_SUB_INTERFACE_PO_MUST_CONDITION_FALSE_TEST": {
         "sonic-vlan-sub-interface:sonic-vlan-sub-interface": {
             "sonic-vlan-sub-interface:VLAN_SUB_INTERFACE": {

--- a/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
@@ -40,11 +40,11 @@ module sonic-vlan-sub-interface {
                 key "name";
 
                 leaf name {
-                    must "(substring-before(current(), '.') = /port:sonic-port/port:PORT/port:PORT_LIST/port:name) or " +
-                         "(starts-with(substring-before(current(), '.'), 'Eth') and " +
-                         "concat('Ethernet', substring-after(substring-before(current(), '.'), 'Eth')) = /port:sonic-port/port:PORT/port:PORT_LIST/port:name) or " +
-                         "(starts-with(substring-before(current(), '.'), 'Po') and " +
-                         "concat('PortChannel', substring-after(substring-before(current(), '.'), 'Po')) = /lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:name)"
+                    must "(string-length(current()) <= 15) and " +
+                         "((substring-before(current(), '.') = /port:sonic-port/port:PORT/port:PORT_LIST/port:name) or " +
+                         "(starts-with(substring-before(current(), '.'), 'Eth') and concat('Ethernet', substring-after(substring-before(current(), '.'), 'Eth')) = /port:sonic-port/port:PORT/port:PORT_LIST/port:name) or " +
+                         "(substring-before(current(), '.') = /lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:name) or " +
+                         "(starts-with(substring-before(current(), '.'), 'Po') and concat('PortChannel', substring-after(substring-before(current(), '.'), 'Po')) = /lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:name))"
                     {
                         error-message "Must condition not satisfied, please follow vlan sub interface naming convention";
                     }


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Allow portchannel vlan sub intf long name format as long as it follows Linux interface name length limit(<16).

#### How I did it
Modify the leaf name check.

#### How to verify it
Test case passes.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

