### PR TITLE
[Bug][Build] Fix the symbol links not supported in the onie unzip command issue

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -647,5 +647,5 @@ fi
 pushd $FILESYSTEM_ROOT && sudo tar czf $OLDPWD/$FILESYSTEM_DOCKERFS -C ${DOCKERFS_PATH}var/lib/docker .; popd
 
 ## Compress together with /boot, /var/lib/docker and $PLATFORM_DIR as an installer payload zip file
-pushd $FILESYSTEM_ROOT && sudo zip $OLDPWD/$ONIE_INSTALLER_PAYLOAD -r boot/ $PLATFORM_DIR/; popd
+pushd $FILESYSTEM_ROOT && sudo zip --symlinks $OLDPWD/$ONIE_INSTALLER_PAYLOAD -r boot/ $PLATFORM_DIR/; popd
 sudo zip -g -n .squashfs:.gz $ONIE_INSTALLER_PAYLOAD $FILESYSTEM_SQUASHFS $FILESYSTEM_DOCKERFS

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -647,5 +647,5 @@ fi
 pushd $FILESYSTEM_ROOT && sudo tar czf $OLDPWD/$FILESYSTEM_DOCKERFS -C ${DOCKERFS_PATH}var/lib/docker .; popd
 
 ## Compress together with /boot, /var/lib/docker and $PLATFORM_DIR as an installer payload zip file
-pushd $FILESYSTEM_ROOT && sudo zip --symlinks $OLDPWD/$ONIE_INSTALLER_PAYLOAD -r boot/ $PLATFORM_DIR/; popd
-sudo zip -g -n .squashfs:.gz $ONIE_INSTALLER_PAYLOAD $FILESYSTEM_SQUASHFS $FILESYSTEM_DOCKERFS
+pushd $FILESYSTEM_ROOT && sudo tar cf $OLDPWD/$ONIE_INSTALLER_PAYLOAD boot/ $PLATFORM_DIR/; popd
+sudo tar uf $ONIE_INSTALLER_PAYLOAD $FILESYSTEM_SQUASHFS $FILESYSTEM_DOCKERFS

--- a/build_image.sh
+++ b/build_image.sh
@@ -179,7 +179,10 @@ elif [ "$IMAGE_TYPE" = "aboot" ]; then
     sudo rm -f $OUTPUT_ABOOT_IMAGE
     sudo rm -f $ABOOT_BOOT_IMAGE
     ## Add main payload
-    cp $ONIE_INSTALLER_PAYLOAD $OUTPUT_ABOOT_IMAGE
+    tmpdir=$(mktemp -d)
+    jar -xf $ONIE_INSTALLER_PAYLOAD -C $tmpdir
+    pushd $tmpdir && zip -n .squashfs:.gz $OUTPUT_ABOOT_IMAGE -r .; popd
+    rm $tmpdir -rf
     ## Add Aboot boot0 file
     j2 -f env files/Aboot/boot0.j2 ./onie-image.conf > files/Aboot/boot0
     sed -i -e "s/%%IMAGE_VERSION%%/$IMAGE_VERSION/g" files/Aboot/boot0

--- a/build_image.sh
+++ b/build_image.sh
@@ -180,7 +180,7 @@ elif [ "$IMAGE_TYPE" = "aboot" ]; then
     sudo rm -f $ABOOT_BOOT_IMAGE
     ## Add main payload
     tmpdir=$(mktemp -d)
-    jar -xf $ONIE_INSTALLER_PAYLOAD -C $tmpdir
+    tar -xf $ONIE_INSTALLER_PAYLOAD -C $tmpdir
     pushd $tmpdir && zip -n .squashfs:.gz $OUTPUT_ABOOT_IMAGE -r .; popd
     rm $tmpdir -rf
     ## Add Aboot boot0 file

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -610,7 +610,9 @@ sudo LANG=C chroot $FILESYSTEM_ROOT depmod -a {{kversion}}
 sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}} || sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -f --download-only
 
 sudo mkdir -p $FILESYSTEM_ROOT/$PLATFORM_DIR/{{dev}}
