### PR TITLE
Fix ndppd occupy high CPU usage problem

### DIFF
--- a/dockers/docker-orchagent/ndppd.conf.j2
+++ b/dockers/docker-orchagent/ndppd.conf.j2
@@ -6,6 +6,7 @@
 {% endblock banner %}
 # Config file for ndppd, the NDP Proxy Daemon
 # See man page for ndppd.conf.5 for descriptions of all available options
+route-ttl 2147483647
 {%  if VLAN_INTERFACE and VLAN_INTERFACE|pfx_filter|length > 0%}
 {#      Get all VLAN interfaces that have proxy_arp enabled #}
 {%      set proxy_interfaces = {} %}
@@ -21,7 +22,7 @@
 {%              set _x = proxy_interfaces[intf].append(prefix) %}
 {%          endif %}
 {%      endfor -%}
-route-ttl 2147483647
+
 {%      for intf, prefix_list in proxy_interfaces.items() %}
 {%          if prefix_list %}
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

In t1-topology, we frequently see the ndppd use a lot of CPU usage.

#### How I did it

Make the route-ttl setting correctly generate inside the /etc/ndppd.conf of swss container.

#### How to verify it

Run the test_cpu_memory_usage.py for multiple times and make sure the ndppd will not fail the test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Based on the PR#7456, the route-ttl setting should not put inside the vlan interface if-else block

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

