### PR TITLE
[snmp.timer]: Fix SNMP service not coming up during first bootup with SONiC

### DIFF
--- a/files/build_templates/snmp.timer
+++ b/files/build_templates/snmp.timer
@@ -2,6 +2,7 @@
 Description=Delays snmp container until SONiC has started
 PartOf=snmp.service
 After=swss.service
+Requisite=updategraph.service
 
 [Timer]
 OnUnitActiveSec=0 sec


### PR DESCRIPTION
Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
SNMP service did not come up in linecard after load minigraph during first boot up of Chassis with SONiC.

What happened:
In the Linecard, SONiC boot up was done without a default minigraph.
Updategraph service was waiting for DHCP response as it had DHCP enabled set to true.
After this, updategraph and config-setup service was stopped.
/etc/sonic/updategraph.conf was updated to "enabled=false"
config load_minigraph -y was executed.
snmp.timer went to elapsed state.
snmp.service never started.

Steps to reproduce on Dell-S6000 device:
1. Simulate first bootup
a.	Remove /etc/sonic/minigraph.xml, /etc/sonic/config_db.json. Stop and remove database docker.
b.	Update /etc/sonic/updategraph.conf to enable=true so that updategraph service waits for DHCP response and does not generate initial configuration, this is essential.
c.	Reboot device
d.	System boots with no initial configuration, only database service is up.
e.	Swss / snmp.timer /snmp.service are all in “inactive (dead)” state.
f.      Wait for 3min 30 sec before proceeding, so that snmp.timer elapses immediately.
2. sudo systemctl stop updategraph.service hostname-config.service -- At this point snmp.timer starts up and is not able to start snmp.service because swss is not up, so snmp.service pre-requisite services are not up. snmp.timer is in running state.
snmp.timer elapses because it is > 3min 30 sec after bootup.
4. Edit /etc/sonic/updategraph.conf with enable=false
5. copy the right minigraph to device and execute 'sudo config load_minigraph -y'
6. At this point, snmp.timer stops and restarts when swss comes up. But because snmp.timer had already started and elapsed,
it goes to "active (elapsed)" state instead of going to "active (running)" state.

