### PR TITLE
[ci] Migrate sonic image pipeline to 1ES agent pool

### DIFF
--- a/.azure-pipelines/prepare_agent.yml
+++ b/.azure-pipelines/prepare_agent.yml
@@ -17,7 +17,7 @@ steps:
 
       if [ ! -d /nfs ];then
         sudo mkdir /nfs
-        sudo mount -t nfs -o sec=sys,vers=4.1 172.16.131.132:/vol1 /nfs
+        sudo mount -t nfs -o sec=sys,vers=4.1 10.0.5.4:/jenkins-vol-1 /nfs
       fi
       if [ ! -d /data ];then
         sudo mkdir /data

--- a/.azure-pipelines/prepare_agent.yml
+++ b/.azure-pipelines/prepare_agent.yml
@@ -8,6 +8,8 @@ steps:
       sudo sed -i "s#{{codename}}#$UBUNTU_CODENAME#" /etc/apt/sources.list
       sudo apt update
 
+      sudo pip3 install jinja2==3.0.0
+
       if [[ $PLATFORM_ARCH == arm* ]];then
         echo arm agent, skip.
         exit 0

--- a/.azure-pipelines/prepare_agent.yml
+++ b/.azure-pipelines/prepare_agent.yml
@@ -1,0 +1,41 @@
+steps:
+  - script: |
+      set -ex
+      # 1ES agent has issues in /etc/apt/sources.list
+      . /etc/os-release
+      sudo sed -i "s#{{mirror}}#http://azure.archive.ubuntu.com/ubuntu#" /etc/apt/sources.list
+      sudo sed -i "s#{{security}}#http://security.ubuntu.com/ubuntu#" /etc/apt/sources.list
+      sudo sed -i "s#{{codename}}#$UBUNTU_CODENAME#" /etc/apt/sources.list
+      sudo apt update
+
+      if [[ $PLATFORM_ARCH == arm* ]];then
+        echo arm agent, skip.
+        exit 0
+      fi
+
+      if [ ! -d /nfs ];then
+        sudo mkdir /nfs
+        sudo mount -t nfs -o sec=sys,vers=4.1 172.16.131.132:/vol1 /nfs
+      fi
+      if [ ! -d /data ];then
+        sudo mkdir /data
+        if [ ! -e /dev/disk/azure/scsi1/lun0 ];then
+          echo Additional disk not found.
+          lsblk
+          exit 1
+        fi
+        disk=$(realpath /dev/disk/azure/scsi1/lun0)
+        sudo sgdisk -n 0:0:0 -t 0:8300 -c 0:data $disk
+        sudo mkfs.ext4 -F ${disk}1 || true
+        sudo mount ${disk}1 /data
+      fi
+      if ! docker info | grep -i root | grep data;then
+        sudo systemctl stop docker
+        sudo sed -i 's#--data-root /mnt/docker#--data-root /data/docker#' /lib/systemd/system/docker.service
+        sudo systemctl daemon-reload
+        sudo systemctl start docker
+      fi
+      df -h
+      lsblk
+      sudo setfacl -R -b /mnt
+    displayName: 'prepare 1ES agent'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,21 +49,25 @@ variables:
 
 stages:
 - stage: BuildVS
-  pool: sonicbld
+  pool: sonicbld-1ES
   jobs:
   - template: .azure-pipelines/azure-pipelines-build.yml
     parameters:
       buildOptions: 'USERNAME=admin SONIC_BUILD_JOBS=$(nproc) ${{ variables.VERSION_CONTROL_OPTIONS }}'
+      preSteps:
+        - template: .azure-pipelines/prepare_agent.yml
       jobGroups:
       - name: vs
 
 - stage: Build
-  pool: sonicbld
+  pool: sonicbld-1ES
   dependsOn: []
   jobs:
   - template: .azure-pipelines/azure-pipelines-build.yml
     parameters:
       buildOptions: 'USERNAME=admin SONIC_BUILD_JOBS=$(nproc) ${{ variables.VERSION_CONTROL_OPTIONS }}'
+      preSteps:
+        - template: .azure-pipelines/prepare_agent.yml
       jobGroups:
       - name: broadcom
         variables:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1ES team will block non-1ES agent pool.
So we migrate sonicbld to 1ES owned sonicbld-1ES agent pool
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

