### PR TITLE
fix armhf for installer.conf usage

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -71,12 +71,12 @@ generate_onie_installer_image()
     output_file=$OUTPUT_ONIE_IMAGE
     [ -n "$1" ] && output_file=$1
     # Copy platform-specific ONIE installer config files where onie-mk-demo.sh expects them
-    rm -rf ./installer/x86_64/platforms/
-    mkdir -p ./installer/x86_64/platforms/
+    rm -rf ./installer/${TARGET_PLATFORM}/platforms/
+    mkdir -p ./installer/${TARGET_PLATFORM}/platforms/
     for VENDOR in `ls ./device`; do
-        for PLATFORM in `ls ./device/$VENDOR`; do
+        for PLATFORM in `ls ./device/$VENDOR | grep ^${TARGET_PLATFORM}`; do
             if [ -f ./device/$VENDOR/$PLATFORM/installer.conf ]; then
-                cp ./device/$VENDOR/$PLATFORM/installer.conf ./installer/x86_64/platforms/$PLATFORM
+                cp ./device/$VENDOR/$PLATFORM/installer.conf ./installer/${TARGET_PLATFORM}/platforms/$PLATFORM
             fi
 
         done

--- a/platform/marvell-armhf/platform.conf
+++ b/platform/marvell-armhf/platform.conf
@@ -9,7 +9,6 @@ kernel_addr=0x1100000
 fdt_addr=0x1000000
 fdt_high=0x10fffff
 initrd_addr=0x2000000
-VAR_LOG=512
 
 kernel_fname="/boot/vmlinuz-5.10.0-12-2-armmp"
 initrd_fname="/boot/initrd.img-5.10.0-12-2-armmp"
@@ -147,8 +146,8 @@ prepare_boot_menu() {
     BORDER='echo "---------------------------------------------------";echo;'
     fw_setenv ${FW_ARG} print_menu $BORDER $BOOT1 $BOOT2 $BOOT3 $BORDER > /dev/null
 
-    fw_setenv ${FW_ARG} linuxargs "net.ifnames=0 loopfstype=squashfs loop=$image_dir/$FILESYSTEM_SQUASHFS systemd.unified_cgroup_hierarchy=0 varlog_size=$VAR_LOG loglevel=4 ${extra_cmdline_linux}" > /dev/null
-    fw_setenv ${FW_ARG} linuxargs_old "net.ifnames=0 loopfstype=squashfs loop=$image_dir_old/$FILESYSTEM_SQUASHFS systemd.unified_cgroup_hierarchy=0 varlog_size=$VAR_LOG loglevel=4" > /dev/null
+    fw_setenv ${FW_ARG} linuxargs "net.ifnames=0 loopfstype=squashfs loop=$image_dir/$FILESYSTEM_SQUASHFS systemd.unified_cgroup_hierarchy=0 varlog_size=$VAR_LOG_SIZE loglevel=4 ${extra_cmdline_linux}" > /dev/null
+    fw_setenv ${FW_ARG} linuxargs_old "net.ifnames=0 loopfstype=squashfs loop=$image_dir_old/$FILESYSTEM_SQUASHFS systemd.unified_cgroup_hierarchy=0 varlog_size=$VAR_LOG_SIZE loglevel=4" > /dev/null
 
     # Set boot configs
     fw_setenv ${FW_ARG} kernel_addr $kernel_addr > /dev/null


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This fixes the build for armhf to be able to use '/device/<company>/<platform>/installer.conf' files.  Specifically, armhf needs support to be able to change the size of /var/log/ directory.  It is hardcoded to 512 bytes on all armhf platforms currently.  This change will allow any armhf platform to be able to use an installer.conf file to customize the installed image.

#### How I did it

#### How to verify it
Build and verify that armhf platform installer.conf is used.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
This fixes the build for armhf to be able to use /device/\<company\>/\<platform\>/installer.conf files.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

