### PR TITLE
[Marvell-armhf] Fix kernel hang due to kernel upgrade to 5.10.103

### DIFF
--- a/platform/marvell-armhf/platform.conf
+++ b/platform/marvell-armhf/platform.conf
@@ -6,9 +6,9 @@ echo "Preparing for installation ... "
 
 # global defines
 kernel_addr=0x1100000
-fdt_addr=0x1000000
-fdt_high=0x10fffff
-initrd_addr=0x2000000
+fdt_addr=0x2800000
+fdt_high=0x28fffff
+initrd_addr=0x2900000
 
 kernel_fname="/boot/vmlinuz-5.10.0-12-2-armmp"
 initrd_fname="/boot/initrd.img-5.10.0-12-2-armmp"


### PR DESCRIPTION
Change-Id: I015856d173d50d94e30d8c555590efb70eb712ae
Signed-off-by: Pavan Naregundi <pnaregundi@marvell.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Kernel hang was cause due to increase in size of kernel during the upgrade to 5.10.103 and uboot env setting for fdt and initrd address was not good enough.

#### How I did it
Have given sufficient room for kernel, by moving fdt_addr and initrd_addr.

#### How to verify it
Verified by loading image on Marvell Armada 380/385.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

