### PR TITLE
[dhcp6relay] Add dhcpv6 option check

### DIFF
--- a/src/dhcp6relay/src/relay.cpp
+++ b/src/dhcp6relay/src/relay.cpp
@@ -60,6 +60,8 @@ std::map<int, std::string> counterMap = {{DHCPv6_MESSAGE_TYPE_UNKNOWN, "Unknown"
                                       {DHCPv6_MESSAGE_TYPE_REPLY, "Reply"},
                                       {DHCPv6_MESSAGE_TYPE_RELEASE, "Release"},
                                       {DHCPv6_MESSAGE_TYPE_DECLINE, "Decline"},
+                                      {DHCPv6_MESSAGE_TYPE_RECONFIGURE, "Reconfigure"},
+                                      {DHCPv6_MESSAGE_TYPE_INFORMATION_REQUEST, "Information-Request"},
                                       {DHCPv6_MESSAGE_TYPE_RELAY_FORW, "Relay-Forward"},
                                       {DHCPv6_MESSAGE_TYPE_RELAY_REPL, "Relay-Reply"},
                                       {DHCPv6_MESSAGE_TYPE_MALFORMED, "Malformed"}};
@@ -84,6 +86,8 @@ void initialize_counter(std::string counterVlan) {
     m_stateDbRedisClient.hset(counterVlan, "Reply", toString(counters[DHCPv6_MESSAGE_TYPE_REPLY]));
     m_stateDbRedisClient.hset(counterVlan, "Release", toString(counters[DHCPv6_MESSAGE_TYPE_RELEASE]));
     m_stateDbRedisClient.hset(counterVlan, "Decline", toString(counters[DHCPv6_MESSAGE_TYPE_DECLINE]));
+    m_stateDbRedisClient.hset(counterVlan, "Reconfigure", toString(counters[DHCPv6_MESSAGE_TYPE_RECONFIGURE]));
+    m_stateDbRedisClient.hset(counterVlan, "Information-Request", toString(counters[DHCPv6_MESSAGE_TYPE_INFORMATION_REQUEST]));
     m_stateDbRedisClient.hset(counterVlan, "Relay-Forward", toString(counters[DHCPv6_MESSAGE_TYPE_RELAY_FORW]));
     m_stateDbRedisClient.hset(counterVlan, "Relay-Reply", toString(counters[DHCPv6_MESSAGE_TYPE_RELAY_REPL]));
     m_stateDbRedisClient.hset(counterVlan, "Malformed", toString(counters[DHCPv6_MESSAGE_TYPE_MALFORMED]));
@@ -203,11 +207,12 @@ const struct dhcpv6_relay_msg *parse_dhcpv6_relay(const uint8_t *buffer) {
  * @return dhcpv6_option   end of dhcpv6 message option
  */
 const struct dhcpv6_option *parse_dhcpv6_opt(const uint8_t *buffer, const uint8_t **out_end) {
-    uint32_t size = 4; // option-code + option-len
-    size += ntohs(*(uint16_t *)(buffer + 2));
-    (*out_end) = buffer + size;
+    auto option = (const struct dhcpv6_option *)buffer;
+    uint8_t size = 4; // option-code + option-len
+    size += *(uint16_t *)(buffer);
+    (*out_end) =  buffer + size + ntohs(option->option_length);
 
-    return (const struct dhcpv6_option *)buffer;
+    return option;
 }
 
 /**
@@ -575,6 +580,7 @@ void relay_relay_forw(int sock, const uint8_t *msg, int32_t len, const ip6_hdr *
 void callback(evutil_socket_t fd, short event, void *arg) {
     struct relay_config *config = (struct relay_config *)(arg);
     static uint8_t message_buffer[4096];
+    std::string counterVlan = counter_table;
     int32_t len = recv(config->filter, message_buffer, 4096, 0);
     if (len <= 0) {
         syslog(LOG_WARNING, "recv: Failed to receive data at filter socket: %s\n", strerror(errno));
@@ -612,10 +618,6 @@ void callback(evutil_socket_t fd, short event, void *arg) {
     auto msg = parse_dhcpv6_hdr(current_position);
     auto option_position = current_position + sizeof(struct dhcpv6_msg);
 
-    counters[msg->msg_type]++;
-    std::string counterVlan = counter_table;
-    update_counter(counterVlan.append(config->interface), msg->msg_type);
-
     switch (msg->msg_type) {
         case DHCPv6_MESSAGE_TYPE_RELAY_FORW:
         {
@@ -624,21 +626,25 @@ void callback(evutil_socket_t fd, short event, void *arg) {
         }
         case DHCPv6_MESSAGE_TYPE_SOLICIT:
         case DHCPv6_MESSAGE_TYPE_REQUEST: 
+        case DHCPv6_MESSAGE_TYPE_CONFIRM:
         case DHCPv6_MESSAGE_TYPE_RENEW:
         case DHCPv6_MESSAGE_TYPE_REBIND:
         case DHCPv6_MESSAGE_TYPE_RELEASE:
         case DHCPv6_MESSAGE_TYPE_DECLINE:
+        case DHCPv6_MESSAGE_TYPE_INFORMATION_REQUEST:
         {
             while (option_position - message_buffer < len) {
                 auto option = parse_dhcpv6_opt(option_position, &tmp);
                 option_position = tmp;
-                if(ntohs(option->option_code) > DHCPv6_OPTION_LIMIT) {
+                if (ntohs(option->option_code) > DHCPv6_OPTION_LIMIT) {
                     counters[DHCPv6_MESSAGE_TYPE_MALFORMED]++;
-                    update_counter(config->db, counterVlan.append(config->interface), DHCPv6_MESSAGE_TYPE_MALFORMED);
+                    update_counter(counterVlan.append(config->interface), DHCPv6_MESSAGE_TYPE_MALFORMED);
                     syslog(LOG_WARNING, "DHCPv6 option is invalid or contains malformed payload\n");
                     return;
                 }
             }
+            counters[msg->msg_type]++;
+            update_counter(counterVlan.append(config->interface), msg->msg_type);
             relay_client(config->local_sock, current_position, ntohs(udp_header->len) - sizeof(udphdr), ip_header, ether_header, config);
             break;
         }

--- a/src/dhcp6relay/src/relay.cpp
+++ b/src/dhcp6relay/src/relay.cpp
@@ -50,18 +50,19 @@ const struct sock_fprog ether_relay_fprog = {
 
 /* DHCPv6 Counter */
 uint64_t counters[DHCPv6_MESSAGE_TYPE_COUNT];
-std::map<int, std::string> counterMap = {{0, "Unknown"},
-                                      {1, "Solicit"},
-                                      {2, "Advertise"},
-                                      {3, "Request"},
-                                      {4, "Confirm"},
-                                      {5, "Renew"},
-                                      {6, "Rebind"},
-                                      {7, "Reply"},
-                                      {8, "Release"},
-                                      {9, "Decline"},
-                                      {12, "Relay-Forward"},
-                                      {13, "Relay-Reply"}};
+std::map<int, std::string> counterMap = {{DHCPv6_MESSAGE_TYPE_UNKNOWN, "Unknown"},
+                                      {DHCPv6_MESSAGE_TYPE_SOLICIT, "Solicit"},
+                                      {DHCPv6_MESSAGE_TYPE_ADVERTISE, "Advertise"},
+                                      {DHCPv6_MESSAGE_TYPE_REQUEST, "Request"},
+                                      {DHCPv6_MESSAGE_TYPE_CONFIRM, "Confirm"},
+                                      {DHCPv6_MESSAGE_TYPE_RENEW, "Renew"},
+                                      {DHCPv6_MESSAGE_TYPE_REBIND, "Rebind"},
+                                      {DHCPv6_MESSAGE_TYPE_REPLY, "Reply"},
+                                      {DHCPv6_MESSAGE_TYPE_RELEASE, "Release"},
+                                      {DHCPv6_MESSAGE_TYPE_DECLINE, "Decline"},
+                                      {DHCPv6_MESSAGE_TYPE_RELAY_FORW, "Relay-Forward"},
+                                      {DHCPv6_MESSAGE_TYPE_RELAY_REPL, "Relay-Reply"},
+                                      {DHCPv6_MESSAGE_TYPE_MALFORMED, "Malformed"}};
 
 /**
  * @code                void initialize_counter(std::string counterVlan);
@@ -85,6 +86,7 @@ void initialize_counter(std::string counterVlan) {
     m_stateDbRedisClient.hset(counterVlan, "Decline", toString(counters[DHCPv6_MESSAGE_TYPE_DECLINE]));
     m_stateDbRedisClient.hset(counterVlan, "Relay-Forward", toString(counters[DHCPv6_MESSAGE_TYPE_RELAY_FORW]));
     m_stateDbRedisClient.hset(counterVlan, "Relay-Reply", toString(counters[DHCPv6_MESSAGE_TYPE_RELAY_REPL]));
+    m_stateDbRedisClient.hset(counterVlan, "Malformed", toString(counters[DHCPv6_MESSAGE_TYPE_MALFORMED]));
 }
 
 /**
@@ -608,6 +610,8 @@ void callback(evutil_socket_t fd, short event, void *arg) {
     current_position = tmp;
 
     auto msg = parse_dhcpv6_hdr(current_position);
+    auto option_position = current_position + sizeof(struct dhcpv6_msg);
+
     counters[msg->msg_type]++;
     std::string counterVlan = counter_table;
     update_counter(counterVlan.append(config->interface), msg->msg_type);
@@ -618,9 +622,29 @@ void callback(evutil_socket_t fd, short event, void *arg) {
             relay_relay_forw(config->local_sock, current_position, ntohs(udp_header->len) - sizeof(udphdr), ip_header, config);
             break;
         }
+        case DHCPv6_MESSAGE_TYPE_SOLICIT:
+        case DHCPv6_MESSAGE_TYPE_REQUEST: 
+        case DHCPv6_MESSAGE_TYPE_RENEW:
+        case DHCPv6_MESSAGE_TYPE_REBIND:
+        case DHCPv6_MESSAGE_TYPE_RELEASE:
+        case DHCPv6_MESSAGE_TYPE_DECLINE:
+        {
+            while (option_position - message_buffer < len) {
+                auto option = parse_dhcpv6_opt(option_position, &tmp);
+                option_position = tmp;
+                if(ntohs(option->option_code) > DHCPv6_OPTION_LIMIT) {
+                    counters[DHCPv6_MESSAGE_TYPE_MALFORMED]++;
+                    update_counter(config->db, counterVlan.append(config->interface), DHCPv6_MESSAGE_TYPE_MALFORMED);
+                    syslog(LOG_WARNING, "DHCPv6 option is invalid or contains malformed payload\n");
+                    return;
+                }
+            }
+            relay_client(config->local_sock, current_position, ntohs(udp_header->len) - sizeof(udphdr), ip_header, ether_header, config);
+            break;
+        }
         default:
         {
-            relay_client(config->local_sock, current_position, ntohs(udp_header->len) - sizeof(udphdr), ip_header, ether_header, config);
+            syslog(LOG_WARNING, "DHCPv6 client message received was not relayed\n");
             break;
         }
     }

--- a/src/dhcp6relay/src/relay.h
+++ b/src/dhcp6relay/src/relay.h
@@ -16,6 +16,7 @@
 #define RELAY_PORT 547
 #define CLIENT_PORT 546
 #define HOP_LIMIT 8     //HOP_LIMIT reduced from 32 to 8 as stated in RFC8415
+#define DHCPv6_OPTION_LIMIT 56      // DHCPv6 option code greater than 56 are currently unassigned
 
 #define lengthof(A) (sizeof (A) / sizeof (A)[0])
 
@@ -37,6 +38,7 @@ typedef enum
     DHCPv6_MESSAGE_TYPE_DECLINE = 9,
     DHCPv6_MESSAGE_TYPE_RELAY_FORW = 12,
     DHCPv6_MESSAGE_TYPE_RELAY_REPL = 13,
+    DHCPv6_MESSAGE_TYPE_MALFORMED = 14,
 
     DHCPv6_MESSAGE_TYPE_COUNT
 } dhcp_message_type_t;

--- a/src/dhcp6relay/src/relay.h
+++ b/src/dhcp6relay/src/relay.h
@@ -36,6 +36,8 @@ typedef enum
     DHCPv6_MESSAGE_TYPE_REPLY = 7,
     DHCPv6_MESSAGE_TYPE_RELEASE = 8,
     DHCPv6_MESSAGE_TYPE_DECLINE = 9,
+    DHCPv6_MESSAGE_TYPE_RECONFIGURE = 10,
+    DHCPv6_MESSAGE_TYPE_INFORMATION_REQUEST = 11,
     DHCPv6_MESSAGE_TYPE_RELAY_FORW = 12,
     DHCPv6_MESSAGE_TYPE_RELAY_REPL = 13,
     DHCPv6_MESSAGE_TYPE_MALFORMED = 14,
@@ -59,6 +61,7 @@ struct relay_config {
 
 struct dhcpv6_msg {
     uint8_t msg_type;
+    uint8_t xid[3];
 };
 
 struct PACKED dhcpv6_relay_msg {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

(cherry picked from commit https://github.com/Azure/sonic-buildimage/commit/cfdb8431df86105698eabe9e5e1ee112c06fd7db)
(cherry picked from commit https://github.com/Azure/sonic-buildimage/commit/2ead3aaefc1c20ff987faab6133accdff43de122)
#### Why I did it
To prevent relaying client packets with malformed payload

#### How I did it
Check for invalid dhcpv6 options

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)


