### PR TITLE
[pr test] increase T1-lag PR test timeout to 5 hours

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -184,7 +184,7 @@ stages:
   - job:
     pool: sonictest-t1-lag
     displayName: "kvmtest-t1-lag"
-    timeoutInMinutes: 240
+    timeoutInMinutes: 300
 
     steps:
     - template: .azure-pipelines/run-test-template.yml


### PR DESCRIPTION
#### Why I did it
Some PR test are timing out on T1-lag kvm test.

#### How I did it
Increase the timeout to 5 hours.

#### How to verify it
Test on this PR.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
