### PR TITLE
Add dependency of determine-reboot-cause to process-reboot-cause service

### DIFF
--- a/src/sonic-host-services-data/debian/sonic-host-services-data.process-reboot-cause.service
+++ b/src/sonic-host-services-data/debian/sonic-host-services-data.process-reboot-cause.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Retrieve the reboot cause from the history files and save them to StateDB
-Requires=database.service
-After=database.service
+Requires=database.service determine-reboot-cause.service
+After=database.service determine-reboot-cause.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
Database container takes long time ( more than 1.5 minutes ) on some vendor platforms.
This makes the determine-reboot-cause starts later than process-reboot-cause service.
And that results in the incorrect reboot-cause determination.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Database container takes long time ( more than 1.5 minutes ) on some vendor platforms.
This makes the determine-reboot-cause starts later than process-reboot-cause service.
And that results in the incorrect reboot-cause determination.
#### How I did it
Add the dependency of determine-reboot-cause service to process-reboot-cause service
#### How to verify it
Reboot and check the reboot-cause once the device boots up.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

