### PR TITLE
[202111] [Mellanox] Fix issue: error message from system-health daemon is observed during system starting

### DIFF
--- a/platform/mellanox/hw-management/0004-Make-SONiC-system-health-service-service-start-after.patch
+++ b/platform/mellanox/hw-management/0004-Make-SONiC-system-health-service-service-start-after.patch
@@ -1,0 +1,27 @@
+From 75725ff405c65a6aba0b936bc2bee6f04aaaed74 Mon Sep 17 00:00:00 2001
+From: Stephen Sun <stephens@nvidia.com>
+Date: Thu, 12 May 2022 08:41:00 +0800
+Subject: [PATCH] Make SONiC system-health service service start after hw-mgmt
+ service
+
+Signed-off-by: Stephen Sun <stephens@nvidia.com>
+---
+ debian/hw-management.hw-management.service | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/debian/hw-management.hw-management.service b/debian/hw-management.hw-management.service
+index 1c25ffb..9d10a32 100755
+--- a/debian/hw-management.hw-management.service
++++ b/debian/hw-management.hw-management.service
+@@ -1,7 +1,7 @@
+ [Unit]
+ Description=Chassis HW management service of Mellanox systems
+ Documentation=man:hw-management.service(8)
+-Before=determine-reboot-cause.service
++Before=determine-reboot-cause.service system-health.service
+ 
+ [Service]
+ Type=oneshot
+-- 
+1.9.1
+


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Error message: "ERR healthd: Failed to read from file /var/run/hw-management/led/led_status_capability" is observed during system starting
The system-health daemon will wait for 5 minutes before it starts to run.
During this time, the only thing it does is to set the LED even before it starts.
However, the corresponding sysfs has not been ready at the time it is being read, which causes the error message.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it
Defer system-health daemon until hw-management service starts

#### How to verify it
Run regression test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

