### PR TITLE
[makefile] remove all fsroot folders

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -463,7 +463,7 @@ reset :
 	@read ans && (
 	    if [ $$ans == y ]; then
 	        echo "Resetting local repository. Please wait...";
-	        $(DOCKER_RUN) $(SLAVE_IMAGE):$(SLAVE_TAG) sudo rm -rf fsroot;
+	        sudo rm -rf fsroot*;
 	        if [ "$(MULTIARCH_QEMU_ENVIRON)" == y ] && [[ "$(CONFIGURED_ARCH)" == "armhf" || "$(CONFIGURED_ARCH)" ==  "arm64" ]]; then
 	            echo "Stopping march $(CONFIGURED_ARCH) docker"
 	            sudo kill -9 `sudo cat /var/run/march/docker.pid` || true


### PR DESCRIPTION
#### Why I did it
Make reset didn't clean-up all fsroot folders.

#### How I did it
Remove all fsroot folders used during build.

#### How to verify it
Run local build and local make reset:

sudo mkdir fsroot-test
sudo touch fsroot-test/foo
make reset
(Without this change, make reset cannot remove fsroot-foo, with the change, the repo become clean after make reset.)

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
