### PR TITLE
[Build]: Support to use the base image version when a package version not specified

### DIFF
--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -256,6 +256,59 @@ release_apt_installation_lock()
     rm -f $DPKG_INSTALLTION_LOCK_FILE
 }
 
+update_preference_deb()
+{
+    local version_file="$VERSION_PATH/versions-deb"
+    if [ -f "$version_file" ]; then
+        rm -f $VERSION_DEB_PREFERENCE
+        for pacakge_version in $(cat "$version_file"); do
+            package=$(echo $pacakge_version | awk -F"==" '{print $1}')
+            version=$(echo $pacakge_version | awk -F"==" '{print $2}')
+            echo -e "Package: $package\nPin: version $version\nPin-Priority: 999\n\n" >> $VERSION_DEB_PREFERENCE
+        done
+    fi
+}
+
+update_version_file()
+{
+    local version_name=$1
+    local pre_version_file="$(ls $PRE_VERSION_PATH/${version_name}-* 2>/dev/null | head -n 1)"
+    local version_file="$VERSION_PATH/$1"
+    if [ ! -f "$pre_version_file" ]; then
+        return 0
+    fi
+    local pacakge_versions="$(cat $pre_version_file)"
+    [ -f "$version_file" ] && pacakge_versions="$pacakge_versions $(cat $version_file)"
+    declare -A versions
+    for pacakge_version in $pacakge_versions; do
+        package=$(echo $pacakge_version | awk -F"==" '{print $1}')
+        version=$(echo $pacakge_version | awk -F"==" '{print $2}')
+        if [ -z "$package" ] || [ -z "$version" ]; then
+            continue
+        fi
+        versions[$package]=$version
+    done
+
+    tmp_file=$(mktemp)
+    for package in "${!versions[@]}"; do
+        echo "$package==${versions[$package]}" >> $tmp_file
+    done
+    sort -u $tmp_file > $version_file
+    rm -f $tmp_file
+    
+    if [[ "${version_name}" == *-deb ]]; then
+        update_preference_deb
+    fi
+}
+
+update_version_files()
+{
+    local version_names="versions-deb versions-py2 versions-py3"
+    for version_name in $version_names; do
+        update_version_file $version_name
+    done
+}
+
 ENABLE_VERSION_CONTROL_DEB=$(check_version_control "deb")
 ENABLE_VERSION_CONTROL_PY2=$(check_version_control "py2")
 ENABLE_VERSION_CONTROL_PY3=$(check_version_control "py3")

--- a/src/sonic-build-hooks/scripts/pre_run_buildinfo
+++ b/src/sonic-build-hooks/scripts/pre_run_buildinfo
@@ -11,6 +11,7 @@ mkdir -p $LOG_PATH
 [ -d $POST_VERSION_PATH ] && rm -rf $POST_VERSION_PATH
 mkdir -p $POST_VERSION_PATH
 collect_version_files $PRE_VERSION_PATH
+update_version_files
 symlink_build_hooks
 set_reproducible_mirrors
 


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Cherry-pick from master.
It is to fix issue: #10952
[Build]: Support to use the base image version when a package version not specified

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

