### PR TITLE
[macsec] CLI Supports display of gearbox macsec counter

### DIFF
--- a/dockers/docker-macsec/cli-plugin-tests/mock_tables.py
+++ b/dockers/docker-macsec/cli-plugin-tests/mock_tables.py
@@ -115,6 +115,19 @@ class SwssSyncClient(mockredis.MockRedis):
         return [key for key in self.redis if regex.match(key)]
 
 
+class MacsecCounter:
+    pass
+
+
+class CounterTable:
+    def __init__(self, db):
+        self.db = db
+
+    def get(self, macsec, name):
+        key = self.db.hget("COUNTERS_MACSEC_NAME_MAP", name)
+        return self.db.get("COUNTERS:" + key)
+
+
 swsssdk.interface.DBInterface._subscribe_keyspace_notification = _subscribe_keyspace_notification
 mockredis.MockRedis.config_set = config_set
 redis.StrictRedis = SwssSyncClient
@@ -122,3 +135,5 @@ SonicV2Connector.connect = connect_SonicV2Connector
 swsscommon.SonicV2Connector = SonicV2Connector
 swsscommon.ConfigDBConnector = ConfigDBConnector
 swsscommon.ConfigDBPipeConnector = ConfigDBPipeConnector
+swsscommon.CounterTable = CounterTable
+swsscommon.MacsecCounter = MacsecCounter


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To support gearbox macsec counter display, following https://github.com/Azure/sonic-swss-common/pull/622.
#### How I did it
Use swsscommon CounterTable API
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

