### PR TITLE
Remove referencing in unit test for arista7800

### DIFF
--- a/src/sonic-config-engine/tests/sample_output/py2/buffer-arista7800r3-48cq2-lc.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffer-arista7800r3-48cq2-lc.json
@@ -62,7 +62,7 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"1280",
             "dynamic_th":"-2",
             "xon_offset":"2560",
@@ -70,18 +70,18 @@
             "xoff":"66048"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "xon_offset":"0",
             "static_th":"30535680"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"33030144"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"-1"
         }
@@ -226,365 +226,365 @@
 
     "BUFFER_QUEUE": {
         "Ethernet180|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet8|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet184|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet188|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet0|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet4|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet108|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet100|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet128|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet104|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet68|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet96|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet124|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet148|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet92|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet120|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet144|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet52|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet140|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet56|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet164|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet76|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet72|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet64|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet32|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet16|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet36|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet12|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet88|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet116|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet80|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet112|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet84|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet152|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet136|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet156|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet132|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet48|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet44|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet176|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet40|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet28|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet60|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet20|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet24|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet180|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet8|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet184|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet188|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet0|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet4|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet108|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet100|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet128|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet104|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet68|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet96|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet124|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet148|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet92|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet120|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet144|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet52|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet140|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet56|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet164|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet76|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet72|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet64|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet32|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet16|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet36|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet12|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet88|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet116|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet80|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet112|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet84|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet152|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet136|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet156|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet132|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet48|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet44|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet176|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet40|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet28|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet60|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet20|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet24|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet180|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet8|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet184|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet188|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet0|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet4|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet108|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet100|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet128|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet104|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet68|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet96|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet124|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet148|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet92|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet120|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet144|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet52|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet140|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet56|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet164|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet76|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet72|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet64|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet32|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet16|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet36|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet12|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet88|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet116|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet80|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet112|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet84|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet152|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet136|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet156|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet132|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet48|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet44|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet176|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet40|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet28|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet60|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet20|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet24|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }   
     }
 }

--- a/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7800r3-48cq2-lc.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7800r3-48cq2-lc.json
@@ -62,7 +62,7 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"1280",
             "dynamic_th":"-2",
             "xon_offset":"2560",
@@ -70,18 +70,18 @@
             "xoff":"66048"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "xon_offset":"0",
             "static_th":"30535680"
         },
         "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "static_th":"33030144"
         },
         "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"ingress_lossless_pool",
             "size":"0",
             "dynamic_th":"-1"
         }
@@ -226,365 +226,365 @@
 
     "BUFFER_QUEUE": {
         "Ethernet0|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet36|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet40|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet44|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet48|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet52|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet56|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet60|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet64|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet68|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet72|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet4|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet76|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet80|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet84|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet88|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet92|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet96|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet100|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet104|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet108|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet112|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet8|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet116|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet120|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet124|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet128|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet132|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet136|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet140|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet144|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet148|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet152|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet12|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet156|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet164|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet176|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet180|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet184|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet188|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet16|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet20|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet24|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet28|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet32|3-4": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile" : "ingress_lossless_profile"
         },
         "Ethernet0|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet36|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet40|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet44|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet48|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet52|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet56|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet60|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet64|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet68|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet72|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet4|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet76|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet80|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet84|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet88|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet92|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet96|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet100|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet104|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet108|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet112|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet8|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet116|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet120|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet124|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet128|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet132|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet136|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet140|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet144|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet148|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet152|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet12|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet156|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet164|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet176|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet180|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet184|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet188|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet16|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet20|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet24|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet28|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet32|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },
         "Ethernet0|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet36|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet40|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet44|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet48|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet52|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet56|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet60|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet64|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet68|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet72|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet4|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet76|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet80|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet84|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet88|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet92|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet96|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet100|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet104|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet108|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet112|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet8|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet116|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet120|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet124|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet128|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet132|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet136|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet140|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet144|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet148|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet152|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet12|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet156|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet164|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet176|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet180|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet184|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet188|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet16|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet20|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet24|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet28|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         },        "Ethernet32|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+            "profile" : "egress_lossy_profile"
         }   
     }
 }


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Address build failures due to sonic config engine unit tests failing. Failures are due to referencing format used in Arista 7800 sample output for buffer template

#### How I did it
Remove referencing format

#### How to verify it
Sonic config engine wheel should be built successfully

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

