### PR TITLE
[Build]: Fix the build target not existing issue when building sonic-rest-api

### DIFF
--- a/rules/restapi.mk
+++ b/rules/restapi.mk
@@ -1,6 +1,6 @@
 # sonic-rest-api package
 
-RESTAPI = sonic-rest-api_1.0.1_amd64.deb
+RESTAPI = sonic-rest-api_1.0.1_$(CONFIGURED_ARCH).deb
 $(RESTAPI)_SRC_PATH = $(SRC_PATH)/sonic-restapi
 $(RESTAPI)_DEPENDS += $(LIBHIREDIS_DEV) $(LIBNL3_DEV) $(LIBNL_GENL3_DEV) \
                             $(LIBNL_ROUTE3_DEV) $(LIBSWSSCOMMON_DEV) $(LIBSWSSCOMMON)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix target target/debs/bullseye/sonic-rest-api_1.0.1_arm64.deb not existing issue, the correct target is target/debs/bullseye/sonic-rest-api_1.0.1_armhf.deb.
Fix issue: https://github.com/Azure/sonic-buildimage/issues/9896
```
[ FAIL LOG START ] [ target/debs/stretch/sonic-rest-api_1.0.1_amd64.deb ]
[ REASON ] :      target/debs/stretch/sonic-rest-api_1.0.1_amd64.deb does not exist   NON-EXISTENT PREREQUISITES: 
[ FLAGS  FILE    ] : [] 
```

#### How I did it

#### How to verify it
make target/debs/bullseye/sonic-rest-api_1.0.1_armhf.deb

```
$ ls target/debs/bullseye/sonic-rest-api_1.0.1_armhf.deb
target/debs/bullseye/sonic-rest-api_1.0.1_armhf.deb
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

