### PR TITLE
[hostcfgd] Initialize `Restart=` in feature's systemd config by the value of `auto_restart` in `CONFIG_DB`

### DIFF
--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -286,8 +286,10 @@ class FeatureHandler(object):
         """
         restart_field_str = "always" if "enabled" in feature_config.auto_restart else "no"
         feature_systemd_config = "[Service]\nRestart={}\n".format(restart_field_str)
-        feature_names, feature_suffixes = self.get_feature_attribute(feature_config)
+        feature_names, feature_suffixes = self.get_multiasic_feature_instances(feature_config)
 
+        # On multi-ASIC device, creates systemd configuration file for each feature instance
+        # residing in difference namespace.
         for feature_name in feature_names:
             syslog.syslog(syslog.LOG_INFO, "Updating feature '{}' systemd config file related to auto-restart ..."
                           .format(feature_name))
@@ -309,7 +311,7 @@ class FeatureHandler(object):
         except Exception as err:
             syslog.syslog(syslog.LOG_ERR, "Failed to reload systemd configuration files!")
 
-    def get_feature_attribute(self, feature):
+    def get_multiasic_feature_instances(self, feature):
         # Create feature name suffix depending feature is running in host or namespace or in both
         feature_names = (
             ([feature.name] if feature.has_global_scope or not self.is_multi_npu else []) +
@@ -340,7 +342,7 @@ class FeatureHandler(object):
 
     def enable_feature(self, feature):
         cmds = []
-        feature_names, feature_suffixes = self.get_feature_attribute(feature)
+        feature_names, feature_suffixes = self.get_multiasic_feature_instances(feature)
         for feature_name in feature_names:
             # Check if it is already enabled, if yes skip the system call
             unit_file_state = self.get_systemd_unit_state("{}.{}".format(feature_name, feature_suffixes[-1]))
@@ -370,7 +372,7 @@ class FeatureHandler(object):
 
     def disable_feature(self, feature):
         cmds = []
-        feature_names, feature_suffixes = self.get_feature_attribute(feature)
+        feature_names, feature_suffixes = self.get_multiasic_feature_instances(feature)
         for feature_name in feature_names:
             # Check if it is already disabled, if yes skip the system call
             unit_file_state = self.get_systemd_unit_state("{}.{}".format(feature_name, feature_suffixes[-1]))

--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -138,7 +138,6 @@ class Feature(object):
         self.has_global_scope = safe_eval(feature_cfg.get('has_global_scope', 'True'))
         self.has_per_asic_scope = safe_eval(feature_cfg.get('has_per_asic_scope', 'False'))
 
-
     def _get_target_state(self, state_configuration, device_config):
         """ Returns the target state for the feature by rendering the state field as J2 template.
 
@@ -157,7 +156,6 @@ class Feature(object):
         if target_state not in ('enabled', 'disabled', 'always_enabled', 'always_disabled'):
             raise ValueError('Invalid state rendered for feature {}: {}'.format(self.name, target_state))
         return target_state
-
 
     def compare_state(self, feature_name, feature_cfg):
         if self.name != feature_name or not isinstance(feature_cfg, dict):

--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -104,6 +104,7 @@ def obfuscate(data):
     else:
         return data
 
+
 def get_pid(procname):
     for dirname in os.listdir('/proc'):
         if dirname == 'curproc':
@@ -116,6 +117,7 @@ def get_pid(procname):
         if procname in content:
             return dirname
     return ""
+
 
 class Feature(object):
     """ Represents a feature configuration from CONFIG_DB data. """
@@ -136,6 +138,7 @@ class Feature(object):
         self.has_global_scope = safe_eval(feature_cfg.get('has_global_scope', 'True'))
         self.has_per_asic_scope = safe_eval(feature_cfg.get('has_per_asic_scope', 'False'))
 
