### PR TITLE
Updated libsaibcm to fix libsaithrift compile issue on BRCM image

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,4 +1,4 @@
-LIBSAIBCM_VERSION = 7.1.0.0
+LIBSAIBCM_VERSION = 7.1.0.0-1
 LIBSAIBCM_BRANCH_NAME = REL_7.0
 LIBSAIBCM_URL_PREFIX = "https://sonicstorage.blob.core.windows.net/public/sai/bcmsai/$(LIBSAIBCM_BRANCH_NAME)/$(LIBSAIBCM_VERSION)"
 

--- a/slave.mk
+++ b/slave.mk
@@ -2,7 +2,7 @@
 ## Presettings
 ###############################################################################
 
-# Select bash for commands
+# Select bash for commands 
 .ONESHELL:
 SHELL = /bin/bash
 .SHELLFLAGS += -e


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To fix compilation issue on libsaithrift on brcm image

#### How I did it
Updated libsaibcm to install SAI experimental files at correct location

#### How to verify it
Compilation goes fine after the change. Also loaded the image on DUT to verify basic things.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Updated libsaibcm to fix libsaithrift compile issue on BRCM image

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

