### PR TITLE
[Mellanox] optimize platform API import time

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -30,7 +30,6 @@ try:
 
     from . import utils
     from .device_data import DeviceDataManager
-    from .sfp import SFP, deinitialize_sdk_handle
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
@@ -113,8 +112,10 @@ class Chassis(ChassisBase):
         if self.sfp_event:
             self.sfp_event.deinitialize()
 
-        if SFP.shared_sdk_handle:
-            deinitialize_sdk_handle(SFP.shared_sdk_handle)
+        if self._sfp_list:
+            from .sfp import SFP, deinitialize_sdk_handle
+            if SFP.shared_sdk_handle:
+                deinitialize_sdk_handle(SFP.shared_sdk_handle)
 
     ##############################################
     # PSU methods

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
@@ -17,7 +17,6 @@
 
 import glob
 import os
-from sonic_py_common import device_info
 
 from . import utils
 
@@ -173,6 +172,7 @@ class DeviceDataManager:
     @classmethod
     @utils.read_only_cache()
     def get_platform_name(cls):
+        from sonic_py_common import device_info
         return device_info.get_platform()
 
     @classmethod


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

"import sonic_platform" takes about 600ms ~ 1000ms, it is kind of slow. After this optimization, the time is about 100ms. The benefit is that those CLIs which does not need the slow import sentence would be faster than before.

#### How I did it

Find slow import and call them when need.

#### How to verify it

Measure the import time.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)