+
     def _get_target_state(self, state_configuration, device_config):
         """ Returns the target state for the feature by rendering the state field as J2 template.
 
@@ -154,6 +157,7 @@ class Feature(object):
         if target_state not in ('enabled', 'disabled', 'always_enabled', 'always_disabled'):
             raise ValueError('Invalid state rendered for feature {}: {}'.format(self.name, target_state))
         return target_state
+
 
     def compare_state(self, feature_name, feature_cfg):
         if self.name != feature_name or not isinstance(feature_cfg, dict):
@@ -198,6 +202,8 @@ class FeatureHandler(object):
         # again the auto restart will kick-in. Another order may leave it in failed state
         # and not auto restart.
         if self._cached_config[feature_name].auto_restart != feature.auto_restart:
+            syslog.syslog(syslog.LOG_INFO, "Auto-restart status of feature '{}' is changed from '{}' to '{}' ..."
+                          .format(feature_name, self._cached_config[feature_name].auto_restart, feature.auto_restart))
             self.update_systemd_config(feature)
             self._cached_config[feature_name].auto_restart = feature.auto_restart
 
@@ -207,7 +213,6 @@ class FeatureHandler(object):
                 self._cached_config[feature_name].state = feature.state
             else:
                 self.resync_feature_state(self._cached_config[feature_name])
-
 
     def sync_state_field(self, feature_table):
         """
@@ -226,7 +231,6 @@ class FeatureHandler(object):
             self.update_systemd_config(feature)
             self.update_feature_state(feature)
             self.resync_feature_state(feature)
-
 
     def update_feature_state(self, feature):
         cached_feature = self._cached_config[feature.name]
@@ -285,18 +289,25 @@ class FeatureHandler(object):
         feature_names, feature_suffixes = self.get_feature_attribute(feature_config)
 
         for feature_name in feature_names:
-            dir_name = self.SYSTEMD_SERVICE_CONF_DIR.format(feature_name)
-            systemd_config_file_path = os.path.join(dir_name, 'auto_restart.conf')
-            if not os.path.exists(dir_name):
-                os.mkdir(dir_name)
-            with open(systemd_config_file_path, 'w') as systemd_config_file:
-                systemd_config_file.write(feature_systemd_config)
+            syslog.syslog(syslog.LOG_INFO, "Updating feature '{}' systemd config file related to auto-restart ..."
+                          .format(feature_name))
+            feature_systemd_config_dir_path = self.SYSTEMD_SERVICE_CONF_DIR.format(feature_name)
+            feature_systemd_config_file_path = os.path.join(feature_systemd_config_dir_path, 'auto_restart.conf')
+
+            if not os.path.exists(feature_systemd_config_dir_path):
+                os.mkdir(feature_systemd_config_dir_path)
+            with open(feature_systemd_config_file_path, 'w') as feature_systemd_config_file_handler:
+                feature_systemd_config_file_handler.write(feature_systemd_config)
+
+            syslog.syslog(syslog.LOG_INFO, "Feautre '{}' systemd config file related to auto-restart is updated!"
+                          .format(feature_name))
 
         try:
+            syslog.syslog(syslog.LOG_INFO, "Reloading systemd configuration files ...")
             run_cmd("sudo systemctl daemon-reload", raise_exception=True)
+            syslog.syslog(syslog.LOG_INFO, "Systemd configuration files are reloaded!")
         except Exception as err:
-            syslog.syslog(syslog.LOG_ERR, "Failed to reload systemd configuration!")
-
+            syslog.syslog(syslog.LOG_ERR, "Failed to reload systemd configuration files!")
 
     def get_feature_attribute(self, feature):
         # Create feature name suffix depending feature is running in host or namespace or in both
@@ -351,7 +362,7 @@ class FeatureHandler(object):
                     run_cmd(cmd, raise_exception=True)
                 except Exception as err:
                     syslog.syslog(syslog.LOG_ERR, "Feature '{}.{}' failed to be enabled and started"
-                                    .format(feature.name, feature_suffixes[-1]))
+                                  .format(feature.name, feature_suffixes[-1]))
                     self.set_feature_state(feature, self.FEATURE_STATE_FAILED)
                     return
 
@@ -376,7 +387,7 @@ class FeatureHandler(object):
                     run_cmd(cmd, raise_exception=True)
                 except Exception as err:
                     syslog.syslog(syslog.LOG_ERR, "Feature '{}.{}' failed to be stopped and disabled"
-                                    .format(feature.name, feature_suffixes[-1]))
+                                  .format(feature.name, feature_suffixes[-1]))
                     self.set_feature_state(feature, self.FEATURE_STATE_FAILED)
                     return
 

--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -182,10 +182,10 @@ class FeatureHandler(object):
         self._cached_config = {}
         self.is_multi_npu = device_info.is_multi_npu()
 
