### PR TITLE
Add yang model unit test for check_up_status field type

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1465,7 +1465,8 @@
                 "has_timer": "False",
                 "high_mem_alert": "disabled",
                 "state": "enabled",
-                "set_owner": "local"
+                "set_owner": "local",
+                "check_up_status": "False"
             },
             "database": {
                 "auto_restart": "always_enabled",
@@ -1474,7 +1475,8 @@
                 "has_timer": "false",
                 "high_mem_alert": "disabled",
                 "state": "always_enabled",
-                "set_owner": "local"
+                "set_owner": "local",
+                "check_up_status": "false"
             },
             "snmp": {
                 "auto_restart": "enabled",
@@ -1483,7 +1485,8 @@
                 "has_timer": "true",
                 "high_mem_alert": "disabled",
                 "state": "enabled",
-                "set_owner": "kube"
+                "set_owner": "kube",
+                "check_up_status": "true"
             },
             "swss": {
                 "auto_restart": "enabled",
@@ -1492,7 +1495,8 @@
                 "has_timer": "false",
                 "high_mem_alert": "disabled",
                 "state": "enabled",
-                "set_owner": "local"
+                "set_owner": "local",
+                "check_up_status": "false"
             },
             "syncd": {
                 "auto_restart": "enabled",
@@ -1501,7 +1505,8 @@
                 "has_timer": "false",
                 "high_mem_alert": "disabled",
                 "state": "enabled",
-                "set_owner": "local"
+                "set_owner": "local",
+                "check_up_status": "false"
             },
             "lldp": {
                 "auto_restart": "enabled",
@@ -1510,7 +1515,8 @@
                 "has_timer": "false",
                 "high_mem_alert": "disabled",
                 "state": "enabled",
-                "set_owner": "kube"
+                "set_owner": "kube",
+                "check_up_status": "false"
             },
             "dhcp_relay": {
                 "auto_restart": "enabled",
@@ -1519,7 +1525,8 @@
                 "has_timer": "false",
                 "high_mem_alert": "disabled",
                 "state": "{% if not (DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] != 'ToRRouter') %}enabled{% else %}disabled{% endif %}",
-                "set_owner": "kube"
+                "set_owner": "kube",
+                "check_up_status": "true"
             }
         },
         "DHCP_RELAY": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/feature.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/feature.json
@@ -10,7 +10,8 @@
                         "has_timer": "False",
                         "has_global_scope": "True",
                         "has_per_asic_scope": "True",
-                        "set_owner": "local"
+                        "set_owner": "local",
+                        "check_up_status": "False"
                     },
                     {
                         "name": "swss",
@@ -19,7 +20,8 @@
                         "has_timer": "false",
                         "has_global_scope": "false",
                         "has_per_asic_scope": "true",
-                        "set_owner": "local"
+                        "set_owner": "local",
+                        "check_up_status": "false"
                     },
                     {
                         "name": "syncd",
@@ -28,7 +30,8 @@
                         "has_timer": "false",
                         "has_global_scope": "false",
                         "has_per_asic_scope": "true",
-                        "set_owner": "local"
+                        "set_owner": "local",
+                        "check_up_status": "false"
                     },
                     {
                         "name": "snmp",
@@ -37,7 +40,8 @@
                         "has_timer": "false",
                         "has_global_scope": "true",
                         "has_per_asic_scope": "false",
-                        "set_owner": "kube"
+                        "set_owner": "kube",
+                        "check_up_status": "false"
                     },
                     {
                         "name": "lldp",
@@ -46,7 +50,8 @@
                         "has_timer": "false",
                         "has_global_scope": "false",
                         "has_per_asic_scope": "true",
-                        "set_owner": "kube"
+                        "set_owner": "kube",
+                        "check_up_status": "false"
                     },
                     {
                         "name": "dhcp_relay",
@@ -55,7 +60,8 @@
                         "has_timer": "false",
                         "has_global_scope": "false",
                         "has_per_asic_scope": "true",
-                        "set_owner": "kube"
+                        "set_owner": "kube",
+                        "check_up_status": "false"
                     }
                 ]
             }
@@ -72,7 +78,8 @@
                         "has_timer": "false",
                         "has_global_scope": "false",
                         "has_per_asic_scope": "true",
-                        "set_owner": "invalid"
+                        "set_owner": "invalid",
+                        "check_up_status": "false"
                     }
                 ]
             }
@@ -88,7 +95,8 @@
                         "auto_restart": "disabled",
                         "has_timer": "false",
                         "has_global_scope": "false",
-                        "has_per_asic_scope": "true"
+                        "has_per_asic_scope": "true",
+                        "check_up_status": "false"
                     }
                 ]
             }
@@ -104,7 +112,8 @@
                         "auto_restart": "always_enabled",
                         "has_timer": "FALSE",
                         "has_global_scope": "TRUE",
-                        "has_per_asic_scope": "TRUE"
+                        "has_per_asic_scope": "TRUE",
+                        "check_up_status": "FALSE"
                     }
                 ]
             }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To address https://github.com/Azure/sonic-buildimage/issues/11110 - Add yang model unit test for check_up_status field type

#### How I did it
Add check_up_status with different values in sample_config_db.json and
the field with correct and incorrect values in feature.json

#### How to verify it
Build sonic_yang_models-1.0-py3-none-any.whl

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

