### PR TITLE
[sonic-sairedis] don't try to build python-pysairedis (python2) on bu…

### DIFF
--- a/rules/sairedis.mk
+++ b/rules/sairedis.mk
@@ -45,6 +45,10 @@ $(LIBSAIMETADATA_DBG)_DEPENDS += $(LIBSAIMETADATA)
 $(LIBSAIMETADATA_DBG)_RDEPENDS += $(LIBSAIMETADATA)
 $(eval $(call add_derived_package,$(LIBSAIREDIS),$(LIBSAIMETADATA_DBG)))
 
+ifeq ($(ENABLE_PY2_MODULES), n)
+    $(LIBSWSSCOMMON)_BUILD_ENV += DEB_BUILD_PROFILES=nopython2
+endif
+
 # The .c, .cpp, .h & .hpp files under src/{$DBG_SRC_ARCHIVE list}
 # are archived into debug one image to facilitate debugging.
 #


### PR DESCRIPTION
…llseye

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To not try to build python2 bindings for sairedis for bullseye. The same solution was done for swss-common package.
Releated changes https://github.com/Azure/sonic-sairedis/pull/1050

#### How I did it

Passed a build profile environment variable

#### How to verify it

Build image and run, basic tests.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

