### PR TITLE
[sonic-config-engine] Fix typo in hwsku name in sample graph

### DIFF
--- a/src/sonic-config-engine/tests/sample-graph-resource-type.xml
+++ b/src/sonic-config-engine/tests/sample-graph-resource-type.xml
@@ -314,7 +314,7 @@
     <Devices>
       <Device i:type="ToRRouter">
         <Hostname>switch-t0</Hostname>
-        <HwSku>Arista-7050QX-32S</HwSku>
+        <HwSku>Arista-7050-QX-32S</HwSku>
         <ClusterName>AAA00PrdStr00</ClusterName>
       </Device>
       <Device i:type="LeafRouter">
@@ -751,7 +751,7 @@
       </EthernetInterfaces>
       <FlowControl>true</FlowControl>
       <Height>0</Height>
-      <HwSku>Arista-7050QX-32S</HwSku>
+      <HwSku>Arista-7050-QX-32S</HwSku>
       <ManagementInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
 	<a:ManagementInterface>
 	  <ElementType>DeviceInterface</ElementType>
@@ -786,5 +786,5 @@
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
   <Hostname>switch-t0</Hostname>
-  <HwSku>Arista-7050QX-32S</HwSku>
+  <HwSku>Arista-7050-QX-32S</HwSku>
 </DeviceMiniGraph>


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
There was a typo in hwsku specified as part of #10889

#### How I did it
Replaced with the correct hwsku

#### How to verify it
test_cfggen.py is passing
