### PR TITLE
[macsec] cli multi-namespace support

### DIFF
--- a/dockers/docker-macsec/cli-plugin-tests/conftest.py
+++ b/dockers/docker-macsec/cli-plugin-tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 import mock_tables # lgtm [py/unused-import]
+import mock_single_asic # lgtm [py/unused-import]
 from unittest import mock
 
 

--- a/dockers/docker-macsec/cli-plugin-tests/conftest.py
+++ b/dockers/docker-macsec/cli-plugin-tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 import mock_tables # lgtm [py/unused-import]
-import mock_single_asic # lgtm [py/unused-import]
+import mock_single_asic # lgtm[py/unused-import]
 from unittest import mock
 
 

--- a/dockers/docker-macsec/cli-plugin-tests/mock_single_asic.py
+++ b/dockers/docker-macsec/cli-plugin-tests/mock_single_asic.py
@@ -1,0 +1,81 @@
+# MONKEY PATCH!!!
+from unittest import mock
+
+from sonic_py_common import multi_asic
+from utilities_common import multi_asic as multi_asic_util
+
+mock_intf_table = {
+    '': {
+        'eth0': {
+            2: [{'addr': '10.1.1.1', 'netmask': '255.255.255.0', 'broadcast': '10.1.1.1'}],
+            10: [{'addr': '3100::1', 'netmask': 'ffff:ffff:ffff:ffff::/64'}]
+        },
+        'Ethernet0': {
+            17: [{'addr': '82:fd:d1:5b:45:2f', 'broadcast': 'ff:ff:ff:ff:ff:ff'}],
+            2: [
+                    {'addr': '20.1.1.1', 'netmask': '255.255.255.0', 'broadcast': '20.1.1.1'},
+                    {'addr': '21.1.1.1', 'netmask': '255.255.255.0', 'broadcast': '21.1.1.1'}
+                ],
+            10: [
+                    {'addr': 'aa00::1', 'netmask': 'ffff:ffff:ffff:ffff::/64'},
+                    {'addr': '2100::1', 'netmask': 'ffff:ffff:ffff:ffff::/64'},
+                    {'addr': 'fe80::64be:a1ff:fe85:c6c4%Ethernet0', 'netmask': 'ffff:ffff:ffff:ffff::/64'}
+                ]
+        },
+        'PortChannel0001': {
+            17: [{'addr': '82:fd:d1:5b:45:2f', 'broadcast': 'ff:ff:ff:ff:ff:ff'}], 
+            2: [{'addr': '30.1.1.1', 'netmask': '255.255.255.0', 'broadcast': '30.1.1.1'}],
+            10: [
+                    {'addr': 'ab00::1', 'netmask': 'ffff:ffff:ffff:ffff::/64'},
+                    {'addr': 'fe80::cc8d:60ff:fe08:139f%PortChannel0001', 'netmask': 'ffff:ffff:ffff:ffff::/64'}
+                ]
+        },
+        'Vlan100': {
+            17: [{'addr': '82:fd:d1:5b:45:2f', 'broadcast': 'ff:ff:ff:ff:ff:ff'}], 
+            2: [{'addr': '40.1.1.1', 'netmask': '255.255.255.0', 'broadcast': '30.1.1.1'}],
+            10: [
+                    {'addr': 'cc00::1', 'netmask': 'ffff:ffff:ffff:ffff::/64'},
+                    {'addr': 'fe80::c029:3fff:fe41:cf56%Vlan100', 'netmask': 'ffff:ffff:ffff:ffff::/64'}
+                ]
+        },
+        'lo': {
+            2: [{'addr': '127.0.0.1', 'netmask': '255.0.0.0', 'broadcast': '127.255.255.255'}],
+            10: [{'addr': '::1', 'netmask':'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128'}]
+        }
+    }
+}
+
+
+def mock_get_num_asics():
+    return 1
+
+def mock_is_multi_asic():
+    return False
+
+def mock_get_namespace_list(namespace=None):
+    return ['']
+
+
+def mock_single_asic_get_ip_intf_from_ns(namespace):
+    interfaces = []
+    try:
+        interfaces = list(mock_intf_table[namespace].keys())
+    except KeyError:
+        pass
+    return interfaces
+
+
+def mock_single_asic_get_ip_intf_addr_from_ns(namespace, iface):
+    ipaddresses = []
+    try:
+        ipaddresses = mock_intf_table[namespace][iface]
+    except KeyError:
+        pass
+    return ipaddresses
+
+
+multi_asic.is_multi_asic = mock_is_multi_asic
+multi_asic.get_num_asics = mock_get_num_asics
+multi_asic.get_namespace_list = mock_get_namespace_list
+multi_asic_util.multi_asic_get_ip_intf_from_ns = mock_single_asic_get_ip_intf_from_ns
+multi_asic_util.multi_asic_get_ip_intf_addr_from_ns = mock_single_asic_get_ip_intf_addr_from_ns

