### PR TITLE
Support symcrypt fips config for aboot/uboot

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -200,8 +200,11 @@ elif [ "$IMAGE_TYPE" = "aboot" ]; then
     generate_device_list ".platforms_asic"
     zip -g $OUTPUT_ABOOT_IMAGE .platforms_asic
 
-    echo "sonic_fips=0" > kernel-cmdline
-    [ "$ENABLE_FIPS" == "y" ] && echo "sonic_fips=1" > kernel-cmdline
+    if [ "$ENABLE_FIPS" = "y" ]; then
+        echo "sonic_fips=1" > kernel-cmdline
+    else
+        echo "sonic_fips=0" > kernel-cmdline
+    fi
     zip -g $OUTPUT_ABOOT_IMAGE kernel-cmdline
     rm kernel-cmdline
 

--- a/build_image.sh
+++ b/build_image.sh
@@ -202,7 +202,7 @@ elif [ "$IMAGE_TYPE" = "aboot" ]; then
 
     echo "sonic_fips=0" > kernel-cmdline
     [ "$ENABLE_FIPS" == "y" ] && echo "sonic_fips=1" > kernel-cmdline
-    zip -g $OLDPWD/$OUTPUT_ABOOT_IMAGE kernel-cmdline
+    zip -g $OUTPUT_ABOOT_IMAGE kernel-cmdline
     rm kernel-cmdline
 
     zip -g $OUTPUT_ABOOT_IMAGE $ABOOT_BOOT_IMAGE

--- a/build_image.sh
+++ b/build_image.sh
@@ -200,6 +200,11 @@ elif [ "$IMAGE_TYPE" = "aboot" ]; then
     generate_device_list ".platforms_asic"
     zip -g $OUTPUT_ABOOT_IMAGE .platforms_asic
 
+    echo "sonic_fips=0" > kernel-cmdline
+    [ "$ENABLE_FIPS" == "y" ] && echo "sonic_fips=1" > kernel-cmdline
+    zip -g $OLDPWD/$OUTPUT_ABOOT_IMAGE kernel-cmdline
+    rm kernel-cmdline
+
     zip -g $OUTPUT_ABOOT_IMAGE $ABOOT_BOOT_IMAGE
     rm $ABOOT_BOOT_IMAGE
     if [ "$SONIC_ENABLE_IMAGE_SIGNATURE" = "y" ]; then

--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -86,7 +86,7 @@ installer_image_path="$image_path/$installer_image"
 
 boot_config="$target_path/boot-config"
 
-cmdline_allowlist="crashkernel hwaddr_ma1 sonic_fips fips"
+cmdline_allowlist="crashkernel hwaddr_ma1 sonic_fips"
 
 # for backward compatibility with the sonic_upgrade= behavior
 install="${install:-${sonic_upgrade:-}}"

--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -86,7 +86,7 @@ installer_image_path="$image_path/$installer_image"
 
 boot_config="$target_path/boot-config"
 
-cmdline_allowlist="crashkernel hwaddr_ma1"
+cmdline_allowlist="crashkernel hwaddr_ma1 sonic_fips fips"
 
 # for backward compatibility with the sonic_upgrade= behavior
 install="${install:-${sonic_upgrade:-}}"

--- a/installer/arm64/install.sh
+++ b/installer/arm64/install.sh
@@ -181,6 +181,9 @@ if [ "$install_env" = "onie" ]; then
     fi
 fi
 
+extra_cmdline_linux=%%EXTRA_CMDLINE_LINUX%%
+echo "EXTRA_CMDLINE_LINUX=$extra_cmdline_linux"
+
 # Update Bootloader Menu with installed image
 bootloader_menu_config
 

--- a/installer/armhf/install.sh
+++ b/installer/armhf/install.sh
@@ -181,6 +181,9 @@ if [ "$install_env" = "onie" ]; then
     fi
 fi
 
+extra_cmdline_linux=%%EXTRA_CMDLINE_LINUX%%
+echo "EXTRA_CMDLINE_LINUX=$extra_cmdline_linux"
+
 # Update Bootloader Menu with installed image
 bootloader_menu_config
 

