### PR TITLE
FIX the build error introduced by textfsm 1.1.3(Published on 2022/7/6)

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -71,7 +71,7 @@ RUN pip install cffi==1.10.0 \
                 six \
                 tabulate \
                 statistics \
-                textfsm \
+                textfsm==1.1.2 \
                 virtualenv \
                 retry \
                 thrift==0.11.0 \
@@ -233,7 +233,7 @@ RUN python3 -m pip install setuptools-rust \
                             rpyc \
                             six \
                             tabulate \
-                            textfsm \
+                            textfsm==1.1.2 \
                             virtualenv \
                             wheel==0.33.6 \
                             pysubnettree \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
sonic-mgmt docker image build error, because of the textfsm new version(1.1.3).
https://dev.azure.com/mssonic/build/_build/results?buildId=119147&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=44e6c678-cb87-52d9-8547-bcdbd0ad6ae4&l=43043
#### How I did it
Fix textfsm version to 1.1.2
#### How to verify it
I build the image on my local env, and reproduce the issue with 1.1.3, it's fixed after I change the version to 1.1.2 .
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

