### PR TITLE
[dhcp6relay] Add retry mechanism for binding socket to interface ipv6 addresses

### DIFF
--- a/src/dhcp6relay/src/relay.cpp
+++ b/src/dhcp6relay/src/relay.cpp
@@ -424,11 +424,11 @@ void prepare_socket(int *local_sock, int *server_sock, relay_config *config, int
     } while (retry < 6);
 
     if ((!bind_addr) || (bind(*local_sock, (sockaddr *)&addr, sizeof(addr)) == -1)) {
-	    syslog(LOG_ERR, "bind: Failed to bind socket to global ipv6 address on interface %s after %d retries with %s\n", config->interface.c_str(), retry, strerror(errno));
+        syslog(LOG_ERR, "bind: Failed to bind socket to global ipv6 address on interface %s after %d retries with %s\n", config->interface.c_str(), retry, strerror(errno));
     }
 
     if ((!bind_ll_addr) || (bind(*server_sock, (sockaddr *)&ll_addr, sizeof(addr)) == -1)) {
-	    syslog(LOG_ERR, "bind: Failed to bind socket to link local ipv6 address on interface %s after %d retries with %s\n", config->interface.c_str(), retry, strerror(errno));
+        syslog(LOG_ERR, "bind: Failed to bind socket to link local ipv6 address on interface %s after %d retries with %s\n", config->interface.c_str(), retry, strerror(errno));
     }
 }
 

--- a/src/dhcp6relay/src/relay.cpp
+++ b/src/dhcp6relay/src/relay.cpp
@@ -378,44 +378,56 @@ void prepare_socket(int *local_sock, int *server_sock, relay_config *config, int
     memset(&ll_addr, 0, sizeof(ll_addr));
 
     if ((*local_sock = socket(AF_INET6, SOCK_DGRAM, 0)) == -1) {
-        syslog(LOG_ERR, "socket: Failed to create socket\n");
+        syslog(LOG_ERR, "socket: Failed to create socket on interface %s\n", config->interface.c_str());
     }
 
     if ((*server_sock= socket(AF_INET6, SOCK_DGRAM, 0)) == -1) {
-        syslog(LOG_ERR, "socket: Failed to create socket\n");
+        syslog(LOG_ERR, "socket: Failed to create socket on interface %s\n", config->interface.c_str());
     }
 
+    int retry = 0;
+    bool bind_addr = false;
+    bool bind_ll_addr = false;
+    do {
+        if (getifaddrs(&ifa) == -1) {
+	    syslog(LOG_WARNING, "getifaddrs: Unable to get network interfaces with %s\n", strerror(errno));
+	}
 
-    if (getifaddrs(&ifa) == -1) {
-        syslog(LOG_WARNING, "getifaddrs: Unable to get network interfaces\n");
-        exit(1);
+	ifa_tmp = ifa;
+	while (ifa_tmp) {
+	    if ((ifa_tmp->ifa_addr->sa_family == AF_INET6) && (strcmp(ifa_tmp->ifa_name, config->interface.c_str()) == 0)) {
+	        struct sockaddr_in6 *in6 = (struct sockaddr_in6*) ifa_tmp->ifa_addr;
+		if(!IN6_IS_ADDR_LINKLOCAL(&in6->sin6_addr)) {  
+		    bind_addr = true;
+		    in6->sin6_family = AF_INET6;
+		    in6->sin6_port = htons(RELAY_PORT);
+		    addr = *in6;
+		}
+		if(IN6_IS_ADDR_LINKLOCAL(&in6->sin6_addr)) {
+		    bind_ll_addr = true;
+		    in6->sin6_family = AF_INET6;
+		    in6->sin6_port = htons(RELAY_PORT);
+	  	    ll_addr = *in6;
+	        }
+	    }
+	    ifa_tmp = ifa_tmp->ifa_next;
+	}
+	freeifaddrs(ifa);
+
+	if (bind_addr && bind_ll_addr) {
+	    break;
+	}
+
+	syslog(LOG_WARNING, "Retry #%d to bind to sockets on interface %s\n", ++retry, config->interface.c_str());
+	sleep(5);
+    } while (retry < 6);
+
+    if ((!bind_addr) || (bind(*local_sock, (sockaddr *)&addr, sizeof(addr)) == -1)) {
+	syslog(LOG_ERR, "bind: Failed to bind socket to global ipv6 address on interface %s after %d retries\n", config->interface.c_str(), retry);
     }
 
-    ifa_tmp = ifa;
-    while (ifa_tmp) {
-        if (ifa_tmp->ifa_addr->sa_family == AF_INET6) {
-            struct sockaddr_in6 *in6 = (struct sockaddr_in6*) ifa_tmp->ifa_addr;
-            if((strcmp(ifa_tmp->ifa_name, config->interface.c_str()) == 0) && !IN6_IS_ADDR_LINKLOCAL(&in6->sin6_addr)) {   
-                in6->sin6_family = AF_INET6;
-                in6->sin6_port = htons(RELAY_PORT);
-                addr = *in6;
-            }
-            if((strcmp(ifa_tmp->ifa_name, config->interface.c_str()) == 0) && IN6_IS_ADDR_LINKLOCAL(&in6->sin6_addr)) {   
-                in6->sin6_family = AF_INET6;
-                in6->sin6_port = htons(RELAY_PORT);
-                ll_addr = *in6;
-            }
-        }
-        ifa_tmp = ifa_tmp->ifa_next;
-    }
-    freeifaddrs(ifa);
-    
-    if (bind(*local_sock, (sockaddr *)&addr, sizeof(addr)) == -1) {
-        syslog(LOG_ERR, "bind: Failed to bind to socket\n");
-    }
-
-    if (bind(*server_sock, (sockaddr *)&ll_addr, sizeof(addr)) == -1) {
-        syslog(LOG_ERR, "bind: Failed to bind to socket\n");
+    if ((!bind_ll_addr) || (bind(*server_sock, (sockaddr *)&ll_addr, sizeof(addr)) == -1)) {
+	syslog(LOG_ERR, "bind: Failed to bind socket to link local ipv6 address on interface %s after %d retries\n", config->interface.c_str(), retry);
     }
 }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
dhcp6relay fails to bind to interface's link-local ipv6 addresses from time to time after interface is brought up due to not waiting for a long enough time period for ipv6 addresses to bind to the interface. 
Enhanced syslog to give more meaningful error log

#### How I did it
Added a retry mechanism to check for interface's ipv6 global and link-local addresses 3 times, every 5 seconds. If ipv6 address is still missing or binding failed, alert in syslog

#### How to verify it
Tested retry mechanism:
#1 brings down Vlan interface, start dhcp6relay, check for "Failed to bind socket to ..." error in syslog
     ss -nlp | grep dhcp6relay: verify sockets did not bind
#2 remove link-local ip from interface, start dhcp6relay, check for "Retry #(1,2,3) to bind to sockets on interface ..."
     ss -nlp | grep dhcp6relay: verify socket did not bind to link-local ipv6 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

