### PR TITLE
[SSHD] Enable SSHD keepalive timeout feature.

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -422,7 +422,7 @@ rm /files/etc/ssh/sshd_config/ClientAliveCountMax
 touch /files/etc/ssh/sshd_config/EmptyLineHack
 rename /files/etc/ssh/sshd_config/EmptyLineHack ""
 set /files/etc/ssh/sshd_config/ClientAliveInterval 900
-set /files/etc/ssh/sshd_config/ClientAliveCountMax 0
+set /files/etc/ssh/sshd_config/ClientAliveCountMax 1
 ins #comment before /files/etc/ssh/sshd_config/ClientAliveInterval
 set /files/etc/ssh/sshd_config/#comment[following-sibling::*[1][self::ClientAliveInterval]] "Close inactive client sessions after 15 minutes"
 save


### PR DESCRIPTION
#### Why I did it
SSHD keepalive timeout feature not enabled on sonic.

#### How I did it
Enable SSHD keepalive timeout feature by set ClientAliveCountMax to 1.

#### How to verify it
Pass All E2E test case.
Manually test with following steps:

1. Change config and restart sshd
2. Connect a ssh with -vvv option to show debug message
3. Get running ssh by command and stop it:

```
azureuser@liuh-dev-vm-02:~$ ps -auxww | grep vvv
azureus+ 1614153  0.0  0.0  12244  6004 pts/1S+   15:48   0:00 ssh admin@10.250.0.101 -vvv
azureus+ 1615570  0.0  0.0   8168  2424 pts/3S+   15:49   0:00 grep --color=auto vvv
azureuser@liuh-dev-vm-02:~$ kill -Stop 1614153
```

4. Check TCP status from server side with ss command:
https://man7.org/linux/man-pages/man8/ss.8.html

```
admin@vlab-01:~$ ss | grep -i ssh
tcp   ESTAB  0  010.250.0.101:ssh 10.250.0.1:58150
tcp   FIN-WAIT-2 0  010.250.0.101:ssh 10.250.0.1:58164
tcp   ESTAB  0  010.250.0.101:ssh 10.250.0.1:57978
```

FIN-WAIT-2 means server already terminate the connection and wait for client response:
https://kb.iu.edu/d/ajmi
.  FIN-WAIT-2  <-- <SEQ=300><ACK=101><CTL=ACK>  <-- CLOSE-WAIT

5. Check again later will show the session been complete closed:

```
admin@vlab-01:~$ ss | grep -i ssh
tcp   ESTAB  0  010.250.0.101:ssh 10.250.0.1:58150
tcp   ESTAB  0  010.250.0.101:ssh 10.250.0.1:57978
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
Enable SSHD keepalive timeout feature by set ClientAliveCountMax to 1.

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

