### PR TITLE
Fixed eth0 DHCP config for /etc/network/interfaces

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -101,6 +101,7 @@ iface {{ name }} {{ 'inet' if prefix | ipv4 else 'inet6' }} static
 {# TODO: COPP policy type rules #}
 {% endfor %}
 {% else %}
+auto eth0
 iface eth0 inet dhcp
     metric 202
 {% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}


### PR DESCRIPTION
Signed-off-by: Andriy Kokhan <andriyx.kokhan@intel.com>

#### Why I did it
Fixed eth0 DHCP config for /etc/network/interfaces to enable autoconfig on boot.
https://github.com/Azure/sonic-buildimage/pull/11204

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

