### PR TITLE
[Build] Upgrade pip3 package docker to 5.0.3 (#10523)

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -435,7 +435,7 @@ sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install 'setup
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install 'wheel==0.35.1'
 
 # docker Python API package is needed by Ansible docker module as well as some SONiC applications
-sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install 'docker==4.3.1'
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install 'docker==5.0.3'
 
 # Install scapy
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install 'scapy==2.4.4'

--- a/files/build/versions/host-image/versions-py3
+++ b/files/build/versions/host-image/versions-py3
@@ -11,7 +11,7 @@ click-log==0.4.0
 colorful==0.5.4
 cryptography==36.0.2
 dbus-python==1.2.18
-docker==4.3.1
+docker==5.0.3
 docker-image-py==0.1.12
 enlighten==1.10.2
 filelock==3.6.0


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Cherry-pick PR: https://github.com/Azure/sonic-buildimage/pull/10523
In sonic-utilities repo, it is required to install docker>=4.4.4
https://github.com/Azure/sonic-utilities/blob/f70dc27827a88d70e91e15ecdcde2ebbc446116d/setup.py#L187

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

