### PR TITLE
Add sai_mdio_access_clause22=1 in td3x2-a720dt-48s-flex.config.bcm

### DIFF
--- a/device/arista/x86_64-arista_720dt_48s/td3x2-a720dt-48s-flex.config.bcm
+++ b/device/arista/x86_64-arista_720dt_48s/td3x2-a720dt-48s-flex.config.bcm
@@ -300,3 +300,4 @@ sram_scan_enable.0=0
 stable_size=0x5500000
 tdma_timeout_usec.0=15000000
 tslam_timeout_usec.0=15000000
+sai_mdio_access_clause22=1

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -317,3 +317,4 @@ phy_an_lt_msft
 system_ref_core_clock_khz
 xflow_macsec_secure_chan_to_num_secure_assoc_encrypt
 xflow_macsec_secure_chan_to_num_secure_assoc_decrypt
+sai_mdio_access_clause22


### PR DESCRIPTION
Signed-off-by: Jiahua Wang <jiahua.wang@broadcom.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The sai switch api as of now only has "switch_mdio_read/switch_mdio_write" functions. SAI needs another configuration parameter to distinguish  mdio access clause 22 from clause 45.

#### How I did it
Adding the new soc property "sai_mdio_access_clause22" will allow the mdio device using the mdio clause 22 access with the same sai switch api functions "switch_mdio_read/switch_mdio_write".

#### How to verify it
On a platform with mdio clause 22 device connected to broadcom NPU mdio bus, PAI/gearbox will only work with the new soc property "sai_mdio_access_clause22=1". 

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

