### PR TITLE
[Master]Add sai_remap_prio_on_tnl_egress property in permitted list

### DIFF
--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -313,3 +313,4 @@ port_gmii_mode
 phy_force_firmware_load
 phy_pcs_repeater
 l3_alpm_hit_skip
+sai_remap_prio_on_tnl_egress


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Per PR https://github.com/Azure/sonic-buildimage/pull/10962, add a new property sai_remap_prio_on_tnl_egress. 

Following the rule, need to add the property into the permitted list file.
#### How I did it
Added a new property sai_remap_prio_on_tnl_egress
#### How to verify it
Added a new property sai_remap_prio_on_tnl_egress
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

