### PR TITLE
Adjust 7260 buffer sizes to accomodate extra lossless queues

### DIFF
--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/buffers_defaults_t0.j2
@@ -7,18 +7,20 @@
     {%- endfor %}
 {%- endmacro %}
 
-{% import 'buffers_pool_sizes_t0.j2' as defs with context %}
+{%- import 'buffers_pool_sizes_t0.j2' as defs with context %}
+{%- set ingress_lossless_pool_size = defs.ingress_lossless_pool_size %}
+{%- set egress_lossy_pool_size = defs.egress_lossy_pool_size %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "{{ defs.ingress_lossless_pool_size }}",
+            "size": "{{ ingress_lossless_pool_size }}",
             "type": "ingress",
             "mode": "dynamic",
             "xoff": "7827456"
         },
         "egress_lossy_pool": {
-            "size": "{{ defs.egress_lossy_pool_size }}",
+            "size": "{{ egress_lossy_pool_size }}",
             "type": "egress",
             "mode": "dynamic"
         },

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/buffers_defaults_t0.j2
@@ -7,16 +7,18 @@
     {%- endfor %}
 {%- endmacro %}
 
+{% import 'buffers_pool_sizes_t0.j2' as defs with context %}
+
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "33329088",
+            "size": "{{ defs.ingress_lossless_pool_size }}",
             "type": "ingress",
             "mode": "dynamic",
             "xoff": "7827456"
         },
         "egress_lossy_pool": {
-            "size": "26663272",
+            "size": "{{ defs.egress_lossy_pool_size }}",
             "type": "egress",
             "mode": "dynamic"
         },

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/buffers_defaults_t1.j2
@@ -7,13 +7,15 @@
     {%- endfor %}
 {%- endmacro %}
 
