### PR TITLE
[DellEMC][201911] S6100 S6000 - Show techsupport enhancement porting changes

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/common/actions.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/common/actions.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+platform="$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)"
+TMP_DIR="/tmp/hw-mgmt-dump"
+rm -rf $TMP_DIR
+mkdir $TMP_DIR
+
+save_cmd(){
+    TOUT=$1
+    CMD=$2
+    CMD_NAME=$3
+
+    echo "##### $CMD_NAME #####">> $TMP_DIR/hw-mgmt-dump.txt
+    eval timeout $TOUT $CMD >> $TMP_DIR/hw-mgmt-dump.txt
+}
+
+tar_file(){
+    tar czf /tmp/hw-mgmt-dump.tar.gz -C $TMP_DIR .
+    rm -rf $TMP_DIR
+}
+

--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6000.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6000.install
@@ -2,9 +2,11 @@ s6000/scripts/s6000_platform.sh usr/local/bin
 s6000/scripts/reset-qsfp usr/local/bin
 s6000/scripts/set-fan-speed usr/local/bin
 s6000/scripts/fancontrol.sh usr/local/bin
+s6000/scripts/hw-management-generate-dump.sh usr/bin
 s6000/systemd/platform-modules-s6000.service etc/systemd/system
 s6000/systemd/fancontrol.service etc/systemd/system
 common/io_rd_wr.py usr/local/bin
+common/actions.sh usr/share/sonic/device/x86_64-dell_s6000_s1220-r0
 s6000/scripts/platform_reboot_override usr/share/sonic/device/x86_64-dell_s6000_s1220-r0
 s6000/scripts/platform_update_reboot_cause usr/share/sonic/device/x86_64-dell_s6000_s1220-r0
 s6000/scripts/override.conf /etc/systemd/system/systemd-reboot.service.d

--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
@@ -14,9 +14,11 @@ s6100/scripts/soft-reboot_plugin usr/share/sonic/device/x86_64-dell_s6100_c2538-
 s6100/scripts/override.conf /etc/systemd/system/systemd-reboot.service.d
 s6100/scripts/s6100_serial_getty_monitor etc/monit/conf.d
 common/dell_lpc_mon.sh usr/local/bin
+common/actions.sh usr/share/sonic/device/x86_64-dell_s6100_c2538-r0
 s6100/scripts/s6100_ssd_mon.sh usr/local/bin
 s6100/scripts/s6100_ssd_upgrade_status.sh usr/local/bin
 s6100/scripts/platform_sensors.py usr/local/bin
+s6100/scripts/hw-management-generate-dump.sh usr/bin
 s6100/scripts/platform_reboot_pre_check usr/share/sonic/device/x86_64-dell_s6100_c2538-r0
 s6100/modules/sonic_platform-1.0-py2-none-any.whl usr/share/sonic/device/x86_64-dell_s6100_c2538-r0
 s6100/scripts/platform_watchdog_enable.sh usr/local/bin

