### PR TITLE
load_db_config before connecting to ConfigDBConnector in portconfig.py

### DIFF
--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -8,6 +8,7 @@ try:
     from swsscommon import swsscommon
     from sonic_py_common import device_info
     from sonic_py_common.multi_asic import get_asic_id_from_name
+    from utilities_common.general import load_db_config
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 
@@ -72,6 +73,7 @@ def db_connect_configdb(namespace=None):
     """
     Connect to configdb
     """
+    load_db_config()
     config_db = swsscommon.ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
     if config_db is None:
         return None


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Running commands like `sfputil show presence` would cause the following error:
```
validateNamespace: Initialize global DB config using API SonicDBConfig::initializeGlobalConfig 
```
A similar issue was already fixed for `show` commands upstream:

https://github.com/Azure/sonic-utilities/pull/1752

#### How I did it
Imported and used the `load_db_config()` function from `utilities_common.general`.

#### How to verify it
Running:
```bash
sfputil show presence
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Adds call to `load_db_config()` before connecting to the `ConfigDBConnector` in _portconfig.py_

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
🐿