-{% import 'buffers_pool_sizes_t1.j2' as defs with context %}
+{%- import 'buffers_pool_sizes_t1.j2' as defs with context %}
+{%- set ingress_lossless_pool_size = defs.ingress_lossless_pool_size %}
+{%- set egress_lossy_pool_size = defs.egress_lossy_pool_size %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
             {# SS Tab2 Row 71 #}
-            "size": "{{ defs.ingress_lossless_pool_size }}",
+            "size": "{{ ingress_lossless_pool_size }}",
             "type": "ingress",
             "mode": "dynamic",
             {# SS Tab2 Row 68 #}
@@ -21,7 +23,7 @@
         },
         "egress_lossy_pool": {
             {# SS Tab2 Row 60 #}
-            "size": "{{ defs.egress_lossy_pool_size }}",
+            "size": "{{ egress_lossy_pool_size }}",
             "type": "egress",
             "mode": "dynamic"
         },

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/buffers_defaults_t1.j2
@@ -7,11 +7,13 @@
     {%- endfor %}
 {%- endmacro %}
 
+{% import 'buffers_pool_sizes_t1.j2' as defs with context %}
+
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
             {# SS Tab2 Row 71 #}
-            "size": "33582016",
+            "size": "{{ defs.ingress_lossless_pool_size }}",
             "type": "ingress",
             "mode": "dynamic",
             {# SS Tab2 Row 68 #}
@@ -19,7 +21,7 @@
         },
         "egress_lossy_pool": {
             {# SS Tab2 Row 60 #}
-            "size": "26866112",
+            "size": "{{ defs.egress_lossy_pool_size }}",
             "type": "egress",
             "mode": "dynamic"
         },

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/buffers_pool_sizes_t0.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/buffers_pool_sizes_t0.j2
@@ -1,0 +1,8 @@
+{% set ingress_lossless_pool_size = '33329088' %}
+{% set egress_lossy_pool_size = '26663272' %}
+
+{%- if ((SYSTEM_DEFAULTS is defined) and ('tunnel_qos_remap' in SYSTEM_DEFAULTS) and (SYSTEM_DEFAULTS['tunnel_qos_remap']['status'] == 'enabled')) and
+((DEVICE_METADATA is defined) and ('localhost' in DEVICE_METADATA) and ('subtype' in DEVICE_METADATA['localhost']) and (DEVICE_METADATA['localhost']['subtype'] == 'DualToR')) %}
+    {%- set ingress_lossless_pool_size = '33169344' %}
+    {%- set egress_lossy_pool_size = '26535808' %}
+{%- endif %}

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/buffers_pool_sizes_t0.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/buffers_pool_sizes_t0.j2
@@ -1,5 +1,5 @@
-{% set ingress_lossless_pool_size = '33329088' %}
-{% set egress_lossy_pool_size = '26663272' %}
+{%- set ingress_lossless_pool_size = '33329088' %}
+{%- set egress_lossy_pool_size = '26663272' %}
 
 {%- if ((SYSTEM_DEFAULTS is defined) and ('tunnel_qos_remap' in SYSTEM_DEFAULTS) and (SYSTEM_DEFAULTS['tunnel_qos_remap']['status'] == 'enabled')) and
 ((DEVICE_METADATA is defined) and ('localhost' in DEVICE_METADATA) and ('subtype' in DEVICE_METADATA['localhost']) and (DEVICE_METADATA['localhost']['subtype'] == 'DualToR')) %}

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/buffers_pool_sizes_t1.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/buffers_pool_sizes_t1.j2
@@ -1,0 +1,8 @@
+{%- set ingress_lossless_pool_size = '33582016' %}
+{%- set egress_lossy_pool_size = '26866112' %}
+
+{%- if ((SYSTEM_DEFAULTS is defined) and ('tunnel_qos_remap' in SYSTEM_DEFAULTS) and (SYSTEM_DEFAULTS['tunnel_qos_remap']['status'] == 'enabled')) and
+((DEVICE_METADATA is defined) and ('localhost' in DEVICE_METADATA) and ('type' in DEVICE_METADATA['localhost']) and (DEVICE_METADATA['localhost']['type'] == 'LeafRouter')) %}
+    {%- set ingress_lossless_pool_size = '33182656' %}
+    {%- set egress_lossy_pool_size = '26546624' %}
+{%- endif %}

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/buffers_pool_sizes_t1.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/buffers_pool_sizes_t1.j2
@@ -3,6 +3,6 @@
 
 {%- if ((SYSTEM_DEFAULTS is defined) and ('tunnel_qos_remap' in SYSTEM_DEFAULTS) and (SYSTEM_DEFAULTS['tunnel_qos_remap']['status'] == 'enabled')) and
 ((DEVICE_METADATA is defined) and ('localhost' in DEVICE_METADATA) and ('type' in DEVICE_METADATA['localhost']) and (DEVICE_METADATA['localhost']['type'] == 'LeafRouter')) %}
-    {%- set ingress_lossless_pool_size = '33182656' %}
-    {%- set egress_lossy_pool_size = '26546624' %}
+    {%- set ingress_lossless_pool_size = '33262528' %}
+    {%- set egress_lossy_pool_size = '26610688' %}
 {%- endif %}

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/buffers_defaults_t0.j2
@@ -15,18 +15,20 @@
     {%- endfor %}
 {%- endmacro %}
 
-{% import 'buffers_pool_sizes_t0.j2' as defs with context %}
+{%- import 'buffers_pool_sizes_t0.j2' as defs with context %}
+{%- set ingress_lossless_pool_size = defs.ingress_lossless_pool_size %}
+{%- set egress_lossy_pool_size = defs.egress_lossy_pool_size %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "{{ defs.ingress_lossless_pool_size }}",
+            "size": "{{ ingress_lossless_pool_size }}",
             "type": "ingress",
             "mode": "dynamic",
             "xoff": "7827456"
         },
         "egress_lossy_pool": {
-            "size": "{{ defs.egress_lossy_pool_size }}",
+            "size": "{{ egress_lossy_pool_size }}",
             "type": "egress",
             "mode": "dynamic"
         },

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/buffers_defaults_t0.j2
@@ -15,16 +15,18 @@
     {%- endfor %}
 {%- endmacro %}
 
+{% import 'buffers_pool_sizes_t0.j2' as defs with context %}
+
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "33329088",
+            "size": "{{ defs.ingress_lossless_pool_size }}",
             "type": "ingress",
             "mode": "dynamic",
             "xoff": "7827456"
         },
         "egress_lossy_pool": {
-            "size": "26663272",
+            "size": "{{ defs.egress_lossy_pool_size }}",
             "type": "egress",
             "mode": "dynamic"
         },

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/buffers_pool_sizes_t0.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/buffers_pool_sizes_t0.j2
@@ -1,0 +1,1 @@
+../Arista-7260CX3-C64/buffers_pool_sizes_t0.j2

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/buffers_defaults_t0.j2
@@ -7,18 +7,20 @@
     {%- endfor %}
 {%- endmacro %}
 
-{% import 'buffers_pool_sizes_t0.j2' as defs with context %}
+{%- import 'buffers_pool_sizes_t0.j2' as defs with context %}
+{%- set ingress_lossless_pool_size = defs.ingress_lossless_pool_size %}
+{%- set egress_lossy_pool_size = defs.egress_lossy_pool_size %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "{{ defs.ingress_lossless_pool_size }}",
+            "size": "{{ ingress_lossless_pool_size }}",
             "type": "ingress",
             "mode": "dynamic",
             "xoff": "7827456"
         },
         "egress_lossy_pool": {
-            "size": "{{ defs.egress_lossy_pool_size }}",
+            "size": "{{ egress_lossy_pool_size }}",
             "type": "egress",
             "mode": "dynamic"
         },

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/buffers_defaults_t0.j2
@@ -7,16 +7,18 @@
     {%- endfor %}
 {%- endmacro %}
 
+{% import 'buffers_pool_sizes_t0.j2' as defs with context %}
+
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "33329088",
+            "size": "{{ defs.ingress_lossless_pool_size }}",
             "type": "ingress",
             "mode": "dynamic",
             "xoff": "7827456"
         },
         "egress_lossy_pool": {
-            "size": "26663272",
+            "size": "{{ defs.egress_lossy_pool_size }}",
             "type": "egress",
             "mode": "dynamic"
         },

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/buffers_defaults_t1.j2
@@ -7,18 +7,20 @@
     {%- endfor %}
 {%- endmacro %}
 
-{% import 'buffers_pool_sizes_t0.j2' as defs with context %}
+{%- import 'buffers_pool_sizes_t0.j2' as defs with context %}
+{%- set ingress_lossless_pool_size = defs.ingress_lossless_pool_size %}
+{%- set egress_lossy_pool_size = defs.egress_lossy_pool_size %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "{{ defs.ingress_lossless_pool_size }}",
+            "size": "{{ ingress_lossless_pool_size }}",
             "type": "ingress",
             "mode": "dynamic",
             "xoff": "7827456"
         },
         "egress_lossy_pool": {
-            "size": "{{ defs.egress_lossy_pool_size }}",
+            "size": "{{ egress_lossy_pool_size }}",
             "type": "egress",
             "mode": "dynamic"
         },

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/buffers_defaults_t1.j2
@@ -7,16 +7,18 @@
     {%- endfor %}
 {%- endmacro %}
 
+{% import 'buffers_pool_sizes_t0.j2' as defs with context %}
+
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "33329088",
+            "size": "{{ defs.ingress_lossless_pool_size }}",
             "type": "ingress",
             "mode": "dynamic",
             "xoff": "7827456"
         },
         "egress_lossy_pool": {
-            "size": "26663272",
+            "size": "{{ defs.egress_lossy_pool_size }}",
             "type": "egress",
             "mode": "dynamic"
         },

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/buffers_pool_sizes_t0.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/buffers_pool_sizes_t0.j2
@@ -1,0 +1,1 @@
+../Arista-7260CX3-C64/buffers_pool_sizes_t0.j2

--- a/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7260-dualtor.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7260-dualtor.json
@@ -128,13 +128,13 @@
 
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "33329088",
+            "size": "33169344",
             "type": "ingress",
             "mode": "dynamic",
             "xoff": "7827456"
         },
         "egress_lossy_pool": {
-            "size": "26663272",
+            "size": "26535808",
             "type": "egress",
             "mode": "dynamic"
         },

--- a/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7260-t1.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7260-t1.json
@@ -72,18 +72,18 @@
 
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-                        "size": "33182656",
+            "size": "33262528",
             "type": "ingress",
             "mode": "dynamic",
-                        "xoff": "8965632"
+            "xoff": "8965632"
         },
         "egress_lossy_pool": {
-                        "size": "26546624",
+            "size": "26610688",
             "type": "egress",
             "mode": "dynamic"
         },
         "egress_lossless_pool": {
-                        "size": "43481152",
+            "size": "43481152",
             "type": "egress",
             "mode": "static"
         }