-    def handle(self, feature_name, op, feature_cfg):
+    def handler(self, feature_name, op, feature_cfg):
         if not feature_cfg:
             syslog.syslog(syslog.LOG_INFO, "Deregistering feature {}".format(feature_name))
-            self._cached_config.pop(feature_name)
+            self._cached_config.pop(feature_name, None)
             self._feature_state_table._del(feature_name)
             return
 
@@ -198,7 +198,7 @@ class FeatureHandler(object):
         # again the auto restart will kick-in. Another order may leave it in failed state
         # and not auto restart.
         if self._cached_config[feature_name].auto_restart != feature.auto_restart:
-            self.update_restart_field_in_systemd_config(feature)
+            self.update_systemd_config(feature)
             self._cached_config[feature_name].auto_restart = feature.auto_restart
 
         # Enable/disable the container service if the feature state was changed from its previous state.
@@ -207,6 +207,7 @@ class FeatureHandler(object):
                 self._cached_config[feature_name].state = feature.state
             else:
                 self.resync_feature_state(self._cached_config[feature_name])
+
 
     def sync_state_field(self, feature_table):
         """
@@ -222,9 +223,10 @@ class FeatureHandler(object):
             feature = Feature(feature_name, feature_table[feature_name], self._device_config)
 
             self._cached_config.setdefault(feature_name, feature)
-            self.update_restart_field_in_systemd_config(feature)
+            self.update_systemd_config(feature)
             self.update_feature_state(feature)
             self.resync_feature_state(feature)
+
 
     def update_feature_state(self, feature):
         cached_feature = self._cached_config[feature.name]
@@ -267,34 +269,34 @@ class FeatureHandler(object):
 
         return True
 
-    def update_restart_field_in_systemd_config(self, feature):
+    def update_systemd_config(self, feature_config):
         """Updates `Restart=` field in feature's systemd configuration file
         according to the value of `auto_restart` field in `FEATURE` table of `CONFIG_DB`.
 
         Args:
-            feature: An object represents a container's configuration in `FEATURE`
+            feature: An object represents a feature's configuration in `FEATURE`
             table of `CONFIG_DB`.
 
         Returns:
             None.
         """
-        restart_config = "always" if feature.auto_restart == "enabled" else "no"
-        service_conf = "[Service]\nRestart={}\n".format(restart_config)
-        feature_names, feature_suffixes = self.get_feature_attribute(feature)
+        restart_field_str = "always" if "enabled" in feature_config.auto_restart else "no"
+        feature_systemd_config = "[Service]\nRestart={}\n".format(restart_field_str)
+        feature_names, feature_suffixes = self.get_feature_attribute(feature_config)
 
-        for name in feature_names:
-            dir_name = self.SYSTEMD_SERVICE_CONF_DIR.format(name)
-            auto_restart_conf = os.path.join(dir_name, 'auto_restart.conf')
+        for feature_name in feature_names:
+            dir_name = self.SYSTEMD_SERVICE_CONF_DIR.format(feature_name)
+            systemd_config_file_path = os.path.join(dir_name, 'auto_restart.conf')
             if not os.path.exists(dir_name):
                 os.mkdir(dir_name)
-            with open(auto_restart_conf, 'w') as cfgfile:
-                cfgfile.write(service_conf)
+            with open(systemd_config_file_path, 'w') as systemd_config_file:
+                systemd_config_file.write(feature_systemd_config)
 
         try:
             run_cmd("sudo systemctl daemon-reload", raise_exception=True)
         except Exception as err:
-            syslog.syslog(syslog.LOG_ERR, "Feature '{}' failed to configure auto_restart".format(feature.name))
-            return
+            syslog.syslog(syslog.LOG_ERR, "Failed to reload systemd configuration!")
+
 
     def get_feature_attribute(self, feature):
         # Create feature name suffix depending feature is running in host or namespace or in both
@@ -1209,7 +1211,7 @@ class HostConfigDaemon:
 
         self.config_db.subscribe('KDUMP', make_callback(self.kdump_handler))
         # Handle FEATURE updates before other tables
-        self.config_db.subscribe('FEATURE', make_callback(self.feature_handler.handle))
+        self.config_db.subscribe('FEATURE', make_callback(self.feature_handler.handler))
         # Handle AAA, TACACS and RADIUS related tables
         self.config_db.subscribe('AAA', make_callback(self.aaa_handler))
         self.config_db.subscribe('TACPLUS', make_callback(self.tacacs_global_handler))

--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -197,7 +197,9 @@ class FeatureHandler(object):
         # the next called self.update_feature_state will start it again. If it will fail
         # again the auto restart will kick-in. Another order may leave it in failed state
         # and not auto restart.
-        self.update_feature_auto_restart(feature, feature_name)
+        if self._cached_config[feature_name].auto_restart != feature.auto_restart:
+            self.update_restart_field_in_systemd_config(feature)
+            self._cached_config[feature_name].auto_restart = feature.auto_restart
 
         # Enable/disable the container service if the feature state was changed from its previous state.
         if self._cached_config[feature_name].state != feature.state:
@@ -220,7 +222,7 @@ class FeatureHandler(object):
             feature = Feature(feature_name, feature_table[feature_name], self._device_config)
 
             self._cached_config.setdefault(feature_name, feature)
-            self.update_feature_auto_restart(feature, feature_name)
+            self.update_restart_field_in_systemd_config(feature)
             self.update_feature_state(feature)
             self.resync_feature_state(feature)
 
@@ -265,22 +267,17 @@ class FeatureHandler(object):
 
         return True
 
-    def update_feature_auto_restart(self, feature, feature_name):
-        dir_name = self.SYSTEMD_SERVICE_CONF_DIR.format(feature_name)
-        auto_restart_conf = os.path.join(dir_name, 'auto_restart.conf')
+    def update_restart_field_in_systemd_config(self, feature):
+        """Updates `Restart=` field in feature's systemd configuration file
+        according to the value of `auto_restart` field in `FEATURE` table of `CONFIG_DB`.
 
