### PR TITLE
add gbsyncd to feature table on supported platforms

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -38,7 +38,7 @@
                    ("syncd", "enabled", false, "enabled"),
                    ("teamd", "enabled", false, "enabled")] %}
 {% do features.append(("dhcp_relay", "{% if not (DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] is not in ['ToRRouter', 'EPMS', 'MgmtTsToR', 'MgmtToRRouter']) %}enabled{% else %}disabled{% endif %}", false, "enabled")) %}
-{%- if sonic_asic_platform == "vs" %}{% do features.append(("gbsyncd", "enabled", false, "enabled")) %}{% endif %}
+{% if sonic_asic_platform == "vs" %}{% do features.append(("gbsyncd", "enabled", false, "enabled")) %}{% else %}{%  do features.append("gbsyncd", "{% if gbsyncd_supported_platform == True  %}enabled{% else %}always_disabled{% endif %}", false, "enabled") }{% endif %}
 {%- if include_iccpd == "y" %}{% do features.append(("iccpd", "disabled", false, "enabled")) %}{% endif %}
 {%- if include_mgmt_framework == "y" %}{% do features.append(("mgmt-framework", "enabled", true, "enabled")) %}{% endif %}
 {%- if include_mux == "y" %}{% do features.append(("mux", "{% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %}enabled{% else %}always_disabled{% endif %}", false, "enabled")) %}{% endif %}

--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -120,7 +120,7 @@ def get_pid(procname):
 class Feature(object):
     """ Represents a feature configuration from CONFIG_DB data. """
 
-    def __init__(self, feature_name, feature_cfg, device_config=None):
+    def __init__(self, feature_name, feature_cfg, feature_state_params=None):
         """ Initialize Feature object based on CONFIG_DB data.
 
         Args:
@@ -130,13 +130,13 @@ class Feature(object):
         """
 
         self.name = feature_name
-        self.state = self._get_target_state(feature_cfg.get('state'), device_config or {})
+        self.state = self._get_target_state(feature_cfg.get('state'), feature_state_params or {})
         self.auto_restart = feature_cfg.get('auto_restart', 'disabled')
         self.has_timer = safe_eval(feature_cfg.get('has_timer', 'False'))
         self.has_global_scope = safe_eval(feature_cfg.get('has_global_scope', 'True'))
         self.has_per_asic_scope = safe_eval(feature_cfg.get('has_per_asic_scope', 'False'))
 
-    def _get_target_state(self, state_configuration, device_config):
+    def _get_target_state(self, state_configuration, feature_state_params):
         """ Returns the target state for the feature by rendering the state field as J2 template.
 
         Args:
@@ -150,7 +150,7 @@ class Feature(object):
             return None
 
         template = jinja2.Template(state_configuration)
-        target_state = template.render(device_config)
+        target_state = template.render(feature_state_params)
         if target_state not in ('enabled', 'disabled', 'always_enabled', 'always_disabled'):
             raise ValueError('Invalid state rendered for feature {}: {}'.format(self.name, target_state))
         return target_state
@@ -181,6 +181,10 @@ class FeatureHandler(object):
         self._device_config = device_config
         self._cached_config = {}
         self.is_multi_npu = device_info.is_multi_npu()
+        self.feature_state_params = {
+            "device_config": device_config,
+            "gbsyncd_supported_platform": device_info.is_gbsyncd_platform()
+        }
 
     def handle(self, feature_name, op, feature_cfg):
         if not feature_cfg:
@@ -189,7 +193,7 @@ class FeatureHandler(object):
             self._feature_state_table._del(feature_name)
             return
 
-        feature = Feature(feature_name, feature_cfg, self._device_config)
+        feature = Feature(feature_name, feature_cfg, self.feature_state_params)
         self._cached_config.setdefault(feature_name, Feature(feature_name, {}))
 
         # Change auto-restart configuration first.
@@ -1230,7 +1234,7 @@ class HostConfigDaemon:
         self.config_db.subscribe('VLAN_SUB_INTERFACE', make_callback(self.vlan_sub_intf_handler))
         self.config_db.subscribe('PORTCHANNEL_INTERFACE', make_callback(self.portchannel_intf_handler))
         self.config_db.subscribe('INTERFACE', make_callback(self.phy_intf_handler))
-        
+
         syslog.syslog(syslog.LOG_INFO,
                       "Waiting for systemctl to finish initialization")
         self.wait_till_system_init_done()
@@ -1251,4 +1255,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -631,3 +631,12 @@ def is_fast_reboot_enabled():
         fb_system_state = stdout.rstrip('\n')
 
     return fb_system_state
+
+def is_gbsyncd_platform():
+    platform = get_platform()
+    if platform is None:
+        return False
+    gbsyncd_ini_file = "/usr/share/sonic/device/{}/gbsyncd.ini".format(platform)
+    if os.path.exists(gbsyncd_ini_file):
+        return True
+    return False


### PR DESCRIPTION
Signed-off-by: Arvindsrinivasan Lakshmi Narasimhan <arlakshm@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
closes #10832 

#### How I did it
currently in `init_cfg.json.j2` `gbsyncd` is added to the feature table only for vs platform.
Add changes to add `gbsyncd` to feature table if the platform supports `gbsyncd`.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

