### PR TITLE
[Ci]: Fix to trigger the publish pipeline in failure build issue

### DIFF
--- a/.azure-pipelines/azure-pipelines-image-template.yml
+++ b/.azure-pipelines/azure-pipelines-image-template.yml
@@ -58,10 +58,11 @@ jobs:
         condition: failed()
         artifact: 'sonic-buildimage.$(GROUP_NAME)$(GROUP_EXTNAME)$(System.JobAttempt)'
         displayName: "Archive failed sonic image"
-      - template: trigger-publish-artifacts-build.yml
-        parameters:
-          artifactName: 'sonic-buildimage.$(GROUP_NAME)$(GROUP_EXTNAME)'
-          publishPrefix: '$(Build.DefinitionName)/$(Build.SourceBranchName)/$(GROUP_NAME)'
+      - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}
+        - template: trigger-publish-artifacts-build.yml
+          parameters:
+            artifactName: 'sonic-buildimage.$(GROUP_NAME)$(GROUP_EXTNAME)'
+            publishPrefix: '$(Build.DefinitionName)/$(Build.SourceBranchName)/$(GROUP_NAME)'
       - ${{ parameters.postSteps }}
       - template: cleanup.yml
     jobGroups: ${{ parameters.jobGroups }}

--- a/.azure-pipelines/azure-pipelines-image-template.yml
+++ b/.azure-pipelines/azure-pipelines-image-template.yml
@@ -58,7 +58,7 @@ jobs:
         condition: failed()
         artifact: 'sonic-buildimage.$(GROUP_NAME)$(GROUP_EXTNAME)$(System.JobAttempt)'
         displayName: "Archive failed sonic image"
-      - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}
+      - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
         - template: trigger-publish-artifacts-build.yml
           parameters:
             artifactName: 'sonic-buildimage.$(GROUP_NAME)$(GROUP_EXTNAME)'

--- a/.azure-pipelines/trigger-publish-artifacts-build.yml
+++ b/.azure-pipelines/trigger-publish-artifacts-build.yml
@@ -20,10 +20,8 @@ steps:
     echo "##vso[task.setvariable variable=sonic_version]$sonic_version"
     echo "##vso[task.setvariable variable=latest_tag]$latest_tag"
     echo "##vso[task.setvariable variable=docker_tags]$docker_tags"
-  condition: ne(variables['Build.Reason'], 'PullRequest')
   displayName: 'Set trigger build variables'
 - task: TriggerBuild@4
-  condition: ne(variables['Build.Reason'], 'PullRequest')
   inputs:
     definitionIsInCurrentTeamProject: false
     teamProject: internal


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
It is not necessary to trigger the publish pipeline when build is failed.

#### How I did it
Remove the condition in the azp task, change to use template condition.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

