### PR TITLE
[202012] [mgmt-framework] explicitelly specify protobuf version when installin…

### DIFF
--- a/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
@@ -21,7 +21,8 @@ RUN pip2 install connexion==1.1.15 \
                 certifi==2017.4.17 \
                 python-dateutil==2.6.0 \
                 six==1.11.0 \
-                urllib3==1.21.1
+                urllib3==1.21.1 \
+                protobuf==3.18.0
 
 RUN pip3 install connexion==2.7.0 \
                  setuptools==21.0.0 \


### PR DESCRIPTION
…g python2 packages

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

grpcio-tools package installs protobuf as a dependency package. However, protobuf has been updated in pip and no longer supports python2. 

There is another problem that python2 isn't available at all in mgmt-framework container:

```
admin@r-boxer-sw01:~$ sonic-cli
r-boxer-sw01# show interface status
/tmp/klish.fifo.946.kyIq7L: 2: /tmp/klish.fifo.946.kyIq7L: python: not found
```

This is another issue. **This PR is meant to fix the build issue**.

#### How I did it

Install older available version in pip.

#### How to verify it

Build.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

