### PR TITLE
[dhcp_relay] Requires IP address on client vlan interface

### DIFF
--- a/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
+++ b/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
@@ -1,19 +1,11 @@
 [group:dhcpmon]
 programs=
 {%- set add_preceding_comma = { 'flag': False } %}
-{% set monitor_instance = { 'flag': False } %}
 {% for vlan_name in VLAN_INTERFACE %}
-{% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
-{% set _dummy = monitor_instance.update({'flag': True}) %}
-{%- endif %}
-{% if VLAN and vlan_name in VLAN and 'dhcpv6_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcpv6_servers']|length > 0 %}
-{% set _dummy = monitor_instance.update({'flag': True}) %}
-{%- endif %}
-{% if monitor_instance.flag %}
+{% if vlan_name in ipv4_vlan_interfaces or vlan_name in ipv6_vlan_interfaces %}
 {% if add_preceding_comma.flag %},{% endif %}
 {% set _dummy = add_preceding_comma.update({'flag': True}) %}
 dhcpmon-{{ vlan_name }}
-{%- set _dummy = monitor_instance.update({'flag': False}) %}
 {%- endif %}
 {% endfor %}
 
@@ -23,20 +15,12 @@ dhcpmon-{{ vlan_name }}
 {% set relay_for_ipv6 = { 'flag': False } %}
 {% for vlan_name in VLAN_INTERFACE %}
 {# Check DHCPv4 agents #}
-{% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
-{% for dhcp_server in VLAN[vlan_name]['dhcp_servers'] %}
-{% if dhcp_server | ipv4 %}
+{% if vlan_name in ipv4_vlan_interfaces %}
 {% set _dummy = relay_for_ipv4.update({'flag': True}) %}
 {% endif %}
-{% endfor %}
-{% endif %}
 {# Check DHCPv6 agents #}
-{% if VLAN and vlan_name in VLAN and 'dhcpv6_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcpv6_servers']|length > 0 %}
-{% for dhcpv6_server in VLAN[vlan_name]['dhcpv6_servers'] %}
-{% if dhcpv6_server | ipv6 %}
+{% if vlan_name in ipv6_vlan_interfaces %}
 {% set _dummy = relay_for_ipv6.update({'flag': True}) %}
-{% endif %}
-{% endfor %}
 {% endif %}
 {% if relay_for_ipv4.flag or relay_for_ipv6.flag %}
 [program:dhcpmon-{{ vlan_name }}]

--- a/dockers/docker-dhcp-relay/dhcp-relay.programs.j2
+++ b/dockers/docker-dhcp-relay/dhcp-relay.programs.j2
@@ -3,13 +3,13 @@ programs=
 {%- set add_preceding_comma = { 'flag': False } %}
 {% for vlan_name in VLAN_INTERFACE %}
 {# Append DHCPv4 agents #}
-{% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
+{% if vlan_name in ipv4_vlan_interfaces %}
 {% if add_preceding_comma.flag %},{% endif %}
 {% set _dummy = add_preceding_comma.update({'flag': True}) %}
 isc-dhcpv4-relay-{{ vlan_name }}
 {%- endif %}
 {# Append DHCPv6 agents #}
-{% if VLAN and vlan_name in VLAN and 'dhcpv6_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcpv6_servers']|length > 0 %}
+{% if vlan_name in ipv6_vlan_interfaces %}
 {% if add_preceding_comma.flag %},{% endif %}
 {% set _dummy = add_preceding_comma.update({'flag': True}) %}
 dhcp6relay

--- a/dockers/docker-dhcp-relay/dhcpv4-relay.agents.j2
+++ b/dockers/docker-dhcp-relay/dhcpv4-relay.agents.j2
@@ -1,12 +1,5 @@
 {# Append DHCPv4 agents #}
-{% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
-{% for dhcp_server in VLAN[vlan_name]['dhcp_servers'] %}
-{% if dhcp_server | ipv4 %}
-{% set _dummy = relay_for_ipv4.update({'flag': True}) %}
-{% endif %}
-{% endfor %}
-{% if relay_for_ipv4.flag %}
-{% set _dummy = relay_for_ipv4.update({'flag': False}) %}
+{% if vlan_name in ipv4_vlan_interfaces %}
 [program:isc-dhcpv4-relay-{{ vlan_name }}]
 {# We treat this VLAN as a downstream interface (-id), as we only want to listen for requests #}
 command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id {{ vlan_name }}
@@ -36,5 +29,4 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=start:exited
 
-{% endif %}
 {% endif %}

--- a/dockers/docker-dhcp-relay/dhcpv6-relay.agents.j2
+++ b/dockers/docker-dhcp-relay/dhcpv6-relay.agents.j2
@@ -1,12 +1,5 @@
 {# Append DHCPv6 agents #}
-{% if VLAN and vlan_name in VLAN and 'dhcpv6_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcpv6_servers']|length > 0 %}
-{% for dhcpv6_server in VLAN[vlan_name]['dhcpv6_servers'] %}
-{% if dhcpv6_server | ipv6 %}
-{% set _dummy = relay_for_ipv6.update({'flag': True}) %}
-{% endif %}
-{% endfor %}
-{% if relay_for_ipv6.flag %}
-{% set _dummy = relay_for_ipv6.update({'flag': False}) %}
+{% if vlan_name in ipv6_vlan_interfaces %}
 [program:dhcp6relay]
 command=/usr/sbin/dhcp6relay
 
@@ -18,5 +11,4 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=start:exited
 
-{% endif %}
 {% endif %}

--- a/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
+++ b/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
@@ -42,18 +42,22 @@ dependent_startup_wait_for=rsyslogd:running
 {# If our configuration has VLANs... #}
 {% if VLAN_INTERFACE %}
 {# Count how many VLANs require a DHCP relay agent... #}
-{% set ipv4_num_relays = { 'count': 0 } %}
-{% set ipv6_num_relays = { 'count': 0 } %}
-{% for vlan_name in VLAN_INTERFACE %}
+{% set ipv4_vlan_interfaces = [] %}
+{% set ipv6_vlan_interfaces = [] %}
+{% for (vlan_name, prefix) in VLAN_INTERFACE|pfx_filter %}
+{% if prefix | ipv4 and vlan_name not in ipv4_vlan_interfaces %}
 {% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
-{% set _dummy = ipv4_num_relays.update({'count': ipv4_num_relays.count + 1}) %}
+{% set ipv4_vlan_interfaces = ipv4_vlan_interfaces.append(vlan_name) %}
 {% endif %}
+{% endif %}
+{% if prefix | ipv6 and vlan_name not in ipv6_vlan_interfaces %}
 {% if VLAN and vlan_name in VLAN and 'dhcpv6_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcpv6_servers']|length > 0 %}
-{% set _dummy = ipv6_num_relays.update({'count': ipv6_num_relays.count + 1}) %}
+{% set ipv6_vlan_interfaces = ipv6_vlan_interfaces.append(vlan_name) %}
+{% endif %}
 {% endif %}
 {% endfor %}
 {# If one or more of the VLANs require a DHCP relay agent... #}
-{% if ipv4_num_relays.count > 0 or ipv6_num_relays.count > 0 %}
+{% if ipv4_vlan_interfaces|length > 0 or ipv6_vlan_interfaces|length > 0 %}
 {% include 'dhcp-relay.programs.j2' %}
 
 

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
@@ -33,9 +33,11 @@ ip prefix-list PL_LoopbackV4 permit 10.1.0.32/32
 !
 ipv6 prefix-list PL_LoopbackV6 permit fc00:1::/64
 !
-ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.200.0/27
-!
 ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 192.168.0.0/27
+!
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 15 permit 192.168.200.0/27
+!
+ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq 5 permit fc02::/126
 !
 !
 !
@@ -60,8 +62,11 @@ router bgp 65100
     network fc00:1::32/64
   exit-address-family
 !
-  network 192.168.200.1/27
+  address-family ipv6
+   network FC02::1/126
+  exit-address-family
   network 192.168.0.1/27
+  network 192.168.200.1/27
 !
 !
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/frr.conf
@@ -52,9 +52,11 @@ ip prefix-list PL_LoopbackV4 permit 10.1.0.32/32
 !
 ipv6 prefix-list PL_LoopbackV6 permit fc00:1::/64
 !
-ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.200.0/27
-!
 ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 192.168.0.0/27
+!
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 15 permit 192.168.200.0/27
+!
+ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq 5 permit fc02::/126
 !
 !
 !
@@ -79,8 +81,11 @@ router bgp 65100
     network fc00:1::32/64
   exit-address-family
 !
-  network 192.168.200.1/27
+  address-family ipv6
+   network FC02::1/126
+  exit-address-family
   network 192.168.0.1/27
+  network 192.168.200.1/27
 !
 !
 !

--- a/src/sonic-config-engine/tests/sample_output/py2/ipinip.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/ipinip.json
@@ -13,7 +13,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dst_ip":"fc00:1::32,fc00::71,fc00::75,fc00::79,fc00::7d",
+            "dst_ip":"fc00:1::32,fc00::71,fc00::75,fc00::79,fc00::7d,fc02::1",
             "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"

--- a/src/sonic-config-engine/tests/sample_output/py2/wait_for_intf.sh
+++ b/src/sonic-config-engine/tests/sample_output/py2/wait_for_intf.sh
@@ -23,8 +23,8 @@ function wait_until_iface_ready
 
 
 # Wait for all interfaces with IPv4 addresses to be up and ready
-wait_until_iface_ready Vlan2000 192.168.200.1/27
 wait_until_iface_ready Vlan1000 192.168.0.1/27
+wait_until_iface_ready Vlan2000 192.168.200.1/27
 wait_until_iface_ready PortChannel02 10.0.0.58/31
 wait_until_iface_ready PortChannel03 10.0.0.60/31
 wait_until_iface_ready PortChannel04 10.0.0.62/31

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
@@ -35,7 +35,9 @@ ipv6 prefix-list PL_LoopbackV6 permit fc00:1::/64
 !
 ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.0.0/27
 !
-ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 192.168.200.0/27
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 15 permit 192.168.200.0/27
+!
+ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq 10 permit fc02::/126
 !
 !
 !
@@ -61,6 +63,9 @@ router bgp 65100
   exit-address-family
 !
   network 192.168.0.1/27
+  address-family ipv6
+   network FC02::1/126
+  exit-address-family
   network 192.168.200.1/27
 !
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/frr.conf
@@ -54,7 +54,9 @@ ipv6 prefix-list PL_LoopbackV6 permit fc00:1::/64
 !
 ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.0.0/27
 !
-ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 10 permit 192.168.200.0/27
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 15 permit 192.168.200.0/27
+!
+ipv6 prefix-list LOCAL_VLAN_IPV6_PREFIX seq 10 permit fc02::/126
 !
 !
 !
@@ -80,6 +82,9 @@ router bgp 65100
   exit-address-family
 !
   network 192.168.0.1/27
+  address-family ipv6
+   network FC02::1/126
+  exit-address-family
   network 192.168.200.1/27
 !
 !

--- a/src/sonic-config-engine/tests/sample_output/py3/ipinip.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/ipinip.json
@@ -13,7 +13,7 @@
     {
         "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
             "tunnel_type":"IPINIP",
-            "dst_ip":"fc00:1::32,fc00::71,fc00::75,fc00::79,fc00::7d",
+            "dst_ip":"fc00:1::32,fc00::71,fc00::75,fc00::79,fc00::7d,fc02::1",
             "dscp_mode":"uniform",
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"

--- a/src/sonic-config-engine/tests/t0-sample-graph.xml
+++ b/src/sonic-config-engine/tests/t0-sample-graph.xml
@@ -353,6 +353,11 @@
           <Prefix>192.168.0.1/27</Prefix>
         </IPInterface>
         <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>Vlan1000</AttachTo>
+          <Prefix>FC02::1/126</Prefix>
+        </IPInterface>
+        <IPInterface>
           <Name i:nil="true"/>
           <AttachTo>Vlan2000</AttachTo>
           <Prefix>192.168.200.1/27</Prefix>


### PR DESCRIPTION
#### Why I did it
In isc-dhcp design, need to set the client vlan interface ip as giaddr so the server can figure out what net it's from and so that we can later forward the response to the correct net.
DHCP Relay will crash when receiving discover from DHCP client because there is no IP address on client vlan interface.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### How I did it
To perform the relay process, there must be an IP address on the client vlan interface.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

