### PR TITLE
[Build] Touch the download files to change the modified time

### DIFF
--- a/src/sonic-fips/Makefile
+++ b/src/sonic-fips/Makefile
@@ -24,6 +24,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	  url=$(FIPS_URL_PREFIX)/$$filename
 	  mkdir -p "$$(dirname $(DEST)/$$target)"
 	  wget -O "$(DEST)/$$target" "$$url"
+	  touch "$(DEST)/$$target"
 	done
 
 $(addprefix $(DEST)/, $(FIPS_DERIVED_TARGET)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
It is to improve the build performance, when building multiple targets.
The modified time of downloaded files should be not older than the file .platform.
If not, the file will be downloaded again, when building any dependent targets.

#### How I did it
When downloading the packages from web site, the modified time will be changed by the command "touch".

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

