### PR TITLE
[Arista] Enable larger number of LAGs on 7800 LCs

### DIFF
--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
@@ -6,7 +6,7 @@ system_headers_mode=1
 suppress_unknown_prop_warnings=1
 l4_protocols_load_balancing_enable=1
 fabric_logical_port_base=512
-trunk_group_max_members=128
+trunk_group_max_members=16
 num_olp_tm_ports.BCM8869X=1
 
 # nif

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -21,6 +21,9 @@ pmf_sexem3_stage=IPMF2
 # Jericho2-mode (description 0x1 used for Jericho 2 mode)
 system_headers_mode=1
 
+# HW mode to support 1024 16-member system wide LAGs
+trunk_group_max_members=16
+
 # Disable link-training
 port_init_cl72=0
 

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -21,6 +21,9 @@ pmf_sexem3_stage=IPMF2
 # Jericho2-mode (description 0x1 used for Jericho 2 mode)
 system_headers_mode=1
 
+# HW mode to support 1024 16-member system wide LAGs
+trunk_group_max_members=16
+
 # Disable link-training
 port_init_cl72=0
 


### PR DESCRIPTION
For 7800 LCs, set LAG mode to support 1024 number of 16-member system
LAGs.

#### Why I did it
The SOC property changes are necessary to match https://github.com/Azure/sonic-buildimage/pull/10519 which increases the number of system LAG IDs to 1024.

#### Description for the changelog
For 7800 LCs, set LAG mode to support 1024 number of 16-member system
LAGs.
