### PR TITLE
[dhcp6relay] Check interface address is not NULL

### DIFF
--- a/src/dhcp6relay/src/relay.cpp
+++ b/src/dhcp6relay/src/relay.cpp
@@ -343,7 +343,7 @@ void prepare_relay_config(relay_config *interface_config, int *local_sock, int f
     }
 
     ifa_tmp = ifa;
-    while (ifa_tmp) {
+    while (ifa_tmp && ifa_tmp->ifa_addr) {
         if (ifa_tmp->ifa_addr->sa_family == AF_INET6) {
             struct sockaddr_in6 *in6 = (struct sockaddr_in6*) ifa_tmp->ifa_addr;
             if((strcmp(ifa_tmp->ifa_name, interface_config->interface.c_str()) == 0) && !IN6_IS_ADDR_LINKLOCAL(&in6->sin6_addr)) {    
@@ -401,7 +401,7 @@ void prepare_socket(int *local_sock, int *server_sock, relay_config *config, int
         }
         else {
             ifa_tmp = ifa;
-            while (ifa_tmp) {
+            while (ifa_tmp && ifa_tmp->ifa_addr) {
                 if ((ifa_tmp->ifa_addr->sa_family == AF_INET6) && (strcmp(ifa_tmp->ifa_name, config->interface.c_str()) == 0)) {
                     struct sockaddr_in6 *in6 = (struct sockaddr_in6*) ifa_tmp->ifa_addr;
                     if(!IN6_IS_ADDR_LINKLOCAL(&in6->sin6_addr)) {  

--- a/src/dhcp6relay/src/relay.cpp
+++ b/src/dhcp6relay/src/relay.cpp
@@ -343,8 +343,8 @@ void prepare_relay_config(relay_config *interface_config, int *local_sock, int f
     }
 
     ifa_tmp = ifa;
-    while (ifa_tmp && ifa_tmp->ifa_addr) {
-        if (ifa_tmp->ifa_addr->sa_family == AF_INET6) {
+    while (ifa_tmp) {
+        if (ifa_tmp->ifa_addr && ifa_tmp->ifa_addr->sa_family == AF_INET6) {
             struct sockaddr_in6 *in6 = (struct sockaddr_in6*) ifa_tmp->ifa_addr;
             if((strcmp(ifa_tmp->ifa_name, interface_config->interface.c_str()) == 0) && !IN6_IS_ADDR_LINKLOCAL(&in6->sin6_addr)) {    
                 non_link_local = *in6;
@@ -401,8 +401,8 @@ void prepare_socket(int *local_sock, int *server_sock, relay_config *config, int
         }
         else {
             ifa_tmp = ifa;
-            while (ifa_tmp && ifa_tmp->ifa_addr) {
-                if ((ifa_tmp->ifa_addr->sa_family == AF_INET6) && (strcmp(ifa_tmp->ifa_name, config->interface.c_str()) == 0)) {
+            while (ifa_tmp) {
+                if (ifa_tmp->ifa_addr && (ifa_tmp->ifa_addr->sa_family == AF_INET6) && (strcmp(ifa_tmp->ifa_name, config->interface.c_str()) == 0)) {
                     struct sockaddr_in6 *in6 = (struct sockaddr_in6*) ifa_tmp->ifa_addr;
                     if(!IN6_IS_ADDR_LINKLOCAL(&in6->sin6_addr)) {  
                         bind_addr = true;


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Daemon dhcp6relay may crash due to null pointer access to `ifa_addr` member of `struct ifaddrs`.  It's not guaranteed that the interface must have available `ifa_addr`. That is true for some special virtual/pseudo interfaces. 

#### How I did it
Check the pointer to `ifa_addr` is valid ahead of accessing it.
#### How to verify it

```
admin@a7280:~$ sudo config reload -y
...
admin@a7280:~$ docker exec dhcp_relay ps ax |grep dhcp6
     44 pts/0    Sl     0:00 /usr/sbin/dhcp6relay
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

