### PR TITLE
Fix buffer template for Arista SKU.

### DIFF
--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/buffers_defaults_t2.j2
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/buffers_defaults_t2.j2
@@ -1,4 +1,3 @@
-
 {%- set default_cable = '5m' %}
 
 {%- macro generate_port_lists(PORT_ALL) %}
@@ -19,7 +18,7 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"1280",
             "dynamic_th":"-2",
             "xon_offset":"2560",
@@ -27,18 +26,18 @@
             "xoff":"66048"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "xon_offset":"0",
             "static_th":"30535680"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"33030144"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"-1"
         }
@@ -49,17 +48,17 @@
     "BUFFER_QUEUE": {
 {% for port in port_names.split(',') %}
         "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
 {% endfor %}
 {% for port in port_names.split(',') %}
         "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }{% if not loop.last %},{% endif %}
 {% endfor %}   
     }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The buffer pool & profile setting in buffer template was not correct and caused the errors like the following:

ERR swss#orchagent: :- parseReference: malformed reference:[BUFFER_PROFILE|ingress_lossless_profile]. Must not be surrounded by [ ] 

#### How I did it
Fix the buffer pool & profile setting by removing "[]".

#### How to verify it
Loaded image with this fix in a switch and made sure the error was not seen anymore.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

