### PR TITLE
[iccpd] Fix missing semicolon.

### DIFF
--- a/src/iccpd/src/scheduler.c
+++ b/src/iccpd/src/scheduler.c
@@ -871,7 +871,7 @@ void scheduler_csm_socket_cleanup(struct CSM* csm, int location)
         return;
 
     if (csm->sock_fd <= 0)
-        return
+        return;
 
     event.data.fd = csm->sock_fd;
     event.events = EPOLLIN;


### PR DESCRIPTION
Signed-off-by: ouxiaolong <ouxiaolong@asterfusion.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The return statement does not end with a semicolon in function scheduler_csm_socket_cleanup, which generates a compilation warning and may cause unexpected problems.
the build log is like this:
```
scheduler.c: In function 'scheduler_csm_socket_cleanup':
scheduler.c:876:19: warning: 'return' with a value, in function returning void
     event.data.fd = csm->sock_fd;
     ~~~~~~~~~~~~~~^~~~~~~~~~~~~~
scheduler.c:861:6: note: declared here
 void scheduler_csm_socket_cleanup(struct CSM* csm, int location)
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
#### How I did it
add the missing semicolon
#### How to verify it
rebuild the iccpd.deb package and check the build log

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [x] 202106
- [x] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