--- a/dockers/docker-macsec/cli-plugin-tests/mock_tables.py
+++ b/dockers/docker-macsec/cli-plugin-tests/mock_tables.py
@@ -125,7 +125,10 @@ class CounterTable:
 
     def get(self, macsec, name):
         key = self.db.hget("COUNTERS_MACSEC_NAME_MAP", name)
-        return self.db.get("COUNTERS:" + key)
+        if key:
+            fvs = self.db.get("COUNTERS:" + key)
+            if fvs: return True, fvs
+        return False, ()
 
 
 swsssdk.interface.DBInterface._subscribe_keyspace_notification = _subscribe_keyspace_notification

--- a/dockers/docker-macsec/cli/config/plugins/macsec.py
+++ b/dockers/docker-macsec/cli/config/plugins/macsec.py
@@ -1,13 +1,27 @@
 import click
 import utilities_common.cli as clicommon
+from sonic_py_common import multi_asic
+from swsscommon.swsscommon import ConfigDBConnector
+from utilities_common.constants import DEFAULT_NAMESPACE
+from utilities_common.db import Db
 
 #
 # 'macsec' group ('config macsec ...')
 #
 @click.group(cls=clicommon.AbbreviationGroup, name='macsec')
-def macsec():
+# TODO add "hidden=True if this is a single ASIC platform, once we have click 7.0 in all branches.
+@click.option('-n', '--namespace', help='Namespace name',
+             required=True if multi_asic.is_multi_asic() else False, type=click.Choice(multi_asic.get_namespace_list()))
+@click.pass_context
+def macsec(ctx, namespace):
     """MACsec-related configuration tasks"""
-    pass
+    if not ctx.obj or isinstance(ctx.obj, Db):
+        # Set namespace to default_namespace if it is None.
+        if namespace is None:
+            namespace = DEFAULT_NAMESPACE
+        config_db = ConfigDBConnector(use_unix_socket_path=True, namespace=str(namespace))
+        config_db.connect()
+        ctx.obj = config_db
 
 
 #
@@ -24,31 +38,30 @@ def macsec_port():
 @macsec_port.command('add')
 @click.argument('port', metavar='<port_name>', required=True)
 @click.argument('profile', metavar='<profile_name>', required=True)
-@clicommon.pass_db
-def add_port(db, port, profile):
+def add_port(port, profile):
     """
     Add MACsec port
     """
     ctx = click.get_current_context()
+    config_db = ctx.obj
 
     if clicommon.get_interface_naming_mode() == "alias":
         alias = port
-        iface_alias_converter = clicommon.InterfaceAliasConverter(db)
-        port = iface_alias_converter.alias_to_name(alias)
+        port = interface_alias_to_name(config_db, port)
         if port is None:
-            ctx.fail("cannot find port name for alias {}".format(alias))
+            ctx.fail("cannot find port name for alias {}".format(port))
 
-    profile_entry = db.cfgdb.get_entry('MACSEC_PROFILE', profile)
+    profile_entry = config_db.get_entry('MACSEC_PROFILE', profile)
     if len(profile_entry) == 0:
         ctx.fail("profile {} doesn't exist".format(profile))
 
-    port_entry = db.cfgdb.get_entry('PORT', port)
+    port_entry = config_db.get_entry('PORT', port)
     if len(port_entry) == 0:
         ctx.fail("port {} doesn't exist".format(port))
 
     port_entry['macsec'] = profile
 
-    db.cfgdb.set_entry("PORT", port, port_entry)
+    config_db.set_entry("PORT", port, port_entry)
 
 
 #
@@ -56,27 +69,26 @@ def add_port(db, port, profile):
 #
 @macsec_port.command('del')
 @click.argument('port', metavar='<port_name>', required=True)
-@clicommon.pass_db
-def del_port(db, port):
+def del_port(port):
     """
     Delete MACsec port
     """
     ctx = click.get_current_context()
+    config_db = ctx.obj
 
     if clicommon.get_interface_naming_mode() == "alias":
         alias = port
-        iface_alias_converter = clicommon.InterfaceAliasConverter(db)
-        port = iface_alias_converter.alias_to_name(alias)
+        port = interface_alias_to_name(config_db, port)
         if port is None:
