### PR TITLE
[initramfs]: SSD firmware upgrade in initramfs

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -188,6 +188,10 @@ sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/arista-
 sudo cp files/initramfs-tools/resize-rootfs $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/resize-rootfs
 sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/resize-rootfs
 
+# Hook into initramfs: upgrade SSD from initramfs
+sudo cp files/initramfs-tools/ssd-upgrade $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/ssd-upgrade
+sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/ssd-upgrade
+
 # Hook into initramfs: run fsck to repair a non-clean filesystem prior to be mounted
 sudo cp files/initramfs-tools/fsck-rootfs $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/fsck-rootfs
 sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/fsck-rootfs

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -114,6 +114,9 @@ migrate_nos_configuration()
         # remove nos-config-part from cmdline
         sed -r -i.bak "s/nos-config-part=[^[:space:]]+//" /host/grub/grub.cfg
 
+        # remove ssd-upgrader-part from cmdline
+        sed -r -i.bak "s/ssd-upgrader-part=[^[:space:]]+//" /host/grub/grub.cfg
+
         # Mount the previous NOS's partition
         NOS_DIR=/mnt/nos_migration
         MG_GZFILE=$NOS_DIR/minigraph.xml.gz.base64.txt

--- a/files/initramfs-tools/ssd-upgrade
+++ b/files/initramfs-tools/ssd-upgrade
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+case $1 in
+    prereqs)
+        exit 0
+        ;;
+esac
+
+# Extract kernel parameters
+set -- $(cat /proc/cmdline)
+for x in "$@"; do
+    case "$x" in
+        ssd-upgrader-part=*)
+            ssd_upgrader_part="${x#ssd-upgrader-part=}"
+            ;;
+    esac
+done
+
+if [ ! -z "$ssd_upgrader_part" ]; then
+    echo "ssd-upgrader-part found in /proc/cmdline" > /tmp/ssd-fw-upgrade.log
+    mkdir -p /mnt/ssd_upgrader_part
+    mount -t "${ssd_upgrader_part#*,}" "${ssd_upgrader_part%,*}" /mnt/ssd_upgrader_part
+    if [ -x /mnt/ssd_upgrader_part/ssd-fw-upgrade ]; then
+        cp /mnt/ssd_upgrader_part/ssd-fw-upgrade /tmp/
+        cd /tmp/
+        umount /mnt/ssd_upgrader_part
+        rm -r /mnt/ssd_upgrader_part
+        ./ssd-fw-upgrade >> /tmp/ssd-fw-upgrade.log 2>&1
+    else
+        echo "ssd-fw-upgrade not found" >> /tmp/ssd-fw-upgrade.log
+        umount /mnt/ssd_upgrader_part
+        rm -r /mnt/ssd_upgrader_part
+    fi
+    gzip /tmp/ssd-fw-upgrade.log
+fi

--- a/files/initramfs-tools/union-mount.j2
+++ b/files/initramfs-tools/union-mount.j2
@@ -190,3 +190,8 @@ fi
 if [ -f /tmp/fsck.log.gz ]; then
     mv /tmp/fsck.log.gz ${rootmnt}/var/log
 fi
+
+## ssd-fw-upgrade log file: /tmp will be lost when overlayfs is mounted
+if [ -f /tmp/ssd-fw-upgrade.log.gz ]; then
+    mv /tmp/ssd-fw-upgrade.log.gz ${rootmnt}/var/log
+fi


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To upgrade SSD firmware in initramfs while rebooting from SONiC to SONiC and during NOS to SONiC migration.

#### How I did it

- New option 'ssd-upgrader-part’ is introduced in grub command line, to indicate the partition and its filesystem type in which the SSD firmware updater is present. ‘ssd-upgrader-part’ syntax is “ssd-upgrader-part=<partition>,<filesystem type>”

-  A new initramfs script ‘ssd-upgrade’ is included in init-premount and it invokes the SSD firmware updater (ssd-fw-upgrade) present in the partition indicated by the boot option 'ssd-upgrader-part'

#### How to verify it

1. In SONiC, the SSD firmware updater is copied to “/host/” directory.
2. Fast-reboot is to be initiated with the ‘-u’ option (to add SONiC partition and filesystem type to the boot option)
3. After reboot, while booting into SONiC the SSD firmware updater will be executed in initramfs.

UT logs: [Dell_S6100_SSD_upgrade_in_initramfs_logs.txt](https://github.com/Azure/sonic-buildimage/files/8630200/SSD_upgrade_in_initramfs_UT_logs.txt)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

[initramfs]: SSD firmware upgrade in initramfs

#### A picture of a cute animal (not mandatory but encouraged)

