### PR TITLE
Revert "[sonic-cfggen] make minigraph parser fail when speed and lanes are not in PORT table (#10228)

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -247,19 +247,6 @@ def _get_jinja2_env(paths):
 
     return env
 
-def _must_field_by_yang(data, table, must_fields):
-    """
-    Check if table contains must field based on yang definition
-    """
-    if table not in data:
-        return
-
-    for must_field in must_fields:
-        for _, fields in data[table].items():
-            if must_field not in fields:
-                print(must_field, 'is a must field in', table, file=sys.stderr)
-                sys.exit(1)
-
 def main():
     parser=argparse.ArgumentParser(description="Render configuration file from minigraph data and jinja2 template.")
     group = parser.add_mutually_exclusive_group()
@@ -354,8 +341,6 @@ def main():
                 deep_update(data, parse_xml(minigraph, platform, asic_name=asic_name))
         else:
             deep_update(data, parse_xml(minigraph, port_config_file=args.port_config, asic_name=asic_name, hwsku_config_file=args.hwsku_config))
-        # check if minigraph parser has speed and lanes in PORT table
-        _must_field_by_yang(data, 'PORT', ['speed', 'lanes'])
 
     if args.device_description is not None:
         deep_update(data, parse_device_desc_xml(args.device_description))


### PR DESCRIPTION
This reverts commit cd330f0e70e646c2ff6fc88c6c8fb9f75e8b40e7.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Revert the PORT table mandatory field check to avoid possible blocks for production flow.
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

