### PR TITLE
Add load_minigraph option to include TSA during config migration

### DIFF
--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -109,7 +109,15 @@ run_hookdir() {
 reload_minigraph()
 {
     echo "Reloading minigraph..."
-    config load_minigraph -y -n 
+    if
+    [[ "$(sonic-cfggen -d -v DEVICE_METADATA.localhost.subtype | tr [:upper:] [:lower:])" == *"dualtor"* ]] ||
+    [[ "$(sonic-cfggen -d -v DEVICE_METADATA.localhost.type | tr [:upper:] [:lower:])" == *"leafrouter"* ]];
+    then
+        #Keep device isolated with traffic-shift-away option on LeafRouter and Dualtor
+        config load_minigraph -y -n -t
+    else
+        config load_minigraph -y -n
+    fi
     config save -y
 }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To keep LeafRouter and Dualtor devices isolated with traffic-shift-away after new image is installed (with no prior config) and the device is configured using load_minigraph

#### How I did it
Using load_minigraph with --traffic_shift_away option introduced in https://github.com/Azure/sonic-utilities/pull/2240 for these device types

#### How to verify it
Two ways-
* config-setup boot command with /tmp/pending_config_migration file present
* New image installation with no previous config-db on LeafRouter or Dualtor

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

