### PR TITLE
[centec] fix some bugs on centec tsingma bsp and v682 sonic_platform package

### DIFF
--- a/platform/centec-arm64/tsingma-bsp/src/ctc-phy/mars.c
+++ b/platform/centec-arm64/tsingma-bsp/src/ctc-phy/mars.c
@@ -314,3 +314,6 @@ static struct mdio_device_id __maybe_unused mars_tbl[] = {
 };
 
 MODULE_DEVICE_TABLE(mdio, mars_tbl);
+
+MODULE_AUTHOR("Centec, Inc.");
+MODULE_LICENSE("GPL");

--- a/platform/centec-arm64/tsingma-bsp/src/i2c-ctc/i2c-ctc.c
+++ b/platform/centec-arm64/tsingma-bsp/src/i2c-ctc/i2c-ctc.c
@@ -789,6 +789,11 @@ static int ctc_i2c_plat_probe(struct platform_device *pdev)
 	of_property_read_u32(pdev->dev.of_node, "clock-frequency", &clk_freq);
 
 	dev->clk_freq = clk_freq;
+
+	dev->functionality = I2C_FUNC_10BIT_ADDR | CTC_IC_DEFAULT_FUNCTIONALITY;
+	dev->master_cfg = CTC_IC_CON_MASTER | CTC_IC_CON_SLAVE_DISABLE |
+		CTC_IC_CON_RESTART_EN;
+
 	if (dev->clk_freq <= 100000)
 		dev->master_cfg |= CTC_IC_CON_SPEED_STD;
 	else if (dev->clk_freq <= 400000)

--- a/platform/centec/sonic-platform-modules-v682/48x8c/sonic_platform/sfp.py
+++ b/platform/centec/sonic-platform-modules-v682/48x8c/sonic_platform/sfp.py
@@ -383,7 +383,7 @@ class Sfp(SfpBase):
 
         try:
             with open(self.port_to_eeprom_mapping[self.port_num], mode='rb', buffering=0) as fd:
-                fd.read()
+                fd.read(256)
         except IOError:
             return False
 

--- a/platform/centec/sonic-platform-modules-v682/48y8c/sonic_platform/sfp.py
+++ b/platform/centec/sonic-platform-modules-v682/48y8c/sonic_platform/sfp.py
@@ -383,7 +383,7 @@ class Sfp(SfpBase):
 
         try:
             with open(self.port_to_eeprom_mapping[self.port_num], mode='rb', buffering=0) as fd:
-                fd.read()
+                fd.read(256)
         except IOError:
             return False
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix some bugs on centec tsingma bsp and v682 sonic_platform package.

#### How I did it
1.  add module license for centec mars phy driver
2.  Fix i2c function ability setting for tsingma soc i2c controller
3.  Fix eeprom read error on v682 sonic_platform sfp module

#### How to verify it
Build SONiC image and verify it on centec E530-48T4X and V682-48Y8C board.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

