### PR TITLE
[asan] add print_suppressions=0 to ASAN configs

### DIFF
--- a/dockers/docker-orchagent/supervisord.conf.j2
+++ b/dockers/docker-orchagent/supervisord.conf.j2
@@ -36,6 +36,7 @@ dependent_startup=true
 {% set orchagent_dependent_startup_wait_for = "rsyslogd:running" %}
 {%- endif %}
 {%- endif %}
+{% set asan_extra_options = ':print_suppressions=0' %}
 
 {% if is_fabric_asic == 0 %}
 [program:gearsyncd]
@@ -50,7 +51,7 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/gearsyncd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/gearsyncd-asan.log{{ asan_extra_options }}"
 {% endif %}
 {%- endif %}
 
@@ -65,7 +66,7 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/portsyncd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/portsyncd-asan.log{{ asan_extra_options }}"
 {% endif %}
 {%- endif %}
 
@@ -79,7 +80,7 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for={{ orchagent_dependent_startup_wait_for }}
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/orchagent-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/orchagent-asan.log{{ asan_extra_options }}"
 {% endif %}
 
 [program:swssconfig]
@@ -94,7 +95,7 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=orchagent:running
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/swssconfig-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/swssconfig-asan.log{{ asan_extra_options }}"
 {% endif %}
 
 {% if is_fabric_asic == 0 %}
@@ -124,7 +125,7 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=orchagent:running
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/coppmgrd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/coppmgrd-asan.log{{ asan_extra_options }}"
 {% endif %}
 {%- endif %}
 
@@ -139,7 +140,7 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=swssconfig:exited
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/neighsyncd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/neighsyncd-asan.log{{ asan_extra_options }}"
 {% endif %}
 {%- endif %}
 
@@ -154,7 +155,7 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=swssconfig:exited
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/vlanmgrd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/vlanmgrd-asan.log{{ asan_extra_options }}"
 {% endif %}
 {%- endif %}
 
@@ -169,7 +170,7 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=swssconfig:exited
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/intfmgrd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/intfmgrd-asan.log{{ asan_extra_options }}"
 {% endif %}
 {%- endif %}
 
@@ -184,7 +185,7 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=swssconfig:exited
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/portmgrd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/portmgrd-asan.log{{ asan_extra_options }}"
 {% endif %}
 {%- endif %}
 
@@ -199,7 +200,7 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=swssconfig:exited
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/buffermgrd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/buffermgrd-asan.log{{ asan_extra_options }}"
 {% endif %}
 {%- endif %}
 
@@ -214,7 +215,7 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=swssconfig:exited
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/vrfmgrd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/vrfmgrd-asan.log{{ asan_extra_options }}"
 {% endif %}
 {%- endif %}
 
@@ -229,7 +230,7 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=swssconfig:exited
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/nbrmgrd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/nbrmgrd-asan.log{{ asan_extra_options }}"
 {% endif %}
 {%- endif %}
 
@@ -244,7 +245,7 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=swssconfig:exited
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/vxlanmgrd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/vxlanmgrd-asan.log{{ asan_extra_options }}"
 {% endif %}
 {%- endif %}
 
@@ -259,7 +260,7 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=swssconfig:exited
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/tunnelmgrd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/tunnelmgrd-asan.log{{ asan_extra_options }}"
 {% endif %}
 {%- endif %}
 
@@ -284,7 +285,7 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=swssconfig:exited
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/fdbsyncd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/fdbsyncd-asan.log{{ asan_extra_options }}"
 {% endif %}
 {%- endif %}
 

--- a/platform/mellanox/docker-syncd-mlnx/supervisord.conf.j2
+++ b/platform/mellanox/docker-syncd-mlnx/supervisord.conf.j2
@@ -1,3 +1,4 @@
+{% set asan_extra_options = ':print_suppressions=0' %}
 [supervisord]
 logfile_maxbytes=1MB
 logfile_backups=2
@@ -38,5 +39,5 @@ stderr_logfile=syslog
 dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/syncd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/syncd-asan.log{{ asan_extra_options }}"
 {% endif %}

--- a/platform/vs/docker-sonic-vs/supervisord.conf.j2
+++ b/platform/vs/docker-sonic-vs/supervisord.conf.j2
@@ -1,3 +1,4 @@
+{% set asan_extra_options = ':print_suppressions=0' %}
 [supervisord]
 logfile_maxbytes=1MB
 logfile_backups=2
