### PR TITLE
[BGP] Update BGP-related j2 templates to advertise Loopback0 IPv6 addresses with configured subnet

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -11,7 +11,11 @@
 ip prefix-list PL_LoopbackV4 permit {{ get_ipv4_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/32
 !
 {% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") != 'None' %}
-ipv6 prefix-list PL_LoopbackV6 permit {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | replace('/128', '/64') | ip_network }}/64
+{% for (name, prefix) in LOOPBACK_INTERFACE|pfx_filter %}
+{% if name == "Loopback0" and prefix | ipv6 %}
+ipv6 prefix-list PL_LoopbackV6 permit {{ prefix | ip_network }}/{{ prefix | prefixlen }}
+{% endif %}
+{% endfor %}
 {% endif %}
 !
 {% if VLAN_INTERFACE is defined %}
@@ -89,7 +93,11 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 !
 {% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") != 'None' %}
   address-family ipv6
-    network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/64
+{% for (name, prefix) in LOOPBACK_INTERFACE|pfx_filter %}
+{% if name == "Loopback0" and prefix | ipv6 %}
+    network {{ prefix | ip_network }}/{{ prefix | prefixlen }}
+{% endif %}
+{% endfor %}
   exit-address-family
 {% endif %}
 {% if ((multi_asic is defined and DEVICE_METADATA['localhost']['switch_type'] != 'chassis-packet') or (DEVICE_METADATA['localhost']['switch_type'] == 'voq')) %}

--- a/dockers/docker-fpm-frr/frr/staticd/staticd.loopback_route.conf.j2
+++ b/dockers/docker-fpm-frr/frr/staticd/staticd.loopback_route.conf.j2
@@ -2,9 +2,13 @@
 {% from "common/functions.conf.j2" import get_ipv4_loopback_address, get_ipv6_loopback_address, get_vnet_interfaces %}
 !
 {% block loopback_route %}
-! add static ipv6 /64 loopback route to allow bgpd to advertise the loopback route prefix
+! add static ipv6 loopback route to allow bgpd to advertise the loopback route prefix
 {% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") != 'None' %}
-ipv6 route {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | replace('/128', '/64') | ip_network }}/64 Loopback0
+{% for (name, prefix) in LOOPBACK_INTERFACE|pfx_filter %}
+{% if name == "Loopback0" and prefix | ipv6 %}
+ipv6 route {{ prefix | ip_network }}/{{ prefix | prefixlen }} Loopback0
+{% endif %}
+{% endfor %}
 {% endif %}
 {% endblock loopback_route %}
 !

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.conf.j2/all.conf
@@ -27,7 +27,7 @@ agentx
 !
 ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
 !
-ipv6 prefix-list PL_LoopbackV6 permit fc00::/64
+ipv6 prefix-list PL_LoopbackV6 permit fc00::1/128
 !
 ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 10.10.10.0/24
 !
@@ -71,7 +71,7 @@ router bgp 55555
   network 55.55.55.56/32 route-map HIDE_INTERNAL
 !
   address-family ipv6
-    network fc00::1/64
+    network fc00::1/128
   exit-address-family
   address-family ipv6
     network fc00::2/128 route-map HIDE_INTERNAL

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/all.conf
@@ -9,7 +9,7 @@
 !
 ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
 !
-ipv6 prefix-list PL_LoopbackV6 permit fc00::/64
+ipv6 prefix-list PL_LoopbackV6 permit fc00::1/128
 !
 ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 10.10.10.0/24
 !
@@ -50,7 +50,7 @@ router bgp 55555
   network 55.55.55.56/32 route-map HIDE_INTERNAL
 !
   address-family ipv6
-    network fc00::1/64
+    network fc00::1/128
   exit-address-family
   address-family ipv6
     network fc00::2/128 route-map HIDE_INTERNAL

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/defaults.conf
@@ -9,7 +9,7 @@
 !
 ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
 !
-ipv6 prefix-list PL_LoopbackV6 permit fc00::/64
+ipv6 prefix-list PL_LoopbackV6 permit fc00::1/128
 !
 ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 10.10.10.0/24
 !
@@ -50,7 +50,7 @@ router bgp 55555
   network 55.55.55.56/32 route-map HIDE_INTERNAL
 !
   address-family ipv6
-    network fc00::1/64
+    network fc00::1/128
   exit-address-family
   address-family ipv6
     network fc00::2/128 route-map HIDE_INTERNAL

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/packet_chassis.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/packet_chassis.conf
@@ -9,7 +9,7 @@
 !
 ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
 !
-ipv6 prefix-list PL_LoopbackV6 permit fc00::/64
+ipv6 prefix-list PL_LoopbackV6 permit fc00::1/128
 !
 ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 10.10.10.0/24
 !
@@ -45,7 +45,7 @@ router bgp 55555
   network 55.55.55.55/32
 !
   address-family ipv6
-    network fc00::1/64
+    network fc00::1/128
   exit-address-family
 !
   network 10.10.10.1/24

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/voq_chassis.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/voq_chassis.conf
@@ -9,7 +9,7 @@
 !
 ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
 !
-ipv6 prefix-list PL_LoopbackV6 permit fc00::/64
+ipv6 prefix-list PL_LoopbackV6 permit fc00::1/128
 !
 ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 10.10.10.0/24
 !
@@ -46,7 +46,7 @@ router bgp 55555
   network 55.55.55.56/32 route-map HIDE_INTERNAL
 !
   address-family ipv6
-    network fc00::1/64
+    network fc00::1/128
   exit-address-family
   address-family ipv6
     network fc00::2/128 route-map HIDE_INTERNAL

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
@@ -32,8 +32,8 @@ link-detect
 !
 !!
 !
-! add static ipv6 /64 loopback route to allow bgpd to advertise the loopback route prefix
-ipv6 route fc00::/64 Loopback0
+! add static ipv6 loopback route to allow bgpd to advertise the loopback route prefix
+ipv6 route fc00::1/128 Loopback0
 !!
 !
 ! template: bgpd/bgpd.main.conf.j2
@@ -46,7 +46,7 @@ ipv6 route fc00::/64 Loopback0
 !
 ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
 !
-ipv6 prefix-list PL_LoopbackV6 permit fc00::/64
+ipv6 prefix-list PL_LoopbackV6 permit fc00::1/128
 !
 ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 10.10.10.0/24
 !
@@ -86,7 +86,7 @@ router bgp 55555
   network 55.55.55.56/32 route-map HIDE_INTERNAL
 !
   address-family ipv6
-    network fc00::1/64
+    network fc00::1/128
   exit-address-family
   address-family ipv6
     network fc00::2/128 route-map HIDE_INTERNAL

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/staticd/staticd.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/staticd/staticd.conf
@@ -16,6 +16,6 @@ log facility local4
 !
 !!
 !
-! add static ipv6 /64 loopback route to allow bgpd to advertise the loopback route prefix
-ipv6 route fc00:1::/64 Loopback0
+! add static ipv6 loopback route to allow bgpd to advertise the loopback route prefix
+ipv6 route fc00:1::32/128 Loopback0
 !!

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/staticd/staticd.loopback_route.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/staticd/staticd.loopback_route.conf
@@ -1,4 +1,4 @@
 !
-! add static ipv6 /64 loopback route to allow bgpd to advertise the loopback route prefix
-ipv6 route fc00:1::/64 Loopback0
+! add static ipv6 loopback route to allow bgpd to advertise the loopback route prefix
+ipv6 route fc00:1::32/128 Loopback0
 !!

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/tsa/isolate_v6.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/tsa/isolate_v6.conf
@@ -1,0 +1,5 @@
+route-map test_rm_name permit 20
+  match ipv6 address prefix-list PL_LoopbackV6
+  set community 12345:555
+route-map test_rm_name deny 30
+!

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/tsa/isolate_v6.json
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/tsa/isolate_v6.json
@@ -1,0 +1,10 @@
+{
+    "constants": {
+        "bgp": {
+            "traffic_shift_community": "12345:555"
+        }
+    },
+    "route_map_name": "test_rm_name",
+    "ip_version": "V6",
+    "ip_protocol": "ipv6"
+}

--- a/src/sonic-bgpcfgd/tests/test_sonic-cfggen.py
+++ b/src/sonic-bgpcfgd/tests/test_sonic-cfggen.py
@@ -63,6 +63,12 @@ def test_tsa_isolate():
              "tsa/isolate.json",
              "tsa/isolate.conf")
 
+def test_tsa_isolate_v6():
+    run_test("tsa/bgpd.tsa.isolate.conf.j2",
+             "bgpd/tsa/bgpd.tsa.isolate.conf.j2",
+             "tsa/isolate_v6.json",
+             "tsa/isolate_v6.conf")
+
 def test_tsa_unisolate():
     run_test("tsa/bgpd.tsa.unisolate.conf.j2",
              "bgpd/tsa/bgpd.tsa.unisolate.conf.j2",

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr.conf
@@ -31,7 +31,7 @@ agentx
 !
 ip prefix-list PL_LoopbackV4 permit 10.1.0.32/32
 !
-ipv6 prefix-list PL_LoopbackV6 permit fc00:1::/64
+ipv6 prefix-list PL_LoopbackV6 permit fc00:1::32/128
 !
 ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.200.0/27
 !
@@ -57,7 +57,7 @@ router bgp 65100
   network 10.1.0.32/32
 !
   address-family ipv6
-    network fc00:1::32/64
+    network fc00:1::32/128
   exit-address-family
 !
   network 192.168.200.1/27

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_backend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_backend_asic.conf
@@ -31,7 +31,7 @@ agentx
 !
 ip prefix-list PL_LoopbackV4 permit 10.1.0.32/32
 !
-ipv6 prefix-list PL_LoopbackV6 permit fc00:1::/64
+ipv6 prefix-list PL_LoopbackV6 permit fc00:1::32/128
 !
 !
 ip prefix-list V4_P2P_IP permit 0.0.0.0/0 ge 31 le 31
@@ -65,7 +65,7 @@ router bgp 65100
   network 8.0.0.5/32 route-map HIDE_INTERNAL
 !
   address-family ipv6
-    network fc00:1::32/64
+    network fc00:1::32/128
   exit-address-family
   address-family ipv6
     network fd00:4::32/128 route-map HIDE_INTERNAL

--- a/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_frontend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/bgpd_frr_frontend_asic.conf
@@ -31,7 +31,7 @@ agentx
 !
 ip prefix-list PL_LoopbackV4 permit 10.1.0.32/32
 !
-ipv6 prefix-list PL_LoopbackV6 permit fc00:1::/64
+ipv6 prefix-list PL_LoopbackV6 permit fc00:1::32/128
 !
 !
 ip prefix-list V4_P2P_IP permit 0.0.0.0/0 ge 31 le 31
@@ -65,7 +65,7 @@ router bgp 65100
   network 8.0.0.0/32 route-map HIDE_INTERNAL
 !
   address-family ipv6
-    network fc00:1::32/64
+    network fc00:1::32/128
   exit-address-family
   address-family ipv6
     network fd00:1::32/128 route-map HIDE_INTERNAL

--- a/src/sonic-config-engine/tests/sample_output/py2/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/frr.conf
@@ -36,8 +36,8 @@ link-detect
 !!
 !
 !
-! add static ipv6 /64 loopback route to allow bgpd to advertise the loopback route prefix
-ipv6 route fc00:1::/64 Loopback0
+! add static ipv6 loopback route to allow bgpd to advertise the loopback route prefix
+ipv6 route fc00:1::32/128 Loopback0
 !!
 !
 ! template: bgpd/bgpd.main.conf.j2
@@ -50,7 +50,7 @@ ipv6 route fc00:1::/64 Loopback0
 !
 ip prefix-list PL_LoopbackV4 permit 10.1.0.32/32
 !
-ipv6 prefix-list PL_LoopbackV6 permit fc00:1::/64
+ipv6 prefix-list PL_LoopbackV6 permit fc00:1::32/128
 !
 ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.200.0/27
 !
@@ -76,7 +76,7 @@ router bgp 65100
   network 10.1.0.32/32
 !
   address-family ipv6
-    network fc00:1::32/64
+    network fc00:1::32/128
   exit-address-family
 !
   network 192.168.200.1/27

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr.conf
@@ -31,7 +31,7 @@ agentx
 !
 ip prefix-list PL_LoopbackV4 permit 10.1.0.32/32
 !
-ipv6 prefix-list PL_LoopbackV6 permit fc00:1::/64
+ipv6 prefix-list PL_LoopbackV6 permit fc00:1::32/128
 !
 ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.0.0/27
 !
@@ -57,7 +57,7 @@ router bgp 65100
   network 10.1.0.32/32
 !
   address-family ipv6
-    network fc00:1::32/64
+    network fc00:1::32/128
   exit-address-family
 !
   network 192.168.0.1/27

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_backend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_backend_asic.conf
@@ -31,7 +31,7 @@ agentx
 !
 ip prefix-list PL_LoopbackV4 permit 10.1.0.32/32
 !
-ipv6 prefix-list PL_LoopbackV6 permit fc00:1::/64
+ipv6 prefix-list PL_LoopbackV6 permit fc00:1::32/128
 !
 !
 ip prefix-list V4_P2P_IP permit 0.0.0.0/0 ge 31 le 31
@@ -65,7 +65,7 @@ router bgp 65100
   network 8.0.0.5/32 route-map HIDE_INTERNAL
 !
   address-family ipv6
-    network fc00:1::32/64
+    network fc00:1::32/128
   exit-address-family
   address-family ipv6
     network fd00:4::32/128 route-map HIDE_INTERNAL

--- a/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_frontend_asic.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/bgpd_frr_frontend_asic.conf
@@ -31,7 +31,7 @@ agentx
 !
 ip prefix-list PL_LoopbackV4 permit 10.1.0.32/32
 !
-ipv6 prefix-list PL_LoopbackV6 permit fc00:1::/64
+ipv6 prefix-list PL_LoopbackV6 permit fc00:1::32/128
 !
 !
 ip prefix-list V4_P2P_IP permit 0.0.0.0/0 ge 31 le 31
@@ -65,7 +65,7 @@ router bgp 65100
   network 8.0.0.0/32 route-map HIDE_INTERNAL
 !
   address-family ipv6
-    network fc00:1::32/64
+    network fc00:1::32/128
   exit-address-family
   address-family ipv6
     network fd00:1::32/128 route-map HIDE_INTERNAL

--- a/src/sonic-config-engine/tests/sample_output/py3/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/frr.conf
@@ -36,8 +36,8 @@ link-detect
 !!
 !
 !
-! add static ipv6 /64 loopback route to allow bgpd to advertise the loopback route prefix
-ipv6 route fc00:1::/64 Loopback0
+! add static ipv6 loopback route to allow bgpd to advertise the loopback route prefix
+ipv6 route fc00:1::32/128 Loopback0
 !!
 !
 ! template: bgpd/bgpd.main.conf.j2
@@ -50,7 +50,7 @@ ipv6 route fc00:1::/64 Loopback0
 !
 ip prefix-list PL_LoopbackV4 permit 10.1.0.32/32
 !
-ipv6 prefix-list PL_LoopbackV6 permit fc00:1::/64
+ipv6 prefix-list PL_LoopbackV6 permit fc00:1::32/128
 !
 ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 192.168.0.0/27
 !
@@ -76,7 +76,7 @@ router bgp 65100
   network 10.1.0.32/32
 !
   address-family ipv6
-    network fc00:1::32/64
+    network fc00:1::32/128
   exit-address-family
 !
   network 192.168.0.1/27


### PR DESCRIPTION
#### Why I did it
Fixes the issue #10603.
Prior to the fix, it is harcoded for Loopback0 IPv6 addresses to be advertised as '/64' subnet disregarding of the subnet which is really configured.

#### How I did it
Use configured subnet to be advertised through BGP for IPv6 adresses assigned on Loopback0.

#### How to verify it
1) Configure IPv6 address on Loopback0 with certain prefix
2) Save configuration and reboot DUT
3) Once DUT is up, check that the IPv6 address from Loopback0 is advertised through BGP as the network calculated based on certain prefix

#### Which release branch to backport (provide reason below if selected)
No need in backport unless properly requested.
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Use configured subnet to be advertised through BGP for IPv6 adresses assigned on Loopback0.

#### Link to config_db schema for YANG module changes
N/A

#### A picture of a cute animal (not mandatory but encouraged)
N/A

Signed-off-by: Olha Omelianenko <olha_omelianenko6293@jabil.com>