### PR TITLE
Update include_macsec flag if type is SpineRouter

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -46,7 +46,7 @@
 {%- if include_p4rt == "y" %}{% do features.append(("p4rt", "enabled", false, "enabled")) %}{% endif %}
 {%- if include_restapi == "y" %}{% do features.append(("restapi", "enabled", false, "enabled")) %}{% endif %}
 {%- if include_sflow == "y" %}{% do features.append(("sflow", "disabled", false, "enabled")) %}{% endif %}
-{%- if include_macsec == "y" %}{% do features.append(("macsec", "disabled", false, "enabled")) %}{% endif %}
+{%- if include_macsec == "y" %}{% do features.append(("macsec", "{% if 'type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'SpineRouter' %}enabled{% else %}disabled{% endif %}", false, "enabled")) %}{% endif %}
 {%- if include_system_telemetry == "y" %}{% do features.append(("telemetry", "enabled", true, "enabled")) %}{% endif %}
     "FEATURE": {
 {# has_timer field if set, will start the feature systemd .timer unit instead of .service unit #}

--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -11,7 +11,7 @@ import signal
 
 import jinja2
 from sonic_py_common import device_info
-from swsscommon.swsscommon import ConfigDBConnector, DBConnector, Table, SonicDBConfig
+from swsscommon.swsscommon import ConfigDBConnector, DBConnector, Table
 
 # FILE
 PAM_AUTH_CONF = "/etc/pam.d/common-auth-sonic"
@@ -399,12 +399,6 @@ class FeatureHandler(object):
     def set_feature_state(self, feature, state):
         self._feature_state_table.set(feature.name, [('state', state)])
 
-        # Update the feature state in STATE_DB in namespaces in multi-asic platform
-        namespaces = device_info.get_namespaces()
-        for namespace in namespaces:
-            db_conn = DBConnector(STATE_DB, 0, False, namespace);
-            feature_state_tbl = Table(db_conn, 'FEATURE')
-            feature_state_tbl.set(feature.name, [('state', state)])
 
 class Iptables(object):
     def __init__(self):
@@ -1091,10 +1085,6 @@ class HostConfigDaemon:
         self.ntpcfg = NtpCfg()
 
         self.is_multi_npu = device_info.is_multi_npu()
-
-        # Initlaize Global config that loads all database*.json
-        if self.is_multi_npu:
-            SonicDBConfig.initializeGlobalConfig()
 
         # Initialize AAACfg
         self.hostname_cache=""

--- a/src/sonic-host-services/scripts/hostcfgd
+++ b/src/sonic-host-services/scripts/hostcfgd
@@ -11,7 +11,7 @@ import signal
 
 import jinja2
 from sonic_py_common import device_info
-from swsscommon.swsscommon import ConfigDBConnector, DBConnector, Table
+from swsscommon.swsscommon import ConfigDBConnector, DBConnector, Table, SonicDBConfig
 
 # FILE
 PAM_AUTH_CONF = "/etc/pam.d/common-auth-sonic"
@@ -399,6 +399,12 @@ class FeatureHandler(object):
     def set_feature_state(self, feature, state):
         self._feature_state_table.set(feature.name, [('state', state)])
 
+        # Update the feature state in STATE_DB in namespaces in multi-asic platform
+        namespaces = device_info.get_namespaces()
+        for namespace in namespaces:
+            db_conn = DBConnector(STATE_DB, 0, False, namespace);
+            feature_state_tbl = Table(db_conn, 'FEATURE')
+            feature_state_tbl.set(feature.name, [('state', state)])
 
 class Iptables(object):
     def __init__(self):
@@ -1085,6 +1091,10 @@ class HostConfigDaemon:
         self.ntpcfg = NtpCfg()
 
         self.is_multi_npu = device_info.is_multi_npu()
+
+        # Initlaize Global config that loads all database*.json
+        if self.is_multi_npu:
+            SonicDBConfig.initializeGlobalConfig()
 
         # Initialize AAACfg
         self.hostname_cache=""


### PR DESCRIPTION
#### Why I did it
 Update the feature table in STATE_DB in database running in namespace for multi-asic platforms.
This will be used by features running in namespaces.

This is needed by features like https://github.com/Azure/sonic-swss/pull/2286, which need to know the state of feature before adding feature based condition

Also add the support to enable macsec when type == "SpineRouter"

#### How I did it
Updated the init_cfg.json.j2 file and hostcfgd.


#### How to verify it
Verified with feature running in multiple namespaces 


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

