### PR TITLE
update centec-sai reference to v1.9.1-1

### DIFF
--- a/platform/centec-arm64/sai.mk
+++ b/platform/centec-arm64/sai.mk
@@ -1,6 +1,6 @@
 # Centec SAI
 
-export CENTEC_SAI_VERSION = 1.9.1-0
+export CENTEC_SAI_VERSION = 1.9.1-1
 export CENTEC_SAI = libsai_$(CENTEC_SAI_VERSION)_$(PLATFORM_ARCH).deb
 
 $(CENTEC_SAI)_URL = https://github.com/CentecNetworks/sonic-binaries/raw/master/$(PLATFORM_ARCH)/sai/$(CENTEC_SAI)

--- a/platform/centec/sdk.mk
+++ b/platform/centec/sdk.mk
@@ -1,5 +1,5 @@
 # Centec SAI
-CENTEC_SAI = libsai_1.9.1-0_amd64.deb
+CENTEC_SAI = libsai_1.9.1-1_amd64.deb
 $(CENTEC_SAI)_URL = https://github.com/CentecNetworks/sonic-binaries/raw/master/amd64/sai/$(CENTEC_SAI)
 $(eval $(call add_conflict_package,$(CENTEC_SAI),$(LIBSAIVS_DEV)))
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Change makefile to reference to new SAI debian package of v1.9.1-1

#### How I did it
Modify sai.mk of arm64 platform and sdk.mk of x86 platform for Centec

#### How to verify it
Build centec amd64 and arm64 sonic image

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

