### PR TITLE
[Build]: Support to use symbol links for lazy installation targets to reduce the image size

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -647,5 +647,5 @@ fi
 pushd $FILESYSTEM_ROOT && sudo tar czf $OLDPWD/$FILESYSTEM_DOCKERFS -C ${DOCKERFS_PATH}var/lib/docker .; popd
 
 ## Compress together with /boot, /var/lib/docker and $PLATFORM_DIR as an installer payload zip file
-pushd $FILESYSTEM_ROOT && sudo zip $OLDPWD/$ONIE_INSTALLER_PAYLOAD -r boot/ $PLATFORM_DIR/; popd
+pushd $FILESYSTEM_ROOT && sudo zip --symlinks $OLDPWD/$ONIE_INSTALLER_PAYLOAD -r boot/ $PLATFORM_DIR/; popd
 sudo zip -g -n .squashfs:.gz $ONIE_INSTALLER_PAYLOAD $FILESYSTEM_SQUASHFS $FILESYSTEM_DOCKERFS

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -647,5 +647,5 @@ fi
 pushd $FILESYSTEM_ROOT && sudo tar czf $OLDPWD/$FILESYSTEM_DOCKERFS -C ${DOCKERFS_PATH}var/lib/docker .; popd
 
 ## Compress together with /boot, /var/lib/docker and $PLATFORM_DIR as an installer payload zip file
-pushd $FILESYSTEM_ROOT && sudo zip --symlinks $OLDPWD/$ONIE_INSTALLER_PAYLOAD -r boot/ $PLATFORM_DIR/; popd
+pushd $FILESYSTEM_ROOT && sudo tar czf platform.tar.gz -C $PLATFORM_DIR . && sudo zip -n .gz $OLDPWD/$ONIE_INSTALLER_PAYLOAD -r boot/ platform.tar.gz; popd
 sudo zip -g -n .squashfs:.gz $ONIE_INSTALLER_PAYLOAD $FILESYSTEM_SQUASHFS $FILESYSTEM_DOCKERFS