--- a/platform/centec-arm64/platform.conf
+++ b/platform/centec-arm64/platform.conf
@@ -16,9 +16,10 @@ mount_partition() {
 
 bootloader_menu_config() {
     if [ "$install_env" = "onie" ]; then
+        fw_setenv -f linuxargs "${extra_cmdline_linux}"
         fw_setenv -f nos_bootcmd "test -n \$boot_once && setenv do_boot_once \$boot_once && setenv boot_once && saveenv && run do_boot_once; run boot_next"
 
-        fw_setenv -f sonic_image_1 "ext4load mmc 0:1 \$loadaddr \$sonic_dir_1/boot/sonic_arm64.fit && setenv bootargs quiet console=\$consoledev,\$baudrate root=/dev/mmcblk0p1 rw rootwait rootfstype=ext4 loopfstype=squashfs loop=\$sonic_dir_1/fs.squashfs systemd.unified_cgroup_hierarchy=0 && bootm \$loadaddr"
+        fw_setenv -f sonic_image_1 "ext4load mmc 0:1 \$loadaddr \$sonic_dir_1/boot/sonic_arm64.fit && setenv bootargs quiet console=\$consoledev,\$baudrate root=/dev/mmcblk0p1 rw rootwait rootfstype=ext4 loopfstype=squashfs loop=\$sonic_dir_1/fs.squashfs systemd.unified_cgroup_hierarchy=0 \${linuxargs} && bootm \$loadaddr"
         fw_setenv -f sonic_image_2 "NONE"
         fw_setenv -f sonic_dir_1 $image_dir
         fw_setenv -f sonic_dir_2 "NONE"
@@ -37,9 +38,10 @@ bootloader_menu_config() {
             fi
         done
 
+        fw_setenv linuxargs "${extra_cmdline_linux}"
         fw_setenv nos_bootcmd "test -n \$boot_once && setenv do_boot_once \$boot_once && setenv boot_once && saveenv && run do_boot_once; run boot_next"
 
-        fw_setenv sonic_image_$idx "ext4load mmc 0:1 \$loadaddr \$sonic_dir_$idx/boot/sonic_arm64.fit && setenv bootargs quiet console=\$consoledev,\$baudrate root=/dev/mmcblk0p1 rw rootwait rootfstype=ext4 loopfstype=squashfs loop=\$sonic_dir_$idx/fs.squashfs systemd.unified_cgroup_hierarchy=0 && bootm \$loadaddr"
+        fw_setenv sonic_image_$idx "ext4load mmc 0:1 \$loadaddr \$sonic_dir_$idx/boot/sonic_arm64.fit && setenv bootargs quiet console=\$consoledev,\$baudrate root=/dev/mmcblk0p1 rw rootwait rootfstype=ext4 loopfstype=squashfs loop=\$sonic_dir_$idx/fs.squashfs systemd.unified_cgroup_hierarchy=0 \${linuxargs} && bootm \$loadaddr"
         fw_setenv sonic_dir_$idx $image_dir
         fw_setenv sonic_version_$idx `echo $image_dir | sed "s/^image-/SONiC-OS-/g"`
 

--- a/platform/marvell-arm64/platform.conf
+++ b/platform/marvell-arm64/platform.conf
@@ -108,7 +108,7 @@ prepare_boot_menu() {
     BORDER='echo "---------------------------------------------------";echo;'
     fw_setenv ${FW_ARG} print_menu $BORDER $BOOT1 $BOOT2 $BOOT3 $BORDER > /dev/null
 
-    fw_setenv ${FW_ARG} linuxargs "net.ifnames=0 loopfstype=squashfs loop=$image_dir/$FILESYSTEM_SQUASHFS systemd.unified_cgroup_hierarchy=0 varlog_size=$VAR_LOG" > /dev/null
+    fw_setenv ${FW_ARG} linuxargs "net.ifnames=0 loopfstype=squashfs loop=$image_dir/$FILESYSTEM_SQUASHFS systemd.unified_cgroup_hierarchy=0 varlog_size=$VAR_LOG ${extra_cmdline_linux}" > /dev/null
     fw_setenv ${FW_ARG} linuxargs_old "net.ifnames=0 loopfstype=squashfs loop=$image_dir_old/$FILESYSTEM_SQUASHFS systemd.unified_cgroup_hierarchy=0 varlog_size=$VAR_LOG" > /dev/null
     sonic_bootargs_old='setenv bootargs root='$demo_dev' rw rootwait rootfstype=ext4 panic=1 console=ttyS0,115200 ${othbootargs} ${mtdparts} ${linuxargs_old}'
     fw_setenv ${FW_ARG} sonic_bootargs_old $sonic_bootargs_old > /dev/null || true

--- a/platform/marvell-armhf/platform.conf
+++ b/platform/marvell-armhf/platform.conf
@@ -147,7 +147,7 @@ prepare_boot_menu() {
     BORDER='echo "---------------------------------------------------";echo;'
     fw_setenv ${FW_ARG} print_menu $BORDER $BOOT1 $BOOT2 $BOOT3 $BORDER > /dev/null
 
-    fw_setenv ${FW_ARG} linuxargs "net.ifnames=0 loopfstype=squashfs loop=$image_dir/$FILESYSTEM_SQUASHFS systemd.unified_cgroup_hierarchy=0 varlog_size=$VAR_LOG loglevel=4" > /dev/null
+    fw_setenv ${FW_ARG} linuxargs "net.ifnames=0 loopfstype=squashfs loop=$image_dir/$FILESYSTEM_SQUASHFS systemd.unified_cgroup_hierarchy=0 varlog_size=$VAR_LOG loglevel=4 ${extra_cmdline_linux}" > /dev/null
     fw_setenv ${FW_ARG} linuxargs_old "net.ifnames=0 loopfstype=squashfs loop=$image_dir_old/$FILESYSTEM_SQUASHFS systemd.unified_cgroup_hierarchy=0 varlog_size=$VAR_LOG loglevel=4" > /dev/null
 
     # Set boot configs


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Support symcrypt fips config for aboot/uboot

#### How I did it
For uboot, use fw_setenv to variable linuxargs to change the boot options.
```
fw_setenv linuxargs "$OTHER_OPTIONS sonic_fips=1"
```
For Aboot, add the config in /host/image-{version}/kernel-cmdline, example:
```
reboot=p console=ttyS0 acpi=on Aboot=Aboot-norcal7-7.2.0-pcie2x4-6128821 <other parameters...> sonic_fips=1
```
#### How to verify it
Download the image sonic-aboot-broadcom.swi from the pipeline in the PR checks. The sonic_fips=1 can be found in /proc/cmdline
```
Aboot# boot sonic-aboot-broadcom.swi
448.25: Cleaning flash content /mnt/flash
448.25: Generating boot-config, machine.conf and cmdline
448.41: Installing image under /mnt/flash/image-master-10729.100664-f781129cc
...
oot@sonic:/host/image-master-10729.100664-f781129cc# cat kernel-cmdline 
reboot=p console=ttyS0 acpi=on Aboot=Aboot-norcal6-6.1.2-4757975 block_flash=pci0000:00/0000:00:14.7/mmc_host/.*$ block_usb1=pci0000:00/0000:00:12.0/usb1/1-1/1-1.1/.*$ block_usb2=pci0000:00/0000:00:12.0/usb1/1-1/1-1.4/.*$ block_drive=pci0000:00/0000:00:11.0/.*host./target.:0:0/.*$ net_ma1=pci0000:00/0000:00:02.4/.*$ platform=crow sid=Upperlake cmdline-aboot-end modprobe.blacklist=radeon,sp5100_tco amd_iommu=off modprobe.blacklist=snd_hda_intel,hdaudio logs_inram=on varlog_size=256 sonic.mode=fixed security=apparmor apparmor=1 rw net.ifnames=0 systemd.unified_cgroup_hierarchy=0 quiet systemd.show_status=auto hwaddr_ma1=28:99:3a:17:1c:08 root=UUID=805ffc5b-0cf7-4abb-a1f4-f7424699fff7 loop=image-master-10729.100664-f781129cc/fs.squashfs loopfstype=squashfs sonic_fips=1

admin@sonic:~$ cat /proc/cmdline 
reboot=p console=ttyS0 acpi=on Aboot=Aboot-norcal6-6.1.2-4757975 block_flash=pci0000:00/0000:00:14.7/mmc_host/.*$ block_usb1=pci0000:00/0000:00:12.0/usb1/1-1/1-1.1/.*$ block_usb2=pci0000:00/0000:00:12.0/usb1/1-1/1-1.4/.*$ block_drive=pci0000:00/0000:00:11.0/.*host./target.:0:0/.*$ net_ma1=pci0000:00/0000:00:02.4/.*$ platform=crow sid=Upperlake cmdline-aboot-end modprobe.blacklist=radeon,sp5100_tco amd_iommu=off modprobe.blacklist=snd_hda_intel,hdaudio logs_inram=on varlog_size=256 sonic.mode=fixed security=apparmor apparmor=1 rw net.ifnames=0 systemd.unified_cgroup_hierarchy=0 quiet systemd.show_status=auto hwaddr_ma1=28:99:3a:17:1c:08 root=UUID=805ffc5b-0cf7-4abb-a1f4-f7424699fff7 loop=image-master-10729.100664-f781129cc/fs.squashfs loopfstype=squashfs sonic_fips=1  kexec_jump_back_entry=0xffffffff
admin@sonic:~$ 
admin@sonic:~$ sudo openssl engine -vv | grep symcrypt
(symcrypt) SCOSSL (SymCrypt engine for OpenSSL)
admin@sonic:~$ 
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