-sudo cp {{ deb }} $FILESYSTEM_ROOT/$PLATFORM_DIR/{{dev}}/
+sudo mkdir -p $FILESYSTEM_ROOT/$PLATFORM_DIR/common
+sudo cp {{ deb }} $FILESYSTEM_ROOT/$PLATFORM_DIR/common/
+sudo ln -sf "../common/{{ debfilename }}" "$FILESYSTEM_ROOT/$PLATFORM_DIR/{{dev}}/{{ debfilename }}"
 for f in $(find $FILESYSTEM_ROOT/var/cache/apt/archives -name "*.deb"); do
     sudo mv $f $FILESYSTEM_ROOT/$PLATFORM_DIR/{{dev}}/
 done

--- a/installer/arm64/install.sh
+++ b/installer/arm64/install.sh
@@ -155,9 +155,9 @@ fi
 # Decompress the file for the file system directly to the partition
 if [ x"$docker_inram" = x"on" ]; then
     # when disk is small, keep dockerfs.tar.gz in disk, expand it into ramfs during initrd
-    unzip -o $ONIE_INSTALLER_PAYLOAD -d $demo_mnt/$image_dir
+    tar -xf $ONIE_INSTALLER_PAYLOAD -C $demo_mnt/$image_dir
 else
-    unzip -o $ONIE_INSTALLER_PAYLOAD -x "$FILESYSTEM_DOCKERFS" -d $demo_mnt/$image_dir
+    tar -xf $ONIE_INSTALLER_PAYLOAD --exclude="$FILESYSTEM_DOCKERFS" -C $demo_mnt/$image_dir
 
     if [ "$install_env" = "onie" ]; then
         TAR_EXTRA_OPTION="--numeric-owner"
@@ -165,7 +165,7 @@ else
         TAR_EXTRA_OPTION="--numeric-owner --warning=no-timestamp"
     fi
     mkdir -p $demo_mnt/$image_dir/$DOCKERFS_DIR
-    unzip -op $ONIE_INSTALLER_PAYLOAD "$FILESYSTEM_DOCKERFS" | tar xz $TAR_EXTRA_OPTION -f - -C $demo_mnt/$image_dir/$DOCKERFS_DIR
+    tar -xf $ONIE_INSTALLER_PAYLOAD "$FILESYSTEM_DOCKERFS" -O | tar xz $TAR_EXTRA_OPTION -f - -C $demo_mnt/$image_dir/$DOCKERFS_DIR
 fi
 
 

--- a/installer/armhf/install.sh
+++ b/installer/armhf/install.sh
@@ -155,9 +155,9 @@ fi
 # Decompress the file for the file system directly to the partition
 if [ x"$docker_inram" = x"on" ]; then
     # when disk is small, keep dockerfs.tar.gz in disk, expand it into ramfs during initrd
-    unzip -o $ONIE_INSTALLER_PAYLOAD -d $demo_mnt/$image_dir
+    tar -xf $ONIE_INSTALLER_PAYLOAD -C $demo_mnt/$image_dir
 else
-    unzip -o $ONIE_INSTALLER_PAYLOAD -x "$FILESYSTEM_DOCKERFS" -d $demo_mnt/$image_dir
+    tar -xf $ONIE_INSTALLER_PAYLOAD --exclude="$FILESYSTEM_DOCKERFS" -C $demo_mnt/$image_dir
 
     if [ "$install_env" = "onie" ]; then
         TAR_EXTRA_OPTION="--numeric-owner"
@@ -165,7 +165,7 @@ else
         TAR_EXTRA_OPTION="--numeric-owner --warning=no-timestamp"
     fi
     mkdir -p $demo_mnt/$image_dir/$DOCKERFS_DIR