-        write_conf = False
-        if not os.path.exists(auto_restart_conf):  # if the auto_restart_conf file is not found, set it
-            write_conf = True
+        Args:
+            feature: An object represents a container's configuration in `FEATURE`
+            table of `CONFIG_DB`.
 
-        if self._cached_config[feature_name].auto_restart != feature.auto_restart:
-            write_conf = True
-
-        if not write_conf:
-            return
-
-        self._cached_config[feature_name].auto_restart = feature.auto_restart # Update Cache
-
+        Returns:
+            None.
+        """
         restart_config = "always" if feature.auto_restart == "enabled" else "no"
         service_conf = "[Service]\nRestart={}\n".format(restart_config)
         feature_names, feature_suffixes = self.get_feature_attribute(feature)

--- a/src/sonic-host-services/tests/hostcfgd/hostcfgd_test.py
+++ b/src/sonic-host-services/tests/hostcfgd/hostcfgd_test.py
@@ -27,9 +27,8 @@ hostcfgd.DBConnector = MockDBConnector
 hostcfgd.Table = mock.Mock()
 
 
-class TestHostcfgd(TestCase):
-    """
-        Test hostcfd daemon - feature
+class TestFeatureHandler(TestCase):
+    """Test methods of `FeatureHandler` class. 
     """
     def __verify_table(self, table, feature_state_table, expected_table):
         """
@@ -61,78 +60,117 @@ class TestHostcfgd(TestCase):
         feature_state_table.set.assert_has_calls([
             mock.call(feature, [('state', get_state(table[feature]['state']))]) for feature in table
         ])
+
         return True if not ddiff else False
 
-    def __verify_fs(self, table):
-        """
-            verify filesystem changes made by hostcfgd.
+    def checks_systemd_config_file(self, feature_table):
+        """Checks whether the systemd configuration file of each feature was created or not
+        and whether the `Restart=` field in the file is set correctly or not.
 
-            Checks whether systemd override configuration files
-            were generated and Restart= for systemd unit is set
-            correctly
+        Args:
+            feature_table: A dictionary indicates `Feature` table in `CONFIG_DB`.
 
-            Args:
-                table(dict): Current Config Db table
-
-            Returns: Boolean wether test passed.
+        Returns: Boolean value indicates whether test passed or not.
         """
 
-        exp_dict = {
-            'enabled': 'always',
-            'disabled': 'no',
-        }
-        auto_restart_conf = os.path.join(hostcfgd.FeatureHandler.SYSTEMD_SERVICE_CONF_DIR, 'auto_restart.conf')
+        truth_table = {'enabled': 'always',
+                       'disabled': 'no'}
 
