### PR TITLE
[Build]: Fix the wrong version used in armhf build issue

### DIFF
--- a/scripts/versions_manager.py
+++ b/scripts/versions_manager.py
@@ -289,11 +289,11 @@ class VersionModule:
             arch = ''
             if len(items) > 2:
                 dist = items[2]
-            if filter_dist and dist and filter_dist != dist and dist != ALL_DIST:
+            if filter_dist and dist and filter_dist != dist and dist != ALL_DIST and dist != ALL_DIST:
                 continue
             if len(items) > 3:
                 arch = items[3]
-            if filter_arch and arch and filter_arch != arch and arch != ALL_ARCH:
+            if filter_arch and arch and filter_arch != arch and arch != ALL_ARCH and arch != ALL_ARCH:
                 continue
             versions = Component.get_versions(file_path)
             component = Component(versions, ctype, dist, arch)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The version file version-py3-all-armhf is not used when generating version file.

#### How I did it
Fix the issue in the build script.

#### How to verify it
In 202106 marvell-armhf build, the expected version of pip3 package cryptography 3.3.1 is used after the change.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

