### PR TITLE
Add backend acl template

### DIFF
--- a/files/build_templates/backend_acl.j2
+++ b/files/build_templates/backend_acl.j2
@@ -1,0 +1,51 @@
+{%- set vlan2ports = {} %}
+{%- for vlan in VLAN %}
+    {% set portlist = [] %}
+    {%- for vlan_name, port in VLAN_MEMBER %}
+        {%- if vlan_name == vlan %}
+            {%- if portlist.append(port) %}{%- endif %}
+        {%- endif %}
+    {%- endfor %}
+    {%- set _ = vlan2ports.update({vlan: portlist| sort | join(',')}) %}
+{%- endfor %}
+
+
+{
+        "acl": {
+                "acl-sets": {
+                        "acl-set": {
+                                "DATAACL": {
+                                        "acl-entries": {
+                                                "acl-entry": {
+                                                 {% for vlan, vlan_entries in VLAN.items() %}
+    "{{ loop.index }}": {
+                                                             "config": {
+                                                                     "sequence-id": {{ loop.index }}
+                                                             },
+                                                             "actions": {
+                                                                     "config": {
+                                                                             "forwarding-action": "ACCEPT"
+                                                                     }
+                                                             },
+                                                             "l2": {
+                                                                     "config": {
+                                                                             "vlan_id": "{{ vlan_entries['vlanid'] }}"
+                                                                     }
+                                                             },
+                                                             "input_interface": {
+                                                                     "interface_ref": {
+                                                                             "config": {
+                                                                                     "interface": "{{ vlan2ports[vlan] }}"
+                                                                             }
+                                                                      }
+                                                             }
+
+                                                     }{% if not loop.last %},{% endif %} 
+                                                 {% endfor -%}
+                                                }
+                                        }
+                                }
+                        }
+                }
+        }
+}

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -521,6 +521,9 @@ then
 fi
 {% endif %}
 
+# Copy backend acl template
+sudo cp $BUILD_TEMPLATES/backend_acl.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/
+
 # Copy hostname configuration scripts
 sudo cp $IMAGE_CONFIGS/hostname/hostname-config.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
 echo "hostname-config.service" | sudo tee -a $GENERATED_SERVICE_FILE

--- a/src/sonic-config-engine/tests/data/backend_acl/acl_multi_vlan.json
+++ b/src/sonic-config-engine/tests/data/backend_acl/acl_multi_vlan.json
@@ -1,0 +1,59 @@
+
+{
+        "acl": {
+                "acl-sets": {
+                        "acl-set": {
+                                "DATAACL": {
+                                        "acl-entries": {
+                                                "acl-entry": {
+                                                     "1": {
+                                                             "config": {
+                                                                     "sequence-id": 1
+                                                             },
+                                                             "actions": {
+                                                                     "config": {
+                                                                             "forwarding-action": "ACCEPT"
+                                                                     }
+                                                             },
+                                                             "l2": {
+                                                                     "config": {
+                                                                             "vlan_id": "1000"
+                                                                     }
+                                                             },
+                                                             "input_interface": {
+                                                                     "interface_ref": {
+                                                                             "config": {
+                                                                                     "interface": "Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76"
+                                                                             }
+                                                                      }
+                                                             }
+
+                                                     },                                                     "2": {
+                                                             "config": {
+                                                                     "sequence-id": 2
+                                                             },
+                                                             "actions": {
+                                                                     "config": {
+                                                                             "forwarding-action": "ACCEPT"
+                                                                     }
+                                                             },
+                                                             "l2": {
+                                                                     "config": {
+                                                                             "vlan_id": "2000"
+                                                                     }
+                                                             },
+                                                             "input_interface": {
+                                                                     "interface_ref": {
+                                                                             "config": {
+                                                                                     "interface": "Ethernet4,Ethernet8"
+                                                                             }
+                                                                      }
+                                                             }
+
+                                                     }                                                 }
+                                        }
+                                }
+                        }
+                }
+        }
+}

