### PR TITLE
[ci] Support to skip vstest using include/exclude config file.

### DIFF
--- a/.azure-pipelines/azure-pipelines-build.yml
+++ b/.azure-pipelines/azure-pipelines-build.yml
@@ -98,6 +98,7 @@ jobs:
             platform_rpc: nephos
 
     buildSteps:
+      - template: template-skipvstest.yml
       - bash: |
           set -ex
           if [ $(GROUP_NAME) == vs ]; then

--- a/.azure-pipelines/template-skipvstest.yml
+++ b/.azure-pipelines/template-skipvstest.yml
@@ -4,9 +4,10 @@ steps:
       set -ex
       git config --global user.email "test@example.com"
       git config --global user.name "CI agent"
-      git rebase origin/$(System.PullRequest.TargetBranch)
-      git diff HEAD~ --name-only | grep -v -f .azure-pipelines/vstest-exclude && exit 0
-      git diff HEAD~ --name-only | grep -f .azure-pipelines/vstest-include && exit 0
+      tar_branch=origin/$(System.PullRequest.TargetBranch)
+      git rebase $tar_branch
+      git diff $tar_branch --name-only | grep -v -f .azure-pipelines/vstest-exclude && exit 0
+      git diff $tar_branch --name-only | grep -f .azure-pipelines/vstest-include && exit 0
       set +x
       echo "Skip vstest jobs"
       echo "##vso[task.setvariable variable=SKIP_VSTEST;isOutput=true]YES"

--- a/.azure-pipelines/template-skipvstest.yml
+++ b/.azure-pipelines/template-skipvstest.yml
@@ -2,12 +2,9 @@ steps:
 - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
   - script: |
       set -ex
-      git config --global user.email "test@example.com"
-      git config --global user.name "CI agent"
       tar_branch=origin/$(System.PullRequest.TargetBranch)
-      git rebase $tar_branch
-      git diff $tar_branch --name-only | grep -v -f .azure-pipelines/vstest-exclude && exit 0
-      git diff $tar_branch --name-only | grep -f .azure-pipelines/vstest-include && exit 0
+      git diff $tar_branch..HEAD --name-only | grep -v -f .azure-pipelines/vstest-exclude && exit 0
+      git diff $tar_branch..HEAD --name-only | grep -f .azure-pipelines/vstest-include && exit 0
       set +x
       echo "Skip vstest jobs"
       echo "##vso[task.setvariable variable=SKIP_VSTEST;isOutput=true]YES"

--- a/.azure-pipelines/template-skipvstest.yml
+++ b/.azure-pipelines/template-skipvstest.yml
@@ -9,4 +9,4 @@ steps:
       echo "Skip vstest jobs"
       echo "##vso[task.setvariable variable=SKIP_VSTEST;isOutput=true]YES"
     name: SetVar
-    displayName: "Set SKIP_VSTST variable"
+    displayName: "Check if vstest is needed."

--- a/.azure-pipelines/template-skipvstest.yml
+++ b/.azure-pipelines/template-skipvstest.yml
@@ -2,6 +2,8 @@ steps:
 - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
   - script: |
       set -ex
+      git config --global user.email "test@example.com"
+      git config --global user.name "CI agent"
       git rebase origin/$(System.PullRequest.TargetBranch)
       git diff HEAD~ --name-only | grep -v -f .azure-pipelines/vstest-exclude && exit 0
       git diff HEAD~ --name-only | grep -f .azure-pipelines/vstest-include && exit 0

--- a/.azure-pipelines/template-skipvstest.yml
+++ b/.azure-pipelines/template-skipvstest.yml
@@ -1,0 +1,12 @@
+steps:
+- ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+  - script: |
+      set -ex
+      git rebase origin/$(System.PullRequest.TargetBranch)
+      git diff HEAD~ --name-only | grep -v -f .azure-pipelines/vstest-exclude && exit 0
+      git diff HEAD~ --name-only | grep -f .azure-pipelines/vstest-include && exit 0
+      set +x
+      echo "Skip vstest jobs"
+      echo "##vso[task.setvariable variable=SKIP_VSTEST;isOutput=true]YES"
+    name: SetVar
+    displayName: "Set SKIP_VSTST variable"

--- a/.azure-pipelines/vstest-exclude
+++ b/.azure-pipelines/vstest-exclude
@@ -1,0 +1,3 @@
+^platform
+^.azure-pipelines
+^files/build/versions

--- a/.azure-pipelines/vstest-include
+++ b/.azure-pipelines/vstest-include
@@ -1,0 +1,2 @@
+^platform/vs
+^.azure-pipelines/run-test-template.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,6 +77,7 @@ stages:
 
 - stage: Test
   dependsOn: BuildVS
+  condition: and(ne(stageDependencies.BuildVS.outputs['vs.SetVar.SKIP_VSTEST'], 'YES'), succeeded())
   variables:
   - name: inventory
     value: veos_vtb


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Some changes didn't change vs image. We should not run vstest in such cases.
#### How I did it
```
example:
├── folderA
│  ├──  fileA (skip vstest)
│  ├──  fileB
│  └──  fileC
If we want to skip vstest when changing /folderA/fileA, and not skip vstest when changing fileB or fileC.

vstest-include:
^folderA/fileA

vstest-exclude:
^folderA
```
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

