### PR TITLE
[sonic-host-services]: Fix import and invalid path

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -75,12 +75,6 @@ else
     sudo chroot $FILESYSTEM_ROOT $DOCKER_CTL_SCRIPT start
 fi
 
-# Apply apt configuration files
-sudo cp $IMAGE_CONFIGS/apt/sources.list $FILESYSTEM_ROOT/etc/apt/
-sudo mkdir -p $FILESYSTEM_ROOT/etc/apt/sources.list.d/
-sudo cp -R $IMAGE_CONFIGS/apt/sources.list.d/${CONFIGURED_ARCH}/* $FILESYSTEM_ROOT/etc/apt/sources.list.d/
-cat $IMAGE_CONFIGS/apt/sonic-dev.gpg.key | sudo LANG=C chroot $FILESYSTEM_ROOT apt-key add -
-
 # Update apt's snapshot of its repos
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get update
 

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -75,6 +75,12 @@ else
     sudo chroot $FILESYSTEM_ROOT $DOCKER_CTL_SCRIPT start
 fi
 
+# Apply apt configuration files
+sudo cp $IMAGE_CONFIGS/apt/sources.list $FILESYSTEM_ROOT/etc/apt/
+sudo mkdir -p $FILESYSTEM_ROOT/etc/apt/sources.list.d/
+sudo cp -R $IMAGE_CONFIGS/apt/sources.list.d/${CONFIGURED_ARCH}/* $FILESYSTEM_ROOT/etc/apt/sources.list.d/
+cat $IMAGE_CONFIGS/apt/sonic-dev.gpg.key | sudo LANG=C chroot $FILESYSTEM_ROOT apt-key add -
+
 # Update apt's snapshot of its repos
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get update
 
@@ -233,7 +239,7 @@ sudo cp -f $IMAGE_CONFIGS/bash/bash.bashrc $FILESYSTEM_ROOT/etc/
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install libcairo2-dev libdbus-1-dev libgirepository1.0-dev libsystemd-dev pkg-config
 
 # Mark runtime dependencies as manually installed to avoid them being auto-removed while uninstalling build dependencies
-sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-mark manual gir1.2-glib-2.0 libdbus-1-3 libgirepository-1.0-1 libsystemd0
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-mark manual gir1.2-glib-2.0 libdbus-1-3 libgirepository-1.0-1 libsystemd0 python3-dbus
 
 # Install SONiC host services package
 SONIC_HOST_SERVICES_PY3_WHEEL_NAME=$(basename {{sonic_host_services_py3_wheel_path}})

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -235,6 +235,9 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
 # Mark runtime dependencies as manually installed to avoid them being auto-removed while uninstalling build dependencies
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-mark manual gir1.2-glib-2.0 libdbus-1-3 libgirepository-1.0-1 libsystemd0 python3-dbus
 
+# Install systemd-python for SONiC host services
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install systemd-python
+
 # Install SONiC host services package
 SONIC_HOST_SERVICES_PY3_WHEEL_NAME=$(basename {{sonic_host_services_py3_wheel_path}})
 sudo cp {{sonic_host_services_py3_wheel_path}} $FILESYSTEM_ROOT/$SONIC_HOST_SERVICES_PY3_WHEEL_NAME

--- a/src/sonic-host-services/scripts/sonic-host-server
+++ b/src/sonic-host-services/scripts/sonic-host-server
@@ -18,8 +18,7 @@ def find_module_path():
     try:
         from host_modules import host_service
         return os.path.dirname(host_service.__file__)
-    except Exception as e:
-        print("error occurred in find_module_path: {}".format(sys.exc_info()[1]))
+    except ImportError as e:
         return None
 
 def register_modules(mod_path):

--- a/src/sonic-host-services/scripts/sonic-host-server
+++ b/src/sonic-host-services/scripts/sonic-host-server
@@ -18,7 +18,8 @@ def find_module_path():
     try:
         from host_modules import host_service
         return os.path.dirname(host_service.__file__)
-    except:
+    except Exception as e:
+        print("error occurred in find_module_path: {}".format(sys.exc_info()[1]))
         return None
 
 def register_modules(mod_path):

--- a/src/sonic-host-services/scripts/sonic-host-server
+++ b/src/sonic-host-services/scripts/sonic-host-server
@@ -15,11 +15,11 @@ from gi.repository import GObject
 
 def find_module_path():
     """Find path for host_moduels"""
-    for path in sys.path:
-        mod_path = path + '/host_modules'
-        if os.path.exists(mod_path):
-            return mod_path
-    return None
+    try:
+        from host_modules import host_service
+        return os.path.dirname(host_service.__file__)
+    except:
+        return None
 
 def register_modules(mod_path):
     """Register all host modules"""

--- a/src/sonic-host-services/scripts/sonic-host-server
+++ b/src/sonic-host-services/scripts/sonic-host-server
@@ -13,9 +13,16 @@ import dbus.mainloop.glib
 
 from gi.repository import GObject
 
-def register_modules():
+def find_module_path():
+    """Find path for host_moduels"""
+    for path in sys.path:
+        mod_path = path + '/host_modules'
+        if os.path.exists(mod_path):
+            return mod_path
+    return None
+
+def register_modules(mod_path):
     """Register all host modules"""
-    mod_path = '/usr/local/lib/python3.7/dist-packages/host_modules'
     sys.path.append(mod_path)
     for mod_file in glob.glob(os.path.join(mod_path, '*.py')):
         if os.path.isfile(mod_file) and not mod_file.endswith('__init__.py'):
@@ -62,7 +69,9 @@ class SignalManager(object):
         loop.quit()
 
 sigmgr = SignalManager()
-register_modules()
+mod_path = find_module_path()
+if mod_path is not None:
+    register_modules(mod_path)
 
 # Only run if we actually have some handlers
 if handlers:

--- a/src/sonic-host-services/setup.py
+++ b/src/sonic-host-services/setup.py
@@ -24,6 +24,7 @@ setup(
     ],
     install_requires = [
         'dbus-python',
+        'systemd-python',
         'Jinja2>=2.10',
         'PyGObject',
         'sonic-py-common'


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Can not start sonic-hostservice

#### How I did it
Install python3-dbus and systemd-python, and replace invalid path

#### How to verify it
Start the service with below commands:
sudo systemctl start sonic-hostservice
sudo systemctl status sonic-hostservice


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix #10647

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

