### PR TITLE
[Build] Fix the missing debian package for reproducible build issue

### DIFF
--- a/src/sonic-build-hooks/hooks/apt-get
+++ b/src/sonic-build-hooks/hooks/apt-get
@@ -20,7 +20,7 @@ if [ "$INSTALL" == y ]; then
     [ "$lock_result" == y ] && release_apt_installation_lock
     exit $command_result
 else
-    if [[ "$1" == "purge" || "$@" == *" purge "* ]]; then
+    if [[ "$1" == "purge" || "$@" == *" purge "* || "$@" == *" remove "* ]]; then
       # When running the purge command, collect the debian versions
       dpkg-query -W -f '${Package}==${Version}\n' >> $POST_VERSION_PATH/purge-versions-deb
       chmod a+wr $POST_VERSION_PATH/purge-versions-deb


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fix the missing debian package for reproducible build issue.

The gnupg2 should be added into the version file.
https://dev.azure.com/mssonic/build/_build/results?buildId=118139&view=logs&j=88ce9a53-729c-5fa9-7b6e-3d98f2488e3f&t=8d99be27-49d0-54d0-99b1-cfc0d47f0318
```
The following packages have unmet dependencies:
 gnupg2 : Depends: gnupg (>= 2.2.27-2+deb11u2) but 2.2.27-2+deb11u1 is to be installed
E: Unable to correct problems, you have held broken packages.

```
The issue was caused by the gnupg2 removed, and not detected.
https://github.com/Azure/sonic-buildimage/blob/4fb6cf03e68856620038a1d3577ede15e89f8211/build_debian.sh#L250

#### How I did it
Export the debian packages when any debian package being removed.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106
- [x] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