-            ctx.fail("cannot find port name for alias {}".format(alias))
+            ctx.fail("cannot find port name for alias {}".format(port))
 
-    port_entry = db.cfgdb.get_entry('PORT', port)
+    port_entry = config_db.get_entry('PORT', port)
     if len(port_entry) == 0:
         ctx.fail("port {} doesn't exist".format(port))
 
     del port_entry['macsec']
 
-    db.cfgdb.set_entry("PORT", port, port_entry)
+    config_db.set_entry("PORT", port, port_entry)
 
 
 #
@@ -109,13 +121,14 @@ def is_hexstring(hexstring: str):
 @click.option('--replay_window', metavar='<enable_replay_protect>', required=False, default=0, show_default=True, type=click.IntRange(0, 2**32), help="Replay window size that is the number of packets that could be out of order. This field works only if ENABLE_REPLAY_PROTECT is true.")
 @click.option('--send_sci/--no_send_sci', metavar='<send_sci>', required=False, default=True, show_default=True, is_flag=True, help="Send SCI in SecTAG field of MACsec header.")
 @click.option('--rekey_period', metavar='<rekey_period>', required=False, default=0, show_default=True, type=click.IntRange(min=0), help="The period of proactively refresh (Unit second).")
-@clicommon.pass_db
-def add_profile(db, profile, priority, cipher_suite, primary_cak, primary_ckn, policy, enable_replay_protect, replay_window, send_sci, rekey_period):
+def add_profile(profile, priority, cipher_suite, primary_cak, primary_ckn, policy, enable_replay_protect, replay_window, send_sci, rekey_period):
     """
     Add MACsec profile
     """
     ctx = click.get_current_context()
-    profile_entry = db.cfgdb.get_entry('MACSEC_PROFILE', profile)
+    config_db = ctx.obj
+
+    profile_entry = config_db.get_entry('MACSEC_PROFILE', profile)
     if not len(profile_entry) == 0:
         ctx.fail("{} already exists".format(profile))
 
