### PR TITLE
DellEMC: S52xx Reboot cause fix

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/chassis.py
@@ -38,7 +38,7 @@ class Chassis(ChassisBase):
 
     oir_fd = -1
     epoll = -1
-
+    REBOOT_CAUSE_PATH = "/host/reboot-cause/platform/reboot_reason"
     _global_port_pres_dict = {}
 
     def __init__(self):
@@ -239,15 +239,15 @@ class Chassis(ChassisBase):
             return (self.REBOOT_CAUSE_NON_HARDWARE, None)
 
         if reboot_cause & 0x1:
-            return (self.REBOOT_CAUSE_POWER_LOSS, None)
+            return (self.REBOOT_CAUSE_POWER_LOSS, "Power on reset")
         elif reboot_cause & 0x2:
             return (self.REBOOT_CAUSE_NON_HARDWARE, None)
         elif reboot_cause & 0x4:
             return (self.REBOOT_CAUSE_HARDWARE_OTHER, "PSU Shutdown")
         elif reboot_cause & 0x8:
-            return (self.REBOOT_CAUSE_THERMAL_OVERLOAD_CPU, None)
+            return (self.REBOOT_CAUSE_THERMAL_OVERLOAD_CPU, "Thermal overload")
         elif reboot_cause & 0x10:
-            return (self.REBOOT_CAUSE_WATCHDOG, None)
+            return (self.REBOOT_CAUSE_WATCHDOG, "Watchdog reset")
         elif reboot_cause & 0x20:
             return (self.REBOOT_CAUSE_HARDWARE_OTHER, "BMC Shutdown")
         elif reboot_cause & 0x40:

--- a/platform/broadcom/sonic-platform-modules-dell/s5248f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5248f/sonic_platform/chassis.py
@@ -309,6 +309,7 @@ class Chassis(ChassisBase):
             An integer represences the number of SFPs on the chassis.
         """
         return self._num_sfps
+
     def get_reboot_cause(self):
         """
         Retrieves the cause of the previous reboot
@@ -326,15 +327,15 @@ class Chassis(ChassisBase):
             return (self.REBOOT_CAUSE_NON_HARDWARE, None)
 
         if reboot_cause & 0x1:
-            return (self.REBOOT_CAUSE_POWER_LOSS, None)
+            return (self.REBOOT_CAUSE_POWER_LOSS, "Power on reset")
         elif reboot_cause & 0x2:
             return (self.REBOOT_CAUSE_NON_HARDWARE, None)
         elif reboot_cause & 0x4:
             return (self.REBOOT_CAUSE_HARDWARE_OTHER, "PSU Shutdown")
         elif reboot_cause & 0x8:
-            return (self.REBOOT_CAUSE_THERMAL_OVERLOAD_CPU, None)
+            return (self.REBOOT_CAUSE_THERMAL_OVERLOAD_CPU, "Thermal overload")
         elif reboot_cause & 0x10:
-            return (self.REBOOT_CAUSE_WATCHDOG, None)
+            return (self.REBOOT_CAUSE_WATCHDOG, "Watchdog reset")
         elif reboot_cause & 0x20:
             return (self.REBOOT_CAUSE_HARDWARE_OTHER, "BMC Shutdown")
         elif reboot_cause & 0x40:


### PR DESCRIPTION
#### Why I did it
Reboot cause is not updated properly in DellEMC S5232f.
#### How I did it
Modified chassis.py to fix the issue
#### How to verify it
Execute different reboot methods and confirm the behavior.
#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
UT: 
[reboot_cause UT.txt](https://github.com/Azure/sonic-buildimage/files/8650377/reboot_cause.UT.txt)
