### PR TITLE
[bgpcfgd] improve the log when delete a loopback interface

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_setsrc.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_setsrc.py
@@ -64,4 +64,4 @@ class ZebraSetSrc(Manager):
     def del_handler(self, key):
         """ Implementation of 'DEL' command for this class """
         self.directory.remove(self.db_name, self.table_name, key)
-        log_warn("Delete command is not supported for 'zebra set src' templates")
+        log_warn("Delete key '%s' is not supported for 'zebra set src' templates" % str(key))

--- a/src/sonic-bgpcfgd/tests/test_setsrc.py
+++ b/src/sonic-bgpcfgd/tests/test_setsrc.py
@@ -58,5 +58,6 @@ def test_set_handler_invalid_ip(mocked_log_err):
 @patch('bgpcfgd.managers_setsrc.log_warn')
 def test_del_handler(mocked_log_warn):
     m = constructor()
-    m.del_handler("Loopback0|10.1.0.32/32")
-    mocked_log_warn.assert_called_with("Delete command is not supported for 'zebra set src' templates")
+    del_key = "Loopback0|10.1.0.32/32"
+    m.del_handler(del_key)
+    mocked_log_warn.assert_called_with("Delete key '%s' is not supported for 'zebra set src' templates" % del_key)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The bgpcfgd doesn't support deletion of 'zebra set src', if an interface is deleted, the bgpcfgd will drop a warning message. In current implementation, we only care about the loopback0 interface but not others. 
To improve the log print to have the key info, which will give the name of the deleted interface. We can ignore it if it is not the loopback0 interface. The application layer should be aware of that update and deletion is not supported, delete or update with a new address of loopback0 could cause issue, this log can give enough info to root cause the issue.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

