### PR TITLE
Change source path for sonic-pcied to use Python 3 variable

### DIFF
--- a/rules/sonic-pcied.dep
+++ b/rules/sonic-pcied.dep
@@ -1,4 +1,4 @@
-SPATH:= $($(SONIC_PCIED_PY2)_SRC_PATH)
+SPATH:= $($(SONIC_PCIED_PY3)_SRC_PATH)
 DEP_FILES:= $(SONIC_COMMON_FILES_LIST) rules/sonic-pcied.mk rules/sonic-pcied.dep
 DEP_FILES+= $(SONIC_COMMON_BASE_FILES_LIST)
 SMDEP_FILES:= $(addprefix $(SPATH)/,$(shell cd $(SPATH) && git ls-files))


### PR DESCRIPTION
Python 2 support for sonic-pcied was removed, and the Python 2 version
of the variable no longer exists.

Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

