### PR TITLE
[202012] Automatically generate extra attributes for tunnel qos remapping

### DIFF
--- a/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7260-dualtor.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7260-dualtor.json
@@ -128,13 +128,13 @@
 
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "33329088",
+            "size": "33169344",
             "type": "ingress",
             "mode": "dynamic",
             "xoff": "7827456"
         },
         "egress_lossy_pool": {
-            "size": "26663272",
+            "size": "26535808",
             "type": "egress",
             "mode": "dynamic"
         },

--- a/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7260-dualtor.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7260-dualtor.json
@@ -128,13 +128,13 @@
 
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-            "size": "33169344",
+            "size": "33329088",
             "type": "ingress",
             "mode": "dynamic",
             "xoff": "7827456"
         },
         "egress_lossy_pool": {
-            "size": "26535808",
+            "size": "26663272",
             "type": "egress",
             "mode": "dynamic"
         },

--- a/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7260-t1.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7260-t1.json
@@ -72,13 +72,13 @@
 
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-                        "size": "33582016",
+                        "size": "33262528",
             "type": "ingress",
             "mode": "dynamic",
                         "xoff": "8965632"
         },
         "egress_lossy_pool": {
-                        "size": "26866112",
+                        "size": "26610688",
             "type": "egress",
             "mode": "dynamic"
         },

--- a/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7260-t1.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7260-t1.json
@@ -72,13 +72,13 @@
 
     "BUFFER_POOL": {
         "ingress_lossless_pool": {
-                        "size": "33262528",
+                        "size": "33582016",
             "type": "ingress",
             "mode": "dynamic",
                         "xoff": "8965632"
         },
         "egress_lossy_pool": {
-                        "size": "26610688",
+                        "size": "26866112",
             "type": "egress",
             "mode": "dynamic"
         },
@@ -92,12 +92,12 @@
         "ingress_lossy_profile": {
             "pool":"[BUFFER_POOL|ingress_lossless_pool]",
             "size":"0",
-            "static_th":"44302336"
+                        "static_th":"44302336"
         },
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
-            "static_th":"43481152"
+                        "static_th":"43481152"
         },
         "egress_lossy_profile": {
             "pool":"[BUFFER_POOL|egress_lossy_pool]",

--- a/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7260-t1.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7260-t1.json
@@ -92,12 +92,12 @@
         "ingress_lossy_profile": {
             "pool":"[BUFFER_POOL|ingress_lossless_pool]",
             "size":"0",
-                        "static_th":"44302336"
+            "static_th":"44302336"
         },
         "egress_lossless_profile": {
             "pool":"[BUFFER_POOL|egress_lossless_pool]",
             "size":"0",
-                        "static_th":"43481152"
+            "static_th":"43481152"
         },
         "egress_lossy_profile": {
             "pool":"[BUFFER_POOL|egress_lossy_pool]",

--- a/src/sonic-config-engine/tests/simple-sample-graph-case-remap-enabled-no-tunnel-attributes.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case-remap-enabled-no-tunnel-attributes.xml
@@ -127,7 +127,7 @@
         </PortChannel>
       </PortChannelInterfaces>
       <TunnelInterfaces>
-        <TunnelInterface Name="MuxTunnel0" Type="IPInIP" AttachTo="Loopback0" DifferentiatedServicesCodePointMode="pipe" EcnEncapsulationMode="standard" EcnDecapsulationMode="copy_from_outer" TtlMode="pipe" DecapDscpToTcMap="[DSCP_TO_TC_MAP|AZURE_TUNNEL]" DecapTcToPgMap="[TC_TO_PRIORITY_GROUP_MAP|AZURE_TUNNEL]" EncapTcToQueueMap="[TC_TO_QUEUE_MAP|AZURE_TUNNEL]" EncapTcToDscpMap="[TC_TO_DSCP_MAP|AZURE_TUNNEL]"/>
+        <TunnelInterface Name="MuxTunnel0" Type="IPInIP" AttachTo="Loopback0" DifferentiatedServicesCodePointMode="uniform" EcnEncapsulationMode="standard" EcnDecapsulationMode="copy_from_outer" TtlMode="pipe"/>
       </TunnelInterfaces>
       <VlanInterfaces>
         <VlanInterface>

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -371,17 +371,26 @@ class TestCfgGenCaseInsensitive(TestCase):
                 "tunnel_type": "IPINIP",
                 "src_ip": "25.1.1.10",
                 "dst_ip": "10.1.0.32",
-                "dscp_mode": "uniform",
+                "dscp_mode": "pipe",
                 "encap_ecn_mode": "standard",
                 "ecn_mode": "copy_from_outer",
                 "ttl_mode": "pipe",
-                "decap_dscp_to_tc_map": "AZURE_TUNNEL",
-                "decap_tc_to_pg_map": "AZURE_TUNNEL",
-                "encap_tc_to_dscp_map": "AZURE_TUNNEL",
-                "encap_tc_to_queue_map": "AZURE_TUNNEL"
+                "decap_dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE_TUNNEL]",
+                "decap_tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE_TUNNEL]",
+                "encap_tc_to_dscp_map": "[TC_TO_DSCP_MAP|AZURE_TUNNEL]",
+                "encap_tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE_TUNNEL]"
             }
         }
 
+        output = self.run_script(argument)
+        self.assertEqual(
+            utils.to_dict(output.strip()),
+            expected_tunnel
+        )
+
+        # Validate extra config for mux tunnel is generated automatically when tunnel_qos_remap = enabled
+        sample_graph_enabled_remap = os.path.join(self.test_dir, 'simple-sample-graph-case-remap-enabled-no-tunnel-attributes.xml')
+        argument = '-m "' + sample_graph_enabled_remap + '" -p "' + self.port_config + '" -v "TUNNEL"'
         output = self.run_script(argument)
         self.assertEqual(
             utils.to_dict(output.strip()),


### PR DESCRIPTION
Signed-off-by: bingwang <wang.bing@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR is to update `minigraph.py` to generate necessary qos remap attributes for mux tunnel.
The auto generated attributes are
```
"decap_dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE_TUNNEL]",
"decap_tc_to_pg_map": "[TC_TO_PRIORITY_GROUP_MAP|AZURE_TUNNEL]",
"encap_tc_to_dscp_map": "[TC_TO_DSCP_MAP|AZURE_TUNNEL]",
"encap_tc_to_queue_map": "[TC_TO_QUEUE_MAP|AZURE_TUNNEL]"
```
The `dscp_mode` is hardcoded to `pipe` if `tunnel_qos_remap` is enable.

#### How I did it
Update `minigraph.py`.

#### How to verify it
Verified by adding a new test scenario.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Automatically generate extra attributes for tunnel qos remapping.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

