### PR TITLE
remove voq chassis check

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_voq_chassis_neighbor.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_voq_chassis_neighbor.json
@@ -2,10 +2,6 @@
     "BGP_VOQ_CHASSIS_NEIGHBOR_TEST" : {
         "desc": "Load bgp voq chassis neighbor"
     },
-    "BGP_VOQ_CHASSIS_WITH_INVALID_SWITCH_TYPE_TEST" : {
-        "desc": "Load bgp voq chassis on non voq chassis switch",
-        "eStr": ["Bgp voq neighbor are applicable only when switch_type is voq"]
-    },
     "BGP_VOQ_CHASSIS_ABSENT_LOCAL_ADDRESS_TEST" : {
         "desc": "Load bgp voq chassis with no local address",
         "eStrKey" : "Mandatory"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_voq_chassis_neighbor.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_voq_chassis_neighbor.json
@@ -40,47 +40,6 @@
             }
         }
     },
-    "BGP_VOQ_CHASSIS_WITH_INVALID_SWITCH_TYPE_TEST": {
-        "sonic-bgp-voq-chassis-neighbor:sonic-bgp-voq-chassis-neighbor": {
-            "sonic-bgp-voq-chassis-neighbor:BGP_VOQ_CHASSIS_NEIGHBOR": {
-                "BGP_VOQ_CHASSIS_NEIGHBOR_LIST": [
-                    {
-                        "neighbor": "10.0.0.1",
-                        "asn": "65001",
-                        "holdtime": "180",
-                        "keepalive": "60",
-                        "local_addr": "10.0.0.2",
-                        "name": "sonic-chassis-lc3",
-                        "nhopself": "0",
-                        "rrclient": "0",
-                        "admin_status": "up"
-                    },
-                    {
-                        "neighbor": "3333::3:6",
-                        "asn": "65001",
-                        "holdtime": "180",
-                        "keepalive": "60",
-                        "local_addr": "3333::3:3",
-                        "name": "sonic-chassis-lc3",
-                        "nhopself": "0",
-                        "rrclient": "0",
-                        "admin_status": "up"
-                    }
-                ]
-            }
-        },
-        "sonic-device_metadata:sonic-device_metadata": {
-            "sonic-device_metadata:DEVICE_METADATA": {
-                "localhost": {
-                    "bgp_asn": "65001",
-                    "default_bgp_status": "up",
-                    "hostname": "sonic-chassis",
-                    "platform": "voq-chassis",
-                    "switch_type": "chassis-packet"
-                }
-            }
-        }
-    },
     "BGP_VOQ_CHASSIS_ABSENT_LOCAL_ADDRESS_TEST": {
         "sonic-bgp-voq-chassis-neighbor:sonic-bgp-voq-chassis-neighbor": {
             "sonic-bgp-voq-chassis-neighbor:BGP_VOQ_CHASSIS_NEIGHBOR": {

--- a/src/sonic-yang-models/yang-models/sonic-bgp-voq-chassis-neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-voq-chassis-neighbor.yang
@@ -54,9 +54,6 @@ module sonic-bgp-voq-chassis-neighbor {
                         }
                     }
                 }
-                must "(/dm:sonic-device_metadata/dm:DEVICE_METADATA/dm:localhost/dm:switch_type = 'voq')" {
-                        error-message "Bgp voq neighbor are applicable only when switch_type is voq";
-                }
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixes #10793 

#### How I did it
Removed the `switch_type` validation from the Yang model.

#### How to verify it
compile `sonic_yang_mgmt-1.0-py3-none-any.whl` and `sonic_yang_mgmt-1.0-py3-none-any.whl`

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

