### PR TITLE
[Mellanox] Credo Y-cable | add more log info, checks, fix exception message

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -187,7 +187,7 @@ class MlxregManager:
                     --set {} -y".format(self.mst_pci_device, self.slot_id, self.sdk_index, device_address, page, num_bytes, dword)
             subprocess.check_call(cmd, shell=True, universal_newlines=True, stdout=subprocess.DEVNULL)
         except subprocess.CalledProcessError as e:
-            logger.log_error("Error! Unable to write data for {} port, page {} offset {}, rc = {}, err msg: {}".format(self.sdk_index, page, device_address, e.returncode, e.output))
+            logger.log_error("Error! Unable to write data dword={} for {} port, page {} offset {}, rc = {}, err msg: {}".format(dword, self.sdk_index, page, device_address, e.returncode, e.output))
             return False
         return True
 
@@ -198,11 +198,14 @@ class MlxregManager:
                     --get".format(self.mst_pci_device, self.slot_id, self.sdk_index, offset, page, num_bytes)
             result = subprocess.check_output(cmd, universal_newlines=True, shell=True)
         except subprocess.CalledProcessError as e:
-            logger.log_error("Error! Unable to write data for {} port, page {} offset {}, rc = {}, err msg: {}".format(self.sdk_index, page, device_address, e.returncode, e.output))
+            logger.log_error("Error! Unable to read data for {} port, page {} offset {}, rc = {}, err msg: {}".format(self.sdk_index, page, offset, e.returncode, e.output))
             return None
         return result
 
     def parse_mlxreg_read_output(self, read_output, num_bytes):
+        if not read_output:
+            return None
+
         res = ""
         dword_num = num_bytes // BYTES_IN_DWORD
         used_bytes_in_dword = num_bytes % BYTES_IN_DWORD


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Script fails when there is an exception while reading

#### How I did it
Add more logs and checks. Fix wrong variable naming and messages.

#### How to verify it
Provoke exception while **read_eeprom()** and check that it is handled properly

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

