### PR TITLE
Fix hostcfgd does not react to SIGINT issue.

### DIFF
--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -11,7 +11,7 @@ import signal
 
 import jinja2
 from sonic_py_common import device_info
-from swsscommon.swsscommon import ConfigDBConnector, DBConnector, Table, SignalHandlerHelper, SIGNAL_INT
+from swsscommon.swsscommon import ConfigDBConnector, DBConnector, Table, SignalHandlerHelper, SIGNAL_INT, SIGNAL_TERM
 
 # FILE
 PAM_AUTH_CONF = "/etc/pam.d/common-auth-sonic"
@@ -61,12 +61,6 @@ def safe_eval(val, default_value=False):
 def signal_handler(sig, frame):
     if sig == signal.SIGHUP:
         syslog.syslog(syslog.LOG_INFO, "HostCfgd: signal 'SIGHUP' is caught and ignoring..")
-    elif sig == signal.SIGINT:
-        syslog.syslog(syslog.LOG_INFO, "HostCfgd: signal 'SIGINT' is caught and exiting...")
-        sys.exit(128 + sig)
-    elif sig == signal.SIGTERM:
-        syslog.syslog(syslog.LOG_INFO, "HostCfgd: signal 'SIGTERM' is caught and exiting...")
-        sys.exit(128 + sig)
     else:
         syslog.syslog(syslog.LOG_INFO, "HostCfgd: invalid signal - ignoring..")
 
@@ -1242,13 +1236,12 @@ class HostConfigDaemon:
 
 
 def main():
-    signal.signal(signal.SIGTERM, signal_handler)
-    signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGHUP, signal_handler)
 
     # Initialize swsscommon signal helper, because python signal handler will be blocked by long running c++ code.
     # For more information please check: https://docs.python.org/3/library/signal.html
     SignalHandlerHelper.registerSignalHandler(SIGNAL_INT)
+    SignalHandlerHelper.registerSignalHandler(SIGNAL_TERM)
 
     daemon = HostConfigDaemon()
     daemon.register_callbacks()

--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -11,7 +11,7 @@ import signal
 
 import jinja2
 from sonic_py_common import device_info
-from swsscommon.swsscommon import ConfigDBConnector, DBConnector, Table
+from swsscommon.swsscommon import ConfigDBConnector, DBConnector, Table, SignalHandlerHelper, SIGNAL_INT
 
 # FILE
 PAM_AUTH_CONF = "/etc/pam.d/common-auth-sonic"
@@ -1245,6 +1245,11 @@ def main():
     signal.signal(signal.SIGTERM, signal_handler)
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGHUP, signal_handler)
+
+    # Initialize swsscommon signal helper, because python signal handler will be blocked by long running c++ code.
+    # For more information please check: https://docs.python.org/3/library/signal.html
+    SignalHandlerHelper.registerSignalHandler(SIGNAL_INT)
+
     daemon = HostConfigDaemon()
     daemon.register_callbacks()
     daemon.start()


### PR DESCRIPTION
#### Why I did it
    There are infinite loops inside PubSub::listen() method, so application using this method can't handle SIGTERM correctly.
    https://github.com/Azure/sonic-swss-common/issues/603

#### How I did it
    Register swsscommon event handler in hostcfgd.

#### How to verify it
    Pass all E2E test case.
    Manually check hostcfgd can be killed with signal.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
    Fix hostcfgd does not react to SIGINT issue by register swsscommon signal handler in hostcfgd.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

