### PR TITLE
Set the version for python2 package protobuf

### DIFF
--- a/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt-framework/Dockerfile.j2
@@ -18,6 +18,7 @@ RUN pip2 install wheel==0.35.1
 RUN pip2 install connexion==1.1.15 \
                 setuptools==21.0.0 \
                 grpcio-tools==1.20.0 \
+                protobuf==4.0.0rc2 \
                 certifi==2017.4.17 \
                 python-dateutil==2.6.0 \
                 six==1.11.0 \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the build failure as below, Python2 not support to install protobuf>=4.21.
```
Step 14/27 : RUN pip2 install connexion==1.1.15                 setuptools==21.0.0                 grpcio-tools==1.20.0                 certifi==2017.4.17                 python-dateutil==2.6.0                 six==1.11.0                 urllib3==1.21.1
 ---> Running in bc15ffa6b57c
....
Collecting protobuf>=3.5.0.post1
  Downloading protobuf-4.21.0-py2.py3-none-any.whl (164 kB)
ERROR: Package 'protobuf' requires a different Python: 2.7.16 not in '>=3.7'
```

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

