### PR TITLE
[Accton] fix inconsistent tabs/spaces in fanutil.py

### DIFF
--- a/platform/broadcom/sonic-platform-modules-accton/as5712-54x/classes/fanutil.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5712-54x/classes/fanutil.py
@@ -122,7 +122,7 @@ class FanUtil(object):
             return None
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             logging.debug('GET. unable to close file. device_path:%s', device_path)
             return None
@@ -153,7 +153,7 @@ class FanUtil(object):
         val_file.write(content)
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             logging.debug('GET. unable to close file. device_path:%s', device_path)
             return None

--- a/platform/broadcom/sonic-platform-modules-accton/as5812-54t/classes/fanutil.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5812-54t/classes/fanutil.py
@@ -135,7 +135,7 @@ class FanUtil(object):
             return None
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             self.logger.debug('GET. unable to close file. device_path:%s', device_path)
             return None
@@ -166,7 +166,7 @@ class FanUtil(object):
         val_file.write(content)
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             self.logger.debug('GET. unable to close file. device_path:%s', device_path)
             return None

--- a/platform/broadcom/sonic-platform-modules-accton/as5812-54x/classes/fanutil.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5812-54x/classes/fanutil.py
@@ -135,7 +135,7 @@ class FanUtil(object):
             return None
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             self.logger.debug('GET. unable to close file. device_path:%s', device_path)
             return None
@@ -166,7 +166,7 @@ class FanUtil(object):
         val_file.write(content)
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             self.logger.debug('GET. unable to close file. device_path:%s', device_path)
             return None

--- a/platform/broadcom/sonic-platform-modules-accton/as5835-54t/classes/fanutil.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as5835-54t/classes/fanutil.py
@@ -104,7 +104,7 @@ class FanUtil(object):
             return None
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             logging.debug('GET. unable to close file. device_path:%s', device_path)
             return None
@@ -135,7 +135,7 @@ class FanUtil(object):
         val_file.write(content)
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             logging.debug('GET. unable to close file. device_path:%s', device_path)
             return None

--- a/platform/broadcom/sonic-platform-modules-accton/as6712-32x/classes/fanutil.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as6712-32x/classes/fanutil.py
@@ -112,7 +112,7 @@ class FanUtil(object):
             return None
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             logging.debug('GET. unable to close file. device_path:%s', device_path)
             return None
@@ -143,7 +143,7 @@ class FanUtil(object):
         val_file.write(content)
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             logging.debug('GET. unable to close file. device_path:%s', device_path)
             return None

--- a/platform/broadcom/sonic-platform-modules-accton/as7716-32x/classes/fanutil.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7716-32x/classes/fanutil.py
@@ -113,7 +113,7 @@ class FanUtil(object):
             return None
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             logging.debug('GET. unable to close file. device_path:%s', device_path)
             return None
@@ -144,7 +144,7 @@ class FanUtil(object):
         val_file.write(content)
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             logging.debug('GET. unable to close file. device_path:%s', device_path)
             return None

--- a/platform/broadcom/sonic-platform-modules-accton/as7716-32xb/classes/fanutil.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7716-32xb/classes/fanutil.py
@@ -117,7 +117,7 @@ class FanUtil(object):
             return None
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             logging.debug('GET. unable to close file. device_path:%s', device_path)
             return None
@@ -148,7 +148,7 @@ class FanUtil(object):
         val_file.write(content)
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             logging.debug('GET. unable to close file. device_path:%s', device_path)
             return None

--- a/platform/broadcom/sonic-platform-modules-accton/as7726-32x/classes/fanutil.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as7726-32x/classes/fanutil.py
@@ -110,7 +110,7 @@ class FanUtil(object):
             return None
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             logging.debug('GET. unable to close file. device_path:%s', device_path)
             return None
@@ -141,7 +141,7 @@ class FanUtil(object):
         val_file.write(content)
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             logging.debug('GET. unable to close file. device_path:%s', device_path)
             return None

--- a/platform/broadcom/sonic-platform-modules-accton/as9716-32d/classes/fanutil.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9716-32d/classes/fanutil.py
@@ -106,7 +106,7 @@ class FanUtil(object):
             return None
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             logging.debug('GET. unable to close file. device_path:%s', device_path)
             return None
@@ -137,7 +137,7 @@ class FanUtil(object):
         val_file.write(content)
 
         try:
-		    val_file.close()
+            val_file.close()
         except:
             logging.debug('GET. unable to close file. device_path:%s', device_path)
             return None

--- a/platform/broadcom/sonic-platform-modules-accton/as9726-32d/classes/fanutil.py
+++ b/platform/broadcom/sonic-platform-modules-accton/as9726-32d/classes/fanutil.py
@@ -104,7 +104,7 @@ class FanUtil(object):
             return None
 
         try:
-		    val_file.close()
+            val_file.close()
         except IOError:
             logging.debug('GET. unable to close file. device_path:%s', device_path)
             return None
@@ -135,7 +135,7 @@ class FanUtil(object):
         val_file.write(content)
 
         try:
-		    val_file.close()
+            val_file.close()
         except BaseException:
             logging.debug('GET. unable to close file. device_path:%s', device_path)
             return None


### PR DESCRIPTION
This prevents the code from failing with a «TabError: inconsistent use of tabs and spaces in indentation» exception from the Python interpreter.

Signed-off-by: Tore Anderson <tore@redpill-linpro.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Saw the script failing with the exception mentioned above on Edge-Core SONiC, and verified that the bug is also present upstream in Azure/sonic-buildimage

#### How I did it

`sed -i 's/\t/    /g' platform/broadcom/sonic-platform-modules-accton/*/classes/fanutil.py`

#### How to verify it

Run the code in question

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 201811
- [x] 201911
- [x] 202006
- [x] 202012
- [x] 202106
- [x] 202111

Reason: the tab characters are present in fanutil.py in all of the above branches.

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

[Accton] fix inconsistent tabs/spaces in fanutil.py

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

N/A

#### A picture of a cute animal (not mandatory but encouraged)

![bilde](https://user-images.githubusercontent.com/4557060/171611846-045adfdc-47da-4f34-b1f0-059f9440f45b.png)
