### PR TITLE
[SY] Adding exceptlionList to validation exception

### DIFF
--- a/src/sonic-yang-mgmt/sonic_yang_ext.py
+++ b/src/sonic-yang-mgmt/sonic_yang_ext.py
@@ -661,8 +661,8 @@ class SonicYangExtMixin:
                 configC.keys()), debug=syslog.LOG_ERR, doPrint=True)
             self.sysLog(msg="exceptionList:{}".format(exceptionList), \
                 debug=syslog.LOG_ERR, doPrint=True)
-            raise(Exception("All Keys are not parsed in {}\n{}".format(table, \
-                configC.keys())))
+            raise(Exception("All Keys are not parsed in {}\n{}\nexceptionList:{}".format(table, \
+                configC.keys(), exceptionList)))
 
         return
 


### PR DESCRIPTION
#### Why I did it
Adding exceptlionList to validation exception

#### How I did it
Check code.

#### How to verify it
Ran manually.
- Run full config validation from a KVM
- Print the thrown exception

**Before**
```
Error: Data Loading Failed
All Keys are not parsed in FEATURE
dict_keys(['telemetry'])
```
**After**
```
Error: Data Loading Failed
All Keys are not parsed in FEATURE
dict_keys(['telemetry'])
exceptionList:["'status'"]
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

