### PR TITLE
[SONiC-CEL]: fix platform fancontrol testcase failure issue

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/services/fancontrol/fancontrol
+++ b/platform/broadcom/sonic-platform-modules-cel/services/fancontrol/fancontrol
@@ -348,8 +348,12 @@ CheckFiles || exit 1
 
 if [ -f "$PIDFILE" ]
 then
-    echo "File $PIDFILE exists, is fancontrol already running?" >&2
-    exit 1
+    # Test if process is really running, if not, no need to exit
+    if ps -p $(echo $PIDFILE) > /dev/null
+    then
+        echo "File $PIDFILE exists, is fancontrol already running?" >&2
+        exit 1
+    fi
 fi
 echo $$ > "$PIDFILE"
 


### PR DESCRIPTION
[SONiC-CEL]: fix platform fancontrol testcase failure issue

#### Why I did it
1. fix platform fancontrol testcase failure

#### How I did it
Running fancontrol platform test case would kill fancontrol daemon directly, the exit logic in fancontrol process detection logic would cause fancontrol daemon could not been pull up by supervisord and lead to the fancontrol daemon fail to start after the test case.

#### How to verify it
Run pmon fancontrol test cases, all cases would successfully pass.
```
$ ./run_tests.sh -d cel-e1031-01 -n cel_e1031_t0 -t t0,any -u -c platform_tests/daemon/test_fancontrol.py

platform_tests/daemon/test_fancontrol.py::test_pmon_fancontrol_running_status PASSED                            [ 25%]
platform_tests/daemon/test_fancontrol.py::test_pmon_fancontrol_stop_and_start_status PASSED                     [ 50%]
platform_tests/daemon/test_fancontrol.py::test_pmon_fancontrol_term_and_start_status PASSED                                                       [ 75%]
platform_tests/daemon/test_fancontrol.py::test_pmon_fancontrol_kill_and_start_status PASSED                                                       [100%]

```

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111

