### PR TITLE
[Ci] Support to trigger a pipeline to download and publish artifacts to storage

### DIFF
--- a/.azure-pipelines/azure-pipelines-image-template.yml
+++ b/.azure-pipelines/azure-pipelines-image-template.yml
@@ -48,7 +48,7 @@ jobs:
           ENABLE_DOCKER_BASE_PULL=y make PLATFORM=$(PLATFORM_AZP) PLATFORM_ARCH=$(PLATFORM_ARCH) $(BUILD_OPTIONS) configure
         displayName: 'Make configure'
     postSteps:
-      - script: cp target -r $(Build.ArtifactStagingDirectory)/
+      - script: mv target $(Build.ArtifactStagingDirectory)/
         displayName: Copy Artifacts
         condition: always()
       - publish:  $(Build.ArtifactStagingDirectory)
@@ -58,6 +58,10 @@ jobs:
         condition: failed()
         artifact: 'sonic-buildimage.$(GROUP_NAME)$(GROUP_EXTNAME)$(System.JobAttempt)'
         displayName: "Archive failed sonic image"
+      - template: trigger-publish-artifacts-build.yml
+        parameters:
+          artifactName: 'sonic-buildimage.$(GROUP_NAME)$(GROUP_EXTNAME)'
+          publishPrefix: '$(Build.DefinitionName)/$(Build.SourceBranchName)/$(GROUP_NAME)'
       - ${{ parameters.postSteps }}
       - template: cleanup.yml
     jobGroups: ${{ parameters.jobGroups }}

--- a/.azure-pipelines/trigger-publish-artifacts-build.yml
+++ b/.azure-pipelines/trigger-publish-artifacts-build.yml
@@ -1,0 +1,64 @@
+# The steps to trigger the pipeline to publish the artifacts
+
+parameters:
+- name: artifactName
+  type: string
+  default: ""
+- name: publishPrefix
+  type: string
+  default: "$(Build.DefinitionName)/$(Build.SourceBranchName)"
+
+steps:
+- script: |
+    . functions.sh
+    sonic_version=$(sonic_get_version)
+    latest_tag=$(git describe --tags --abbrev=0)
+    docker_tags="$sonic_version $(Build.SourceBranchName)"
+    if [ "$(Build.SourceBranchName)" == "master" ]; then
+      docker_tags="$docker_tags latest"
+    fi
+    echo "##vso[task.setvariable variable=sonic_version]$sonic_version"
+    echo "##vso[task.setvariable variable=latest_tag]$latest_tag"
+    echo "##vso[task.setvariable variable=docker_tags]$docker_tags"
+  condition: ne(variables['Build.Reason'], 'PullRequest')
+  displayName: 'Set trigger build variables'
+- task: TriggerBuild@4
+  condition: ne(variables['Build.Reason'], 'PullRequest')
+  inputs:
+    definitionIsInCurrentTeamProject: false
+    teamProject: internal
+    tfsServer: $(System.CollectionUri)
+    buildDefinition: 'publish-artifacts'
+    queueBuildForUserThatTriggeredBuild: true
+    ignoreSslCertificateErrors: false
+    useSameSourceVersion: false
+    useCustomSourceVersion: false
+    useSameBranch: false
+    waitForQueuedBuildsToFinish: false
+    storeInEnvironmentVariable: true
+    authenticationMethod: 'Personal Access Token'
+    password: '$(system.accesstoken)'
+    enableBuildInQueueCondition: false
+    dependentOnSuccessfulBuildCondition: false
+    dependentOnFailedBuildCondition: false
+    checkbuildsoncurrentbranch: false
+    failTaskIfConditionsAreNotFulfilled: false
+    buildParameters: ''
+    templateParameters: |
+      pipelineContext: {"buildId":"$(Build.BuildId)",
+        "pipelineId":"$(System.DefinitionId)",
+        "project": "$(System.TeamProject)",
+        "branchName":"$(Build.SourceBranchName)"},
+      artifactContext: {"artifactName":"${{ parameters.artifactName }}",
+        "artifactPatterns":"**/*.bin\n
+              **/*.swi\n
+              **/*.raw\n
+              **/*.image.gz\n
+              **/*-rpc.gz\n
+              **/python-saithrift*.deb"},
+      publishContext: {"publishPrefix":"${{ parameters.publishPrefix }}",
+        "keepArtifactName":false,
+        "dockerImagePatterns":"target/*-rpc.gz",
+        "dockerTags":"$(docker_tags)",
+        "version":"$(sonic_version)",
+        "latestTag":"$(latest_tag)"}

--- a/.azure-pipelines/trigger-publish-artifacts-build.yml
+++ b/.azure-pipelines/trigger-publish-artifacts-build.yml
@@ -53,7 +53,7 @@ steps:
         "artifactPatterns":"**/*.bin\n
               **/*.swi\n
               **/*.raw\n
-              **/*.image.gz\n
+              **/*.img.gz\n
               **/*-rpc.gz\n
               **/python-saithrift*.deb"},
       publishContext: {"publishPrefix":"${{ parameters.publishPrefix }}",


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Support to trigger a pipeline to download and publish artifacts to storage and container registry.
Support to specify the patterns which docker images to upload.

#### How I did it
Pass the pipeline information and the artifact information by pipeline parameters to the pipeline which will be triggered a new build. It is to decouple the artifacts generation and the publish logic, how and where the artifacts/docker images will be published, depends on the triggered pipeline.

#### How to verify it
Trigger a new pipeline:
```
2022-05-12T12:43:24.1163401Z Found parameter artifactContext with value: {"artifactName":"sonic-buildimage.broadcom", "artifactPatterns":"**/*.bin\n
2022-05-12T12:43:24.1164110Z         **/*.swi\n
2022-05-12T12:43:24.1164377Z         **/*.raw\n
2022-05-12T12:43:24.1164840Z         **/*-rpc.gz\n
2022-05-12T12:43:24.1165296Z         **/python-saithrift*.deb"}
2022-05-12T12:43:24.1166045Z Identified value as Json Object - will use as is
2022-05-12T12:43:24.1167483Z Found parameter publishContext with value: {"publishPrefix":"xumia.official.broadcom/support-publish-docker-images-1/broadcom", "keepArtifactName":false, "dockerImagePatterns":"target/*-rpc.gz", "dockerTags":"HEAD.98650-06c14cf7f support-publish-docker-images-1", "version":"HEAD.98650-06c14cf7f", "latestTag":"201803.01"}
2022-05-12T12:43:27.7562922Z Queued new Build for definition publish-artifacts: https://dev.azure.com/mssonic/12b9cbf4-b1d3-4768-8e49-669345c32e5d/_build/results?buildId=98651
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

