### PR TITLE
[Marvell] Marvell armhf SAI debian

### DIFF
--- a/platform/marvell-armhf/sai.mk
+++ b/platform/marvell-armhf/sai.mk
@@ -1,6 +1,6 @@
 # Marvell SAI
 
-export MRVL_SAI_VERSION = 1.7.1-8
+export MRVL_SAI_VERSION = 1.7.1-9
 export MRVL_SAI = mrvllibsai_$(MRVL_SAI_VERSION)_$(PLATFORM_ARCH).deb
 
 $(MRVL_SAI)_SRC_PATH = $(PLATFORM_PATH)/sai


### PR DESCRIPTION
Addressed system-health failure, when src-mac learned same as switchMac when two ports connected in fiber-loopback

Signed-off-by: rajkumar38 <rpennadamram@marvell.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
system-health status goes to "NOT OK" state on connecting two ports in fiber loop-back in l2 topology.
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Drop FDB mac notification to NOS when learned src mac address is same as switch mac address.
#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
sonic-cfggen -H -k Nokia-7215 –preset l2 
#### A picture of a cute animal (not mandatory but encouraged)

