### PR TITLE
Fix ctrmgrd unexpectedly restart service issue

### DIFF
--- a/src/sonic-ctrmgrd/ctrmgr/ctrmgrd.py
+++ b/src/sonic-ctrmgrd/ctrmgr/ctrmgrd.py
@@ -457,7 +457,11 @@ class FeatureTransitionHandler:
         service_restart = False
 
         if set_owner == "local":
-            if ct_owner != "local":
+            # none is a default value for current_owner when docker stop.
+            # It is not necessary to restart the feature again when the system
+            #  config a new value for it from none.
+            # The container script will handle the restart operation.
+            if (ct_owner != "local") and (ct_owner != "none"):
                 service_restart = True
         else:
             if (ct_owner != "none") and (remote_state == "pending"):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

During our test time, we run config reload and reboot for multiple times. We found occasionally the ctrmgrd.py will restart some features(services) and that will disturb the system status. 

#### How I did it

Prevent the ctrmgrd.py to restart the services when the owner is setting a new value from "none". Which is a default value setting by container script when docker stop.

#### How to verify it

Run the same test for few days and make sure the following type syslog will not occur.
```
May 14 07:41:58.653540 admin DEBUG ctrmgrd.py: restart_systemd_service: Restart service syncd to owner:local
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

If the state_db has any docker stop setting which will set the current_owner to none, the ctrmgrd will then restart the service when it receive config_db change.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

