### PR TITLE
[cherry-pick][201811][minigraph] Support parse IPv6 in device_desc.xml

### DIFF
--- a/src/sonic-config-engine/tests/simple-sample-device-desc-ipv6-only.xml
+++ b/src/sonic-config-engine/tests/simple-sample-device-desc-ipv6-only.xml
@@ -1,0 +1,11 @@
+<Device i:type="ToRRouter" xmlns="Microsoft.Search.Autopilot.Evolution" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Hostname>switch-t0</Hostname>
+  <HwSku>Force10-S6000</HwSku>
+  <ClusterName>AAA00PrdStr00</ClusterName>
+  <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+    <a:IPPrefix>0.0.0.0/0</a:IPPrefix>
+    </ManagementAddress>
+    <ManagementAddressV6 xmlns:a="Microsoft.Search.Autopilot.NetMux">
+    <a:IPPrefix>FC00:1::32/64</a:IPPrefix>
+  </ManagementAddressV6>
+</Device>

--- a/src/sonic-config-engine/tests/simple-sample-device-desc.xml
+++ b/src/sonic-config-engine/tests/simple-sample-device-desc.xml
@@ -1,0 +1,11 @@
+<Device i:type="ToRRouter" xmlns="Microsoft.Search.Autopilot.Evolution" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Hostname>switch-t0</Hostname>
+  <HwSku>Force10-S6000</HwSku>
+  <ClusterName>AAA00PrdStr00</ClusterName>
+  <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+    <a:IPPrefix>10.0.0.100/24</a:IPPrefix>
+    </ManagementAddress>
+    <ManagementAddressV6 xmlns:a="Microsoft.Search.Autopilot.NetMux">
+    <a:IPPrefix>FC00:1::32/64</a:IPPrefix>
+  </ManagementAddressV6>
+</Device>

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -10,8 +10,6 @@ class TestCfgGenCaseInsensitive(TestCase):
         self.test_dir = os.path.dirname(os.path.realpath(__file__))
         self.script_file = os.path.join(self.test_dir, '..', 'sonic-cfggen')
         self.sample_graph = os.path.join(self.test_dir, 'simple-sample-graph-case.xml')
-        self.sample_resource_graph = os.path.join(self.test_dir, 'sample-graph-resource-type.xml')
-        self.sample_subintf_graph = os.path.join(self.test_dir, 'sample-graph-subintf.xml')
         self.sample_simple_device_desc = os.path.join(self.test_dir, 'simple-sample-device-desc.xml')
         self.sample_simple_device_desc_ipv6_only = os.path.join(self.test_dir, 'simple-sample-device-desc-ipv6-only.xml')
         self.port_config = os.path.join(self.test_dir, 't0-sample-port-config.ini')

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -1,13 +1,19 @@
 from unittest import TestCase
 import subprocess
 import os
+import ipaddr as ipaddress
 import minigraph
+
 class TestCfgGenCaseInsensitive(TestCase):
 
     def setUp(self):
         self.test_dir = os.path.dirname(os.path.realpath(__file__))
         self.script_file = os.path.join(self.test_dir, '..', 'sonic-cfggen')
         self.sample_graph = os.path.join(self.test_dir, 'simple-sample-graph-case.xml')
+        self.sample_resource_graph = os.path.join(self.test_dir, 'sample-graph-resource-type.xml')
+        self.sample_subintf_graph = os.path.join(self.test_dir, 'sample-graph-subintf.xml')
+        self.sample_simple_device_desc = os.path.join(self.test_dir, 'simple-sample-device-desc.xml')
+        self.sample_simple_device_desc_ipv6_only = os.path.join(self.test_dir, 'simple-sample-device-desc-ipv6-only.xml')
         self.port_config = os.path.join(self.test_dir, 't0-sample-port-config.ini')
 
     def run_script(self, argument, check_stderr=False):
@@ -146,5 +152,20 @@ class TestCfgGenCaseInsensitive(TestCase):
             output.strip(),
             "{'Vlan1000': {'dhcpv6_servers': ['fc02:2000::1', 'fc02:2000::2']}}" 
         )
-        
-    
+
+    def test_parse_device_desc_xml_mgmt_interface(self):
+        # Regular device_desc.xml with both IPv4 and IPv6 mgmt address
+        result = minigraph.parse_device_desc_xml(self.sample_simple_device_desc)
+        mgmt_intf = result['MGMT_INTERFACE']
+        self.assertEqual(len(mgmt_intf.keys()), 2)
+        self.assertTrue(('eth0', '10.0.0.100/24') in mgmt_intf.keys())
+        self.assertTrue(('eth0', 'FC00:1::32/64') in mgmt_intf.keys())
+        self.assertTrue(ipaddress.IPAddress('10.0.0.1') == mgmt_intf[('eth0', '10.0.0.100/24')]['gwaddr'])
+        self.assertTrue(ipaddress.IPAddress('fc00:1::1') == mgmt_intf[('eth0', 'FC00:1::32/64')]['gwaddr'])
+
+        # Special device_desc.xml with IPv6 mgmt address only
+        result = minigraph.parse_device_desc_xml(self.sample_simple_device_desc_ipv6_only)
+        mgmt_intf = result['MGMT_INTERFACE']
+        self.assertEqual(len(mgmt_intf.keys()), 1)
+        self.assertTrue(('eth0', 'FC00:1::32/64') in mgmt_intf.keys())
+        self.assertTrue(ipaddress.IPAddress('fc00:1::1') == mgmt_intf[('eth0', 'FC00:1::32/64')]['gwaddr'])


### PR DESCRIPTION
…l (#11095) (#11273)

* [minigraph] Support parse IPv6 in device_desc.xml (#11095)

Signed-off-by: Jing Kan jika@microsoft.com

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
https://github.com/Azure/sonic-buildimage/pull/11095

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

