### PR TITLE
[tunnel_packet_handler] Add a whitespace in the warning syslog message

### DIFF
--- a/dockers/docker-orchagent/tunnel_packet_handler.py
+++ b/dockers/docker-orchagent/tunnel_packet_handler.py
@@ -192,7 +192,7 @@ class TunnelPacketHandler(object):
             peer_switch = self.config_db.get_keys(PEER_SWITCH_TABLE)[0]
             tunnel = self.config_db.get_keys(TUNNEL_TABLE)[0]
         except IndexError:
-            logger.log_warning('PEER_SWITCH or TUNNEL table'
+            logger.log_warning('PEER_SWITCH or TUNNEL table '
                                'not found in config DB')
             return None, None
 


### PR DESCRIPTION
Signed-off-by: Yong Zhao <yozhao@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR aims to add a whitespace in the warning syslog message of process `tunnel_packet_handler`.

This minor issue was found by an incident ticket.

#### How I did it
I added a whitespace in the log string.

#### How to verify it
I tested on a lab device to intentionally raise an expection and check the fomrat of log messages in syslog.

`WARNING swss#tunnel_packet_handler.py: PEER_SWITCH or TUNNEL table not found in config DB`

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ x] 202012
- [ ] 202106
- [x ] 202111
- [ x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

