### PR TITLE
Update bcm config file system_ref_core_clock_khz param for j2cplus linecards

### DIFF
--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/0/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/0/ramon-a7800-7804r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=300
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/1/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/1/ramon-a7800-7804r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=301
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/10/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/10/ramon-a7800-7804r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=310
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/11/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/11/ramon-a7800-7804r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=311
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/2/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/2/ramon-a7800-7804r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=302
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/3/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/3/ramon-a7800-7804r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=303
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/4/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/4/ramon-a7800-7804r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=304
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/5/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/5/ramon-a7800-7804r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=305
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/6/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/6/ramon-a7800-7804r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=306
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/7/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/7/ramon-a7800-7804r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=307
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/8/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/8/ramon-a7800-7804r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=308
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/9/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/9/ramon-a7800-7804r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=309
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/0/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/0/ramon-a7800-7808r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=300
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/1/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/1/ramon-a7800-7808r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=301
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/10/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/10/ramon-a7800-7808r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=310
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/11/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/11/ramon-a7800-7808r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=311
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/12/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/12/ramon-a7800-7808r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=312
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/13/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/13/ramon-a7800-7808r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=313
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/14/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/14/ramon-a7800-7808r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=314
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/15/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/15/ramon-a7800-7808r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=315
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/16/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/16/ramon-a7800-7808r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=316
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/17/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/17/ramon-a7800-7808r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=317
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/2/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/2/ramon-a7800-7808r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=302
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/3/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/3/ramon-a7800-7808r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=303
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/4/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/4/ramon-a7800-7808r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=304
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/5/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/5/ramon-a7800-7808r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=305
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/6/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/6/ramon-a7800-7808r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=306
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/7/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/7/ramon-a7800-7808r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=307
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/8/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/8/ramon-a7800-7808r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=308
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/9/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/9/ramon-a7800-7808r3-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=309
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/0/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/0/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=300
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/1/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/1/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=301
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/10/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/10/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=310
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/11/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/11/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=311
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/2/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/2/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=302
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/3/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/3/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=303
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/4/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/4/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=304
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/5/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/5/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=305
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/6/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/6/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=306
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/7/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/7/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=307
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/8/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/8/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=308
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/9/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/9/ramon-a7800-7808r3a-fm.config.bcm
@@ -1,4 +1,5 @@
 appl_param_module_id=309
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 port_init_cl72=1

--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
@@ -1,4 +1,5 @@
 soc_family.BCM8869X=BCM8869X
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 custom_feature_ucode_path=u_code_db2pem.txt

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1,4 +1,5 @@
 soc_family=BCM8885X
+system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
 

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -314,3 +314,4 @@ phy_force_firmware_load
 phy_pcs_repeater
 l3_alpm_hit_skip
 phy_an_lt_msft
+system_ref_core_clock_khz


### PR DESCRIPTION
Update the bcm config file system_ref_core_clock_khz param to handlesystems with J2cplus linecards.

We need system_ref_core_clock_khz to be set to 1600000 for supporting j2 and j2cplus linecards on the same chassis.