### PR TITLE
[phy-credo]: update deb for speed change and bug fix

### DIFF
--- a/rules/phy-credo.mk
+++ b/rules/phy-credo.mk
@@ -1,3 +1,3 @@
 PHY_CREDO = phy-credo_1.0_amd64.deb
-$(PHY_CREDO)_URL = "https://github.com/aristanetworks/sonic-firmware/raw/0c1359ce68bbccb301269e77884de5643055d1de/phy/phy-credo_1.0_amd64.deb"
+$(PHY_CREDO)_URL = "https://github.com/aristanetworks/sonic-firmware/raw/e89a1696954fd381e1e95edf208cffc97caf15d4/phy/phy-credo_1.0_amd64.deb"
 SONIC_ONLINE_DEBS += $(PHY_CREDO)

--- a/rules/phy-credo.mk
+++ b/rules/phy-credo.mk
@@ -1,3 +1,3 @@
 PHY_CREDO = phy-credo_1.0_amd64.deb
-$(PHY_CREDO)_URL = "https://github.com/aristanetworks/sonic-firmware/raw/d227160f981f27df020ab50b9e0f16b1bd9166ea/phy/phy-credo_1.0_amd64.deb"
+$(PHY_CREDO)_URL = "https://github.com/aristanetworks/sonic-firmware/raw/0c1359ce68bbccb301269e77884de5643055d1de/phy/phy-credo_1.0_amd64.deb"
 SONIC_ONLINE_DEBS += $(PHY_CREDO)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add support for reacting to speed change between 40G and 100G in CONFIG_DB
Fix a bug on optical bit setting.
Avoid the random error in shutdown for issue: https://github.com/aristanetworks/sonic/issues/40  
Avoid to run on SmartsvilleBkMs, which depends on a different driver (credo-sai).
  
#### How I did it

#### How to verify it
Verified on the duts that the commands printed in the log are matching the expectation and the interfaces are up.
 
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

