### PR TITLE
S52xx bug fixes

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/s5212f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5212f/sonic_platform/sfp.py
@@ -13,6 +13,7 @@ try:
     import time
     import struct
     import mmap
+    import subprocess
     from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
 
 except ImportError as e:
@@ -39,6 +40,7 @@ class Sfp(SfpOptoeBase):
     def __init__(self, index, sfp_type, eeprom_path):
         SfpOptoeBase.__init__(self)
         self.sfp_type = sfp_type
+        self.port_type = sfp_type
         self.index = index
         self.eeprom_path = eeprom_path
         self._initialize_media(delay=False)

--- a/platform/broadcom/sonic-platform-modules-dell/s5224f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5224f/sonic_platform/sfp.py
@@ -13,6 +13,7 @@ try:
     import time
     import struct
     import mmap
+    import subprocess
     from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
 
 except ImportError as e:
@@ -39,6 +40,7 @@ class Sfp(SfpOptoeBase):
     def __init__(self, index, sfp_type, eeprom_path):
         SfpOptoeBase.__init__(self)
         self.sfp_type = sfp_type
+        self.port_type = sfp_type
         self.index = index
         self.eeprom_path = eeprom_path
         self._initialize_media(delay=False)

--- a/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/sfp.py
@@ -13,6 +13,7 @@ try:
     import time
     import struct
     import mmap
+    import subprocess
     from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
 
 except ImportError as e:
@@ -39,6 +40,7 @@ class Sfp(SfpOptoeBase):
     def __init__(self, index, sfp_type, eeprom_path):
         SfpOptoeBase.__init__(self)
         self.sfp_type = sfp_type
+        self.port_type = sfp_type
         self.index = index
         self.eeprom_path = eeprom_path
         self._initialize_media(delay=False)

--- a/platform/broadcom/sonic-platform-modules-dell/s5248f/scripts/s5248f_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s5248f/scripts/s5248f_platform.sh
@@ -56,11 +56,15 @@ switch_board_qsfp_mux() {
 switch_board_qsfp() {
         case $1 in
         "new_device")
-                        for ((i=2;i<=57;i++));
+                        for ((i=2;i<=49;i++));
                         do
-                            echo optoe1 0x50 > /sys/bus/i2c/devices/i2c-$i/$1
+                            echo optoe2 0x50 > /sys/bus/i2c/devices/i2c-$i/$1
                         done
-                        ;;
+			for ((i=50;i<=57;i++));
+			do
+				echo optoe1 0x50 > /sys/bus/i2c/devices/i2c-$i/$1
+			done
+			;;
  
         "delete_device")
                         for ((i=2;i<=57;i++));

--- a/platform/broadcom/sonic-platform-modules-dell/s5248f/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5248f/sonic_platform/chassis.py
@@ -127,11 +127,11 @@ class Chassis(ChassisBase):
         self.PORT_START = 1
         self.PORT_END = 56 
         self.PORTS_IN_BLOCK = (self.PORT_END + 1)
-        _sfp_port = range(49, self.PORTS_IN_BLOCK)
+        qsfp_port = range(49, self.PORTS_IN_BLOCK)
         eeprom_base = "/sys/class/i2c-adapter/i2c-{0}/{0}-0050/eeprom"
         for index in range(self.PORT_START, self.PORTS_IN_BLOCK):
             eeprom_path = eeprom_base.format(self._port_to_i2c_mapping[index])
-            port_type = 'QSFP' if index in _sfp_port else 'SFP'
+            port_type = 'QSFP' if index in qsfp_port else 'SFP'
             sfp_node = Sfp(index, port_type, eeprom_path)
             self._sfp_list.append(sfp_node)
 

--- a/platform/broadcom/sonic-platform-modules-dell/s5248f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5248f/sonic_platform/sfp.py
@@ -13,6 +13,7 @@ try:
     import time
     import struct
     import mmap
+    import subprocess
     from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
 
 except ImportError as e:
@@ -39,6 +40,7 @@ class Sfp(SfpOptoeBase):
     def __init__(self, index, sfp_type, eeprom_path):
         SfpOptoeBase.__init__(self)
         self.sfp_type = sfp_type
+        self.port_type = sfp_type
         self.index = index
         self.eeprom_path = eeprom_path
         self._initialize_media(delay=False)

--- a/platform/broadcom/sonic-platform-modules-dell/s5296f/scripts/s5296f_platform.sh
+++ b/platform/broadcom/sonic-platform-modules-dell/s5296f/scripts/s5296f_platform.sh
@@ -71,9 +71,13 @@ switch_board_qsfp_mux() {
 switch_board_qsfp() {
     case $1 in
         "new_device")
-            for ((i=2;i<=105;i++));
+            for ((i=2;i<=97;i++));
             do
-                echo sff8436 0x50 > /sys/bus/i2c/devices/i2c-$i/$1
+                echo optoe2 0x50 > /sys/bus/i2c/devices/i2c-$i/$1
+            done
+	    for ((i=98;i<=105;i++));
+            do
+                echo optoe1 0x50 > /sys/bus/i2c/devices/i2c-$i/$1
             done
             ;;
         


### PR DESCRIPTION
#### Why I did it
S52xx Platform Chassis initialization was taking longer time.
#### How I did it
Attach appropriate optoe drivers in platform init script
#### How to verify it
Check sfpshow eeprom, chassis initialization timings in python3 interpreter.
#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
[S5248f_UT.txt](https://github.com/Azure/sonic-buildimage/files/8796794/S5248f_UT.txt)

