### PR TITLE
[device/celestica]:Fix failed test case of Haliburton snmp 

### DIFF
--- a/device/celestica/x86_64-cel_e1031-r0/sonic_platform/psu.py
+++ b/device/celestica/x86_64-cel_e1031-r0/sonic_platform/psu.py
@@ -234,7 +234,7 @@ class Psu(PsuBase):
         Returns:
             integer: The 1-based relative physical position in parent device or -1 if cannot determine the position
         """
-        return -1
+        return self.index + 1
 
     def is_replaceable(self):
         """

--- a/device/celestica/x86_64-cel_e1031-r0/sonic_platform/thermal.py
+++ b/device/celestica/x86_64-cel_e1031-r0/sonic_platform/thermal.py
@@ -324,6 +324,5 @@ class Thermal(ThermalBase):
         Returns:
             A int value, 0 represent ASIC thermal, 1 represent CPU thermal info
         """
-        if self.postion == "cpu":
-            return 1
-        return 0
+        
+        return self.index + 1


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix snmp test case(snmp/test_snmp_phy_entity.py) failed.
#### How I did it
Update the return value of the get_position_in_parent method in psu.py and thermo.py.
#### How to verify it
Rerun test case to verify.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 201811
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

