### PR TITLE
Revert "[202012][openssh] openssh: Upgrade from 7.9 to 8.4, to match version in buster-backports"

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -281,6 +281,7 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     tcpdump                 \
     dbus                    \
     ntpstat                 \
+    openssh-server          \
     python                  \
     python-apt              \
     traceroute              \
@@ -321,10 +322,6 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     cron                    \
     haveged                 \
     jq
-
-## Install openssh-server from buster-backports for required security patches
-sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install -t buster-backports \
-    openssh-server
 
 if [[ $CONFIGURED_ARCH == amd64 ]]; then
 ## Pre-install the fundamental packages for amd64 (x86)

--- a/files/build/versions/host-image/versions-deb-buster
+++ b/files/build/versions/host-image/versions-deb-buster
@@ -251,9 +251,9 @@ netfilter-persistent==1.0.11+deb10u1
 ntp==1:4.2.8p12+dfsg-4+deb10u2
 ntpstat==0.0.0.1-2
 opennsl-modules==4.3.0.10-2
-openssh-client==1:8.4p1-2~bpo10+1
-openssh-server==1:8.4p1-2~bpo10+1
-openssh-sftp-server==1:8.4p1-2~bpo10+1
+openssh-client==1:7.9p1-10+deb10u2
+openssh-server==1:7.9p1-10+deb10u2
+openssh-sftp-server==1:7.9p1-10+deb10u2
 openssl==1.1.1n-0+deb10u2
 patch==2.7.6-3+deb10u1
 pciutils==1:3.5.2-1

--- a/rules/openssh.mk
+++ b/rules/openssh.mk
@@ -1,15 +1,14 @@
 # openssh package
 
-OPENSSH_VERSION = 8.4p1
-OPENSSH_VERSION_FULL = ${OPENSSH_VERSION}-2~bpo10+1
+OPENSSH_VERSION = 7.9p1-10+deb10u2
 
-export OPENSSH_VERSION OPENSSH_VERSION_FULL
+export OPENSSH_VERSION
 
-OPENSSH_SERVER = openssh-server_$(OPENSSH_VERSION_FULL)_$(CONFIGURED_ARCH).deb
+OPENSSH_SERVER = openssh-server_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb
 $(OPENSSH_SERVER)_SRC_PATH = $(SRC_PATH)/openssh
 SONIC_MAKE_DEBS += $(OPENSSH_SERVER)
 
-OPENSSH_SERVER_DBG = openssh-server-dbgsym_$(OPENSSH_VERSION_FULL)_$(CONFIGURED_ARCH).deb
-$(eval $(call add_derived_package,$(OPENSSH_SERVER),$(OPENSSH_SERVER_DBG)))
-
-export OPENSSH_SERVER OPENSSH_SERVER_DBG
+# The .c, .cpp, .h & .hpp files under src/{$DBG_SRC_ARCHIVE list}
+# are archived into debug one image to facilitate debugging.
+#
+DBG_SRC_ARCHIVE += openssh

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -49,6 +49,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
         apt-utils \
         default-jre-headless \
+        openssh-server \
         curl \
         wget \
         unzip \
@@ -332,10 +333,6 @@ RUN apt-get update && apt-get install -y \
         libgtest-dev \
         libgcc-8-dev
 
-# For openssh-server
-RUN apt-get -y install -t buster-backports \
-        openssh-server \
-        libfido2-dev
 RUN apt-get -y build-dep openssh
 
 # Build fix for ARMHF buster libsairedis

--- a/src/openssh/Makefile
+++ b/src/openssh/Makefile
@@ -2,19 +2,17 @@
 SHELL = /bin/bash
 .SHELLFLAGS += -e
 
-MAIN_TARGET = $(OPENSSH_SERVER)
-DERIVED_TARGETS = $(OPENSSH_SERVER_DBG)
+MAIN_TARGET = openssh-server_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb
+DERIVED_TARGETS = openssh-server-dbgsym_$(OPENSSH_VERSION)_$(CONFIGURED_ARCH).deb
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
-	# Remove stale files
-	rm -rf ./openssh-$(OPENSSH_VERSION)
+	# Obtain openssh: https://salsa.debian.org/ssh-team/openssh/-/tree/debian/1%257.9p1-10+deb10u2
+	rm -rf ./openssh-server
+	git clone https://salsa.debian.org/ssh-team/openssh.git openssh-server
+	pushd ./openssh-server
 
-	dget https://deb.debian.org/debian/pool/main/o/openssh/openssh_$(OPENSSH_VERSION_FULL).dsc
-	pushd ./openssh-$(OPENSSH_VERSION)
-
-	git init
-	git add -f *
-	git commit -qm "initial commit"
+	# Check out tag: debian/1%7.9p1-10+deb10u2
+	git checkout -b openssh-src -f 6d9ca74c48d9911342c6ca5aaac8a25974fa2619
 
 	# Apply patch series
 	stg init


### PR DESCRIPTION
Reverts Azure/sonic-buildimage#10910

Reason can be found in this issue: https://github.com/Azure/sonic-buildimage/issues/11134

1. The change will cause armhf sshd failed to start
2. The change will introduce a double-free memory corruption issue (CVE-2021-28041)