### PR TITLE
[BFN] Fixed settings for BMC interface

### DIFF
--- a/platform/barefoot/sonic-platform-modules-bfn-montara/configs/network/interfaces.d/usb0
+++ b/platform/barefoot/sonic-platform-modules-bfn-montara/configs/network/interfaces.d/usb0
@@ -2,4 +2,5 @@
 auto usb0
 allow-hotplug usb0
 iface usb0 inet6
+up sysctl net.ipv6.neigh.usb0.base_reachable_time_ms=30000
 up ifconfig usb0 txqueuelen 64

--- a/platform/barefoot/sonic-platform-modules-bfn-newport/configs/network/interfaces.d/usb0
+++ b/platform/barefoot/sonic-platform-modules-bfn-newport/configs/network/interfaces.d/usb0
@@ -2,4 +2,5 @@
 auto usb0
 allow-hotplug usb0
 iface usb0 inet6
+up sysctl net.ipv6.neigh.usb0.base_reachable_time_ms=30000
 up ifconfig usb0 txqueuelen 64

--- a/platform/barefoot/sonic-platform-modules-bfn/configs/network/interfaces.d/usb0
+++ b/platform/barefoot/sonic-platform-modules-bfn/configs/network/interfaces.d/usb0
@@ -2,4 +2,5 @@
 auto usb0
 allow-hotplug usb0
 iface usb0 inet6
+up sysctl net.ipv6.neigh.usb0.base_reachable_time_ms=30000
 up ifconfig usb0 txqueuelen 64


### PR DESCRIPTION
Signed-off-by: Taras Keryk <tarasx.keryk@intel.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In some situations, the connection to the BMC may be lost when the ip settings differ on the BMC and CPU (SONiC) sides
#### How I did it
I changed ipv6 neighbor base_reachable_time_ms on the CPU (SONiC). Currently, base_reachable_time_ms  on the CPU and BMC sides will be the same.
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

