### PR TITLE
[build] Add version files to docker image dependencies

### DIFF
--- a/Makefile.cache
+++ b/Makefile.cache
@@ -561,10 +561,12 @@ define SHA_DEP_RULES
 ALL_DEP_FILES_LIST += $(foreach pkg,$(2), $($(filter none,$($(1)_CACHE_MODE)), \
                       $(addsuffix .$(3),$(addprefix $(pkg)/, $(1))) \
                       $(addsuffix .$(3).sha,$(addprefix $(pkg)/, $(1)))))
-$(if $(filter $(SONIC_DOCKER_IMAGES) $(SONIC_DOCKER_DBG_IMAGES), $(1)), \
-	$(foreach docker, $(1), \
+$(foreach docker, $(filter $(SONIC_DOCKER_IMAGES), $(1)), \
 	$(eval $(docker)_DEP_FILES+=$(wildcard files/build/versions/default/*) \
-	$(wildcard files/build/versions/dockers/$(subst -dbg,,$(basename $(docker)))/*))))
+	$(wildcard files/build/versions/dockers/$(basename $(docker))/*)))
+$(foreach docker, $(filter $(SONIC_DOCKER_DBG_IMAGES), $(1)), \
+	$(eval $(docker)_DEP_FILES+=$(wildcard files/build/versions/default/*) \
+	$(wildcard files/build/versions/dockers/$(patsubst %-$(DBG_IMAGE_MARK).gz,%,$(docker))/*)))
 $(addsuffix .$(3),$(addprefix $(2)/, $(1))) : $(2)/%.$(3) : \
 	$(2)/%.flags $$$$($$$$*_DEP_FILES) $$$$(if $$$$($$$$*_SMDEP_FILES), $(2)/%.smdep)
 	@$$(eval $$*_DEP_FILES_MODIFIED := $$? )

--- a/Makefile.cache
+++ b/Makefile.cache
@@ -561,6 +561,10 @@ define SHA_DEP_RULES
 ALL_DEP_FILES_LIST += $(foreach pkg,$(2), $($(filter none,$($(1)_CACHE_MODE)), \
                       $(addsuffix .$(3),$(addprefix $(pkg)/, $(1))) \
                       $(addsuffix .$(3).sha,$(addprefix $(pkg)/, $(1)))))
+$(if $(filter $(SONIC_DOCKER_IMAGES) $(SONIC_DOCKER_DBG_IMAGES), $(1)), \
+	$(foreach docker, $(1), \
+	$(eval $(docker)_DEP_FILES+=$(wildcard files/build/versions/default/*) \
+	$(wildcard files/build/versions/dockers/$(subst -dbg,,$(basename $(docker)))/*))))
 $(addsuffix .$(3),$(addprefix $(2)/, $(1))) : $(2)/%.$(3) : \
 	$(2)/%.flags $$$$($$$$*_DEP_FILES) $$$$(if $$$$($$$$*_SMDEP_FILES), $(2)/%.smdep)
 	@$$(eval $$*_DEP_FILES_MODIFIED := $$? )


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Docker image cache need involve package versions.
When we update version dependencies, we need to build new docker image. Loading from old cache may have unmatched dependencies.
#### How I did it
Add version files to dpkg cache dependency file.
#### How to verify it
```
shilongliu@50adfce3534b:/sonic$ make -f slave.mk target/docker-database.gz -p > log
dpkg: error: cannot access archive 'amd64/buildinfo/sonic-build-hooks_*.deb': No such file or directory
cp: cannot stat 'amd64/buildinfo/*': No such file or directory
/bin/bash: line 4: /sonic/target/files/buster/sysctl-net.conf.log: No such file or directory
make: *** [slave.mk:335: target/files/buster/sysctl-net.conf] Error 1

shilongliu@50adfce3534b:/sonic$ grep "docker-database.gz_DEP_FILES " log    
docker-database.gz_DEP_FILES :=  .platform slave.mk rules/functions Makefile.cache rules/docker-database.mk rules/docker-database.dep    sonic-slave-jessie/Dockerfile.j2 sonic-slave-jessie/Dockerfile.user.j2 sonic-slave-stretch/Dockerfile.j2 sonic-slave-stretch/Dockerfile.user.j2 sonic-slave-buster/Dockerfile.j2 sonic-slave-buster/Dockerfile.user.j2 dockers/docker-database/Dockerfile.j2 dockers/docker-database/base_image_files/redis-cli dockers/docker-database/critical_processes dockers/docker-database/database_config.json.j2 dockers/docker-database/database_global.json.j2 dockers/docker-database/docker-database-init.sh dockers/docker-database/flush_unused_database dockers/docker-database/supervisord.conf.j2 files/build/versions/default/versions-git files/build/versions/default/versions-web files/build/versions/default/versions-docker files/build/versions/dockers/docker-database/versions-web files/build/versions/dockers/docker-database/versions-deb-buster

We can see this file: https://artprodcus3.artifacts.visualstudio.com/Af91412a5-a906-4990-9d7c-f697b81fc04d/be1b070f-be15-4154-aade-b1d3bfb17054/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL21zc29uaWMvcHJvamVjdElkL2JlMWIwNzBmLWJlMTUtNDE1NC1hYWRlLWIxZDNiZmIxNzA1NC9idWlsZElkLzExMjMyMC9hcnRpZmFjdE5hbWUvc29uaWMtYnVpbGRpbWFnZS5tYXJ2ZWxsLWFybWhm0/content?format=file&subPath=%2Ftarget%2Fdocker-base-buster.gz.dep
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

