### PR TITLE
[caclmgrd]: Add infrastructure to support adding feature specific acls

### DIFF
--- a/src/sonic-host-services/scripts/caclmgrd
+++ b/src/sonic-host-services/scripts/caclmgrd
@@ -29,6 +29,7 @@ SYSLOG_IDENTIFIER = "caclmgrd"
 
 DEFAULT_NAMESPACE = ''
 
+
 # ========================== Helper Functions =========================
 
 

--- a/src/sonic-host-services/scripts/caclmgrd
+++ b/src/sonic-host-services/scripts/caclmgrd
@@ -54,6 +54,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
     Attributes:
         config_db: Handle to Config Redis database via SwSS SDK
     """
+    FEATURE_TABLE = "FEATURE"
     ACL_TABLE = "ACL_TABLE"
     ACL_RULE = "ACL_RULE"
     DEVICE_METADATA_TABLE = "DEVICE_METADATA"

--- a/src/sonic-host-services/scripts/caclmgrd
+++ b/src/sonic-host-services/scripts/caclmgrd
@@ -29,9 +29,6 @@ SYSLOG_IDENTIFIER = "caclmgrd"
 
 DEFAULT_NAMESPACE = ''
 
-FEATURES_PRESENT = [""]
-
-
 # ========================== Helper Functions =========================
 
 
@@ -120,9 +117,9 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         self.namespace_docker_mgmt_ip = {}
         self.namespace_docker_mgmt_ipv6 = {}
 
+        # Get all features that are present {feature_name : True/False}
         self.feature_present = {}
-        for feature in FEATURES_PRESENT:
-            self.feature_present[feature] = self.is_feature_present(feature)
+        self.update_feature_present()
 
         metadata = self.config_db_map[DEFAULT_NAMESPACE].get_table(self.DEVICE_METADATA_TABLE)
         if 'subtype' in metadata['localhost'] and metadata['localhost']['subtype'] == 'DualToR':
@@ -208,14 +205,11 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         tcp_flags_str = tcp_flags_str[:-1]
         return tcp_flags_str
 
-    def is_feature_present(self, feature_name):
+    def update_feature_present(self):
         feature_tb_info = self.config_db_map[DEFAULT_NAMESPACE].get_table(self.FEATURE_TABLE)
         if feature_tb_info:
             for k, v in feature_tb_info.items():
-                if feature_name == k:
-                    return True
-
-        return False
+                self.feature_present[k] = True
 
     def generate_block_ip2me_traffic_iptables_commands(self, namespace):
         INTERFACE_TABLE_NAME_LIST = [

--- a/src/sonic-host-services/scripts/caclmgrd
+++ b/src/sonic-host-services/scripts/caclmgrd
@@ -29,6 +29,8 @@ SYSLOG_IDENTIFIER = "caclmgrd"
 
 DEFAULT_NAMESPACE = ''
 
+FEATURES_PRESENT = [""]
+
 
 # ========================== Helper Functions =========================
 
@@ -117,6 +119,10 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         self.namespace_docker_mgmt_ip = {}
         self.namespace_docker_mgmt_ipv6 = {}
 
+        self.feature_present = {}
+        for feature in FEATURES_PRESENT:
+            self.feature_present[feature] = self.is_feature_present(feature)
+
         metadata = self.config_db_map[DEFAULT_NAMESPACE].get_table(self.DEVICE_METADATA_TABLE)
         if 'subtype' in metadata['localhost'] and metadata['localhost']['subtype'] == 'DualToR':
             self.DualToR = True
@@ -200,6 +206,15 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
         # Delete the trailing comma
         tcp_flags_str = tcp_flags_str[:-1]
         return tcp_flags_str
+
+    def is_feature_present(self, feature_name):
+        feature_tb_info = self.config_db_map[DEFAULT_NAMESPACE].get_table(self.FEATURE_TABLE)
+        if feature_tb_info:
+            for k, v in feature_tb_info.items():
+                if feature_name == k:
+                    return True
+
+        return False
 
     def generate_block_ip2me_traffic_iptables_commands(self, namespace):
         INTERFACE_TABLE_NAME_LIST = [

--- a/src/sonic-host-services/tests/caclmgrd/caclmgrd_feature_test.py
+++ b/src/sonic-host-services/tests/caclmgrd/caclmgrd_feature_test.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import swsscommon
+
+from parameterized import parameterized
+from sonic_py_common.general import load_module_from_source
+from unittest import TestCase, mock
+from pyfakefs.fake_filesystem_unittest import patchfs
+
+from .test_bfd_vectors import CACLMGRD_BFD_TEST_VECTOR
+from tests.common.mock_configdb import MockConfigDb
+from unittest.mock import MagicMock, patch
+
+DBCONFIG_PATH = '/var/run/redis/sonic-db/database_config.json'
+
+class TestFeature(TestCase):
+    """
+        Test caclmgrd feature present 
+    """
+    def setUp(self):
+        swsscommon.swsscommon.ConfigDBConnector = MockConfigDb
+        test_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        modules_path = os.path.dirname(test_path)
+        scripts_path = os.path.join(modules_path, "scripts")
+        sys.path.insert(0, modules_path)
+        caclmgrd_path = os.path.join(scripts_path, 'caclmgrd')
+        self.caclmgrd = load_module_from_source('caclmgrd', caclmgrd_path)
+
+    @parameterized.expand(CACLMGRD_BFD_TEST_VECTOR)
+    @patchfs
+    def test_feature_present(self, test_name, test_data, fs):
+        if not os.path.exists(DBCONFIG_PATH):
+            fs.create_file(DBCONFIG_PATH) # fake database_config.json
+
+        MockConfigDb.set_config_db(test_data["config_db"])
+
+        with mock.patch("caclmgrd.subprocess") as mocked_subprocess:
+            popen_mock = mock.Mock()
+            popen_attrs = test_data["popen_attributes"]
+            popen_mock.configure_mock(**popen_attrs)
+            mocked_subprocess.Popen.return_value = popen_mock
+            mocked_subprocess.PIPE = -1
+
+            call_rc = test_data["call_rc"]
+            mocked_subprocess.call.return_value = call_rc
+
+            caclmgrd_daemon = self.caclmgrd.ControlPlaneAclManager("caclmgrd")
+            caclmgrd_daemon.update_feature_present()
+            self.assertTrue("bgp" in caclmgrd_daemon.feature_present)
+            self.assertEqual(caclmgrd_daemon.feature_present["bgp"], True)

--- a/src/sonic-host-services/tests/caclmgrd/test_bfd_vectors.py
+++ b/src/sonic-host-services/tests/caclmgrd/test_bfd_vectors.py
@@ -15,6 +15,8 @@ CACLMGRD_BFD_TEST_VECTOR = [
                         "type": "ToRRouter",
                     }
                 },
+                "FEATURE": {
+                },
             },
             "expected_subprocess_calls": [
                 call("iptables -I INPUT 2 -p udp -m multiport --dports 3784,4784 -j ACCEPT", shell=True, universal_newlines=True, stdout=subprocess.PIPE),

--- a/src/sonic-host-services/tests/caclmgrd/test_bfd_vectors.py
+++ b/src/sonic-host-services/tests/caclmgrd/test_bfd_vectors.py
@@ -16,6 +16,10 @@ CACLMGRD_BFD_TEST_VECTOR = [
                     }
                 },
                 "FEATURE": {
+                    "bgp": {
+                        "auto_restart": "enabled",
+                        "state": "enabled",
+                    }
                 },
             },
             "expected_subprocess_calls": [

--- a/src/sonic-host-services/tests/caclmgrd/test_dhcp_vectors.py
+++ b/src/sonic-host-services/tests/caclmgrd/test_dhcp_vectors.py
@@ -14,6 +14,8 @@ CACLMGRD_DHCP_TEST_VECTOR = [
                         "type": "ToRRouter",
                     }
                 },
+                "FEATURE": {
+                },
             },
             "mux_update": [
                 ("Ethernet4", {"state": "active"}),
@@ -42,6 +44,8 @@ CACLMGRD_DHCP_TEST_VECTOR = [
                         "type": "ToRRouter",
                     }
                 },
+                "FEATURE": {
+                },
             },
             "mux_update": [
                 ("Ethernet4", {"state": "active"}),
@@ -66,6 +70,8 @@ CACLMGRD_DHCP_TEST_VECTOR = [
                         "subtype": "DualToR",
                         "type": "ToRRouter",
                     }
+                },
+                "FEATURE": {
                 },
             },
             "mux_update": [
@@ -93,6 +99,8 @@ CACLMGRD_DHCP_TEST_VECTOR = [
                         "type": "ToRRouter",
                     }
                 },
+                "FEATURE": {
+                },
             },
             "mux_update": [
                 ("Ethernet4", {"state": "active"}),
@@ -116,6 +124,8 @@ CACLMGRD_DHCP_TEST_VECTOR = [
                         "subtype": "DualToR",
                         "type": "ToRRouter",
                     }
+                },
+                "FEATURE": {
                 },
             },
             "mux_update": [
@@ -143,6 +153,8 @@ CACLMGRD_DHCP_TEST_VECTOR = [
                         "type": "ToRRouter",
                     }
                 },
+                "FEATURE": {
+                },
             },
             "mux_update": [
                 ("Ethernet4", {"state": "standby"}),
@@ -166,6 +178,8 @@ CACLMGRD_DHCP_TEST_VECTOR = [
                         "subtype": "DualToR",
                         "type": "ToRRouter",
                     }
+                },
+                "FEATURE": {
                 },
             },
             "mux_update": [
@@ -195,6 +209,8 @@ CACLMGRD_DHCP_TEST_VECTOR = [
                         "type": "ToRRouter",
                     }
                 },
+                "FEATURE": {
+                },
             },
             "mux_update": [
                 ("Ethernet4", {"state": "standby"}),
@@ -219,6 +235,8 @@ CACLMGRD_DHCP_TEST_VECTOR = [
                         "subtype": "DualToR",
                         "type": "ToRRouter",
                     }
+                },
+                "FEATURE": {
                 },
             },
             "mux_update": [
@@ -248,6 +266,8 @@ CACLMGRD_DHCP_TEST_VECTOR = [
                         "type": "ToRRouter",
                     }
                 },
+                "FEATURE": {
+                },
             },
             "mux_update": [
                 ("Ethernet4", {"state": "unknown"}),
@@ -272,6 +292,8 @@ CACLMGRD_DHCP_TEST_VECTOR = [
                         "subtype": "DualToR",
                         "type": "ToRRouter",
                     }
+                },
+                "FEATURE": {
                 },
             },
             "mux_update": [
@@ -298,6 +320,8 @@ CACLMGRD_DHCP_TEST_VECTOR = [
                         "subtype": "DualToR",
                         "type": "ToRRouter",
                     }
+                },
+                "FEATURE": {
                 },
             },
             "mux_update": [


### PR DESCRIPTION
Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add infrastructure to support adding feature specific acls.
If feature specific ACLs has to be added:
```
if feature_name in self.feature_present and self.feature_present.get('feature_name'):
    add_feature_specific_acls()
```

#### How I did it
Add function to get features present in feature table.

#### How to verify it
unit-test passes.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

