### PR TITLE
Remove minigraph loading in script

### DIFF
--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -31,7 +31,6 @@ CONFIG_DB_JSON=/etc/sonic/config_db.json
 CONFIG_DB_PATH=/etc/sonic/
 CONFIG_DB_PREFIX=config_db
 CONFIG_DB_SUFFIX=.json
-MINGRAPH_FILE=/etc/sonic/minigraph.xml
 TMP_ZTP_CONFIG_DB_JSON=/tmp/ztp_config_db.json
 FACTORY_DEFAULT_HOOKS=/etc/config-setup/factory-default-hooks.d
 CONFIG_PRE_MIGRATION_HOOKS=/etc/config-setup/config-migration-pre-hooks.d
@@ -103,14 +102,6 @@ run_hookdir() {
     fi
 
     return $exit_status
-}
-
-# Reload minigraph.xml file on disk
-reload_minigraph()
-{
-    echo "Reloading minigraph..."
-    config load_minigraph -y -n 
-    config save -y
 }
 
 # Apply tacacs config
@@ -305,7 +296,7 @@ check_all_config_db_present()
 do_config_migration()
 {
     # Identify list of files to migrate
-    copy_list="minigraph.xml snmp.yml acl.json port_config.json frr telemetry"
+    copy_list="snmp.yml acl.json port_config.json frr telemetry"
 
     # Migrate all configuration files from old to new
     copy_config_files_and_directories $copy_list
@@ -329,13 +320,8 @@ do_config_migration()
         reload_configdb
         # Disable updategraph
         disable_updategraph
-    elif [ -r ${MINGRAPH_FILE} ]; then
-        echo "Use minigraph.xml from old system..."
-        reload_minigraph
-        # Disable updategraph
-        disable_updategraph
     else
-        echo "Didn't found neither config_db.json nor minigraph.xml ..."
+        echo "Didn't found neither config_db.json..."
     fi
 
     rm -f /tmp/pending_config_migration
@@ -367,7 +353,7 @@ boot_config()
     fi
 
     # For multi-npu platfrom we don't support config initialization. Assumption
-    # is there should be existing minigraph or config_db from previous image
+    # is there should be existing config_db from previous image
     # file system to trigger. pending_config_initialization will remain set
     # for multi-npu platforms if we reach this case.
     if [[ ($NUM_ASIC -gt 1) ]]; then

--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -321,7 +321,7 @@ do_config_migration()
         # Disable updategraph
         disable_updategraph
     else
-        echo "Didn't found neither config_db.json..."
+        echo "Didn't found config_db.json..."
     fi
 
     rm -f /tmp/pending_config_migration

--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -31,6 +31,7 @@ CONFIG_DB_JSON=/etc/sonic/config_db.json
 CONFIG_DB_PATH=/etc/sonic/
 CONFIG_DB_PREFIX=config_db
 CONFIG_DB_SUFFIX=.json
+MINGRAPH_FILE=/etc/sonic/minigraph.xml
 TMP_ZTP_CONFIG_DB_JSON=/tmp/ztp_config_db.json
 FACTORY_DEFAULT_HOOKS=/etc/config-setup/factory-default-hooks.d
 CONFIG_PRE_MIGRATION_HOOKS=/etc/config-setup/config-migration-pre-hooks.d
@@ -102,6 +103,14 @@ run_hookdir() {
     fi
 
     return $exit_status
+}
+
+# Reload minigraph.xml file on disk
+reload_minigraph()
+{
+    echo "Reloading minigraph..."
+    config load_minigraph -y -n 
+    config save -y
 }
 
 # Apply tacacs config
@@ -296,7 +305,7 @@ check_all_config_db_present()
 do_config_migration()
 {
     # Identify list of files to migrate
-    copy_list="snmp.yml acl.json port_config.json frr telemetry"
+    copy_list="minigraph.xml snmp.yml acl.json port_config.json frr telemetry"
 
     # Migrate all configuration files from old to new
     copy_config_files_and_directories $copy_list
@@ -320,8 +329,13 @@ do_config_migration()
         reload_configdb
         # Disable updategraph
         disable_updategraph
+    elif [ -r ${MINGRAPH_FILE} ]; then
+        echo "Use minigraph.xml from old system..."
+        reload_minigraph
+        # Disable updategraph
+        disable_updategraph
     else
-        echo "Didn't found config_db.json..."
+        echo "Didn't found neither config_db.json nor minigraph.xml ..."
     fi
 
     rm -f /tmp/pending_config_migration
@@ -353,7 +367,7 @@ boot_config()
     fi
 
     # For multi-npu platfrom we don't support config initialization. Assumption
-    # is there should be existing config_db from previous image
+    # is there should be existing minigraph or config_db from previous image
     # file system to trigger. pending_config_initialization will remain set
     # for multi-npu platforms if we reach this case.
     if [[ ($NUM_ASIC -gt 1) ]]; then

--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-reload_minigraph()
-{
-    echo "Reloading minigraph..."
-    config load_minigraph -y -n 
-    config save -y
-}
-
 # read SONiC immutable variables
 [ -f /etc/sonic/sonic-environment ] && . /etc/sonic/sonic-environment
 
@@ -16,13 +9,6 @@ if [ ! -f /etc/sonic/updategraph.conf ]; then
 fi
 
 . /etc/sonic/updategraph.conf
-
-if [ "$enabled" = "reload_only" ]; then
-    reload_minigraph
-    sed -i "/enabled=/d" /etc/sonic/updategraph.conf
-    echo "enabled=false" >> /etc/sonic/updategraph.conf
-    exit 0
-fi
 
 if [ "$enabled" != "true" ]; then
     echo "Disabled in updategraph.conf. Skipping graph update."

--- a/files/image_config/updategraph/updategraph
+++ b/files/image_config/updategraph/updategraph
@@ -10,6 +10,11 @@ fi
 
 . /etc/sonic/updategraph.conf
 
+if [ "$enabled" = "reload_only" ]; then
+    echo "reload_only will not be supported in file updategraph.conf"
+    exit 1
+fi
+
 if [ "$enabled" != "true" ]; then
     echo "Disabled in updategraph.conf. Skipping graph update."
     exit 0


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Minigraph will be deprecated in the future. So minigraph related reload should be deleted.
#### How I did it
Remove unused load_minigraph
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