-        for feature in table:
-            auto_restart = table[feature].get('auto_restart', 'disabled')
-            with open(auto_restart_conf.format(feature)) as conf:
-                conf = conf.read().strip()
-            assert conf == '[Service]\nRestart={}'.format(exp_dict[auto_restart])
+        systemd_config_file_path = os.path.join(hostcfgd.FeatureHandler.SYSTEMD_SERVICE_CONF_DIR,
+                                                'auto_restart.conf')
+
+        for feature_name in feature_table:
+            auto_restart_status = feature_table[feature_name].get('auto_restart', 'disabled')
+            if "enabled" in auto_restart_status:
+                auto_restart_status = "enabled"
+            elif "disabled" in auto_restart_status:
+                auto_restart_status = "disabled"
+
+            feature_systemd_config_file_path = systemd_config_file_path.format(feature_name)
+            assert os.path.exists(feature_systemd_config_file_path), "Systemd configuration file of feature '{}' does not exist!".format(feature_name)
+            #print(feature_systemd_config_file_path)
+            with open(feature_systemd_config_file_path) as systemd_config_file:
+                status = systemd_config_file.read().strip()
+            assert status == '[Service]\nRestart={}'.format(truth_table[auto_restart_status])
 
 
     @parameterized.expand(HOSTCFGD_TEST_VECTOR)
     @patchfs
-    def test_hostcfgd_feature_handler(self, test_name, test_data, fs):
-        """
-            Test feature config capability in the hostcfd
+    def test_sync_state_field(self, test_scenario_name, config_data, fs):
+        """Tests the method `sync_state_field(...)` of `FeatureHandler` class.
 
-            Args:
-                test_name(str): test name
-                test_data(dict): test data which contains initial Config Db tables, and expected results
+        Args:
+            test_secnario_name: A string indicates different testing scenario.
+            config_data: A dictionary contains initial `CONFIG_DB` tables and expected results.
 
