### PR TITLE
Fix calculation of $(1)_DEP_PKGS_SHA in Makefile.cache

### DIFF
--- a/Makefile.cache
+++ b/Makefile.cache
@@ -186,7 +186,7 @@ define GET_MOD_DEP_SHA
 	$(if $($(1)_DEP_FILES_MISSING), $(warning "[ DPKG ] Dependecy file(s) are not found for $(1) : $($(1)_DEP_FILES_MISSING)))
 
 	# Include package dependencies hash values into package hash calculation
-	$(eval $(1)_DEP_PKGS_SHA := $(foreach dfile,$(1)_MOD_DEP_PKGS,$(dfile)_DEP_MOD_SHA $(dfile)_MOD_HASH))
+	$(eval $(1)_DEP_PKGS_SHA := $(foreach dfile,$($(1)_MOD_DEP_PKGS),$($(dfile)_DEP_MOD_SHA) $($(dfile)_MOD_HASH)))
 
 	$(eval $(1)_DEP_MOD_SHA := $(shell bash -c "git hash-object  $($(1)_DEP_MOD_SHA_FILES) && echo $($(1)_DEP_PKGS_SHA)" \
                             | sha1sum | awk '{print substr($$1,0,23);}'))


### PR DESCRIPTION
Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

In `Makefile.cache`, for `$(1)_DEP_PKGS_SHA`, the intention is to include
the `DEP_MOD_SHA` and `MOD_HASH` of each of the current package's
dependencies. However, there's a level of dereferencing missing; instead
of grabbing the value of `$(dfile)_DEP_MOD_SHA`, it is literally using the
variable name `$(dfile)_DEP_MOD_SHA`. This means that the value of this
variable will not change when some dependency changes.

The impact of this is in indirect dependencies. For a specific
example, if there is some change in sairedis, then sairedis will be
rebuilt (because there's a change within that component), and swss will
be rebuilt (because it's a direct dependency), but
docker-swss-layer-buster will not get rebuilt, because only the direct
dependencies are effectively being checked, and those aren't changing.

#### How I did it

Make sure the value of `$(1)_MOD_DEP_PKGS`, `$(dfile)_DEP_MOD_SHA`, and `$(dfile)_MOD_HASH` are used, not the literal text.

Before:

```
FLAGS: target/debs/buster/libsnmp-base_5.7.3+dfsg-5_all.deb.flags, DEP:
DEP: target/debs/buster/libsnmp-base_5.7.3+dfsg-5_all.deb.dep, MOD:Makefile.cache
libsnmp-base_5.7.3+dfsg-5_all.deb_MOD_DEP_PKGS: libnl-3-200_3.5.0-1_amd64.deb  libnl-3-200_3.5.0-1_amd64.deb
libsnmp-base_5.7.3+dfsg-5_all.deb_DEP_MOD_SHA_FILES: target/debs/buster/libnl-3-200_3.5.0-1_amd64.deb.flags target/debs/buster/libnl-3-200_3.5.0-1_amd64.deb.dep.sha   target/debs/buster/libnl-3-200_3.5.0-1_amd64.deb.flags target/debs/buster/libnl-3-200_3.5.0-1_amd64.deb.dep.sha
libsnmp-base_5.7.3+dfsg-5_all.deb_DEP_PKGS_SHA: libsnmp-base_5.7.3+dfsg-5_all.deb_MOD_DEP_PKGS_DEP_MOD_SHA libsnmp-base_5.7.3+dfsg-5_all.deb_MOD_DEP_PKGS_MOD_HASH
libsnmp-base_5.7.3+dfsg-5_all.deb_MOD_DEP_FILES: target/debs/buster/libsnmp-base_5.7.3+dfsg-5_all.deb.flags target/debs/buster/libsnmp-base_5.7.3+dfsg-5_all.deb.dep.sha
libsnmp-base_5.7.3+dfsg-5_all.deb_MODE_CACHE_FILE := libsnmp-base_5.7.3+dfsg-5_all.deb-555bd7e832cdb7993b180d0-5ec7ff76937dcabf40f58bd.tgz
FLAGS: target/debs/buster/libyang1_1.0.184-2_amd64.deb.flags, DEP:
DEP: target/debs/buster/libyang1_1.0.184-2_amd64.deb.dep, MOD:Makefile.cache
libyang1_1.0.184-2_amd64.deb_MOD_DEP_PKGS:
libyang1_1.0.184-2_amd64.deb_DEP_MOD_SHA_FILES:
libyang1_1.0.184-2_amd64.deb_DEP_PKGS_SHA: libyang1_1.0.184-2_amd64.deb_MOD_DEP_PKGS_DEP_MOD_SHA libyang1_1.0.184-2_amd64.deb_MOD_DEP_PKGS_MOD_HASH
libyang1_1.0.184-2_amd64.deb_MOD_DEP_FILES: target/debs/buster/libyang1_1.0.184-2_amd64.deb.flags target/debs/buster/libyang1_1.0.184-2_amd64.deb.dep.sha
libyang1_1.0.184-2_amd64.deb_MODE_CACHE_FILE := libyang1_1.0.184-2_amd64.deb-7ce90aa69332df946e0b075-44189ebcfc77adbf0294393.tgz
```

After:

```
FLAGS: target/debs/buster/libsnmp-base_5.7.3+dfsg-5_all.deb.flags, DEP:
DEP: target/debs/buster/libsnmp-base_5.7.3+dfsg-5_all.deb.dep, MOD:Makefile.cache
libsnmp-base_5.7.3+dfsg-5_all.deb_MOD_DEP_PKGS: libnl-3-200_3.5.0-1_amd64.deb  libnl-3-200_3.5.0-1_amd64.deb
libsnmp-base_5.7.3+dfsg-5_all.deb_DEP_MOD_SHA_FILES: target/debs/buster/libnl-3-200_3.5.0-1_amd64.deb.flags target/debs/buster/libnl-3-200_3.5.0-1_amd64.deb.dep.sha   target/debs/buster/libnl-3-200_3.5.0-1_amd64.deb.flags target/debs/buster/libnl-3-200_3.5.0-1_amd64.deb.dep.sha
libsnmp-base_5.7.3+dfsg-5_all.deb_DEP_PKGS_SHA: adc83b19e793491b1c6ea0f da9b9d27a4105e6b83efe49 adc83b19e793491b1c6ea0f da9b9d27a4105e6b83efe49
libsnmp-base_5.7.3+dfsg-5_all.deb_DEP_MOD_SHA: a9ab5ade419cadaca31289c
libsnmp-base_5.7.3+dfsg-5_all.deb_MOD_DEP_FILES: target/debs/buster/libsnmp-base_5.7.3+dfsg-5_all.deb.flags target/debs/buster/libsnmp-base_5.7.3+dfsg-5_all.deb.dep.sha
libsnmp-base_5.7.3+dfsg-5_all.deb_MODE_CACHE_FILE := libsnmp-base_5.7.3+dfsg-5_all.deb-a9ab5ade419cadaca31289c-bffe759ac3036e4bc1f26c0.tgz
FLAGS: target/debs/buster/libyang1_1.0.184-2_amd64.deb.flags, DEP:
DEP: target/debs/buster/libyang1_1.0.184-2_amd64.deb.dep, MOD:Makefile.cache
libyang1_1.0.184-2_amd64.deb_MOD_DEP_PKGS:
libyang1_1.0.184-2_amd64.deb_DEP_MOD_SHA_FILES:
libyang1_1.0.184-2_amd64.deb_DEP_PKGS_SHA:
libyang1_1.0.184-2_amd64.deb_DEP_MOD_SHA: adc83b19e793491b1c6ea0f
libyang1_1.0.184-2_amd64.deb_MOD_DEP_FILES: target/debs/buster/libyang1_1.0.184-2_amd64.deb.flags target/debs/buster/libyang1_1.0.184-2_amd64.deb.dep.sha
libyang1_1.0.184-2_amd64.deb_MODE_CACHE_FILE := libyang1_1.0.184-2_amd64.deb-adc83b19e793491b1c6ea0f-3403cc0cfda553ecdbb02d6.tgz
```

#### How to verify it

Change the git hash used for the `src/sonic-sairedis/SAI` submodule, and verify that `docker-swss-layer-buster` gets rebuilt.

Note that this also means that PR build times may increase, since indirect dependencies are now properly being checked.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