--- a/platform/broadcom/sonic-platform-modules-dell/s6000/scripts/hw-management-generate-dump.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6000/scripts/hw-management-generate-dump.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+platform="$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)"
+source /usr/share/sonic/device/$platform/actions.sh
+
+I2C_ADAPTER="/sys/class/i2c-adapter"
+
+save_cmd "10" "hexdump -C /dev/nvram" "NVRAM dump"
+save_cmd "10" "hexdump -C $I2C_ADAPTER/i2c-10/10-0053/eeprom" "System EEPROM"
+save_cmd "10" "grep -H '' /sys/devices/platform/dell-s6000-cpld.0/*" "CPLD"
+
+save_cmd "10" "grep -H '' $I2C_ADAPTER/i2c-11/11-0029/*" "FAN"
+save_cmd "10" "grep -H '' $I2C_ADAPTER/i2c-11/11-0029/hwmon/hwmon*/*" "FAN"
+save_cmd "10" "grep -H '' $I2C_ADAPTER/i2c-11/11-002a/*" "FAN"
+save_cmd "10" "grep -H '' $I2C_ADAPTER/i2c-11/11-002a/hwmon/hwmon*/*" "FAN"
+save_cmd "10" "grep -H '' $I2C_ADAPTER/i2c-11/11-0042/hwmon/hwmon*/*" "PSU"
+save_cmd "10" "grep -H '' $I2C_ADAPTER/i2c-11/11-0040/hwmon/hwmon*/*" "PSU"
+
+save_cmd "10" "grep -H '' $I2C_ADAPTER/i2c-11/11-004c/*" "TMP75"
+save_cmd "10" "grep -H '' $I2C_ADAPTER/i2c-11/11-004c/hwmon/hwmon*/*" "TMP75"
+save_cmd "10" "grep -H '' $I2C_ADAPTER/i2c-11/11-004d/*" "TMP75"
+save_cmd "10" "grep -H '' $I2C_ADAPTER/i2c-11/11-004d/hwmon/hwmon*/*" "TMP75"
+save_cmd "10" "grep -H '' $I2C_ADAPTER/i2c-11/11-004e/*" "TMP75"
+save_cmd "10" "grep -H '' $I2C_ADAPTER/i2c-11/11-004e/hwmon/hwmon*/*" "TMP75"
+
+INDEX=20
+while [ $INDEX -lt 52 ]; do
+    save_cmd "10" "hexdump -C $I2C_ADAPTER/i2c-$INDEX/$INDEX-0050/eeprom" "SFP ports"
+    save_cmd "10" "grep -H '' $I2C_ADAPTER/i2c-$INDEX/$INDEX-0050/name $I2C_ADAPTER/i2c-$INDEX/$INDEX-0050/modalias" "SFP ports"
+    let INDEX=$INDEX+1
+done
+
+save_cmd "10" "smartctl -a /dev/sda" "SSD"
+save_cmd "10" "sgdisk -p /dev/sda" "SSD Partitions"
+
+save_cmd "10" "cat /host/reboot-cause/reboot-cause.txt" "Reboot Reason"
+save_cmd "10" "show reboot-cause" "Reboot cause"
+
+tar_file

