### PR TITLE
Yang model for xcvr tx power and frequency configuration

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -1176,7 +1176,9 @@ optional attributes.
             "mtu": "9100",
             "alias": "fortyGigE1/1/1",
             "speed": "40000",
-            "link_training": "off"
+            "link_training": "off",
+            "laser_freq": "191300",
+            "tx_power": "-27.3"
         },
         "Ethernet1": {
             "index": "1",
@@ -1186,7 +1188,9 @@ optional attributes.
             "alias": "fortyGigE1/1/2",
             "admin_status": "up",
             "speed": "40000",
-            "link_training": "on"
+            "link_training": "on",
+            "laser_freq": "191300",
+            "tx_power": "-27.3"
         },
         "Ethernet63": {
             "index": "63",
@@ -1194,7 +1198,9 @@ optional attributes.
             "description": "fortyGigE1/4/16",
             "mtu": "9100",
             "alias": "fortyGigE1/4/16",
-            "speed": "40000"
+            "speed": "40000",
+            "laser_freq": "191300",
+            "tx_power": "-27.3"
         }
     }
 }

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -446,7 +446,9 @@
                 "asic_port_name": "Eth0-ASIC1",
                 "role": "Ext",
                 "macsec": "test",
-                "link_training": "off"
+                "link_training": "off",
+                "laser_freq": "191600",
+                "tx_power": "-26.6"
             },
             "Ethernet1": {
                 "alias": "Eth1/2",
@@ -458,7 +460,9 @@
                 "autoneg": "on",
                 "adv_speeds": "100000,50000",
                 "adv_interface_types": "CR,CR4",
-                "link_training": "on"
+                "link_training": "on",
+                "laser_freq": "191300",
+                "tx_power": "-27.3"
             },
             "Ethernet2": {
                 "alias": "Eth1/3",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
@@ -69,6 +69,22 @@
         "desc": "PORT_INVALID_ADVTYPES_TEST_2 must condition failure.",
         "eStrKey" : "Must"
     },
+    "PORT_VALID_XCVR_FREQ_TEST": {
+        "desc": "PORT_VALID_XCVR_FREQ_TEST no failure"
+    },
+    "PORT_VALID_XCVR_TX_POWER_TEST": {
+        "desc": "PORT_VALID_XCVR_TX_POWER_TEST no failure"
+    },
+    "PORT_INVALID_XCVR_FREQ_TEST": {
+        "desc": "PORT_INVALID_XCVR_FREQ_TEST non-integer value, expect failure",
+        "eStrKey": "InvalidValue",
+        "eStr": ["laser_freq"]
+    },
+    "PORT_INVALID_XCVR_TX_POWER_TEST": {
+        "desc": "PORT_INVALID_XCVR_TX_POWER_TEST non-float value, expect failure",
+        "eStrKey": "InvalidValue",
+        "eStr": ["tx_power"]
+    },
     "PORT_VALID_LINK_TRAINING_TEST_1": {
         "desc": "PORT_VALID_LINK_TRAINING_TEST_1 no failure."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
@@ -311,6 +311,74 @@
         }
     },
 
+    "PORT_VALID_XCVR_FREQ_TEST": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "alias": "eth8",
+                        "lanes": "65",
+                        "speed": 25000,
+                        "tpid": "0x8100",
+                        "laser_freq": 193100
+                    }
+                ]
+            }
+        }
+    },
+
+    "PORT_VALID_XCVR_TX_POWER_TEST": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "alias": "eth8",
+                        "lanes": "65",
+                        "speed": 25000,
+                        "tpid": "0x8100",
+                        "tx_power": "27.3"
+                    }
+                ]
+            }
+        }
+    },
+
+    "PORT_INVALID_XCVR_FREQ_TEST": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "alias": "eth8",
+                        "lanes": "65",
+                        "speed": 25000,
+                        "tpid": "0x8100",
+                        "laser_freq": "27.3"
+                    }
+                ]
+            }
+        }
+    },
+
+    "PORT_INVALID_XCVR_TX_POWER_TEST": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "alias": "eth8",
+                        "lanes": "65",
+                        "speed": 25000,
+                        "tpid": "0x8100",
+                        "tx_power": "27/4"
+                    }
+                ]
+            }
+        }
+    },
+
     "PORT_VALID_LINK_TRAINING_TEST_1": {
         "sonic-port:sonic-port": {
             "sonic-port:PORT": {

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -171,6 +171,18 @@ module sonic-port{
 					}
 				}
 
+				leaf tx_power {
+						description "Target output power(dBm) for the 400G ZR transceiver";
+						type decimal64 {
+							fraction-digits 1;
+						}
+				}
+
+				leaf laser_freq {
+						description "Target laser frequency(GHz) for the 400G ZR transceiver";
+						type int32;
+				}
+
 			} /* end of list PORT_LIST */
 
 		} /* end of container PORT */


### PR DESCRIPTION
#### Why I did it
Add yang model for configuring TX power and laser frequency of ZR transceiver module

#### How to verify it

```
root@sonic:~#  config interface transceiver tx_power Ethernet0 -- -27.3
Setting target Tx output power to -27.3 dBm on port Ethernet0
root@sonic:~# redis-cli -n 4 hgetall "PORT|Ethernet0"                  
 1) "admin_status"
 2) "up"
 3) "alias"
 4) "Ethernet1/1"
 5) "index"
 6) "1"
 7) "lanes"
 8) "1,2,3,4,5,6,7,8"
 9) "laser_freq"
10) "170000"
11) "speed"
12) "400000"
13) "tx_power"
14) "-27.3"
root@sonic:~# 
```

```
root@sonic:~# config interface transceiver tx_power Ethernet0 -27   
Usage: config interface transceiver tx_power [OPTIONS] <interface_name> <tx-
                                             power>
Try "config interface transceiver tx_power -h" for help.

Error: no such option: -2

root@sonic:~# config interface transceiver frequency Ethernet0 -1
Usage: config interface transceiver frequency [OPTIONS] <interface_name>
                                              <frequency>
Try "config interface transceiver frequency -h" for help.

Error: no such option: -1

root@sonic:~# config interface transceiver frequency Ethernet0 1000
Setting laser frequency to 1000 GHz on port Ethernet0
root@sonic:~# redis-cli -n 4 hgetall "PORT|Ethernet0"              
 1) "admin_status"
 2) "up"
 3) "alias"
 4) "Ethernet1/1"
 5) "index"
 6) "1"
 7) "lanes"
 8) "1,2,3,4,5,6,7,8"
 9) "laser_freq"
10) "1000"
11) "speed"
12) "400000"
13) "tx_power"
14) "-27.0"
root@sonic:~# 
root@sonic:~# 
root@sonic:~# 
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
ConfigDB schema for configuring TX power and laser frequency of ZR transceiver module

#### Link to config_db schema for YANG module changes
[https://github.com/sonic-net/SONiC/wiki/Configuration#port](https://github.com/sonic-net/SONiC/wiki/Configuration#port)
