### PR TITLE
[yang] update TCP_FLAGS format in sonic-acl.yang

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
@@ -129,5 +129,8 @@
     },
     "ACL_RULE_WITH_VALID_MIRROR_INGRESS_ACTION": {
         "desc": "Configure ACL_RULE with valid mirror action."
+    },
+    "ACL_RULE_VALID_TCP_FLAGS": {
+        "desc": "Configure ACL_RULE with valid TCP_FLAGS."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
@@ -953,7 +953,7 @@
                         "ACL_TABLE_NAME": "EVERFLOW_DSCP",
                         "policy_desc": "EVERFLOW_DSCP",
                         "ports": [
-			    ""
+                            ""
                         ],
                         "stage": "ingress",
                         "type": "MIRROR_DSCP"
@@ -981,7 +981,7 @@
                         "ACL_TABLE_NAME": "EVERFLOW_DSCP",
                         "policy_desc": "EVERFLOW_DSCP",
                         "ports": [
-			    ""
+                            ""
                         ],
                         "stage": "ingress",
                         "type": "MIRROR_DSCP"
@@ -999,6 +999,42 @@
                         "src_ip": "10.1.1.1",
                         "gre_type": "0x1234",
                         "dscp": "10"
+                    }
+                ]
+            }
+        }
+    },
+    "ACL_RULE_VALID_TCP_FLAGS": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "TCP_FLAGS_TEST",
+                        "ETHER_TYPE": "2048",
+                        "PACKET_ACTION": "DROP",
+                        "PRIORITY": 9981,
+                        "TCP_FLAGS": "0x24",
+                        "RULE_NAME": "Rule_19"
+                    },
+                    {
+                        "ACL_TABLE_NAME": "TCP_FLAGS_TEST",
+                        "ETHER_TYPE": "2048",
+                        "PACKET_ACTION": "DROP",
+                        "PRIORITY": 9981,
+                        "TCP_FLAGS": "0x24/0x24",
+                        "RULE_NAME": "Rule_20"
+                    }
+
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "TCP_FLAGS_TEST",
+                        "policy_desc": "TCP_FLAGS_TEST",
+                        "ports": [ "" ],
+                        "stage": "INGRESS",
+                        "type": "L3"
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
@@ -184,7 +184,7 @@ module sonic-acl {
 
 				leaf TCP_FLAGS {
 					type string {
-						pattern '0[x][0-9a-fA-F]{1,2}|0[X][0-9a-fA-F]{1,2}';
+						pattern '0[xX][0-9a-fA-F]{1,2}(/0[xX][0-9a-fA-F]{1,2})?';
 					}
 				}
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix https://github.com/Azure/sonic-buildimage/issues/11224
TCP_FLAGS supports `flags/mask` pattern. Refs https://github.com/Azure/sonic-utilities/blob/master/acl_loader/main.py#L574
#### How I did it
Change the pattern.
#### How to verify it
Add unit test.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

