### PR TITLE
[platform] Fix system-health.service start failed

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/service/as4630-54pe-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/service/as4630-54pe-platform-monitor.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS4630-54PE Platform Monitoring service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=sysinit.target
 DefaultDependencies=no
 

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54te/service/as4630-54te-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54te/service/as4630-54te-platform-monitor.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS4630-54TE Platform Monitoring service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=sysinit.target
 DefaultDependencies=no
 

--- a/platform/broadcom/sonic-platform-modules-accton/as5712-54x/service/as5712-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as5712-54x/service/as5712-platform-monitor.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS5712-54X Platform Monitoring service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=sysinit.target
 DefaultDependencies=no
 

--- a/platform/broadcom/sonic-platform-modules-accton/as5812-54t/service/as5812-platform-init.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as5812-54t/service/as5812-platform-init.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS5812-54X Platform Monitoring service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=sysinit.target
 DefaultDependencies=no
 

--- a/platform/broadcom/sonic-platform-modules-accton/as5812-54x/service/as5812-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as5812-54x/service/as5812-platform-monitor.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS5812-54X Platform Monitoring service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=sysinit.target
 DefaultDependencies=no
 

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/service/as5835-54t-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/service/as5835-54t-platform-monitor.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS5835-54T Platform Monitoring service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=sysinit.target
 DefaultDependencies=no
 

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54x/service/as5835-54x-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54x/service/as5835-54x-platform-monitor.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS5835-54X Platform Monitoring service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=sysinit.target
 DefaultDependencies=no
 

--- a/platform/broadcom/sonic-platform-modules-accton/as6712-32x/service/as6712-platform-init.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as6712-32x/service/as6712-platform-init.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS6712-32X Platform Monitoring service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=sysinit.target
 DefaultDependencies=no
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7312-54x/service/as7312-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as7312-54x/service/as7312-platform-monitor.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS7312-54X Platform Monitoring service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=sysinit.target
 DefaultDependencies=no
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7312-54xs/service/as7312-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as7312-54xs/service/as7312-platform-monitor.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS7312-54X Platform Monitoring service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=sysinit.target
 DefaultDependencies=no
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7315-27xb/service/as7315-platform-init.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as7315-27xb/service/as7315-platform-init.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS7315-27XB Platform initialization service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=sysinit.target
 DefaultDependencies=no
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/service/as7326-56x-pddf-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/service/as7326-56x-pddf-platform-monitor.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS7326-56X Platform Monitoring service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=pddf-platform-init.service
 DefaultDependencies=no
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7326-56x/service/as7326-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as7326-56x/service/as7326-platform-monitor.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS7326-56X Platform Monitoring service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=as7326-platform-handle_mac.service
 DefaultDependencies=no
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/service/as7712-pddf-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/service/as7712-pddf-platform-monitor.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS7712 Platform Monitoring service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=pddf-platform-init.service
 DefaultDependencies=no
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7712-32x/service/as7712-platform-init.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as7712-32x/service/as7712-platform-init.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS7712-32X Platform initialization service
-Before=pmon.service
+Before=pmon.service system-health.service
 DefaultDependencies=no
 
 [Service]

--- a/platform/broadcom/sonic-platform-modules-accton/as7716-32x/service/as7716-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as7716-32x/service/as7716-platform-monitor.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS7716-32X Platform Monitoring service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=sysinit.target
 DefaultDependencies=no
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7716-32xb/service/as7716_32xb-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as7716-32xb/service/as7716_32xb-platform-monitor.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS7716-32XB Platform Monitoring service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=sysinit.target
 DefaultDependencies=no
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/service/as7726-32x-pddf-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/service/as7726-32x-pddf-platform-monitor.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS7726-32X Platform Monitoring service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=pddf-platform-init.service
 DefaultDependencies=no
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/service/as7726-32x-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/service/as7726-32x-platform-monitor.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS7726-32X Platform Monitoring service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=as7726-32x-platform-handle_mac.service
 DefaultDependencies=no
 

--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/service/as7816-64x-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/service/as7816-64x-platform-monitor.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS7816-64X Platform Monitoring service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=as7816-64x-platform-init.service
 Requires=as7816-64x-platform-init.service
 DefaultDependencies=no

--- a/platform/broadcom/sonic-platform-modules-accton/as7816-64x/service/as7816-pddf-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as7816-64x/service/as7816-pddf-platform-monitor.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS7816-64X Platform Monitoring service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=pddf-platform-init.service
 DefaultDependencies=no
 

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/service/as9716-32d-pddf-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/service/as9716-32d-pddf-platform-monitor.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS9716-32D Platform Monitoring service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=pddf-platform-init.service
 DefaultDependencies=no
 

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/service/as9716-32d-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/service/as9716-32d-platform-monitor.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS9716-32D Platform Monitoring service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=sysinit.target
 DefaultDependencies=no
 

--- a/platform/broadcom/sonic-platform-modules-accton/as9726-32d/service/as9726-32d-platform-monitor.service
+++ b/platform/broadcom/sonic-platform-modules-accton/as9726-32d/service/as9726-32d-platform-monitor.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton AS9726_32D Platform Monitoring service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=sysinit.target
 DefaultDependencies=no
 

--- a/platform/broadcom/sonic-platform-modules-accton/minipack/service/minipack-platform-init.service
+++ b/platform/broadcom/sonic-platform-modules-accton/minipack/service/minipack-platform-init.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Accton MiniPack Platform Monitoring service
-Before=pmon.service
+Before=pmon.service system-health.service
 After=sysinit.target
 DefaultDependencies=no
 


### PR DESCRIPTION
Signed-off-by: Brandon Chuang <brandon_chuang@edge-core.com>

#### Why I did it
system-health.service will start failed if sonic_platform is not installed.

#### How I did it
Add system-health.service into platform-monitor.service to make sure sonic_platform is installed.

#### How to verify it
Check system-health.service status

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

