### PR TITLE
[Build]: fix build version conflict issue in 202111 branch

### DIFF
--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -169,6 +169,10 @@ run_pip_command()
         elif [[ "$para" == *.whl ]]; then
             package_name=$(echo $para | cut -d- -f1 | tr _ .)
             $SUDO sed "/^${package_name}==/d" -i $tmp_version_file
+        elif [[ "$para" == *==* ]]; then
+            # fix pip package constraint conflict issue
+            package_name=$(echo $para | cut -d= -f1)
+            $SUDO sed "/^${package_name}==/d" -i $tmp_version_file
         fi
     done
 

--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -18,7 +18,7 @@ DPKG_INSTALLTION_LOCK_FILE=/tmp/.dpkg_installation.lock
 
 URL_PREFIX=$(echo "${PACKAGE_URL_PREFIX}" | sed -E "s#(//[^/]*/).*#\1#")
 
-if [ $USER != 'root' ] && [ -n $(which sudo) ];then
+if [ "$(whoami)" != "root" ] && [ -n "$(which sudo)" ];then
     SUDO=sudo
 else
     SUDO=''


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Some of the PRs are missed to cherry-pick to the 202111 branch.

[build] docker-sonic-mgmt replace USER by whoami (Azure#9702)
[Build]: Fix pip version constraint conflict issue (Azure#10525) 

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

