### PR TITLE
[dualtor][minigraph.py] Add `soc_ipv4` and `cable_type` to `MUX_CABLE`

### DIFF
--- a/src/sonic-config-engine/tests/simple-sample-graph-case.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case.xml
@@ -258,7 +258,7 @@
         <EndDevice>switch-t0</EndDevice>
         <EndPort>fortyGigE0/4</EndPort>
         <FlowControl>true</FlowControl>
-        <StartDevice>mux-cable</StartDevice>
+        <StartDevice>server1-SC</StartDevice>
         <StartPort>L</StartPort>
         <Validate>true</Validate>
       </DeviceLinkBase>
@@ -269,7 +269,7 @@
         <EndDevice>switch-t0</EndDevice>
         <EndPort>fortyGigE0/8</EndPort>
         <FlowControl>true</FlowControl>
-        <StartDevice>mux-cable</StartDevice>
+        <StartDevice>server2-SC</StartDevice>
         <StartPort>U</StartPort>
         <Validate>true</Validate>
       </DeviceLinkBase>
@@ -317,6 +317,23 @@
         </ManagementAddress> 
         <HwSku>Force10-S6000</HwSku>
       </Device>
+      <Device i:type="SmartCable">
+        <ElementType>SmartCable</ElementType>
+        <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
+          <d5p1:IPPrefix>0.0.0.0/0</d5p1:IPPrefix>
+        </Address>
+        <AddressV6 xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
+          <d5p1:IPPrefix>::/0</d5p1:IPPrefix>
+        </AddressV6>
+        <ManagementAddress xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
+          <d5p1:IPPrefix>0.0.0.0/0</d5p1:IPPrefix>
+        </ManagementAddress>
+        <ManagementAddressV6 xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
+          <d5p1:IPPrefix>::/0</d5p1:IPPrefix>
+        </ManagementAddressV6>
+        <SerialNumber i:nil="true" />
+        <Hostname>server1-SC</Hostname>
+      </Device>
       <Device i:type="Server">
         <ElementType>Server</ElementType>
         <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
@@ -330,6 +347,24 @@
         </ManagementAddress>
         <Hostname>server1</Hostname>
         <HwSku>server-sku</HwSku>
+      </Device>
+      <Device i:type="SmartCable">
+        <ElementType>SmartCable</ElementType>
+        <SubType>active-active</SubType>
+        <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
+          <d5p1:IPPrefix>10.10.10.3/32</d5p1:IPPrefix>
+        </Address>
+        <AddressV6 xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
+          <d5p1:IPPrefix>::/0</d5p1:IPPrefix>
+        </AddressV6>
+        <ManagementAddress xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
+          <d5p1:IPPrefix>0.0.0.0/0</d5p1:IPPrefix>
+        </ManagementAddress>
+        <ManagementAddressV6 xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
+          <d5p1:IPPrefix>::/0</d5p1:IPPrefix>
+        </ManagementAddressV6>
+        <SerialNumber i:nil="true" />
+        <Hostname>server1-SC</Hostname>
       </Device>
       <Device i:type="Server">
         <ElementType>Server</ElementType>

--- a/src/sonic-config-engine/tests/simple-sample-graph-case.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case.xml
@@ -333,6 +333,7 @@
         </ManagementAddressV6>
         <SerialNumber i:nil="true" />
         <Hostname>server1-SC</Hostname>
+        <HwSku>smartcable-sku</HwSku>
       </Device>
       <Device i:type="Server">
         <ElementType>Server</ElementType>
@@ -365,6 +366,7 @@
         </ManagementAddressV6>
         <SerialNumber i:nil="true" />
         <Hostname>server2-SC</Hostname>
+        <HwSku>smartcable-sku</HwSku>
       </Device>
       <Device i:type="Server">
         <ElementType>Server</ElementType>

--- a/src/sonic-config-engine/tests/simple-sample-graph-case.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case.xml
@@ -364,7 +364,7 @@
           <d5p1:IPPrefix>::/0</d5p1:IPPrefix>
         </ManagementAddressV6>
         <SerialNumber i:nil="true" />
-        <Hostname>server1-SC</Hostname>
+        <Hostname>server2-SC</Hostname>
       </Device>
       <Device i:type="Server">
         <ElementType>Server</ElementType>

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -226,6 +226,21 @@ class TestCfgGenCaseInsensitive(TestCase):
                 'lo_addr_v6': 'fe80::0002/128',
                 'mgmt_addr': '10.0.0.2/32',
                 'type': 'Server'
+            },
+            'server1-SC': {
+                'hwsku': 'smartcable-sku',
+                'lo_addr': '0.0.0.0/0',
+                'lo_addr_v6': '::/0',
+                'mgmt_addr': '0.0.0.0/0',
+                'type': 'SmartCable'
+            },
+            'server2-SC': {
+                'hwsku': 'smartcable-sku',
+                'lo_addr': '10.10.10.3/32',
+                'lo_addr_v6': '::/0',
+                'mgmt_addr': '0.0.0.0/0',
+                'type': 'SmartCable',
+                'subtype': 'active-active'
             }
         }
         output = self.run_script(argument)

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -365,7 +365,9 @@ class TestCfgGenCaseInsensitive(TestCase):
             'Ethernet8': {
                 'state': 'auto',
                 'server_ipv4': '10.10.10.2/32',
-                'server_ipv6': 'fe80::2/128'
+                'server_ipv6': 'fe80::2/128',
+                'soc_ipv4': '10.10.10.3/32',
+                'cable_type': 'active-active'
             }
         }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To further add `cable_type` and `soc_ipv4` field to table `MUX_CABLE`, this PR tries to parse minigraph like the following:
```
      <Device i:type="SmartCable">
        <ElementType>SmartCable</ElementType>
        <SubType>active-active</SubType>
        <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
          <d5p1:IPPrefix>192.168.0.3/21</d5p1:IPPrefix>
        </Address>
        <AddressV6 xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
          <d5p1:IPPrefix>::/0</d5p1:IPPrefix>
        </AddressV6>
        <ManagementAddress xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
          <d5p1:IPPrefix>0.0.0.0/0</d5p1:IPPrefix>
        </ManagementAddress>
        <ManagementAddressV6 xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
          <d5p1:IPPrefix>::/0</d5p1:IPPrefix>
        </ManagementAddressV6>
        <SerialNumber i:nil="true" />
        <Hostname>svcstr-7050-acs-1-Servers0-SC</Hostname>
      </Device>
      <Device i:type="Server">
        <ElementType>Server</ElementType>
        <Address xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
          <d5p1:IPPrefix>192.168.0.2/21</d5p1:IPPrefix>
        </Address> 
        <AddressV6 xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
          <d5p1:IPPrefix>fc02:1000::2/64</d5p1:IPPrefix>
        </AddressV6>
        <ManagementAddress xmlns:d5p1="Microsoft.Search.Autopilot.NetMux">
          <d5p1:IPPrefix>0.0.0.0/0</d5p1:IPPrefix>
        </ManagementAddress>
        <Hostname>Servers0</Hostname>
      </Device>
```
Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How I did it
`get_mux_cable_entries` will try to get the mux cable device from the devices list and get the cable type and soc ip address from the device definition.

#### How to verify it
Pass the unit-test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)
![kui011](https://user-images.githubusercontent.com/35479537/167250349-a0f4b125-18a5-46d6-836c-a72a6a820a36.jpg)

