### PR TITLE
[Bug]: fix the version file name issue

### DIFF
--- a/scripts/build_debian_base_system.sh
+++ b/scripts/build_debian_base_system.sh
@@ -21,7 +21,7 @@ generate_version_file()
     sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "dpkg-query -W -f '\${Package}==\${Version}\n'" > $TARGET_BASEIMAGE_PATH/versions-deb-${IMAGE_DISTRO}-${CONFIGURED_ARCH}
 }
 
-if [ "$ENABLE_VERSION_CONTROL_DEB" != "y" ]; then
+if [ "$ENABLE_VERSION_CONTROL_DEB" != "y" ] || [ ! -d files/build/versions/host-base-image ]; then
     if [[ $CONFIGURED_ARCH == armhf || $CONFIGURED_ARCH == arm64 ]]; then
         if [ $MULTIARCH_QEMU_ENVIRON == "y" ]; then
             # qemu arm bin executable for cross-building

--- a/scripts/build_debian_base_system.sh
+++ b/scripts/build_debian_base_system.sh
@@ -55,7 +55,7 @@ fi
 # Generate the version files for the host base image
 TEMP_DIR=$(mktemp -d)
 ./scripts/versions_manager.py generate -t $TEMP_DIR -n host-base-image -d $IMAGE_DISTRO -a $CONFIGURED_ARCH
-PACKAGES=$(sed -E 's/=(=[^=]*)$/\1/' $TEMP_DIR/version-deb)
+PACKAGES=$(sed -E 's/=(=[^=]*)$/\1/' $TEMP_DIR/versions-deb)
 if [ -z "$PACKAGES" ]; then
     echo "Not found host-base-image packages, please check the version files in files/build/versions/host-base-image" 2>&1
     exit 1


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
[Bug]: fix the version file name issue
Fix the build failure: https://dev.azure.com/mssonic/build/_build/results?buildId=107211&view=results

```
+ scripts/build_debian_base_system.sh amd64 bullseye ./fsroot-centec
sed: can't read /tmp/tmp.glTzJefV24/version-deb: No such file or directory
Not found host-base-image packages, please check the version files in files/build/versions/host-base-image

```

#### How I did it
Change the version-deb, to versions-deb
And add an improvement for host base image build, if the version path not exist, skipped the version control for base image.

#### How to verify it
https://dev.azure.com/mssonic/build/_build/results?buildId=107587&view=results


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

