### PR TITLE
[macsec-cli]: Fixing to config MACsec on the port will clear port attributes in config db

### DIFF
--- a/dockers/docker-macsec/cli-plugin-tests/conftest.py
+++ b/dockers/docker-macsec/cli-plugin-tests/conftest.py
@@ -9,6 +9,7 @@ def mock_cfgdb():
     CONFIG = {
         'PORT': {
             'Ethernet0': {
+                "admin_status": "up"
             }
         }
     }

--- a/dockers/docker-macsec/cli-plugin-tests/test_config_macsec.py
+++ b/dockers/docker-macsec/cli-plugin-tests/test_config_macsec.py
@@ -116,6 +116,7 @@ class TestConfigMACsec(object):
         port_table = db.cfgdb.get_entry("PORT", "Ethernet0")
         assert port_table 
         assert port_table["macsec"] == "test"
+        assert port_table["admin_status"] == "up"
 
         result = runner.invoke(macsec.macsec.commands["profile"].commands["del"], ["test"], obj=db)
         assert result.exit_code != 0
@@ -123,7 +124,8 @@ class TestConfigMACsec(object):
         result = runner.invoke(macsec.macsec.commands["port"].commands["del"], ["Ethernet0"], obj=db)
         assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
         port_table = db.cfgdb.get_entry("PORT", "Ethernet0")
-        assert not port_table["macsec"]
+        assert "macsec" not in port_table or not port_table["macsec"]
+        assert port_table["admin_status"] == "up"
 
 
     def test_macsec_invalid_operation(self, mock_cfgdb):

--- a/dockers/docker-macsec/cli/config/plugins/macsec.py
+++ b/dockers/docker-macsec/cli/config/plugins/macsec.py
@@ -42,7 +42,13 @@ def add_port(db, port, profile):
     if len(profile_entry) == 0:
         ctx.fail("profile {} doesn't exist".format(profile))
 
-    db.cfgdb.set_entry("PORT", port, {'macsec': profile})
+    port_entry = db.cfgdb.get_entry('PORT', port)
+    if len(port_entry) == 0:
+        ctx.fail("port {} doesn't exist".format(port))
+
+    port_entry['macsec'] = profile
+
+    db.cfgdb.set_entry("PORT", port, port_entry)
 
 
 #
@@ -64,7 +70,13 @@ def del_port(db, port):
         if port is None:
             ctx.fail("cannot find port name for alias {}".format(alias))
 
-    db.cfgdb.set_entry("PORT", port, {'macsec': ""})
+    port_entry = db.cfgdb.get_entry('PORT', port)
+    if len(port_entry) == 0:
+        ctx.fail("port {} doesn't exist".format(port))
+
+    del port_entry['macsec']
+
+    db.cfgdb.set_entry("PORT", port, port_entry)
 
 
 #


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
There is a bug that the Port attributes in CONFIG_DB will be cleared if using `sudo config macsec port add Ethernet0` or `sudo config macsec port del Ethernet0`

#### How I did it
To fetch the port attributes before set/remove MACsec field in port table.

#### How to verify it
Check Azp.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

