### PR TITLE
[Accton] Fix wrong system eeprom data of 0x25 field

### DIFF
--- a/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/eeprom.py
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/sonic_platform/eeprom.py
@@ -6,7 +6,7 @@ try:
         from io import StringIO
     else:
         from cStringIO import StringIO
-    
+
     from sonic_platform_base.sonic_eeprom import eeprom_tlvinfo
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
@@ -33,7 +33,7 @@ class Tlv(eeprom_tlvinfo.TlvInfoDecoder):
         for line in lines:
             try:
                 match = re.search(
-                    '(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)([\S]+)', line)
+                    '(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)(.+)', line)
                 if match is not None:
                     idx = match.group(1)
                     value = match.group(3).rstrip('\0')

--- a/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/eeprom.py
+++ b/device/accton/x86_64-accton_as4630_54te-r0/sonic_platform/eeprom.py
@@ -33,7 +33,7 @@ class Tlv(eeprom_tlvinfo.TlvInfoDecoder):
         for line in lines:
             try:
                 match = re.search(
-                    '(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)([\S]+)', line)
+                    '(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)(.+)', line)
                 if match is not None:
                     idx = match.group(1)
                     value = match.group(3).rstrip('\0')

--- a/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/eeprom.py
+++ b/device/accton/x86_64-accton_as5835_54x-r0/sonic_platform/eeprom.py
@@ -6,7 +6,7 @@ try:
         from io import StringIO
     else:
         from cStringIO import StringIO
-    
+
     from sonic_platform_base.sonic_eeprom import eeprom_tlvinfo
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
@@ -33,7 +33,7 @@ class Tlv(eeprom_tlvinfo.TlvInfoDecoder):
         for line in lines:
             try:
                 match = re.search(
-                    '(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)([\S]+)', line)
+                    '(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)(.+)', line)
                 if match is not None:
                     idx = match.group(1)
                     value = match.group(3).rstrip('\0')
@@ -129,6 +129,6 @@ class Tlv(eeprom_tlvinfo.TlvInfoDecoder):
 
     def get_mac(self):
         return self._eeprom.get('0x24', NULL)
-    
+
     def get_product_name(self):
         return self._eeprom.get('0x21', NULL)

--- a/device/accton/x86_64-accton_as7116_54x-r0/sonic_platform/eeprom.py
+++ b/device/accton/x86_64-accton_as7116_54x-r0/sonic_platform/eeprom.py
@@ -44,7 +44,7 @@ class Tlv(eeprom_tlvinfo.TlvInfoDecoder):
         for line in lines:
             try:
                 match = re.search(
-                    '(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)([\S]+)', line)
+                    '(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)(.+)', line)
                 if match is not None:
                     idx = match.group(1)
                     value = match.group(3).rstrip('\0')

--- a/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/eeprom.py
+++ b/device/accton/x86_64-accton_as7312_54x-r0/sonic_platform/eeprom.py
@@ -6,7 +6,7 @@ try:
         from io import StringIO
     else:
         from cStringIO import StringIO
-    
+
     from sonic_platform_base.sonic_eeprom import eeprom_tlvinfo
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
@@ -33,7 +33,7 @@ class Tlv(eeprom_tlvinfo.TlvInfoDecoder):
         for line in lines:
             try:
                 match = re.search(
-                    '(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)([\S]+)', line)
+                    '(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)(.+)', line)
                 if match is not None:
                     idx = match.group(1)
                     value = match.group(3).rstrip('\0')
@@ -41,7 +41,7 @@ class Tlv(eeprom_tlvinfo.TlvInfoDecoder):
                 _eeprom_info_dict[idx] = value
             except Exception:
                 pass
-               
+
         return _eeprom_info_dict
 
     def _load_eeprom(self):

--- a/device/accton/x86_64-accton_as7326_56x-r0/sonic_platform/eeprom.py
+++ b/device/accton/x86_64-accton_as7326_56x-r0/sonic_platform/eeprom.py
@@ -37,7 +37,7 @@ class Tlv(eeprom_tlvinfo.TlvInfoDecoder):
 
         for line in lines:
             try:
-                match = re.search('(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)([\S]+)',
+                match = re.search('(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)(.+)',
                                   line)
                 if match is not None:
                     idx = match.group(1)

--- a/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/eeprom.py
+++ b/device/accton/x86_64-accton_as7816_64x-r0/sonic_platform/eeprom.py
@@ -6,7 +6,7 @@ try:
         from io import StringIO
     else:
         from cStringIO import StringIO
-    
+
     from sonic_platform_base.sonic_eeprom import eeprom_tlvinfo
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
@@ -33,7 +33,7 @@ class Tlv(eeprom_tlvinfo.TlvInfoDecoder):
         for line in lines:
             try:
                 match = re.search(
-                    '(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)([\S]+)', line)
+                    '(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)(.+)', line)
                 if match is not None:
                     idx = match.group(1)
                     value = match.group(3).rstrip('\0')
@@ -129,6 +129,6 @@ class Tlv(eeprom_tlvinfo.TlvInfoDecoder):
 
     def get_mac(self):
         return self._eeprom.get('0x24', NULL)
-    
+
     def get_product_name(self):
         return self._eeprom.get('0x21', NULL)

--- a/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/eeprom.py
+++ b/device/accton/x86_64-accton_as9726_32d-r0/sonic_platform/eeprom.py
@@ -33,7 +33,7 @@ class Tlv(eeprom_tlvinfo.TlvInfoDecoder):
         for line in lines:
             try:
                 match = re.search(
-                    '(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)([\S]+)', line)
+                    '(0x[0-9a-fA-F]{2})([\s]+[\S]+[\s]+)(.+)', line)
                 if match is not None:
                     idx = match.group(1)
                     value = match.group(3).rstrip('\0')


### PR DESCRIPTION
The timestamp will be discarded by eeprom.__parse_output()

Corrected data:
    Manufacture Date     0x25       19  06/22/2018 17:23:18
Wrong data:
    Manufacture Date     0x25       19  06/22/2018

Signed-off-by: Brandon Chuang <brandon_chuang@edge-core.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