@@ -157,7 +170,7 @@ def add_profile(db, profile, priority, cipher_suite, primary_cak, primary_ckn, p
                 profile_table[k] = "false"
         else:
             profile_table[k] = str(v)
-    db.cfgdb.set_entry("MACSEC_PROFILE", profile, profile_table)
+    config_db.set_entry("MACSEC_PROFILE", profile, profile_table)
 
 
 #
@@ -165,24 +178,24 @@ def add_profile(db, profile, priority, cipher_suite, primary_cak, primary_ckn, p
 #
 @macsec_profile.command('del')
 @click.argument('profile', metavar='<profile_name>', required=True)
-@clicommon.pass_db
-def del_profile(db, profile):
+def del_profile( profile):
     """
     Delete MACsec profile
     """
     ctx = click.get_current_context()
+    config_db = ctx.obj
 
-    profile_entry = db.cfgdb.get_entry('MACSEC_PROFILE', profile)
+    profile_entry = config_db.get_entry('MACSEC_PROFILE', profile)
     if len(profile_entry) == 0:
         ctx.fail("{} doesn't exist".format(profile))
 
     # Check if the profile is being used by any port
-    for port in db.cfgdb.get_keys('PORT'):
-        attr = db.cfgdb.get_entry('PORT', port)
+    for port in config_db.get_keys('PORT'):
+        attr = config_db.get_entry('PORT', port)
         if 'macsec' in attr and attr['macsec'] == profile:
             ctx.fail("{} is being used by port {}, Please remove the MACsec from the port firstly".format(profile, port))
 
-    db.cfgdb.set_entry("MACSEC_PROFILE", profile, None)
+    config_db.set_entry("MACSEC_PROFILE", profile, None)
 
 
 def register(cli):

--- a/dockers/docker-macsec/cli/config/plugins/macsec.py
+++ b/dockers/docker-macsec/cli/config/plugins/macsec.py
@@ -46,7 +46,6 @@ def add_port(port, profile):
     config_db = ctx.obj
 
     if clicommon.get_interface_naming_mode() == "alias":
-        alias = port
         port = interface_alias_to_name(config_db, port)
         if port is None:
             ctx.fail("cannot find port name for alias {}".format(port))
@@ -77,7 +76,6 @@ def del_port(port):
     config_db = ctx.obj
 
     if clicommon.get_interface_naming_mode() == "alias":
-        alias = port
         port = interface_alias_to_name(config_db, port)
         if port is None:
             ctx.fail("cannot find port name for alias {}".format(port))

--- a/dockers/docker-macsec/cli/show/plugins/show_macsec.py
+++ b/dockers/docker-macsec/cli/show/plugins/show_macsec.py
@@ -5,7 +5,6 @@ import click
 from tabulate import tabulate
 
 import utilities_common.multi_asic as multi_asic_util
-from swsscommon.swsscommon import SonicV2Connector
 from swsscommon.swsscommon import CounterTable, MacsecCounter
 
 

--- a/dockers/docker-macsec/cli/show/plugins/show_macsec.py
+++ b/dockers/docker-macsec/cli/show/plugins/show_macsec.py
@@ -4,22 +4,20 @@ from natsort import natsorted
 import click
 from tabulate import tabulate
 
+import utilities_common.multi_asic as multi_asic_util
 from swsscommon.swsscommon import SonicV2Connector
 from swsscommon.swsscommon import CounterTable, MacsecCounter
 
 
-DB_CONNECTOR = SonicV2Connector(use_unix_socket_path=False)
-DB_CONNECTOR.connect(DB_CONNECTOR.APPL_DB)
-DB_CONNECTOR.connect(DB_CONNECTOR.COUNTERS_DB)
-COUNTER_TABLE = CounterTable(DB_CONNECTOR.get_redis_client(DB_CONNECTOR.COUNTERS_DB))
+DB_CONNECTOR = None
+COUNTER_TABLE = None
 
 
 class MACsecAppMeta(object):
-    SEPARATOR = DB_CONNECTOR.get_db_separator(DB_CONNECTOR.APPL_DB)
-
     def __init__(self, *args) -> None:
-        key = self.__class__.get_appl_table_name() + MACsecAppMeta.SEPARATOR + \
-            MACsecAppMeta.SEPARATOR.join(args)
+        SEPARATOR = DB_CONNECTOR.get_db_separator(DB_CONNECTOR.APPL_DB)
+        key = self.__class__.get_appl_table_name() + SEPARATOR + \
+            SEPARATOR.join(args)
         self.meta = DB_CONNECTOR.get_all(
             DB_CONNECTOR.APPL_DB, key)
         if len(self.meta) == 0:
@@ -184,19 +182,36 @@ def create_macsec_objs(interface_name: str) -> typing.List[MACsecAppMeta]:
 
 @click.command()
 @click.argument('interface_name', required=False)
-def macsec(interface_name):
-    ctx = click.get_current_context()
-    objs = []
-    interface_names = [name.split(":")[1] for name in DB_CONNECTOR.keys(DB_CONNECTOR.APPL_DB, "MACSEC_PORT*")]
-    if interface_name is not None:
-        if interface_name not in interface_names:
-            ctx.fail("Cannot find the port {} in MACsec port lists {}".format(interface_name, interface_names))
-        else:
+@multi_asic_util.multi_asic_click_options
+def macsec(interface_name, namespace, display):
+    MacsecContext(namespace, display).show(interface_name)
+
+
+class MacsecContext(object):
+
+    def __init__(self, namespace_option, display_option):
+        self.db = None
+        self.multi_asic = multi_asic_util.MultiAsic(
+            display_option, namespace_option)
+
+    @multi_asic_util.run_on_multi_asic
+    def show(self, interface_name):
+        global DB_CONNECTOR
+        global COUNTER_TABLE
+        DB_CONNECTOR = self.db
+        COUNTER_TABLE = CounterTable(self.db.get_redis_client(self.db.COUNTERS_DB))
+
+        interface_names = [name.split(":")[1] for name in self.db.keys(self.db.APPL_DB, "MACSEC_PORT*")]
+        if interface_name is not None:
+            if interface_name not in interface_names:
+                return
             interface_names = [interface_name]
-    for interface_name in natsorted(interface_names):
-        objs += create_macsec_objs(interface_name)
-    for obj in objs:
-        print(obj.dump_str())
+
+        objs = []
+        for interface_name in natsorted(interface_names):
+            objs += create_macsec_objs(interface_name)
+        for obj in objs:
+            print(obj.dump_str())
 
 
 def register(cli):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Enable multi-asic platform support for macsec cli
#### How I did it
Add an option `-n, --namespace <name>` in config/show macsec.

```
admin@dut:~$ show macsec -h
Usage: show macsec [OPTIONS] [INTERFACE_NAME]
Options:
  -d, --display [all]  Show internal interfaces  [default: all]
  -n, --namespace []   Namespace name or all
  -?, -h, --help       Show this message and exit.

admin@dut:~$ sudo config macsec -h
Usage: config macsec [OPTIONS] COMMAND [ARGS]...
  MACsec-related configuration tasks
Options:
  -n, --namespace []  Namespace name
  -?, -h, --help      Show this message and exit.
```

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

