### PR TITLE
[BFN] Reset BMC port on syncd start

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -28,6 +28,14 @@ function startplatform() {
         debug "Firmware update procedure ended"
     fi
 
+    if [[ x"$sonic_asic_platform" == x"barefoot" ]]; then
+        is_usb0=$(ls /sys/class/net | grep usb0)
+        if [[ "$is_usb0" == "usb0" ]]; then
+            /usr/bin/ip link set usb0 down
+            /usr/bin/ip link set usb0 up
+        fi
+    fi
+
     if [[ x"$WARM_BOOT" != x"true" ]]; then
         if [ x$sonic_asic_platform == x'cavium' ]; then
             /etc/init.d/xpnet.sh start


### PR DESCRIPTION
**_It's cherry-pick from master branch:_** https://github.com/Azure/sonic-buildimage/pull/9941

**Why I did it**
improvement of starting barefoot SDK

**How I did it**
restart of the interface for cleaning txquee through which communication takes place between Sonic and openBMC

**How to verify it**
run sonic autorestart tests

Signed-off-by: Petro Bratash [petrox.bratash@intel.com](mailto:petrox.bratash@intel.com)