--- a/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/hw-management-generate-dump.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s6100/scripts/hw-management-generate-dump.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+platform="$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)"
+source /usr/share/sonic/device/$platform/actions.sh
+
+I2C_ADAPTER="/sys/class/i2c-adapter"
+
+save_cmd "10" "hexdump -C /dev/port" "SMF dump"
+save_cmd "10" "hexdump -C /dev/nvram" "NVRAM dump"
+save_cmd "30" "sfputil show eeprom" "SFPUTIL eeprom"
+save_cmd "10" "hexdump -C $I2C_ADAPTER/i2c-2/2-0050/eeprom" "System EEPROM"
+save_cmd "10" "hexdump -C $I2C_ADAPTER/i2c-14/14-0050/eeprom" "IOM 1 EEPROM"
+save_cmd "10" "hexdump -C $I2C_ADAPTER/i2c-16/16-0050/eeprom" "IOM 2 EEPROM"
+save_cmd "10" "hexdump -C $I2C_ADAPTER/i2c-15/15-0050/eeprom" "IOM 3 EEPROM"
+save_cmd "10" "hexdump -C $I2C_ADAPTER/i2c-17/17-0050/eeprom" "IOM 4 EEPROM"
+
+save_cmd "10" "pcisysfs.py --get --offset 0x108 --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0 " "ISMT MCTRL"
+save_cmd "10" "pcisysfs.py --get --offset 0x10c --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0 " "ISMT MSTS"
+save_cmd "10" "pcisysfs.py --get --offset 0x38c --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0 " "ISMT DBSTS"
+save_cmd "10" "pcisysfs.py --get --offset 0x300 --res /sys/devices/pci0000\:00/0000\:00\:13.0/resource0 " "ISMT SPGT"
+
+IOM_INDEX=66
+CURRENT_IOM=1
+while [ $CURRENT_IOM -lt 5 ]; do
+    let CHANNEL=$CURRENT_IOM+3
+    let I2C_SWITCH=$CURRENT_IOM+5
+    let PORT_INDEX=$IOM_INDEX
+    SECOND_CHANNEL=0
+    while [ $SECOND_CHANNEL -lt 8 ]; do
+        save_cmd "10" "hexdump -C $I2C_ADAPTER/i2c-0/0-0070/channel-$CHANNEL/$I2C_SWITCH-0071/channel-$SECOND_CHANNEL/$PORT_INDEX-0050/eeprom" "First 8 ports of IOM $CURRENT_IOM PORT $PORT_INDEX"
+        let PORT_INDEX=$PORT_INDEX+1
+        let SECOND_CHANNEL=$SECOND_CHANNEL+1
+    done
+    SECOND_CHANNEL=0
+    while [ $SECOND_CHANNEL -lt 8 ]; do
+        save_cmd "10" "hexdump -C $I2C_ADAPTER/i2c-0/0-0070/channel-$CHANNEL/$I2C_SWITCH-0072/channel-$SECOND_CHANNEL/$PORT_INDEX-0050/eeprom" "Second 8 ports of IOM $CURRENT_IOM PORT $PORT_INDEX"
+        let PORT_INDEX=$PORT_INDEX+1
+        let SECOND_CHANNEL=$SECOND_CHANNEL+1
+    done
+    let IOM_INDEX=$IOM_INDEX-16
+    let CURRENT_IOM=$CURRENT_IOM+1
+done
+
+save_cmd "10" "hexdump -C $I2C_ADAPTER/i2c-0/0-0070/channel-2/4-0071/channel-4/14-003e/modalias" "IOM 1 CPLD MUX"
+save_cmd "10" "hexdump -C $I2C_ADAPTER/i2c-0/0-0070/channel-2/4-0071/channel-6/16-003e/modalias" "IOM 2 CPLD MUX"
+save_cmd "10" "hexdump -C $I2C_ADAPTER/i2c-0/0-0070/channel-2/4-0071/channel-5/15-003e/modalias" "IOM 3 CPLD MUX"
+save_cmd "10" "hexdump -C $I2C_ADAPTER/i2c-0/0-0070/channel-2/4-0071/channel-7/17-003e/modalias" "IOM 4 CPLD MUX"
+
+save_cmd "10" "hexdump -C $I2C_ADAPTER/i2c-0/0-0070/channel-2/4-0071/channel-1/11-0050/eeprom" "SFP ports"
+save_cmd "10" "hexdump -C $I2C_ADAPTER/i2c-0/0-0070/channel-2/4-0071/channel-2/12-0050/eeprom" "SFP ports"
+
+save_cmd "10" "grep -H '' $I2C_ADAPTER/i2c-14/14-003e/*" "IOM1"
+save_cmd "10" "grep -H '' $I2C_ADAPTER/i2c-16/16-003e/*" "IOM2"
+save_cmd "10" "grep -H '' $I2C_ADAPTER/i2c-15/15-003e/*" "IOM3"
+save_cmd "10" "grep -H '' $I2C_ADAPTER/i2c-17/17-003e/*" "IOM4"
+
+save_cmd "30" "grep -H '' /sys/devices/platform/SMF.512/hwmon/hwmon*/*" "SMF DIR"
+save_cmd "10" "i2cdetect -l" "I2C trees"
+
+save_cmd "10" "smartctl -a /dev/sda" "SSD"
+save_cmd "10" "sgdisk -p /dev/sda" "SSD partitions"
+
+save_cmd "10" "cat /host/reboot-cause/platform/reset_reason" "Reset Reason"
+save_cmd "10" "cat /host/reboot-cause/platform/reboot_reason" "Reboot Reason"
+save_cmd "10" "cat /host/reboot-cause/platform/bios_minor_version" "BIOS Version"
+save_cmd "10" "show reboot-cause" "Reboot cause"
+
+tar_file


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
- To collect platform based logs along with "show techsupport" on S6000 and S6100 platforms.
- Porting changes of https://github.com/Azure/sonic-buildimage/pull/6410 from master branch to 201911 branch.

#### How I did it
On branch 201911_dell_techsupport_dump
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        new file:   platform/broadcom/sonic-platform-modules-dell/common/actions.sh
        modified:   platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6000.install
        modified:   platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-s6100.install
        new file:   platform/broadcom/sonic-platform-modules-dell/s6000/scripts/hw-management-generate-dump.sh
        new file:   platform/broadcom/sonic-platform-modules-dell/s6100/scripts/hw-management-generate-dump.sh

#### How to verify it
hw-mgmt-dump.tar.gz will be found in sonic_dump__< YYYYMMDD_HHMMSS>.tar.gz.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