--- a/src/sonic-config-engine/tests/data/backend_acl/acl_single_vlan.json
+++ b/src/sonic-config-engine/tests/data/backend_acl/acl_single_vlan.json
@@ -1,0 +1,38 @@
+
+{
+        "acl": {
+                "acl-sets": {
+                        "acl-set": {
+                                "DATAACL": {
+                                        "acl-entries": {
+                                                "acl-entry": {
+                                                     "1": {
+                                                             "config": {
+                                                                     "sequence-id": 1
+                                                             },
+                                                             "actions": {
+                                                                     "config": {
+                                                                             "forwarding-action": "ACCEPT"
+                                                                     }
+                                                             },
+                                                             "l2": {
+                                                                     "config": {
+                                                                             "vlan_id": "1000"
+                                                                     }
+                                                             },
+                                                             "input_interface": {
+                                                                     "interface_ref": {
+                                                                             "config": {
+                                                                                     "interface": "Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet4,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet8"
+                                                                             }
+                                                                      }
+                                                             }
+
+                                                     }
+                                                 }
+                                        }
+                                }
+                        }
+                }
+        }
+}

--- a/src/sonic-config-engine/tests/data/backend_acl/multi_vlan.json
+++ b/src/sonic-config-engine/tests/data/backend_acl/multi_vlan.json
@@ -1,0 +1,69 @@
+{
+    "VLAN": {
+        "Vlan1000": {
+            "vlanid": "1000"
+        },
+        "Vlan2000": {
+            "vlanid": "2000"
+        }
+    },
+    "VLAN_MEMBER": {
+        "Vlan1000|Ethernet12": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet16": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet20": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet24": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet28": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet32": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet36": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet40": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet44": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet48": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet52": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet56": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet60": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet64": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet68": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet72": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet76": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan2000|Ethernet4": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan2000|Ethernet8": {
+            "tagging_mode": "tagged"
+        }
+    }
+}

--- a/src/sonic-config-engine/tests/data/backend_acl/single_vlan.json
+++ b/src/sonic-config-engine/tests/data/backend_acl/single_vlan.json
@@ -1,0 +1,66 @@
+{
+    "VLAN": {
+        "Vlan1000": {
+            "vlanid": "1000"
+        }
+    },
+    "VLAN_MEMBER": {
+        "Vlan1000|Ethernet4": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet8": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet12": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet16": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet20": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet24": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet28": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet32": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet36": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet40": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet44": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet48": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet52": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet56": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet60": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet64": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet68": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet72": {
+            "tagging_mode": "tagged"
+        },
+        "Vlan1000|Ethernet76": {
+            "tagging_mode": "tagged"
+        }
+    }
+}

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -574,6 +574,34 @@ class TestJ2Files(TestCase):
         self.run_script(argument)
         assert utils.cmp(expected, self.output_file), self.run_diff(expected, self.output_file)
 
+    def test_backend_acl_template_render(self):
+        acl_template = os.path.join(
+            self.test_dir, '..', '..', '..', 'files', 'build_templates',
+            'backend_acl.j2'
+        )
+        test_list = {
+            'single_vlan': {
+                'input': 'single_vlan.json',
+                'output': 'acl_single_vlan.json'
+            },
+            'multi_vlan': {
+                'input': 'multi_vlan.json',
+                'output': 'acl_multi_vlan.json'
+            },
+        }
+        for _, v in test_list.items():
+            input_file = os.path.join(
+                self.test_dir, 'data', 'backend_acl', v['input']
+            )
+            argument = " -j {} -t {} > {}".format(
+                input_file, acl_template, self.output_file
+            )
+            sample_output_file = os.path.join(
+                self.test_dir, 'data', 'backend_acl', v['output']
+            )
+            self.run_script(argument)
+            assert utils.cmp(sample_output_file, self.output_file), self.run_diff(sample_output_file, self.output_file)
+
     def tearDown(self):
         os.environ["CFGGEN_UNIT_TESTING"] = ""
         try:


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Storage backend has all vlan members tagged. If untagged packets are received on those links, they are accounted as RX_DROPS which can lead to false alarms in monitoring tools. Using this acl to hide these drops.

#### How I did it
Created a acl template which will be loaded during minigraph load for backend. This template will allow tagged vlan packets and dropped untagged

#### How to verify it
Unit tests

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [x] 202111
- [x] 202205
