### PR TITLE
[dhcp6relay] Fix option parsing and add dhcpv6 client messages

### DIFF
--- a/dockers/docker-dhcp-relay/cli-plugin-tests/test_show_dhcp6relay_counters.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/test_show_dhcp6relay_counters.py
@@ -18,21 +18,23 @@ except KeyError:
     pass
 
 expected_counts = """\
-  Message Type     Vlan1000
---------------  -----------
-       Unknown
-       Solicit
-     Advertise
-       Request
-       Confirm
-         Renew
-        Rebind
-         Reply
-       Release
-       Decline
- Relay-Forward
-   Relay-Reply
-     Malformed
+       Message Type     Vlan1000
+-------------------  -----------
+            Unknown
+            Solicit
+          Advertise
+            Request
+            Confirm
+              Renew
+             Rebind
+              Reply
+            Release
+            Decline
+        Reconfigure
+Information-Request
+      Relay-Forward
+        Relay-Reply
+          Malformed
 
 """
 

--- a/dockers/docker-dhcp-relay/cli/show/plugins/show_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli/show/plugins/show_dhcp_relay.py
@@ -12,7 +12,7 @@ from swsscommon.swsscommon import SonicV2Connector
 DHCPv6_COUNTER_TABLE = 'DHCPv6_COUNTER_TABLE'
 
 # DHCPv6 Counter Messages
-messages = ["Unknown", "Solicit", "Advertise", "Request", "Confirm", "Renew", "Rebind", "Reply", "Release", "Decline", "Relay-Forward", "Relay-Reply", "Malformed"]
+messages = ["Unknown", "Solicit", "Advertise", "Request", "Confirm", "Renew", "Rebind", "Reply", "Release", "Decline", "Reconfigure", "Information-Request", "Relay-Forward", "Relay-Reply", "Malformed"]
 
 # DHCP_RELAY Config Table
 DHCP_RELAY = 'DHCP_RELAY'

--- a/src/dhcp6relay/src/relay.cpp
+++ b/src/dhcp6relay/src/relay.cpp
@@ -638,6 +638,7 @@ void callback(evutil_socket_t fd, short event, void *arg) {
         }
         case DHCPv6_MESSAGE_TYPE_SOLICIT:
         case DHCPv6_MESSAGE_TYPE_REQUEST: 
+	case DHCPv6_MESSAGE_TYPE_CONFIRM:
         case DHCPv6_MESSAGE_TYPE_RENEW:
         case DHCPv6_MESSAGE_TYPE_REBIND:
         case DHCPv6_MESSAGE_TYPE_RELEASE:

--- a/src/dhcp6relay/src/relay.cpp
+++ b/src/dhcp6relay/src/relay.cpp
@@ -643,7 +643,7 @@ void callback(evutil_socket_t fd, short event, void *arg) {
         }
         case DHCPv6_MESSAGE_TYPE_SOLICIT:
         case DHCPv6_MESSAGE_TYPE_REQUEST: 
-	    case DHCPv6_MESSAGE_TYPE_CONFIRM:
+        case DHCPv6_MESSAGE_TYPE_CONFIRM:
         case DHCPv6_MESSAGE_TYPE_RENEW:
         case DHCPv6_MESSAGE_TYPE_REBIND:
         case DHCPv6_MESSAGE_TYPE_RELEASE:

--- a/src/dhcp6relay/src/relay.h
+++ b/src/dhcp6relay/src/relay.h
@@ -36,6 +36,8 @@ typedef enum
     DHCPv6_MESSAGE_TYPE_REPLY = 7,
     DHCPv6_MESSAGE_TYPE_RELEASE = 8,
     DHCPv6_MESSAGE_TYPE_DECLINE = 9,
+    DHCPv6_MESSAGE_TYPE_RECONFIGURE = 10,
+    DHCPv6_MESSAGE_TYPE_INFORMATION_REQUEST = 11,
     DHCPv6_MESSAGE_TYPE_RELAY_FORW = 12,
     DHCPv6_MESSAGE_TYPE_RELAY_REPL = 13,
     DHCPv6_MESSAGE_TYPE_MALFORMED = 14,
@@ -60,6 +62,7 @@ struct relay_config {
 
 struct dhcpv6_msg {
     uint8_t msg_type;
+    uint8_t xid[3];
 };
 
 struct PACKED dhcpv6_relay_msg {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixed option parsing function and added missing dhcpv6 messages.
Confirm message type was not added in PR https://github.com/Azure/sonic-buildimage/pull/10486 when client side message types are checked.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