Below are logs:
```
admin@str-s6000-acs-11:~$ sudo systemctl status swss
â— swss.service - switch state service
     Loaded: loaded (/lib/systemd/system/swss.service; enabled; vendor preset: e
     Active: inactive (dead)
admin@str-s6000-acs-11:~$ sudo systemctl status snmp
â— snmp.service - SNMP container
     Loaded: loaded (/lib/systemd/system/snmp.service; static)
     Active: inactive (dead)
TriggeredBy: â— snmp.timer
admin@str-s6000-acs-11:~$ sudo systemctl status database
â— database.service - Database container
     Loaded: loaded (/lib/systemd/system/database.service; enabled; vendor prese
     Active: active (running) since Mon 2022-04-18 19:29:03 UTC; 1min 22s ago
    Process: 569 ExecStartPre=/usr/bin/database.sh start (code=exited, status=0/
   Main PID: 882 (database.sh)
      Tasks: 11 (limit: 9306)
     Memory: 92.2M
     CGroup: /system.slice/database.service
             â”œâ”€882 /bin/bash /usr/bin/database.sh wait
             â””â”€885 docker wait database

Apr 18 19:29:03 str-s6000-acs-11 database.sh[879]: usage: db_migrator.py [-h] [-
Apr 18 19:29:03 str-s6000-acs-11 database.sh[879]:                       [-s uni
Apr 18 19:29:03 str-s6000-acs-11 database.sh[879]: optional arguments:
Apr 18 19:29:03 str-s6000-acs-11 database.sh[879]:   -h, --help            show 
Apr 18 19:29:03 str-s6000-acs-11 database.sh[879]:   -o operation (migrate, set_
Apr 18 19:29:03 str-s6000-acs-11 database.sh[879]:                         opera
Apr 18 19:29:03 str-s6000-acs-11 database.sh[879]:   -s unix socket        the u
Apr 18 19:29:03 str-s6000-acs-11 database.sh[879]:   -n asic namespace     The a
Apr 18 19:29:03 str-s6000-acs-11 database.sh[879]:                         conne
Apr 18 19:29:03 str-s6000-acs-11 systemd[1]: Started Database container.
admin@str-s6000-acs-11:~$ sudo systemctl status updategraph
â— updategraph.service - Update minigraph and set configuration based on minigrap
     Loaded: loaded (/lib/systemd/system/updategraph.service; enabled-runtime; v
     Active: activating (start) since Mon 2022-04-18 19:29:03 UTC; 1min 29s ago
   Main PID: 891 (updategraph)
      Tasks: 3 (limit: 9306)
     Memory: 7.3M
     CGroup: /system.slice/updategraph.service
             â”œâ”€ 891 /bin/bash /usr/bin/updategraph
             â”œâ”€ 901 /sbin/dhclient -4 -v -pf /run/dhclient.eth0.pid -lf /var/lib
             â””â”€1329 sleep 1

Apr 18 19:30:24 str-s6000-acs-11 updategraph[891]: Waiting for DHCP response...
Apr 18 19:30:25 str-s6000-acs-11 updategraph[891]: Waiting for DHCP response...
Apr 18 19:30:26 str-s6000-acs-11 updategraph[891]: Waiting for DHCP response...
Apr 18 19:30:27 str-s6000-acs-11 updategraph[891]: Waiting for DHCP response...
Apr 18 19:30:28 str-s6000-acs-11 updategraph[891]: Waiting for DHCP response...
Apr 18 19:30:29 str-s6000-acs-11 updategraph[891]: Waiting for DHCP response...
Apr 18 19:30:30 str-s6000-acs-11 updategraph[891]: Waiting for DHCP response...
Apr 18 19:30:31 str-s6000-acs-11 updategraph[891]: Waiting for DHCP response...
Apr 18 19:30:32 str-s6000-acs-11 updategraph[891]: Waiting for DHCP response...
Apr 18 19:30:33 str-s6000-acs-11 updategraph[891]: Waiting for DHCP response...
admin@str-s6000-acs-11:~$ sudo systemctl status snmp.timer
â— snmp.timer - Delays snmp container until SONiC has started
     Loaded: loaded (/lib/systemd/system/snmp.timer; enabled; vendor preset: ena
     Active: inactive (dead)
    Trigger: n/a
   Triggers: â— snmp.service

admin@str-s6000-acs-11:~$ 



sudo systemctl stop updategraph.service hostname-config.service

Edit the file /etc/sonic/updategraph.conf

admin@str-s6000-acs-11:~$ sudo config load_minigraph -y
Warning: failed to retrieve PORT table from ConfigDB!
Stopping SONiC target ...
Running command: /usr/local/bin/sonic-cfggen -H -m -j /etc/sonic/init_cfg.json   --write-to-db
Running command: /usr/local/bin/sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/sonic-environment.j2,/etc/sonic/sonic-environment
Running command: config qos reload --no-dynamic-buffer
Running command: /usr/local/bin/sonic-cfggen  -d --write-to-db -t /usr/share/sonic/device/x86_64-dell_s6000_s1220-r0/Force10-S6000/buffers.json.j2,config-db -t /usr/share/sonic/device/x86_64-dell_s6000_s1220-r0/Force10-S6000/qos.json.j2,config-db -y /etc/sonic/sonic_version.yml
Running command: pfcwd start_default
Restarting SONiC target ...
Reloading Monit configuration ...
Reinitializing monit daemon
Please note setting loaded from minigraph will bupdategraph^Csystem reboot. To preserve setting, run `config save`.        atus snmp.timer
admin@str-s6000-acs-11:~$ 
admin@str-s6000-acs-11:~$ 
admin@str-s6000-acs-11:~$ 
admin@str-s6000-acs-11:~$ 
admin@str-s6000-acs-11:~$ sudo systemctl status updategraph
â— updategraph.service - Update minigraph and set configuration based on minigrap
     Loaded: loaded (/lib/systemd/system/updategraph.service; enabled-runtime; v
     Active: active (exited) since Mon 2022-04-18 19:32:20 UTC; 1min 6s ago
    Process: 1953 ExecStart=/usr/bin/updategraph (code=exited, status=0/SUCCESS)
   Main PID: 1953 (code=exited, status=0/SUCCESS)

Apr 18 19:32:20 str-s6000-acs-11 systemd[1]: Starting Update minigraph and set c
Apr 18 19:32:20 str-s6000-acs-11 updategraph[1953]: Disabled in updategraph.conf
Apr 18 19:32:20 str-s6000-acs-11 systemd[1]: Finished Update minigraph and set c
admin@str-s6000-acs-11:~$ sudo systemctl status swss
â— swss.service - switch state service
     Loaded: loaded (/lib/systemd/system/swss.service; enabled; vendor preset: e
     Active: active (running) since Mon 2022-04-18 19:32:56 UTC; 34s ago
    Process: 2976 ExecStartPre=/usr/local/bin/swss.sh start (code=exited, status
   Main PID: 3365 (swss.sh)
      Tasks: 5 (limit: 9306)
     Memory: 20.8M
     CGroup: /system.slice/swss.service
             â”œâ”€3365 /bin/bash /usr/local/bin/swss.sh wait
             â””â”€3906 python3 /usr/bin/docker-wait-any -s swss -d syncd teamd

Apr 18 19:32:52 str-s6000-acs-11 swss.sh[3191]: Starting existing swss container
Apr 18 19:32:54 str-s6000-acs-11 /container[3207]: container_start: BEGIN
Apr 18 19:32:54 str-s6000-acs-11 /container[3207]: read_data: config:True featur
Apr 18 19:32:54 str-s6000-acs-11 /container[3207]: read_data: config:False featu
Apr 18 19:32:54 str-s6000-acs-11 /container[3207]: container_start: swss: set_ow
Apr 18 19:32:54 str-s6000-acs-11 /container[3207]: update_data: feature:swss dat
Apr 18 19:32:55 str-s6000-acs-11 /container[3207]: docker cmd: start for swss
Apr 18 19:32:55 str-s6000-acs-11 /container[3207]: container_start: END
Apr 18 19:32:56 str-s6000-acs-11 root[3357]: Started swss service...
Apr 18 19:32:56 str-s6000-acs-11 systemd[1]: Started switch state service.
admin@str-s6000-acs-11:~$ sudo systemctl status snmp
â— snmp.service - SNMP container
     Loaded: loaded (/lib/systemd/system/snmp.service; static)
     Active: inactive (dead)
TriggeredBy: â— snmp.timer
admin@str-s6000-acs-11:~$ sudo systemctl status snmp.timer
â— snmp.timer - Delays snmp container until SONiC has started
     Loaded: loaded (/lib/systemd/system/snmp.timer; enabled; vendor preset: ena
     Active: active (elapsed) since Mon 2022-04-18 19:32:56 UTC; 43s ago
    Trigger: n/a
   Triggers: â— snmp.service

Apr 18 19:32:56 str-s6000-acs-11 systemd[1]: Started Delays snmp container until
```

Main Issue:
snmp.timer started and elapsed at a point when snmp.service could not have started. (at step 2 from above)
Once snmp.timer enters "active (elapsed)" state, the only way to recover is to restart snmp.service.
Similar issues reported:
https://bugzilla.redhat.com/show_bug.cgi?id=1764908
https://github.com/systemd/systemd/issues/6680


Dependencies of snmp.timer 
WantedBy swss - this ensures that snmp.timer is triggered to startup when swss tries comes up. (looks like this triggered the first snmp.timer trigger in step2). This is required to start snmp.timer.
After swss.service - this ensures that snmp.timer starts after swss.service

#### How I did it
Make sure that snmp.timer starts at a point when snmp service can come up.
Make sure that snmp.timer does not enter active(elapsed) state.
snmp.service should come up after updategraph, swss, syncd.
so make sure that snmp.timer comes up after updategraph and swss.

Added a dependency to start snmp.timer after updategraph service comes up.

#### How to verify it
Re-do steps above on Dell-S6000 and make sure snmp.timer starts only after config load_minigraph is executed.
and never enters active(elapsed) state.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

