### PR TITLE
[202012] [sonic-config-engine] Generate expected output with different cable len

### DIFF
--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -69,6 +69,20 @@ class TestJ2Files(TestCase):
         if not dir_exist:
             os.system('sudo rmdir /host')
 
+    def modify_cable_len(self, base_file, file_dir):
+        input_file = os.path.join(file_dir, base_file)
+        with open(input_file, 'r') as ifd:
+            object = json.load(ifd)
+            if 'CABLE_LENGTH' in object and 'AZURE' in object['CABLE_LENGTH']:
+                for key in object['CABLE_LENGTH']['AZURE']:
+                    object['CABLE_LENGTH']['AZURE'][key] = '300m'
+        prefix, extension = base_file.split('.')
+        output_file = '{}_300m.{}'.format(prefix, extension)
+        out_file_path = os.path.join(file_dir, output_file)
+        with open(out_file_path, 'w') as wfd:
+            json.dump(object, wfd, indent=4)
+        return output_file
+
     def test_interfaces(self):
         interfaces_template = os.path.join(self.test_dir, '..', '..', '..', 'files', 'image_config', 'interfaces', 'interfaces.j2')
         argument = '-m ' + self.t0_minigraph + ' -a \'{\"hwaddr\":\"e4:1d:2d:a5:f3:ad\"}\' -t ' + interfaces_template + ' > ' + self.output_file
@@ -355,8 +369,24 @@ class TestJ2Files(TestCase):
         os.remove(buffers_config_file_new)
         self.remove_machine_conf(file_exist, dir_exist)
 
-        sample_output_file = os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR, expected)
-        assert utils.cmp(sample_output_file, self.output_file), self.run_diff(sample_output_file, self.output_file)
+        out_file_dir = os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR)
+        expected_files = [expected, self.modify_cable_len(expected, out_file_dir)]
+        match = False
+        diff = ''
+        for out_file in expected_files:
+            sample_output_file = os.path.join(out_file_dir, out_file)
+            if utils.cmp(sample_output_file, self.output_file):
+                match = True
+                break
+            else:
+                diff = diff + str(self.run_diff(sample_output_file, self.output_file))
+
+        os.remove(os.path.join(out_file_dir, expected_files[1]))
+
+        if match:
+            assert True
+        else:
+            assert False, diff
 
     def test_extra_lossless_buffer_for_tunnel_remapping(self):
         if utils.PYvX_DIR != 'py3':

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -383,10 +383,7 @@ class TestJ2Files(TestCase):
 
         os.remove(os.path.join(out_file_dir, expected_files[1]))
 
-        if match:
-            assert True
-        else:
-            assert False, diff
+        assert match, diff
 
     def test_extra_lossless_buffer_for_tunnel_remapping(self):
         if utils.PYvX_DIR != 'py3':


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To address internal build failures where the cable len for some of the skus is set to 300m for all tiers. 

#### How I did it
For the buffers test, generate a new output file based off the original expected output with CABLE_LENGTH table updated to use 300m. In the comparison logic, compare against each of the expected output files and if any matches, the testcase is set to pass

#### How to verify it
Build sonic-config-engine wheel with the changes
