### PR TITLE
Update scripts in sonic-buildimage from py-swsssdk to swsscommon

### DIFF
--- a/dockers/docker-database/flush_unused_database
+++ b/dockers/docker-database/flush_unused_database
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-import swsssdk
+from swsscommon import swsscommon
 import redis
 import subprocess
 import time
@@ -11,15 +11,15 @@ while(True):
         break
     time.sleep(1)
 
-instlists = swsssdk.SonicDBConfig.get_instancelist()
+instlists = swsscommon.SonicDBConfig.get_instancelist()
 for instname, v in instlists.items():
     insthost = v['hostname']
     instsocket = v['unix_socket_path']
 
-    dblists = swsssdk.SonicDBConfig.get_dblist()
+    dblists = swsscommon.SonicDBConfig.get_dblist()
     for dbname in dblists:
-        dbid = swsssdk.SonicDBConfig.get_dbid(dbname)
-        dbinst = swsssdk.SonicDBConfig.get_instancename(dbname)
+        dbid = swsscommon.SonicDBConfig.get_dbid(dbname)
+        dbinst = swsscommon.SonicDBConfig.get_instancename(dbname)
 
         # this DB is on current instance, skip flush
         if dbinst == instname:

--- a/dockers/docker-orchagent/enable_counters.py
+++ b/dockers/docker-orchagent/enable_counters.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import time
-import swsssdk
+from swsscommon import swsscommon
 
 # ALPHA defines the size of the window over which we calculate the average value. ALPHA is 2/(N+1) where N is the interval(window size)
 # In this case we configure the window to be 10s. This way if we have a huge 1s spike in traffic,
@@ -23,7 +23,7 @@ def enable_counter_group(db, name):
 
 def enable_rates():
     # set the default interval for rates
-    counters_db = swsssdk.SonicV2Connector()
+    counters_db = swsscommon.SonicV2Connector()
     counters_db.connect('COUNTERS_DB')
     counters_db.set('COUNTERS_DB', 'RATES:PORT', 'PORT_SMOOTH_INTERVAL', DEFAULT_SMOOTH_INTERVAL)
     counters_db.set('COUNTERS_DB', 'RATES:PORT', 'PORT_ALPHA', DEFAULT_ALPHA)
@@ -36,7 +36,7 @@ def enable_rates():
 
 
 def enable_counters():
-    db = swsssdk.ConfigDBConnector()
+    db = swsscommon.ConfigDBConnector()
     db.connect()
     default_enabled_counters = ['PORT', 'RIF', 'QUEUE', 'PFCWD', 'PG_WATERMARK', 'PG_DROP', 
                                 'QUEUE_WATERMARK', 'BUFFER_POOL_WATERMARK', 'PORT_BUFFER_DROP', 'ACL']

--- a/dockers/docker-orchagent/tunnel_packet_handler.py
+++ b/dockers/docker-orchagent/tunnel_packet_handler.py
@@ -12,7 +12,7 @@ import time
 from datetime import datetime
 from ipaddress import ip_interface
 
-from swsssdk import ConfigDBConnector, SonicV2Connector
+from swsscommon.swsscommon import ConfigDBConnector, SonicV2Connector
 from sonic_py_common import logger as log
 
 from pyroute2 import IPRoute

--- a/dockers/docker-sflow/port_index_mapper.py
+++ b/dockers/docker-sflow/port_index_mapper.py
@@ -5,7 +5,7 @@ import sys
 import traceback
 from sonic_py_common.logger import Logger
 from socket import if_nametoindex
-from swsssdk import SonicV2Connector, port_util
+from sonic_py_common import port_util
 from swsscommon import swsscommon
 
 SYSLOG_IDENTIFIER = 'port_index_mapper'
@@ -26,7 +26,7 @@ class PortIndexMapper(object):
                                               REDIS_TIMEOUT_MS,
                                               True)
 
-        self.state_db = SonicV2Connector(host='127.0.0.1', decode_responses=True)
+        self.state_db = swsscommon.SonicV2Connector(host='127.0.0.1', decode_responses=True)
         self.state_db.connect(self.state_db.STATE_DB, False)
         self.sel = swsscommon.Select()
         self.tbls = [swsscommon.SubscriberStateTable(self.appl_db, t)

--- a/dockers/docker-snmp/snmp_yml_to_configdb.py
+++ b/dockers/docker-snmp/snmp_yml_to_configdb.py
@@ -5,7 +5,7 @@ import sys
 
 import yaml
 from sonic_py_common.logger import Logger
-from swsssdk import ConfigDBConnector
+from swsscommon.swsscommon import ConfigDBConnector
 
 db = ConfigDBConnector()
 db.connect()

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -5,7 +5,7 @@ import subprocess
 import time
 import syslog
 import os
-from swsssdk import ConfigDBConnector
+from swsscommon.swsscommon import ConfigDBConnector
 import socket
 import threading
 import queue

--- a/src/sonic-frr-mgmt-framework/tests/test_config.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_config.py
@@ -2,9 +2,11 @@ import copy
 import re
 from unittest.mock import MagicMock, NonCallableMagicMock, patch
 
-swsssdk_module_mock = MagicMock(ConfigDBConnector = NonCallableMagicMock)
+swsscommon_module_mock = MagicMock(ConfigDBConnector = NonCallableMagicMock)
+# because can’t use dotted names directly in a call, have to create a dictionary and unpack it using **:
+mockmapping = {'swsscommon.swsscommon': swsscommon_module_mock}
 
-@patch.dict('sys.modules', swsssdk = swsssdk_module_mock)
+@patch.dict('sys.modules', **mockmapping)
 def test_contructor():
     from frrcfgd.frrcfgd import BGPConfigDaemon
     daemon = BGPConfigDaemon()
@@ -147,7 +149,7 @@ bgp_globals_data = [
                        conf_bgp_af_cmd('Vrf_red', 200, 'ipv6') + ['{}import vrf route-map test_map']),
 ]
 
-@patch.dict('sys.modules', swsssdk = swsssdk_module_mock)
+@patch.dict('sys.modules', **mockmapping)
 @patch('frrcfgd.frrcfgd.g_run_command')
 def data_set_del_test(test_data, run_cmd):
     from frrcfgd.frrcfgd import BGPConfigDaemon

--- a/src/sonic-frr-mgmt-framework/tests/test_constructor.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_constructor.py
@@ -2,9 +2,11 @@ import socket
 import pytest
 from unittest.mock import MagicMock, NonCallableMagicMock, patch
 
-swsssdk_module_mock = MagicMock(ConfigDBConnector = NonCallableMagicMock)
+swsscommon_module_mock = MagicMock(ConfigDBConnector = NonCallableMagicMock)
+# because can’t use dotted names directly in a call, have to create a dictionary and unpack it using **:
+mockmapping = {'swsscommon.swsscommon': swsscommon_module_mock}
 
-with patch.dict('sys.modules', swsssdk = swsssdk_module_mock):
+with patch.dict('sys.modules', **mockmapping):
     from frrcfgd.frrcfgd import CachedDataWithOp
     from frrcfgd.frrcfgd import BGPPeerGroup
     from frrcfgd.frrcfgd import BGPKeyMapInfo


### PR DESCRIPTION

#### Why I did it
Update scripts in sonic-buildimage from py-swsssdk to swsscommon


#### How I did it
Change code to use swsscommon.

#### How to verify it
Pass all E2E test case

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
Update scripts in sonic-buildimage from py-swsssdk to swsscommon

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

