### PR TITLE
[202012][Tunnel PFC] Add property for tunnel PFC (#10962)

### DIFF
--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/config.bcm.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/config.bcm.j2
@@ -1,7 +1,16 @@
+{# Construct config.bcm to include additional soc properties per specific device metadata requirement #}
+{%- set map_prio = '' -%}
+{%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['subtype'] is defined -%}
+{%-     set switch_subtype = DEVICE_METADATA['localhost']['subtype'] -%}
+{%-     if 'dualtor' in switch_subtype.lower() %}
+{%-         set map_prio = 'sai_remap_prio_on_tnl_egress=1' -%}
+{%-     endif %}
+{%- endif %}
 sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 l3_alpm_hit_skip=1
 sai_adjust_acl_drop_in_rx_drop=1
 sai_verify_incoming_chksum=0
+{{ map_prio }}
 host_as_route_disable=1
 use_all_splithorizon_groups=1
 riot_enable=1

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/sai.profile
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/sai.profile
@@ -1,2 +1,2 @@
-SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/td3-a7050cx3-32s-32x100G.config.bcm
+SAI_INIT_CONFIG_FILE=/etc/sai.d/config.bcm
 SAI_NUM_ECMP_MEMBERS=64

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/config.bcm.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/config.bcm.j2
@@ -1,7 +1,16 @@
+{# Construct config.bcm to include additional soc properties per specific device metadata requirement #}
+{%- set map_prio = '' -%}
+{%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['subtype'] is defined -%}
+{%-     set switch_subtype = DEVICE_METADATA['localhost']['subtype'] -%}
+{%-     if 'dualtor' in switch_subtype.lower() %}
+{%-         set map_prio = 'sai_remap_prio_on_tnl_egress=1' -%}
+{%-     endif %}
+{%- endif %}
 sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_issu/b870.6.4.1/
 l3_alpm_hit_skip=1
 sai_adjust_acl_drop_in_rx_drop=1
 sai_verify_incoming_chksum=0
+{{ map_prio }}
 host_as_route_disable=1
 use_all_splithorizon_groups=1
 riot_enable=1

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/sai.profile
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/sai.profile
@@ -1,2 +1,2 @@
-SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/td3-a7050cx3-32s-48x50G+8x100G.config.bcm
+SAI_INIT_CONFIG_FILE=/etc/sai.d/config.bcm
 SAI_NUM_ECMP_MEMBERS=64

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/config.bcm.j2
@@ -1,6 +1,7 @@
 {# Construct config.bcm to include additional soc properties per specific device metadata requirement #}
 {%- set mmu_sock = 'mmu_init_config="MSFT-TH2-Tier1"' -%}
 {%- set IPinIP_sock = '' -%}
+{%- set map_prio = '' -%}
 {%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined -%}
 {%-     if DEVICE_METADATA['localhost']['type'] is defined -%}
 {%-         set switch_role = DEVICE_METADATA['localhost']['type'] -%}
@@ -15,6 +16,7 @@
                                    sai_tunnel_underlay_route_mode=1
                                    host_as_route_disable=1
                                    l3_ecmp_levels=2' -%}
+{%-             set map_prio = 'sai_remap_prio_on_tnl_egress=1' -%}
 {%-         endif %}
 {%-     endif %}
 {%- endif %}
@@ -22,6 +24,7 @@
 
 l3_alpm_hit_skip=1
 sai_adjust_acl_drop_in_rx_drop=1
+{{ map_prio }}
 PHY_AN_ALLOW_PLL_CHANGE=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/config.bcm.j2
@@ -1,17 +1,20 @@
 {# Construct config.bcm to include additional soc properties per specific device metadata requirement #}
 {%- set IPinIP_sock = '' -%}
+{%- set map_prio = '' -%}
 {%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['subtype'] is defined -%}
 {%-     set switch_subtype = DEVICE_METADATA['localhost']['subtype'] -%}
 {%-     if 'dualtor' in switch_subtype.lower() %}
 {%-         set IPinIP_sock = 'sai_tunnel_support=1
                                sai_tunnel_underlay_route_mode=1
                                host_as_route_disable=1
-                               l3_ecmp_levels=2' -%}
+                               l3_ecmp_levels=2' -%} -%}
+{%-         set map_prio = 'sai_remap_prio_on_tnl_egress=1' -%}
 {%-     endif %}
 {%- endif %}
 {# The following is the common soc properties that used to be named "th2-a7260cx3-64-112x50G+8x100G.config.bcm" #}
 l3_alpm_hit_skip=1
 sai_adjust_acl_drop_in_rx_drop=1
+{{ map_prio }}
 PHY_AN_ALLOW_PLL_CHANGE=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/config.bcm.j2
@@ -1,6 +1,7 @@
 {# Construct config.bcm to include additional soc properties per specific device metadata requirement #}
 {%- set mmu_sock = 'mmu_init_config="MSFT-TH2-Tier1"' -%}
 {%- set IPinIP_sock = '' -%}
+{%- set map_prio = '' -%}
 {%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined -%}
 {%-     if DEVICE_METADATA['localhost']['type'] is defined -%}
 {%-         set switch_role = DEVICE_METADATA['localhost']['type'] -%}
@@ -15,12 +16,14 @@
                                    sai_tunnel_underlay_route_mode=1
                                    host_as_route_disable=1
                                    l3_ecmp_levels=2' -%}
+{%-             set map_prio = 'sai_remap_prio_on_tnl_egress=1' -%}
 {%-         endif %}
 {%-     endif %}
 {%- endif %}
 {# The following is the common soc properties that used to be named "th2-a7260cx3-64-64x40G.config.bcm" #}
 l3_alpm_hit_skip=1
 sai_adjust_acl_drop_in_rx_drop=1
+{{ map_prio }}
 PHY_AN_ALLOW_PLL_CHANGE=1
 arl_clean_timeout_usec=15000000
 asf_mem_profile=2


### PR DESCRIPTION
*[Cherry-pick] [Tunnel PFC] Add property for tunnel PFC  (#10962)

Replace the config.bcm file with j2 template file
- Add 'sai_remap_prio_on_tnl_egress=1' property when device metadata local
- Host subtype is 'dualtor'
- Change sai.profile foe the new config.bcm.j2

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

