### PR TITLE
Skip CMIS manager

### DIFF
--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -96,9 +96,9 @@ dependent_startup_wait_for=rsyslogd:running
 {% if not skip_xcvrd %}
 [program:xcvrd]
 {% if delay_xcvrd %}
-command=bash -c "sleep 30 && {% if API_VERSION == 3 and 'xcvrd' not in python2_daemons %}python3 {% else %} python2 {% endif %}/usr/local/bin/xcvrd"
+command={% if skip_cmis_mgr %} bash -c "sleep 30 && python3 /usr/local/bin/xcvrd --skip_cmis_mgr" {% else %} bash -c "sleep 30 && python3 /usr/local/bin/xcvrd" {% endif % }
 {% else %}
-command={% if API_VERSION == 3 and 'xcvrd' not in python2_daemons %}python3 {% else %} python2 {% endif %}/usr/local/bin/xcvrd
+command={% if skip_cmis_mgr %} python3 /usr/local/bin/xcvrd --skip_cmis_mgr {% else %} python3 /usr/local/bin/xcvrd {% endif %}
 {% endif %}
 priority=6
 autostart=false

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -96,7 +96,7 @@ dependent_startup_wait_for=rsyslogd:running
 {% if not skip_xcvrd %}
 [program:xcvrd]
 {% if delay_xcvrd %}
-command={% if skip_cmis_mgr %} bash -c "sleep 30 && python3 /usr/local/bin/xcvrd --skip_cmis_mgr" {% else %} bash -c "sleep 30 && python3 /usr/local/bin/xcvrd" {% endif % }
+command={% if skip_cmis_mgr %} bash -c "sleep 30 && python3 /usr/local/bin/xcvrd --skip_cmis_mgr" {% else %} bash -c "sleep 30 && python3 /usr/local/bin/xcvrd" {% endif %}
 {% else %}
 command={% if skip_cmis_mgr %} python3 /usr/local/bin/xcvrd --skip_cmis_mgr {% else %} python3 /usr/local/bin/xcvrd {% endif %}
 {% endif %}

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -97,8 +97,10 @@ dependent_startup_wait_for=rsyslogd:running
 [program:xcvrd]
 {% if delay_xcvrd %}
 command={% if skip_xcvrd_cmis_mgr %} bash -c "sleep 30 && python3 /usr/local/bin/xcvrd --skip_cmis_mgr" {% else %} bash -c "sleep 30 && python3 /usr/local/bin/xcvrd" {% endif %}
+
 {% else %}
 command={% if skip_xcvrd_cmis_mgr %} python3 /usr/local/bin/xcvrd --skip_cmis_mgr {% else %} python3 /usr/local/bin/xcvrd {% endif %}
+
 {% endif %}
 priority=6
 autostart=false

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -96,9 +96,9 @@ dependent_startup_wait_for=rsyslogd:running
 {% if not skip_xcvrd %}
 [program:xcvrd]
 {% if delay_xcvrd %}
-command={% if skip_cmis_mgr %} bash -c "sleep 30 && python3 /usr/local/bin/xcvrd --skip_cmis_mgr" {% else %} bash -c "sleep 30 && python3 /usr/local/bin/xcvrd" {% endif %}
+command={% if skip_xcvrd_cmis_mgr %} bash -c "sleep 30 && python3 /usr/local/bin/xcvrd --skip_cmis_mgr" {% else %} bash -c "sleep 30 && python3 /usr/local/bin/xcvrd" {% endif %}
 {% else %}
-command={% if skip_cmis_mgr %} python3 /usr/local/bin/xcvrd --skip_cmis_mgr {% else %} python3 /usr/local/bin/xcvrd {% endif %}
+command={% if skip_xcvrd_cmis_mgr %} python3 /usr/local/bin/xcvrd --skip_cmis_mgr {% else %} python3 /usr/local/bin/xcvrd {% endif %}
 {% endif %}
 priority=6
 autostart=false


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
CMIS manager needs to be skipped if a platform wants to. The changes are as per the HLD:-
[https://github.com/sonic-net/SONiC/pull/971/](https://github.com/sonic-net/SONiC/pull/971/)

#### How I did it
Platform provides input to supervisord via pmon_daemon_control.json to pass "skip_cmis_mgr" argument to Xcvrd while launching it

#### How to verify it

Use SN2700 platform to verify and ensure CMIS manager is not running.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

