### PR TITLE
Avoid write_standby in warm restart context 

### DIFF
--- a/files/scripts/write_standby.py
+++ b/files/scripts/write_standby.py
@@ -141,7 +141,7 @@ class MuxStateWriter(object):
 
         if self.is_warmrestart:
             # If in warmrestart context, take no action
-            logger.log_warning("Taking no action due to ongoing warmrestart.")
+            logger.log_warning("Skip setting mux state due to ongoing warmrestart.")
             return
 
         intfs = self.get_auto_mux_intfs()

--- a/files/scripts/write_standby.py
+++ b/files/scripts/write_standby.py
@@ -3,8 +3,8 @@
 import time
 
 from sonic_py_common import logger as log
-from swsscommon.swsscommon import ConfigDBConnector, DBConnector, FieldValuePairs, ProducerStateTable, SonicV2Connector
-from swsscommon.swsscommon import APPL_DB 
+from swsscommon.swsscommon import ConfigDBConnector, DBConnector, FieldValuePairs, ProducerStateTable, SonicV2Connector, Table
+from swsscommon.swsscommon import APPL_DB, STATE_DB 
 
 logger = log.Logger('write_standby')
 
@@ -22,6 +22,7 @@ class MuxStateWriter(object):
     def __init__(self):
         self.config_db_connector = None
         self.appl_db_connector = None
+        self.state_db_connector = None
         self.asic_db_connector = None
 
     @property
@@ -45,6 +46,16 @@ class MuxStateWriter(object):
         if self.appl_db_connector is None:
             self.appl_db_connector = DBConnector(APPL_DB, REDIS_SOCK_PATH, True)
         return self.appl_db_connector
+    
+    @property
+    def state_db(self):
+        """
+        Returns the state DB connector.
+        Intializes the connector during the first call
+        """
+        if self.state_db_connector is None:
+            self.state_db_connector = DBConnector(STATE_DB, REDIS_SOCK_PATH, True)
+        return self.state_db_connector
 
     @property
     def asic_db(self):
@@ -74,6 +85,16 @@ class MuxStateWriter(object):
         metadata = self.config_db.get_entry('DEVICE_METADATA', localhost_key)
 
         return 'subtype' in metadata and 'dualtor' in metadata['subtype'].lower()
+
+    @property
+    def is_warmrestart(self):
+        """
+        Checks if a warmrestart is going on
+        """
+        tbl = Table(self.state_db, 'WARM_RESTART_ENABLE_TABLE')
+        (status, value) = tbl.hget('system', 'enable')
+
+        return status and value == 'true' 
 
     def get_auto_mux_intfs(self):
         """
@@ -117,6 +138,12 @@ class MuxStateWriter(object):
         if not self.is_dualtor:
             # If not running on a dual ToR system, take no action
             return
+
+        if self.is_warmrestart:
+            # If in warmrestart context, take no action
+            logger.log_warning("Taking no action due to ongoing warmrestart.")
+            return
+
         intfs = self.get_auto_mux_intfs()
         state = 'standby'
         if self.wait_for_tunnel():


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Avoid write_standby in warm restart context.

sign-off: Jing Zhang zhangjing@microsoft.com

#### Why I did it
In warm restart context, we should avoid mux state change. 

#### How I did it
Check warm restart flag before applying changes to app db. 

#### How to verify it
* Ran write_standby in table missing, key missing, field missing scenarios. 
* Did a warm restart, app db changes were skipped. Saw this in syslog:  
  `WARNING write_standby: Taking no action due to ongoing warmrestart.`

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

