### PR TITLE
[202012] Automatically enable tunnel_qos_remap on T1 and T0 in DualToR deployment

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1282,13 +1282,13 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
         results['DEVICE_METADATA']['localhost']['peer_switch'] = list(results['PEER_SWITCH'].keys())[0]
     
     # Enable tunnel_qos_remap if downstream_redundancy_types(T1) or redundancy_type(T0) = Gemini/Libra
-    force_enable_tunnel_qos_map = False
+    enable_tunnel_qos_map = False
     if results['DEVICE_METADATA']['localhost']['type'].lower() == 'leafrouter' and ('gemini' in str(downstream_redundancy_types).lower() or 'libra' in str(downstream_redundancy_types).lower()):
-        force_enable_tunnel_qos_map = True
+        enable_tunnel_qos_map = True
     elif results['DEVICE_METADATA']['localhost']['type'].lower() == 'torrouter' and ('gemini' in str(redundancy_type).lower() or 'libra' in str(redundancy_type).lower()):
-        force_enable_tunnel_qos_map = True
+        enable_tunnel_qos_map = True
 
-    if force_enable_tunnel_qos_map:
+    if enable_tunnel_qos_map:
         system_defaults['tunnel_qos_remap'] = {"status": "enabled"}
 
     if len(system_defaults) > 0:

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -847,6 +847,9 @@ def parse_meta(meta, hname):
     resource_type = None
     downstream_subrole = None
     kube_data = {}
+    redundancy_type = None
+    downstream_redundancy_types = None
+
     device_metas = meta.find(str(QName(ns, "Devices")))
     for device in device_metas.findall(str(QName(ns1, "DeviceMetadata"))):
         if device.find(str(QName(ns1, "Name"))).text.lower() == hname.lower():
@@ -881,29 +884,11 @@ def parse_meta(meta, hname):
                     kube_data["enable"] = value
                 elif name == "KubernetesServerIp":
                     kube_data["ip"] = value
-    return syslog_servers, dhcp_servers, dhcpv6_servers, ntp_servers, tacacs_servers, mgmt_routes, erspan_dst, deployment_id, region, cloudtype, resource_type, downstream_subrole, kube_data
-
-def parse_system_defaults(meta):
-    system_default_values = {}
-
-    system_defaults = meta.find(str(QName(ns1, "SystemDefaults")))
-    
-    if system_defaults is None:
-        return system_default_values
-    
-    for system_default in system_defaults.findall(str(QName(ns1, "SystemDefault"))):
-        name = system_default.find(str(QName(ns1, "Name"))).text
-        value = system_default.find(str(QName(ns1, "Value"))).text
-
-        # Tunnel Qos remapping 
-        if name == "TunnelQosRemapEnabled":
-            if value.lower() == "true":
-                status = "enabled"
-            else:
-                status = "disabled"
-            system_default_values["tunnel_qos_remap"] = {"status": status}
-
-    return system_default_values
+                elif name == "DownstreamRedundancyTypes":
+                    downstream_redundancy_types = value
+                elif name == "RedundancyType":
+                    redundancy_type = value
+    return syslog_servers, dhcp_servers, dhcpv6_servers, ntp_servers, tacacs_servers, mgmt_routes, erspan_dst, deployment_id, region, cloudtype, resource_type, downstream_subrole, kube_data, downstream_redundancy_types, redundancy_type
 
 def parse_linkmeta(meta, hname):
     link = meta.find(str(QName(ns, "Link")))
@@ -1202,6 +1187,8 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     local_devices = []
     kube_data = {}
     system_defaults = {}
+    downstream_redundancy_types = None
+    redundancy_type = None
 
     hwsku_qn = QName(ns, "HwSku")
     hostname_qn = QName(ns, "Hostname")
@@ -1232,13 +1219,11 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
             elif child.tag == str(QName(ns, "UngDec")):
                 (u_neighbors, u_devices, _, _, _, _, _, _) = parse_png(child, hostname, None)
             elif child.tag == str(QName(ns, "MetadataDeclaration")):
-                (syslog_servers, dhcp_servers, dhcpv6_servers, ntp_servers, tacacs_servers, mgmt_routes, erspan_dst, deployment_id, region, cloudtype, resource_type, downstream_subrole, kube_data) = parse_meta(child, hostname)
+                (syslog_servers, dhcp_servers, dhcpv6_servers, ntp_servers, tacacs_servers, mgmt_routes, erspan_dst, deployment_id, region, cloudtype, resource_type, downstream_subrole, kube_data, downstream_redundancy_types, redundancy_type) = parse_meta(child, hostname)
             elif child.tag == str(QName(ns, "LinkMetadataDeclaration")):
                 linkmetas = parse_linkmeta(child, hostname)
             elif child.tag == str(QName(ns, "DeviceInfos")):
                 (port_speeds_default, port_descriptions) = parse_deviceinfo(child, hwsku)