@@ -92,12 +92,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-                        "static_th":"44302336"
+            "static_th":"44302336"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-                        "static_th":"43481152"
+            "static_th":"43481152"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossy_pool",

--- a/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7260-t1.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7260-t1.json
@@ -72,13 +72,13 @@
 
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-                        "size": "33582016",
+                        "size": "33182656",
             "type": "ingress",
             "mode": "dynamic",
                         "xoff": "8965632"
         },
         "egress_lossy_pool": {
-                        "size": "26866112",
+                        "size": "26546624",
             "type": "egress",
             "mode": "dynamic"
         },

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -378,7 +378,7 @@ class TestJ2Files(TestCase):
             ('arista', 'x86_64-arista_7260cx3_64', 'Arista-7260CX3-C64', 'sample-arista-7260-t1-minigraph.xml', 'buffers.json.j2', 'buffer-arista7260-t1.json'),
             ('arista', 'x86_64-arista_7260cx3_64', 'Arista-7260CX3-C64', 'sample-arista-7260-t1-minigraph-remap-disabled.xml', 'buffers.json.j2', 'buffer-arista7260-t1-remap-disabled.json')
         ]
-        
+
         for test_data in TEST_DATA:
             self._test_buffers_render_template(vendor=test_data[0],
                                                 platform=test_data[1],

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -42,6 +42,31 @@ class TestJ2Files(TestCase):
     def run_diff(self, file1, file2):
         return subprocess.check_output('diff -u {} {} || true'.format(file1, file2), shell=True)
 
+    def create_machine_conf(self, platform, vendor):
+        file_exist = True
+        dir_exist = True
+        mode = {'arista': 'aboot',
+                'dell': 'onie',
+                'mellanox': 'onie'
+               }
+        echo_cmd = "echo '{}_platform={}' | sudo tee -a /host/machine.conf > /dev/null".format(mode[vendor], platform)
+        if not os.path.exists('/host/machine.conf'):
+            file_exist = False
+            if not os.path.isdir('/host'):
+                dir_exist = False
+                os.system('sudo mkdir /host')
+            os.system('sudo touch /host/machine.conf')
+            os.system(echo_cmd)
+
+        return file_exist, dir_exist
+
+    def remove_machine_conf(self, file_exist, dir_exist):
+        if not file_exist:
+            os.system('sudo rm -f /host/machine.conf')
+
+        if not dir_exist:
+            os.system('sudo rmdir /host')
+
     def test_interfaces(self):
         interfaces_template = os.path.join(self.test_dir, '..', '..', '..', 'files', 'image_config', 'interfaces', 'interfaces.j2')
         argument = '-m ' + self.t0_minigraph + ' -p ' + self.t0_port_config + ' -a \'{\"hwaddr\":\"e4:1d:2d:a5:f3:ad\"}\' -t ' + interfaces_template + ' > ' + self.output_file
@@ -333,6 +358,7 @@ class TestJ2Files(TestCase):
             os.remove(test_output)
 
     def _test_buffers_render_template(self, vendor, platform, sku, minigraph, buffer_template, expected):
+        file_exist, dir_exist = self.create_machine_conf(platform, vendor)
         dir_path = os.path.join(self.test_dir, '..', '..', '..', 'device', vendor, platform, sku)
         buffers_file = os.path.join(dir_path, buffer_template)
         port_config_ini_file = os.path.join(dir_path, 'port_config.ini')
@@ -348,6 +374,7 @@ class TestJ2Files(TestCase):
         # cleanup
         buffers_config_file_new = os.path.join(dir_path, 'buffers_config.j2')
         os.remove(buffers_config_file_new)
+        self.remove_machine_conf(file_exist, dir_exist)
 
         sample_output_file = os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR, expected)
         assert utils.cmp(sample_output_file, self.output_file), self.run_diff(sample_output_file, self.output_file)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
As part of PCBB changes, we need to enable 2 extra lossless queues. The changes in this PR are done to adjust only the reserved sizes on Th2 for the additional 2 lossless queues
Calculations are done based on 40 downlinks for T1 and 16 uplinks for dual ToR

#### How to verify it
- Verified that the rendering works fine on Th2 dut
- Unit tests have been updated to reflect the modified buffer sizes when pcbb is enabled. There are existing testcases that will test the original buffer sizes when pcbb is disabled. With these changes, was able to build sonic-config-engine wheel successfully

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [x] 202111
