### PR TITLE
[reboiot-cause] Fix a broken symlink of previous-reboot-cause file removal issue

### DIFF
--- a/src/sonic-host-services/scripts/determine-reboot-cause
+++ b/src/sonic-host-services/scripts/determine-reboot-cause
@@ -174,7 +174,7 @@ def main():
         os.makedirs(REBOOT_CAUSE_DIR)
 
     # Remove stale PREVIOUS_REBOOT_CAUSE_FILE if it exists
-    if os.path.exists(PREVIOUS_REBOOT_CAUSE_FILE):
+    if os.path.exists(PREVIOUS_REBOOT_CAUSE_FILE) or os.path.islink(PREVIOUS_REBOOT_CAUSE_FILE):
         os.remove(PREVIOUS_REBOOT_CAUSE_FILE)
 
     # This variable is kept for future-use purpose. When proc_cmd_line/vendor/software provides


### PR DESCRIPTION

#### Why I did it
When the previous-reboot-cause has a broken symlink, the following back trace is shown in the syslog and system-running state show degraded. And rebooting the system will not be able to generated a new symlink of the new previous-reboot-cause. 
fixes #10746
#### How I did it
Somehow, when the  symlink file /host/reboot-cause/previous-reboot-cause is broken (which its destination files doesn't exist in this case),  the current condition check "if os.path,exists(PREVIOUS_REBOOT_CAUSE_FILE)" will return False in determine-reboot-cause script.  Hence, the current previous-reboot-cause is not been removed and the recreation of the new previous-reboot-cause failed.  In case of previous-reboot-cause is a broken synlink file, add condition os.path.islink(PREVIOUS_REBOOT_CAUSE) to check and allow the remove operation happens.

#### How to verify it
1) Manually make the /host/reboot-cause/previous-reboot-cause to be a broken symlink file by removing its destination file
2) reboot the system
3) verify the syslog, the backtrace should not be shown and "systemctl is-system-running" should show "running" instead of "degraded"


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

