### PR TITLE
[ci] Set variable to control the days to keep cache file.

### DIFF
--- a/.azure-pipelines/dpkg-cache-cleanup.yml
+++ b/.azure-pipelines/dpkg-cache-cleanup.yml
@@ -2,7 +2,7 @@
 # Start with a minimal pipeline that you can customize to build and deploy your code.
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
-# Clean up the cache 30 days ago
+# Clean up the cache $(keep_days) days ago
 
 schedules:
 - cron: "0 0 * * *"
@@ -22,6 +22,6 @@ jobs:
   - checkout: none
   - script: |
       set -xe
-      sudo find /nfs/dpkg_cache/ -name *.tgz -mtime +30 -type f -delete
+      sudo find /nfs/dpkg_cache/ -name *.tgz -mtime +$(keep_days) -type f -delete
     displayName: clean dpkg cache
     


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Our CI/CD pipeline has no space in cache folder. Change the days to keep cache file by variable.
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

