### PR TITLE
[AN/LT][Enable]:enable phy_an_lt_msft attribute on broadcom platforms

### DIFF
--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/config.bcm.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/config.bcm.j2
@@ -527,3 +527,4 @@ serdes_preemphasis_123=0x14410a
 serdes_preemphasis_127=0x14410a
 serdes_driver_current_130=0xe
 serdes_preemphasis_130=0x102804
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/config.bcm.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/config.bcm.j2
@@ -570,3 +570,4 @@ serdes_preemphasis_123=0x85804
 serdes_preemphasis_125=0x85804
 serdes_preemphasis_127=0x85804
 serdes_preemphasis_129=0x85804
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/th-a7060-cx32s-32x100G-t1.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/th-a7060-cx32s-32x100G-t1.config.bcm
@@ -450,3 +450,4 @@ serdes_driver_current_109=0xa
 serdes_preemphasis_109=0x284008
 
 mmu_init_config="MSFT-TH-Tier1"
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-D48C8/th-a7060-cx32s-8x100G+48x50G.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-D48C8/th-a7060-cx32s-8x100G+48x50G.config.bcm
@@ -551,3 +551,4 @@ serdes_driver_current_115=0xa
 serdes_preemphasis_115=0x284008
 
 mmu_init_config="MSFT-TH-Tier0"
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q24C8/th-a7060-cx32s-8x100G+24x40G.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q24C8/th-a7060-cx32s-8x100G+24x40G.config.bcm
@@ -450,3 +450,4 @@ serdes_driver_current_109=0x4
 serdes_preemphasis_109=0x145c00
 
 mmu_init_config="MSFT-TH-Tier1"
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t0.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t0.config.bcm
@@ -448,3 +448,4 @@ serdes_driver_current_109=0x4
 serdes_preemphasis_109=0x145c00
 
 mmu_init_config="MSFT-TH-Tier0"
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t1.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t1.config.bcm
@@ -448,3 +448,4 @@ serdes_driver_current_109=0x4
 serdes_preemphasis_109=0x145c00
 
 mmu_init_config="MSFT-TH-Tier1"
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-T96C8/th-a7060-cx32s-8x100G+96x25G.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-T96C8/th-a7060-cx32s-8x100G+96x25G.config.bcm
@@ -784,3 +784,4 @@ serdes_driver_current_126=0xa
 serdes_preemphasis_126=0x284008
 serdes_driver_current_127=0xa
 serdes_preemphasis_127=0x284008
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-C64/config.bcm.j2
@@ -1041,3 +1041,4 @@ serdes_preemphasis_117=0x133c06
 
 {{ mmu_sock }}
 {{ IPinIP_sock }}
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-D108C8/config.bcm.j2
@@ -952,3 +952,4 @@ serdes_preemphasis_131=0x580c
 
 mmu_init_config="MSFT-TH2-Tier0"
 {{ IPinIP_sock }}
+phy_an_lt_msft=1

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/config.bcm.j2
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/config.bcm.j2
@@ -1040,3 +1040,4 @@ serdes_preemphasis_117=0x105004
 
 {{ mmu_sock }}
 {{ IPinIP_sock }}
+phy_an_lt_msft=1

--- a/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t0.config.bcm
+++ b/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t0.config.bcm
@@ -380,3 +380,4 @@ phy_xaui_tx_polarity_flip_130=0x0006
 phy_xaui_rx_polarity_flip_130=0x0000
 
 mmu_init_config="MSFT-TH-Tier0"
+phy_an_lt_msft=1

--- a/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t1.config.bcm
+++ b/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-C32/th-seastone-dx010-32x100G-t1.config.bcm
@@ -700,3 +700,4 @@ serdes_preemphasis_lane2_130=0x2b4104
 serdes_preemphasis_lane3_130=0x2b4104
 
 mmu_init_config="MSFT-TH-Tier1"
+phy_an_lt_msft=1

--- a/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-D48C8/th-seastone-dx010-48x50G+8x100G.config.bcm
+++ b/device/celestica/x86_64-cel_seastone-r0/Celestica-DX010-D48C8/th-seastone-dx010-48x50G+8x100G.config.bcm
@@ -652,3 +652,4 @@ serdes_preemphasis_lane1_5=0x244a02
 serdes_preemphasis_lane2_5=0x244a02
 serdes_preemphasis_lane3_5=0x254902
 
+phy_an_lt_msft=1

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -313,3 +313,4 @@ port_gmii_mode
 phy_force_firmware_load
 phy_pcs_repeater
 l3_alpm_hit_skip
+phy_an_lt_msft


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
According to this PR https://github.com/Azure/sonic-buildimage/pull/7547, we need to add 'phy_an_lt_msft' attribute to bcm config files to be consistent with 202012 branch settings.
#### How I did it
- Add 'phy_an_lt_msft' to BCM config permitted list.
- Set 'phy_an_lt_msft' attribute in bcm config files of some Broadcom-based platforms [Arista 7060CX, 7260CX3, 7050cx3, Celestica DX010].
#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