-    unzip -op $ONIE_INSTALLER_PAYLOAD "$FILESYSTEM_DOCKERFS" | tar xz $TAR_EXTRA_OPTION -f - -C $demo_mnt/$image_dir/$DOCKERFS_DIR
+    tar -xf $ONIE_INSTALLER_PAYLOAD "$FILESYSTEM_DOCKERFS" -O | tar xz $TAR_EXTRA_OPTION -f - -C $demo_mnt/$image_dir/$DOCKERFS_DIR
 fi
 
 

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -536,9 +536,9 @@ fi
 # Decompress the file for the file system directly to the partition
 if [ x"$docker_inram" = x"on" ]; then
     # when disk is small, keep dockerfs.tar.gz in disk, expand it into ramfs during initrd
-    unzip -o $ONIE_INSTALLER_PAYLOAD -d $demo_mnt/$image_dir
+    tar xvf $ONIE_INSTALLER_PAYLOAD -C $demo_mnt/$image_dir
 else
-    unzip -o $ONIE_INSTALLER_PAYLOAD -x "$FILESYSTEM_DOCKERFS" -d $demo_mnt/$image_dir
+    tar xvf $ONIE_INSTALLER_PAYLOAD --exclude="$FILESYSTEM_DOCKERFS" -C $demo_mnt/$image_dir
 
     if [ "$install_env" = "onie" ]; then
         TAR_EXTRA_OPTION="--numeric-owner"
@@ -546,7 +546,7 @@ else
         TAR_EXTRA_OPTION="--numeric-owner --warning=no-timestamp"
     fi
     mkdir -p $demo_mnt/$image_dir/$DOCKERFS_DIR
-    unzip -op $ONIE_INSTALLER_PAYLOAD "$FILESYSTEM_DOCKERFS" | tar xz $TAR_EXTRA_OPTION -f - -C $demo_mnt/$image_dir/$DOCKERFS_DIR
+    tar -xf $ONIE_INSTALLER_PAYLOAD "$FILESYSTEM_DOCKERFS" -O | tar xz $TAR_EXTRA_OPTION -f - -C $demo_mnt/$image_dir/$DOCKERFS_DIR
 fi
 
 if [ "$install_env" = "onie" ]; then

--- a/onie-image-arm64.conf
+++ b/onie-image-arm64.conf
@@ -19,7 +19,7 @@ FILESYSTEM_ROOT=./fsroot-${TARGET_MACHINE}
 FILESYSTEM_SQUASHFS=fs.squashfs
 
 ## Filename for onie installer payload, will be the main part of onie installer
-ONIE_INSTALLER_PAYLOAD=fs.zip
+ONIE_INSTALLER_PAYLOAD=fs.tar
 
 ## Filename for docker file system
 FILESYSTEM_DOCKERFS=dockerfs.tar.gz

--- a/onie-image-armhf.conf
+++ b/onie-image-armhf.conf
@@ -19,7 +19,7 @@ FILESYSTEM_ROOT=./fsroot-${TARGET_MACHINE}
 FILESYSTEM_SQUASHFS=fs.squashfs
 
 ## Filename for onie installer payload, will be the main part of onie installer
-ONIE_INSTALLER_PAYLOAD=fs.zip
+ONIE_INSTALLER_PAYLOAD=fs.tar
 
 ## Filename for docker file system
 FILESYSTEM_DOCKERFS=dockerfs.tar.gz

--- a/onie-image.conf
+++ b/onie-image.conf
@@ -19,7 +19,7 @@ FILESYSTEM_ROOT=./fsroot-${TARGET_MACHINE}
 FILESYSTEM_SQUASHFS=fs.squashfs
 
 ## Filename for onie installer payload, will be the main part of onie installer
-ONIE_INSTALLER_PAYLOAD=fs.zip
+ONIE_INSTALLER_PAYLOAD=fs.tar
 
 ## Filename for docker file system
 FILESYSTEM_DOCKERFS=dockerfs.tar.gz


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the symbol links not found issue in lazy installation packages.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

