### PR TITLE
[swss] Adding bgp container as dependent of swss

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DEPENDENT="radv dhcp_relay"
+DEPENDENT="radv dhcp_relay bgp"
 MULTI_INST_DEPENDENT="teamd"
 
 function debug()


### PR DESCRIPTION
What I did:
Added bgp as a dependent of swss

Why I did it:
bgp container was not restarting on swss crash. When swss crashes, linkmgrd
doesn't initate a switchover because it cannot access the default route from
orchagent. Bringing down bgp with swss will isolate the ToR, causing linkmgrd
to initiate a switchover to the peer ToR avoiding significant packet loss.

How I did it:
Added bgp to DEPENDENT

Signed-off-by: Nikola Dancejic <ndancejic@microsoft.com>