-            elif child.tag == str(QName(ns, "SystemDefaultsDeclaration")):
-                system_defaults = parse_system_defaults(child)
         else:
             if child.tag == str(QName(ns, "DpgDec")):
                 (intfs, lo_intfs, mvrf, mgmt_intf, vlans, vlan_members, dhcp_relay_table, pcs, pc_members, acls, vni, tunnel_intfs, dpg_ecmp_content, tunnel_intfs_qos_remap_config) = parse_dpg(child, asic_name)
@@ -1253,8 +1238,6 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
                 linkmetas = parse_linkmeta(child, hostname)
             elif child.tag == str(QName(ns, "DeviceInfos")):
                 (port_speeds_default, port_descriptions) = parse_deviceinfo(child, hwsku)
-            elif child.tag == str(QName(ns, "SystemDefaultsDeclaration")):
-                system_defaults = parse_system_defaults(child)
 
     # set the host device type in asic metadata also
     device_type = [devices[key]['type'] for key in devices if key.lower() == hostname.lower()][0]
@@ -1289,9 +1272,6 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
             }
         }
 
-    if len(system_defaults) > 0:
-        results['SYSTEM_DEFAULTS'] = system_defaults
-
     results['PEER_SWITCH'], mux_tunnel_name, peer_switch_ip = get_peer_switch_info(linkmetas, devices)
 
     if bool(results['PEER_SWITCH']):
@@ -1300,7 +1280,20 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
             print("Warning: more than one peer switch was found. Only the first will be parsed: {}".format(results['PEER_SWITCH'].keys()[0]))
 
         results['DEVICE_METADATA']['localhost']['peer_switch'] = list(results['PEER_SWITCH'].keys())[0]
+    
+    # Enable tunnel_qos_remap if downstream_redundancy_types(T1) or redundancy_type(T0) = Gemini/Libra
+    force_enable_tunnel_qos_map = False
+    if results['DEVICE_METADATA']['localhost']['type'].lower() == 'leafrouter' and ('gemini' in str(downstream_redundancy_types).lower() or 'libra' in str(downstream_redundancy_types).lower()):
+        force_enable_tunnel_qos_map = True
+    elif results['DEVICE_METADATA']['localhost']['type'].lower() == 'torrouter' and ('gemini' in str(redundancy_type).lower() or 'libra' in str(redundancy_type).lower()):
+        force_enable_tunnel_qos_map = True
 
+    if force_enable_tunnel_qos_map:
+        system_defaults['tunnel_qos_remap'] = {"status": "enabled"}
+
+    if len(system_defaults) > 0:
+        results['SYSTEM_DEFAULTS'] = system_defaults
+    
     # for this hostname, if sub_role is defined, add sub_role in 
     # device_metadata
     if sub_role is not None:

--- a/src/sonic-config-engine/tests/sample-arista-7050cx3-dualtor-minigraph.xml
+++ b/src/sonic-config-engine/tests/sample-arista-7050cx3-dualtor-minigraph.xml
@@ -2334,19 +2334,16 @@
             <a:Reference i:nil="true"/>
             <a:Value>10.20.6.16</a:Value>
          </a:DeviceProperty>
+         <a:DeviceProperty>
+            <a:Name>RedundancyType</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>Gemini</a:Value>
+         </a:DeviceProperty>
         </a:Properties>
       </a:DeviceMetadata>
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <SystemDefaultsDeclaration>
-  <a:SystemDefaults xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-    <a:SystemDefault>
-      <a:Name>TunnelQosRemapEnabled</a:Name>
-      <a:Value>True</a:Value>
-    </a:SystemDefault>
-  </a:SystemDefaults>
-</SystemDefaultsDeclaration>
   <LinkMetadataDeclaration>
     <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:LinkMetadata>

--- a/src/sonic-config-engine/tests/sample-arista-7260-dualtor-minigraph.xml
+++ b/src/sonic-config-engine/tests/sample-arista-7260-dualtor-minigraph.xml
@@ -4600,19 +4600,16 @@
             <a:Reference i:nil="true"/>
             <a:Value>10.20.6.16</a:Value>
          </a:DeviceProperty>
+         <a:DeviceProperty>
+            <a:Name>RedundancyType</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>Gemini</a:Value>
+         </a:DeviceProperty>
         </a:Properties>
       </a:DeviceMetadata>
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <SystemDefaultsDeclaration>
-  <a:SystemDefaults xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-    <a:SystemDefault>
-      <a:Name>TunnelQosRemapEnabled</a:Name>
-      <a:Value>True</a:Value>
-    </a:SystemDefault>
-  </a:SystemDefaults>
-</SystemDefaultsDeclaration>
   <LinkMetadataDeclaration>
     <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:LinkMetadata>

