### PR TITLE
Revert "[portconfig]: Remove try block for db config initialization"

### DIFF
--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -72,7 +72,12 @@ def db_connect_configdb(namespace=None):
     """
     Connect to configdb
     """
-    config_db = swsscommon.ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+    try:
+        if namespace is not None:
+            swsscommon.SonicDBConfig.load_sonic_global_db_config(namespace=namespace)
+        config_db = swsscommon.ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+    except Exception as e:
+        return None
     if config_db is None:
         return None
     try:

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -32,7 +32,7 @@ from functools import partial
 from minigraph import minigraph_encoder, parse_xml, parse_device_desc_xml, parse_asic_sub_role, parse_asic_switch_type
 from portconfig import get_port_config, get_breakout_mode
 from redis_bcc import RedisBytecodeCache
-from sonic_py_common.multi_asic import get_asic_id_from_name, get_asic_device_id, is_multi_asic
+from sonic_py_common.multi_asic import get_asic_id_from_name, get_asic_device_id
 from sonic_py_common import device_info
 from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector, SonicDBConfig, ConfigDBPipeConnector
 
@@ -296,12 +296,6 @@ def main():
                                 'localhost': {'namespace_id': namespace_id}
                              }
                           })
-    # load db config
-    if not SonicDBConfig.isInit():
-        if is_multi_asic():
-            SonicDBConfig.load_sonic_global_db_config(namespace=asic_name)
-        else:
-            SonicDBConfig.load_sonic_db_config()
     if hwsku is not None:
         hardware_data = {'DEVICE_METADATA': {'localhost': {
             'hwsku': hwsku


### PR DESCRIPTION
Reverts Azure/sonic-buildimage#10581
Below error seen when sonic-cfggen tries to get the hwsku(/usr/local/bin/sonic-cfggen -H -v DEVICE_METADATA.localhost.platform) for device path directory, during boot up

Traceback (most recent call last):
  File "/usr/local/bin/sonic-cfggen", line 451, in <module>
    main()
  File "/usr/local/bin/sonic-cfggen", line 304, in main
    SonicDBConfig.load_sonic_db_config()
  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 1252, in load_sonic_db_config
    SonicDBConfig.initialize(sonic_db_file_path)
  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 1247, in initialize
    return _swsscommon.SonicDBConfig_initialize(*args, **kwargs)
RuntimeError: Sonic database config file doesn't exist at /var/run/redis/sonic-db/database_config.json