### PR TITLE
[Testbed2.0, sonic-mgmt]Install celery in sonic-mgmt docker image

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -94,7 +94,8 @@ RUN pip install cffi==1.10.0 \
     && rm -f 1.0.0.tar.gz  \
     && pip install nnpy    \
     && pip install dpkt    \
-    && pip install scapy==2.4.5 --upgrade
+    && pip install scapy==2.4.5 --upgrade \
+    && pip install celery[redis]
 
 # Install docker-ce-cli
 RUN apt-get update                  \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In testbed2.0, Scheduler needs sonic-mgmt dockers to execute test cases remotely as agents.
Celery is the task queue, so install it in sonic-mgmt docker image.
#### How I did it
pip install celery[redis]

#### How to verify it
Start sonic-mgmt container after the new image is built, add see whether celery is installed.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

