### PR TITLE
[Build]: Support to use the base image version when a package version not specified

### DIFF
--- a/src/sonic-build-hooks/scripts/pre_run_buildinfo
+++ b/src/sonic-build-hooks/scripts/pre_run_buildinfo
@@ -11,6 +11,7 @@ mkdir -p $LOG_PATH
 [ -d $POST_VERSION_PATH ] && rm -rf $POST_VERSION_PATH
 mkdir -p $POST_VERSION_PATH
 collect_version_files $PRE_VERSION_PATH
+update_version_files
 symlink_build_hooks
 set_reproducible_mirrors
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Cherry-pick from master.
It is to fix issue: #10952
[Build]: Support to use the base image version when a package version not specified

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

