### PR TITLE
[201911] Updated Broadcom SAI version to 3.7.6.1-1

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,8 +1,8 @@
-BRCM_SAI = libsaibcm_3.7.6.1_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm_3.7.6.1_amd64.deb?sv=2015-04-05&sr=b&sig=PXZNHvLaofj6qevZqf3eDUX7SGp%2BJnblyEV%2FkMFcwus%3D&se=2035-04-15T19%3A36%3A16Z&sp=r"
-BRCM_SAI_DEV = libsaibcm-dev_3.7.6.1_amd64.deb
+BRCM_SAI = libsaibcm_3.7.6.1-1_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm_3.7.6.1-1_amd64.deb?sv=2015-04-05&sr=b&sig=NQ1hWKi6zjqigwb%2BDhM239G6AhL0HvktYE7FW79VdmY%3D&se=2030-08-03T23%3A01%3A11Z&sp=r"
+BRCM_SAI_DEV = libsaibcm-dev_3.7.6.1-1_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm-dev_3.7.6.1_amd64.deb?sv=2015-04-05&sr=b&sig=S67%2FNP8J2xshBYhDV6NwP7LBnvyUOO1EZKspL1O6bCY%3D&se=2035-04-15T19%3A37%3A50Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm-dev_3.7.6.1-1_amd64.deb?sv=2015-04-05&sr=b&sig=aUS4ZFCfD%2Bct29T%2B0xJAtFHfmtX1dTTsxKTyNtOw1O4%3D&se=2030-08-03T23%3A02%3A56Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
What:
Updated BRCM SAI Version to 3.7.6.1-1

Why:-

Following fixes:

```
CS00012204307 SID articleid=25192/SDK-233993 & SDK-260647
CS00012182148,SONIC-46555:Rate Limit Parity error message to syncd/sonic
SONIC-47434:(SID) Integrate SDK patch from SDK-261158, SDK-258005
CS00012208995,SONIC-48752:Reconfigure MMU Buffer and OBM settings after port speed change
CS00012229816,SONIC-56721:Segmentation fault in DMA timeout retry, need uplift for SDK-286668
CS00012239291,SONIC-60152:RFE - throttle ECC events based on sai_switch_ecc_event_throttle soc property setting
Pick up fixes (CS00012204307,CS00012182148,SONIC-47434:(SID),CS00012208995,CS00012225760,CS00012229816,CS00012239291) and manual default not to report correctable ECC error via syslog
```

How I verify:

Basic Sanity looks good. Run following tests:
It boots fine, all interfaces up, BGP healthy.
Run following tests:
                fib/test_fib.py
                acl/test_acl.py
                copp/test_copp.py
                crm/test_crm.py
                everflow/test_everflow_ipv6.py
                everflow/test_everflow_testbed.py
