### PR TITLE
[202012][cherry-pick] DellEMC: Z9332f - Component API Fixes

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/common/ipmihelper.py
+++ b/platform/broadcom/sonic-platform-modules-dell/common/ipmihelper.py
@@ -90,7 +90,10 @@ class IpmiSensor(object):
         R_exp = get_twos_complement((factors[6] & 0xF0) >> 4, 4)
         B_exp = get_twos_complement(factors[6] & 0x0F, 4)
 
-        converted_reading = ((M * raw_value) + (B * 10**B_exp)) * 10**R_exp
+        if R_exp < 0:
+            converted_reading = ((M * raw_value) + (B * 10**B_exp)) / 10**(-R_exp)
+        else:
+            converted_reading = ((M * raw_value) + (B * 10**B_exp)) * 10**R_exp
 
         return True, converted_reading
 

--- a/platform/broadcom/sonic-platform-modules-dell/common/onie_stage_fwpkg
+++ b/platform/broadcom/sonic-platform-modules-dell/common/onie_stage_fwpkg
@@ -45,7 +45,7 @@ function show_help_and_exit()
     echo " "
     echo "    Available options:"
     echo "        -h, -? : getting this help"
-    echo "        -o [fwpkg]    : stages the firmware update package"
+    echo "        -a [fwpkg]    : stages the firmware update package"
 
     exit 0
 }

--- a/platform/broadcom/sonic-platform-modules-dell/common/sonic_platform/hwaccess.py
+++ b/platform/broadcom/sonic-platform-modules-dell/common/sonic_platform/hwaccess.py
@@ -39,7 +39,10 @@ def pci_set_value(resource, val, offset):
 # Read I2C device
 
 def i2c_get(bus, i2caddr, ofs):
-    return int(subprocess.check_output(['/usr/sbin/i2cget', '-y', str(bus), str(i2caddr), str(ofs)]), 16)
+    try:
+        return int(subprocess.check_output(['/usr/sbin/i2cget', '-y', str(bus), str(i2caddr), str(ofs)]), 16)
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return -1
 
 def io_reg_read(io_resource, offset):
     fd = os.open(io_resource, os.O_RDONLY)

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/component.py
@@ -23,20 +23,36 @@ except ImportError as e:
 
 
 def get_bios_version():
-    return subprocess.check_output(
-        ['dmidecode', '-s', 'bios-version']).decode('utf-8').strip()
+    try:
+        return subprocess.check_output(['dmidecode', '-s', 'bios-version'],
+                                       text=True).strip()
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return 'NA'
 
 def get_fpga_version():
     val = hwaccess.pci_get_value('/sys/bus/pci/devices/0000:09:00.0/resource0', 0)
     return '{}.{}'.format((val >> 16) & 0xffff, val & 0xffff)
 
 def get_bmc_version():
-    return subprocess.check_output(
-        ['cat', '/sys/class/ipmi/ipmi0/device/bmc/firmware_revision']
-        ).decode('utf-8').strip()
+    val = 'NA'
+    try:
+        bmc_ver = subprocess.check_output(['ipmitool', 'mc', 'info'],
+                                          stderr=subprocess.STDOUT, text=True)
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        pass
+    else:
+        version = re.search(r'Firmware Revision\s*:\s(.*)', bmc_ver)
+        if version:
+            val = version.group(1).strip()
+
+    return val
 
 def get_cpld_version(bus, i2caddr):
-    return '{}'.format(hwaccess.i2c_get(bus, i2caddr, 0))
+    val = hwaccess.i2c_get(bus, i2caddr, 0)
+    if val != -1:
+        return '{:x}.{:x}'.format((val >> 4) & 0xf, val & 0xf)
+    else:
+        return 'NA'
 
 def get_cpld0_version():
     return get_cpld_version(5, 0x0d)
@@ -67,7 +83,7 @@ def get_pciephy_version():
     except Exception:
         return val
     else:
-        version = re.search(r'PCIe FW loader version:\s(.*)', pcie_ver)
+        version = re.search(r'PCIe FW version:\s(.*)', pcie_ver)
         if version:
             val = version.group(1).strip()
 
@@ -156,6 +172,14 @@ class Component(ComponentBase):
 
             ver_info = ver_info.get("x86_64-dellemc_z9332f_d1508-r0")
             if ver_info:
+                components = list(ver_info.keys())
+                for component in components:
+                    if "CPLD" in component and ver_info[component].get('version'):
+                        val = ver_info.pop(component)
+                        ver = int(val['version'], 16)
+                        val['version'] = "{:x}.{:x}".format((ver >> 4) & 0xf, ver & 0xf)
+                        ver_info[component.replace("-", " ")] = val
+
                 return True, ver_info
             else:
                 return False, "ERROR: Version info not available"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To update the available and current firmware versions provided by Component APIs (backport #10187)

#### How I did it

Update the platform API methods in component.py

#### How to verify it

Verified that component data is displayed by show platform firmware status.
Logs:[UT_logs.txt](https://github.com/Azure/sonic-buildimage/files/8813396/UT_logs.txt)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

[202012] DellEMC: Z9332f - Component API Fixes

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