--- a/src/sonic-config-engine/tests/sample-arista-7260-t1-minigraph.xml
+++ b/src/sonic-config-engine/tests/sample-arista-7260-t1-minigraph.xml
@@ -2481,19 +2481,16 @@
             <a:Reference i:nil="true"/>
             <a:Value>10.20.6.16</a:Value>
          </a:DeviceProperty>
+         <a:DeviceProperty>
+            <a:Name>DownstreamRedundancyTypes</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>Gemini</a:Value>
+         </a:DeviceProperty>
         </a:Properties>
       </a:DeviceMetadata>
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <SystemDefaultsDeclaration>
-  <a:SystemDefaults xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-    <a:SystemDefault>
-      <a:Name>TunnelQosRemapEnabled</a:Name>
-      <a:Value>True</a:Value>
-    </a:SystemDefault>
-  </a:SystemDefaults>
-</SystemDefaultsDeclaration>
   <Hostname>str-7260cx3-acs-7</Hostname>
   <HwSku>Arista-7260CX3-C64</HwSku>
 </DeviceMiniGraph>

--- a/src/sonic-config-engine/tests/simple-sample-graph-case-remap-disabled.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case-remap-disabled.xml
@@ -474,14 +474,6 @@
  </Devices>
  <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
 </MetadataDeclaration>
-<SystemDefaultsDeclaration>
-  <a:SystemDefaults xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-    <a:SystemDefault>
-      <a:Name>TunnelQosRemapEnabled</a:Name>
-      <a:Value>False</a:Value>
-    </a:SystemDefault>
-  </a:SystemDefaults>
-</SystemDefaultsDeclaration>
   <DeviceInfos>
     <DeviceInfo>
       <EthernetInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">

--- a/src/sonic-config-engine/tests/simple-sample-graph-case-remap-enabled-no-tunnel-attributes.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case-remap-enabled-no-tunnel-attributes.xml
@@ -469,19 +469,16 @@
      <a:Reference i:nil="true"/>
      <a:Value>Storage</a:Value>
     </a:DeviceProperty>
+    <a:DeviceProperty>
+     <a:Name>RedundancyType</a:Name>
+     <a:Reference i:nil="true"/>
+     <a:Value>Gemini</a:Value>
+    </a:DeviceProperty>
   </a:Properties>
   </a:DeviceMetadata>
  </Devices>
  <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
 </MetadataDeclaration>
-<SystemDefaultsDeclaration>
-  <a:SystemDefaults xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-    <a:SystemDefault>
-      <a:Name>TunnelQosRemapEnabled</a:Name>
-      <a:Value>True</a:Value>
-    </a:SystemDefault>
-  </a:SystemDefaults>
-</SystemDefaultsDeclaration>
   <DeviceInfos>
     <DeviceInfo>
       <EthernetInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">

--- a/src/sonic-config-engine/tests/simple-sample-graph-case-remap-enabled.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case-remap-enabled.xml
@@ -469,19 +469,16 @@
      <a:Reference i:nil="true"/>
      <a:Value>Storage</a:Value>
     </a:DeviceProperty>
+    <a:DeviceProperty>
+     <a:Name>RedundancyType</a:Name>
+     <a:Reference i:nil="true"/>
+     <a:Value>Gemini</a:Value>
+    </a:DeviceProperty>
   </a:Properties>
   </a:DeviceMetadata>
  </Devices>
  <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
 </MetadataDeclaration>
-<SystemDefaultsDeclaration>
-  <a:SystemDefaults xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-    <a:SystemDefault>
-      <a:Name>TunnelQosRemapEnabled</a:Name>
-      <a:Value>True</a:Value>
-    </a:SystemDefault>
-  </a:SystemDefaults>
-</SystemDefaultsDeclaration>
   <DeviceInfos>
     <DeviceInfo>
       <EthernetInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">


### PR DESCRIPTION
Signed-off-by: bingwang <wang.bing@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR is to enable `tunnel_qos_remap` on `T1` and `T0` in DualToR deployment.
On T1, we check the property `DownstreamRedundancyTypes`. On T0, we check the property `RedundancyType`.
`tunnel_qos_remap` is set to `enabled` if `gemini` is in  `DownstreamRedundancyTypes` (on T1) or `RedundancyType` (on T0).

#### How I did it
The change is implemented in `minigraph.py`.

#### How to verify it
Verified by `test_minigraph_case.py` and 'test_j2files.py`.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Automatically enable tunnel_qos_remap on T1 and T0 in DualToR deployment.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