-            Returns:
-                None
+        Returns:
+            Boolean value indicates whether test will pass or not.
         """
-        fs.add_real_paths(swsscommon_package.__path__)  # add real path of swsscommon for database_config.json
+        # add real path of sesscommon for database_config.json
+        fs.add_real_paths(swsscommon_package.__path__)
         fs.create_dir(hostcfgd.FeatureHandler.SYSTEMD_SYSTEM_DIR)
-        MockConfigDb.set_config_db(test_data['config_db'])
+
+        MockConfigDb.set_config_db(config_data['config_db'])
         feature_state_table_mock = mock.Mock()
         with mock.patch('hostcfgd.subprocess') as mocked_subprocess:
             popen_mock = mock.Mock()
-            attrs = test_data['popen_attributes']
+            attrs = config_data['popen_attributes']
             popen_mock.configure_mock(**attrs)
             mocked_subprocess.Popen.return_value = popen_mock
 
-            # Initialize Feature Handler
             device_config = {}
             device_config['DEVICE_METADATA'] = MockConfigDb.CONFIG_DB['DEVICE_METADATA']
             feature_handler = hostcfgd.FeatureHandler(MockConfigDb(), feature_state_table_mock, device_config)
 
-            # sync the state field and Handle Feature Updates
-            features = MockConfigDb.CONFIG_DB['FEATURE']
-            feature_handler.sync_state_field(features)
-            for key, fvs in features.items():
-                feature_handler.handle(key, 'SET', fvs)
+            feature_table = MockConfigDb.CONFIG_DB['FEATURE']
+            feature_handler.sync_state_field(feature_table)
 
             # Verify if the updates are properly updated
-            assert self.__verify_table(
-                MockConfigDb.get_config_db()['FEATURE'],
-                feature_state_table_mock,
-                test_data['expected_config_db']['FEATURE']
-            ), 'Test failed for test data: {0}'.format(test_data)
-            mocked_subprocess.check_call.assert_has_calls(test_data['expected_subprocess_calls'], any_order=True)
+            assert self.__verify_table(MockConfigDb.get_config_db()['FEATURE'],
+                                       feature_state_table_mock,
+                                       config_data['expected_config_db']['FEATURE']), 'Test failed for test data: {0}'.format(config_data)
 
-            self.__verify_fs(test_data['config_db']['FEATURE'])
+            mocked_subprocess.check_call.assert_has_calls(config_data['enable_feature_subprocess_calls'],
+                                                          any_order=True)
+            self.checks_systemd_config_file(config_data['config_db']['FEATURE'])
+
+
+    @parameterized.expand(HOSTCFGD_TEST_VECTOR)
+    @patchfs
+    def test_handler(self, test_scenario_name, config_data, fs):
+        """Tests the method `handle(...)` of `FeatureHandler` class.
+
+        Args:
+            test_secnario_name: A string indicates different testing scenario.
+            config_data: A dictionary contains initial `CONFIG_DB` tables and expected results.
+
+        Returns:
+            Boolean value indicates whether test will pass or not.
+        """
+        # add real path of sesscommon for database_config.json
+        fs.add_real_paths(swsscommon_package.__path__)
+        fs.create_dir(hostcfgd.FeatureHandler.SYSTEMD_SYSTEM_DIR)
+
+        MockConfigDb.set_config_db(config_data['config_db'])
+        feature_state_table_mock = mock.Mock()
+        with mock.patch('hostcfgd.subprocess') as mocked_subprocess:
+            popen_mock = mock.Mock()
+            attrs = config_data['popen_attributes']
+            popen_mock.configure_mock(**attrs)
+            mocked_subprocess.Popen.return_value = popen_mock
+
+            device_config = {}
+            device_config['DEVICE_METADATA'] = MockConfigDb.CONFIG_DB['DEVICE_METADATA']
+            feature_handler = hostcfgd.FeatureHandler(MockConfigDb(), feature_state_table_mock, device_config)
+
+            feature_table = MockConfigDb.CONFIG_DB['FEATURE']
+
+            for feature_name, feature_config in feature_table.items():
+                feature_handler.handler(feature_name, 'SET', feature_config)
+
+            self.checks_systemd_config_file(config_data['config_db']['FEATURE'])
+            mocked_subprocess.check_call.assert_has_calls(config_data['enable_feature_subprocess_calls'],
+                                                          any_order=True)
 
     def test_feature_config_parsing(self):
         swss_feature = hostcfgd.Feature('swss', {
@@ -211,7 +249,6 @@ class TesNtpCfgd(TestCase):
 
             ntpcfgd.handle_ntp_source_intf_chg('eth0')
             mocked_subprocess.check_call.assert_has_calls([call('systemctl restart ntp-config', shell=True)])
-
 
 class TestHostcfgdDaemon(TestCase):
 

--- a/src/sonic-host-services/tests/hostcfgd/test_vectors.py
+++ b/src/sonic-host-services/tests/hostcfgd/test_vectors.py
@@ -496,8 +496,7 @@ HOSTCFGD_TEST_VECTOR = [
                     },
                 },
             },
-            "enable_feature_subprocess_calls": [
-            ],
+            "enable_feature_subprocess_calls": [],
             "daemon_reload_subprocess_call": [
                 call("sudo systemctl daemon-reload", shell=True),
             ],

--- a/src/sonic-host-services/tests/hostcfgd/test_vectors.py
+++ b/src/sonic-host-services/tests/hostcfgd/test_vectors.py
@@ -41,7 +41,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "state": "{% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %}enabled{% else %}always_disabled{% endif %}"
                     },
                     "telemetry": {
-                        "auto_restart": "disabled",
+                        "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
                         "has_timer": "True",
@@ -73,7 +73,7 @@ HOSTCFGD_TEST_VECTOR = [
                         "state": "enabled"
                     },
                     "telemetry": {
-                        "auto_restart": "disabled",
+                        "auto_restart": "enabled",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "False",
                         "has_timer": "True",
@@ -84,7 +84,7 @@ HOSTCFGD_TEST_VECTOR = [
                     },
                 },
             },
-            "expected_subprocess_calls": [
+            "enable_feature_subprocess_calls": [
                 call("sudo systemctl unmask dhcp_relay.service", shell=True),
                 call("sudo systemctl enable dhcp_relay.service", shell=True),
                 call("sudo systemctl start dhcp_relay.service", shell=True),
@@ -95,6 +95,9 @@ HOSTCFGD_TEST_VECTOR = [
                 call("sudo systemctl unmask telemetry.timer", shell=True),
                 call("sudo systemctl enable telemetry.timer", shell=True),
                 call("sudo systemctl start telemetry.timer", shell=True),
+            ],
+            "daemon_reload_subprocess_call": [
+                call("sudo systemctl daemon-reload", shell=True),
             ],
             "popen_attributes": {
                 'communicate.return_value': ('output', 'error')
@@ -198,7 +201,7 @@ HOSTCFGD_TEST_VECTOR = [
                     },
                 },
             },
-            "expected_subprocess_calls": [
+            "enable_feature_subprocess_calls": [
                 call("sudo systemctl stop mux.service", shell=True),
                 call("sudo systemctl disable mux.service", shell=True),
                 call("sudo systemctl mask mux.service", shell=True),
@@ -209,6 +212,9 @@ HOSTCFGD_TEST_VECTOR = [
                 call("sudo systemctl unmask sflow.service", shell=True),
                 call("sudo systemctl enable sflow.service", shell=True),
                 call("sudo systemctl start sflow.service", shell=True),
+            ],
+            "daemon_reload_subprocess_call": [
+                call("sudo systemctl daemon-reload", shell=True),
             ],
             "popen_attributes": {
                 'communicate.return_value': ('output', 'error')
@@ -294,7 +300,7 @@ HOSTCFGD_TEST_VECTOR = [
                     },
                 },
             },
-            "expected_subprocess_calls": [
+            "enable_feature_subprocess_calls": [
                 call("sudo systemctl stop mux.service", shell=True),
                 call("sudo systemctl disable mux.service", shell=True),
                 call("sudo systemctl mask mux.service", shell=True),
@@ -302,6 +308,9 @@ HOSTCFGD_TEST_VECTOR = [
                 call("sudo systemctl unmask telemetry.timer", shell=True),
                 call("sudo systemctl enable telemetry.timer", shell=True),
                 call("sudo systemctl start telemetry.timer", shell=True),
+            ],
+            "daemon_reload_subprocess_call": [
+                call("sudo systemctl daemon-reload", shell=True),
             ],
             "popen_attributes": {
                 'communicate.return_value': ('output', 'error')
@@ -387,7 +396,7 @@ HOSTCFGD_TEST_VECTOR = [
                     },
                 },
             },
-            "expected_subprocess_calls": [
+            "enable_feature_subprocess_calls": [
                 call("sudo systemctl unmask dhcp_relay.service", shell=True),
                 call("sudo systemctl enable dhcp_relay.service", shell=True),
                 call("sudo systemctl start dhcp_relay.service", shell=True),
@@ -398,6 +407,9 @@ HOSTCFGD_TEST_VECTOR = [
                 call("sudo systemctl unmask telemetry.timer", shell=True),
                 call("sudo systemctl enable telemetry.timer", shell=True),
                 call("sudo systemctl start telemetry.timer", shell=True),
+            ],
+            "daemon_reload_subprocess_call": [
+                call("sudo systemctl daemon-reload", shell=True),
             ],
             "popen_attributes": {
                 'communicate.return_value': ('output', 'error')
@@ -484,7 +496,10 @@ HOSTCFGD_TEST_VECTOR = [
                     },
                 },
             },
-            "expected_subprocess_calls": [
+            "enable_feature_subprocess_calls": [
+            ],
+            "daemon_reload_subprocess_call": [
+                call("sudo systemctl daemon-reload", shell=True),
             ],
             "popen_attributes": {
                 'communicate.return_value': ('enabled', 'error')


### PR DESCRIPTION
Signed-off-by: Yong Zhao <yozhao@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Recently the nightly testing pipeline found that the `autorestart` test case was failed when it was run against **master** image. The reason is `Restart=` field in each container's systemd configuration file was set to `Restart=no` even the value of `auto_restart` field in `FEATURE` table of `CONFIG_DB` is `enabled`. 

This issue introduced by https://github.com/Azure/sonic-buildimage/pull/10168 can be reproduced by the following steps:

1. Issues the `config` command to disable the `auto-restart` feature of a container
2. Runs command `config reload` or `config reload minigraph` to enable `auto-restart` of the container
3. Checks `Restart=` field in the container's systemd config file mentioned in step 1 by running the command 
    `sudo systemctl cat <container_name>.service`

Initially this PR (https://github.com/Azure/sonic-buildimage/pull/10168) wants to revert the changes proposed by this: https://github.com/Azure/sonic-buildimage/pull/8861. However, it did not fully revert all the changes.

**Following is the full story to tell how this regression did happen:**

Step 1: Initially the field `Restart=always` was set in each container's systemd configuration file. Then Nvidia team submitted a 
PR ([[hostcfgd] Configure service auto-restart in hostcfgd. by stepanblyschak · Pull Request #5744 · Azure/sonic-buildimage (github.com)](https://github.com/Azure/sonic-buildimage/pull/5744)) to dynamically change this field according to the value of `auto_restart` field in CONFIG_DB. I agreed with this proposal.

In this PR, the `Restart=` field in each container's systemd configuration file was set when either `hostcfgd` service was restarted
(https://github.com/stepanblyschak/sonic-buildimage/blob/32df167af7e5c494b4a8585abebbcd65f05ef0a3/src/sonic-host-services/scripts/hostcfgd#L150) or a user issued `config` command to change the `auto_restart` field in `CONFIG_DB`.

If `hostcfgd` service was started/restarted due to device was rebooted or other reasons, the value of `Restart=` field in systemd 
configuration file will be reset according to value of `auto_restart` field in `CONFIG_DB`. After this, systemd daemon should be
reloaded since its configuration files are changed.

Step 2: However, reloading systemd daemon will need around 10 seconds as stated by this issue
[[hostcfgd] hoscfgd doesn't honor CFG DB updates if they arrive in a specific time interval · Issue #8619 · Azure/sonic-buildimage (github.com)](https://github.com/Azure/sonic-buildimage/issues/8619).

Since `hostcfgd` service will listen to the notifications from `CONFIG_DB` only after systemd daemon was reloaded, any change in tables of CONFIG_DB during systemd daemon reload will be lost. As such, another PR was submitted to address this issue
[[hostcfgd] Fixed the brief blackout in hostcfgd using SubscriberStateTable by vivekreddynv · Pull Request #8861 · Azure/sonic-buildimage (github.com)](https://github.com/Azure/sonic-buildimage/pull/8861).

In this PR, `SubscriberStateTable and Selector` were used to send and handle notifications from `CONFIG_DB` instead of `config_db.subscribe() and config_db.listen()`. The benefits of this change are: any existing data and new change in tables of `CONFIG_DB` will be processed; do not need explicitly initialize `Restart=` field in each container's systemd configuration file.

Step 3: However, `SusbscriberStateTable` will create multiple file descriptors against the Redis DB which is inefficient compared to  `ConfigDBConnector` which only opens a single file descriptor. 

As discussed in Step 2, disadvantages of `config_db.subcribe() and config_db.listen()` is that any change in the tables of
`CONFIG_DB` will be lost before `config_db.listen()` was called. Then Nvidia team submitted a PR to fix this issue:
[Add API endpoints to ConfigDBConnector to support pre-loading data without blackout by alexrallen · Pull Request #587 · Azure/sonic-swss-common (github.com)](https://github.com/Azure/sonic-swss-common/pull/587). At the same time, a PR was submitted to revert the change proposed in Step 2: [[hostcfgd] Move hostcfgd back to ConfigDBConnector for subscribing to updates by alexrallen · Pull Request #10168 · Azure/sonic-buildimage (github.com)](https://github.com/Azure/sonic-buildimage/pull/10168). However, the change was not fully reverted.

Specifically in this PR, the `Restart=` field in each container's systemd configuration file only needs to be initialized according to the value of `auto_restart` field in `CONFIG_DB`. But the change (line 269 ~ 282) proposed in Step 2 was not removed.

#### How I did it
When `hostcfgd` started or was restarted, the `Restart=` field in each container's systemd configuration file should be initialized according to the value of `auto_restart` field in `FEATURE` table of `CONFIG_DB`.

#### How to verify it
I verified this change by running `auto-restart` test case against newly built `master` image and also ran the unittest:

        tests/determine-reboot-cause_test.py .........          [ 20%]
        tests/procdockerstatsd_test.py .                            [ 22%]
        tests/caclmgrd/caclmgrd_bfd_test.py .                  [ 25%]
        tests/caclmgrd/caclmgrd_dhcp_test.py ............      [ 52%]
        tests/hostcfgd/hostcfgd_radius_test.py ..              [ 56%]
        tests/hostcfgd/hostcfgd_tacacs_test.py .              [ 59%]
        tests/hostcfgd/hostcfgd_test.py ..................            [100%]

#### Which release branch to backport (provide reason below if selected)
N/A

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