--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -350,6 +350,12 @@ extract_image() {
     ## Unzip the image except boot0 and dockerfs archive
     unzip -oq "$swipath" -x boot0 "$dockerfs" -d "$image_path"
 
+    ## Extrat the platform.tar.gz
+    info "Extracting platform.tar.gz"
+    mkdir -p $image_path/platform
+    tar xzf $image_path/platform.tar.gz -C $image_path/platform
+    rm -rf $image_path/platform.tar.gz
+
     ## detect rootfs type
     local mountstr="$(grep " $target_path " /proc/mounts)"
     local rootdev="$(echo $mountstr | cut -f1 -d' ')"

--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -350,7 +350,7 @@ extract_image() {
     ## Unzip the image except boot0 and dockerfs archive
     unzip -oq "$swipath" -x boot0 "$dockerfs" "platform.tar.gz" -d "$image_path"
 
-    ## Extrat the platform.tar.gz
+    ## Extract the platform.tar.gz
     info "Extracting platform.tar.gz"
     mkdir -p "$image_path/platform"
     unzip -oqp "$swipath" "platform.tar.gz" | tar xzf - -C "$image_path/platform" $TAR_EXTRA_OPTION

--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -348,13 +348,12 @@ extract_image() {
 
     info "Extracting swi content"
     ## Unzip the image except boot0 and dockerfs archive
-    unzip -oq "$swipath" -x boot0 "$dockerfs" -d "$image_path"
+    unzip -oq "$swipath" -x boot0 "$dockerfs" "platform.tar.gz" -d "$image_path"
 
     ## Extrat the platform.tar.gz
     info "Extracting platform.tar.gz"
-    mkdir -p $image_path/platform
-    tar xzf $image_path/platform.tar.gz -C $image_path/platform
-    rm -rf $image_path/platform.tar.gz
+    mkdir -p "$image_path/platform"
+    unzip -oqp "$swipath" "platform.tar.gz" | tar xzf - -C "$image_path/platform" $TAR_EXTRA_OPTION
 
     ## detect rootfs type
     local mountstr="$(grep " $target_path " /proc/mounts)"

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -614,7 +614,9 @@ sudo LANG=C chroot $FILESYSTEM_ROOT depmod -a {{kversion}}
 sudo dpkg --root=$FILESYSTEM_ROOT -i {{deb}} || sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -f --download-only
 
 sudo mkdir -p $FILESYSTEM_ROOT/$PLATFORM_DIR/{{dev}}
-sudo cp {{ deb }} $FILESYSTEM_ROOT/$PLATFORM_DIR/{{dev}}/
+sudo mkdir -p $FILESYSTEM_ROOT/$PLATFORM_DIR/common
+sudo cp {{ deb }} $FILESYSTEM_ROOT/$PLATFORM_DIR/common/
+sudo ln -sf "../common/{{ debfilename }}" "$FILESYSTEM_ROOT/$PLATFORM_DIR/{{dev}}/{{ debfilename }}"
 for f in $(find $FILESYSTEM_ROOT/var/cache/apt/archives -name "*.deb"); do
     sudo mv $f $FILESYSTEM_ROOT/$PLATFORM_DIR/{{dev}}/
 done

--- a/installer/arm64/install.sh
+++ b/installer/arm64/install.sh
@@ -155,9 +155,9 @@ fi
 # Decompress the file for the file system directly to the partition
 if [ x"$docker_inram" = x"on" ]; then
     # when disk is small, keep dockerfs.tar.gz in disk, expand it into ramfs during initrd
-    unzip -o $ONIE_INSTALLER_PAYLOAD -d $demo_mnt/$image_dir
+    unzip -o $ONIE_INSTALLER_PAYLOAD -x "platform.tar.gz" -d $demo_mnt/$image_dir
 else
-    unzip -o $ONIE_INSTALLER_PAYLOAD -x "$FILESYSTEM_DOCKERFS" -d $demo_mnt/$image_dir
+    unzip -o $ONIE_INSTALLER_PAYLOAD -x "$FILESYSTEM_DOCKERFS" "platform.tar.gz" -d $demo_mnt/$image_dir
 
     if [ "$install_env" = "onie" ]; then
         TAR_EXTRA_OPTION="--numeric-owner"
@@ -169,8 +169,7 @@ else
 fi
 
 mkdir -p $demo_mnt/$image_dir/platform
-tar xzf $demo_mnt/$image_dir/platform.tar.gz -C $demo_mnt/$image_dir/platform
-rm -rf $demo_mnt/$image_dir/platform.tar.gz
+unzip -op $ONIE_INSTALLER_PAYLOAD "platform.tar.gz" | tar xz $TAR_EXTRA_OPTION -f - -C $demo_mnt/$image_dir/platform
 
 if [ "$install_env" = "onie" ]; then
     # Store machine description in target file system

--- a/installer/arm64/install.sh
+++ b/installer/arm64/install.sh
@@ -168,6 +168,9 @@ else
     unzip -op $ONIE_INSTALLER_PAYLOAD "$FILESYSTEM_DOCKERFS" | tar xz $TAR_EXTRA_OPTION -f - -C $demo_mnt/$image_dir/$DOCKERFS_DIR
 fi
 
+mkdir -p $demo_mnt/$image_dir/platform
+tar xzf $demo_mnt/$image_dir/platform.tar.gz -C $demo_mnt/$image_dir/platform
+rm -rf $demo_mnt/$image_dir/platform.tar.gz
 
 if [ "$install_env" = "onie" ]; then
     # Store machine description in target file system

--- a/installer/armhf/install.sh
+++ b/installer/armhf/install.sh
@@ -155,9 +155,9 @@ fi
 # Decompress the file for the file system directly to the partition
 if [ x"$docker_inram" = x"on" ]; then
     # when disk is small, keep dockerfs.tar.gz in disk, expand it into ramfs during initrd
-    unzip -o $ONIE_INSTALLER_PAYLOAD -d $demo_mnt/$image_dir
+    unzip -o $ONIE_INSTALLER_PAYLOAD -x "platform.tar.gz" -d $demo_mnt/$image_dir
 else
-    unzip -o $ONIE_INSTALLER_PAYLOAD -x "$FILESYSTEM_DOCKERFS" -d $demo_mnt/$image_dir
+    unzip -o $ONIE_INSTALLER_PAYLOAD -x "$FILESYSTEM_DOCKERFS" "platform.tar.gz" -d $demo_mnt/$image_dir
 
     if [ "$install_env" = "onie" ]; then
         TAR_EXTRA_OPTION="--numeric-owner"
@@ -169,8 +169,7 @@ else
 fi
 
 mkdir -p $demo_mnt/$image_dir/platform
-tar xzf $demo_mnt/$image_dir/platform.tar.gz -C $demo_mnt/$image_dir/platform
-rm -rf $demo_mnt/$image_dir/platform.tar.gz
+unzip -op $ONIE_INSTALLER_PAYLOAD "platform.tar.gz" | tar xz $TAR_EXTRA_OPTION -f - -C $demo_mnt/$image_dir/platform
 
 if [ "$install_env" = "onie" ]; then
     # Store machine description in target file system

--- a/installer/armhf/install.sh
+++ b/installer/armhf/install.sh
@@ -168,6 +168,9 @@ else
     unzip -op $ONIE_INSTALLER_PAYLOAD "$FILESYSTEM_DOCKERFS" | tar xz $TAR_EXTRA_OPTION -f - -C $demo_mnt/$image_dir/$DOCKERFS_DIR
 fi
 
+mkdir -p $demo_mnt/$image_dir/platform
+tar xzf $demo_mnt/$image_dir/platform.tar.gz -C $demo_mnt/$image_dir/platform
+rm -rf $demo_mnt/$image_dir/platform.tar.gz
 
 if [ "$install_env" = "onie" ]; then
     # Store machine description in target file system

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -549,6 +549,10 @@ else
     unzip -op $ONIE_INSTALLER_PAYLOAD "$FILESYSTEM_DOCKERFS" | tar xz $TAR_EXTRA_OPTION -f - -C $demo_mnt/$image_dir/$DOCKERFS_DIR
 fi
 
+mkdir -p $demo_mnt/$image_dir/platform
+tar xzf $demo_mnt/$image_dir/platform.tar.gz -C $demo_mnt/$image_dir/platform
+rm -rf $demo_mnt/$image_dir/platform.tar.gz
+
 if [ "$install_env" = "onie" ]; then
     # Store machine description in target file system
     if [ -f /etc/machine-build.conf ]; then

--- a/installer/x86_64/install.sh
+++ b/installer/x86_64/install.sh
@@ -536,9 +536,9 @@ fi
 # Decompress the file for the file system directly to the partition
 if [ x"$docker_inram" = x"on" ]; then
     # when disk is small, keep dockerfs.tar.gz in disk, expand it into ramfs during initrd
-    unzip -o $ONIE_INSTALLER_PAYLOAD -d $demo_mnt/$image_dir
+    unzip -o $ONIE_INSTALLER_PAYLOAD -x "platform.tar.gz" -d $demo_mnt/$image_dir
 else
-    unzip -o $ONIE_INSTALLER_PAYLOAD -x "$FILESYSTEM_DOCKERFS" -d $demo_mnt/$image_dir
+    unzip -o $ONIE_INSTALLER_PAYLOAD -x "$FILESYSTEM_DOCKERFS" "platform.tar.gz"  -d $demo_mnt/$image_dir
 
     if [ "$install_env" = "onie" ]; then
         TAR_EXTRA_OPTION="--numeric-owner"
@@ -550,8 +550,7 @@ else
 fi
 
 mkdir -p $demo_mnt/$image_dir/platform
-tar xzf $demo_mnt/$image_dir/platform.tar.gz -C $demo_mnt/$image_dir/platform
-rm -rf $demo_mnt/$image_dir/platform.tar.gz
+unzip -op $ONIE_INSTALLER_PAYLOAD "platform.tar.gz" | tar xz $TAR_EXTRA_OPTION -f - -C $demo_mnt/$image_dir/platform
 
 if [ "$install_env" = "onie" ]; then
     # Store machine description in target file system


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Support to use symbol links in platform folder to reduce the image size.
The current solution is to copy each lazy installation targets (xxx.deb files) to each of the folders in the platform folder. The size will keep growing when more and more packages added in the platform folder. For cisco-8000 as an example, the size will be up to 2G, while most of them are duplicate packages in the platform folder.
 
#### How I did it
Create a new folder in platform/common, all the deb packages are copied to the folder, any other folders where use the packages are the symbol links to the common folder.

Why platform.tar?
We have implemented a patch for it, see https://github.com/Azure/sonic-buildimage/pull/10775, but the problem is the the onie use really old unzip version, cannot support the symbol links.
The current solution is similar to the PR 10775, but make the platform folder into a tar package, which can be supported by onie. During the installation, the package.tar will be extracted to the original folder and removed.

#### How to verify it
1. Verified Arista installation
Installed by sonic-installer.
```
+ unzip -oq /tmp/tmp.0QZcH4zcM2/sonic_image.swi -x boot0 dockerfs.tar.gz platform.tar.gz -d /host/image-master-10923.107767-68d3228d0
+ info Extracting platform.tar.gz
+ cut -f1 -d  /proc/uptime
+ printf %04.2f: Extracting platform.tar.gz\n 28172.20
+ mkdir -p /host/image-master-10923.107767-68d3228d0/platform
+ tar xzf - -C /host/image-master-10923.107767-68d3228d0/platform
+ unzip -oqp /tmp/tmp.0QZcH4zcM2/sonic_image.swi platform.tar.gz
+ grep  /host  /proc/mounts

root@str-a7060cx-acs-1:/host/image-master-10923.107767-68d3228d0# ls
allowlist_paths.conf  boot  docker  fs.squashfs  kernel-cmdline  platform  sonic-config  swi-signature  version
root@str-a7060cx-acs-1:/host/image-master-10923.107767-68d3228d0# find platform/
platform/
platform/x86_64-grub
platform/x86_64-grub/grub-pc-bin_2.04-20_amd64.deb
platform/firsttime
```
Boot from Aboot.
```
Aboot# boot flash:sonic.swi
202.64: Cleaning flash content /mnt/flash
211.48: Generating boot-config, machine.conf and cmdline
211.59: Installing image under /mnt/flash/image-master-10923.107767-68d3228d0
211.60: Moving swi to a tmpfs
213.50: Extracting swi content
215.34: Extracting platform.tar.gz
215.38: Extracting dockerfs.tar.gz from swi

root@sonic:/host# ls
acl.json     image-master-10923.107767-68d3228d0  machine.conf  warmboot
boot-config  kernel-params-base                   reboot-cause
root@sonic:/host# ls image-master-10923.107767-68d3228d0/
allowlist_paths.conf  docker       kernel-cmdline  rw             version
boot                  fs.squashfs  platform        swi-signature  work
root@sonic:/host# ls image-master-10923.107767-68d3228d0/platform/
x86_64-grub
root@sonic:/host# 

```

2. Verified Mellanox, installed by onie
```
Installing SONiC to /tmp/tmp.dm5r6G/image-master-10923.107767-68d3228d0
Archive:  fs.zip
   creating: boot/
  inflating: boot/config-5.10.0-12-2-amd64
  inflating: boot/initrd.img-5.10.0-12-2-amd64
  inflating: boot/vmlinuz-5.10.0-12-2-amd64
  inflating: boot/System.map-5.10.0-12-2-amd64
  inflating: fs.squashfs
Success: Support tarball created: /tmp/onie-support-mlnx_msn2700.tar.bz2
Installing for i386-pc platform.
Installation finished. No error reported.
Switch CPU vendor is: GenuineIntel
Switch CPU cstates are: disabled
EXTRA_CMDLINE_LINUX=sonic_fips=1
Installed SONiC base image SONiC-OS successfully


root@sonic:/host/image-master-10923.107767-68d3228d0# ls platform/
x86_64-grub

```

3. Verified on cisco-8000, installed by onie, it worked fine.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