@@ -43,7 +44,7 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/syncd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/syncd-asan.log{{ asan_extra_options }}"
 {% endif %}
 
 [program:gbsyncd]
@@ -71,7 +72,7 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/portsyncd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/portsyncd-asan.log{{ asan_extra_options }}"
 {% endif %}
 
 [program:orchagent]
@@ -82,7 +83,7 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/orchagent-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/orchagent-asan.log{{ asan_extra_options }}"
 {% endif %}
 
 [program:coppmgrd]
@@ -93,7 +94,7 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/coppmgrd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/coppmgrd-asan.log{{ asan_extra_options }}"
 {% endif %}
 
 [program:neighsyncd]
@@ -104,7 +105,7 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/neighsyncd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/neighsyncd-asan.log{{ asan_extra_options }}"
 {% endif %}
 
 [program:teamsyncd]
@@ -115,7 +116,7 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/teamsyncd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/teamsyncd-asan.log{{ asan_extra_options }}"
 {% endif %}
 
 [program:vlanmgrd]
@@ -126,7 +127,7 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/vlanmgrd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/vlanmgrd-asan.log{{ asan_extra_options }}"
 {% endif %}
 
 [program:intfmgrd]
@@ -137,7 +138,7 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/intfmgrd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/intfmgrd-asan.log{{ asan_extra_options }}"
 {% endif %}
 
 [program:portmgrd]
@@ -148,7 +149,7 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/portmgrd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/portmgrd-asan.log{{ asan_extra_options }}"
 {% endif %}
 
 [program:teammgrd]
@@ -159,7 +160,7 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/teammgrd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/teammgrd-asan.log{{ asan_extra_options }}"
 {% endif %}
 
 [program:zebra]
@@ -194,7 +195,7 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/fpmsyncd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/fpmsyncd-asan.log{{ asan_extra_options }}"
 {% endif %}
 
 [program:arp_update]
@@ -213,7 +214,7 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/buffermgrd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/buffermgrd-asan.log{{ asan_extra_options }}"
 {% endif %}
 
 [program:vrfmgrd]
@@ -224,7 +225,7 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/vrfmgrd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/vrfmgrd-asan.log{{ asan_extra_options }}"
 {% endif %}
 
 [program:restore_neighbors]
@@ -245,7 +246,7 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/nbrmgrd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/nbrmgrd-asan.log{{ asan_extra_options }}"
 {% endif %}
 
 [program:vxlanmgrd]
@@ -256,7 +257,7 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/vxlanmgrd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/vxlanmgrd-asan.log{{ asan_extra_options }}"
 {% endif %}
 
 [program:sflowmgrd]
@@ -267,7 +268,7 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/sflowmgrd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/sflowmgrd-asan.log{{ asan_extra_options }}"
 {% endif %}
 
 [program:natmgrd]
@@ -278,7 +279,7 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/natmgrd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/natmgrd-asan.log{{ asan_extra_options }}"
 {% endif %}
 
 [program:natsyncd]
@@ -289,7 +290,7 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/natsyncd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/natsyncd-asan.log{{ asan_extra_options }}"
 {% endif %}
 
 [program:fdbsyncd]
@@ -300,7 +301,7 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/fdbsyncd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/fdbsyncd-asan.log{{ asan_extra_options }}"
 {% endif %}
 
 [program:tunnelmgrd]
@@ -311,5 +312,5 @@ autorestart=false
 stdout_logfile=syslog
 stderr_logfile=syslog
 {% if ENABLE_ASAN == "y" %}
-environment=ASAN_OPTIONS="log_path=/var/log/asan/tunnelmgrd-asan.log"
+environment=ASAN_OPTIONS="log_path=/var/log/asan/tunnelmgrd-asan.log{{ asan_extra_options }}"
 {% endif %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To provide an ability to suppress ASAN false positives and have a clean ASAN report for docker-sonic-vs/mlnx-syncd/orchagent docker
#### How I did it
Added the "print_suppressions=0" to ASAN configs.
#### How to verify it
* add a suppression to some ASAN-enabled component (the suppression should catch some leak)
* build with ENABLE_ASAN=y
* run a test and see that the ASAN report is empty instead of having the suppression summary
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

