### PR TITLE
Added Support for deployment_id parsing for Device Asic metadata

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1037,6 +1037,7 @@ def parse_asic_meta(meta, hname):
     switch_id = None
     switch_type = None
     max_cores = None
+    deployment_id = None
     macsec_profile = {}
     device_metas = meta.find(str(QName(ns, "Devices")))
     for device in device_metas.findall(str(QName(ns1, "DeviceMetadata"))):
@@ -1053,10 +1054,12 @@ def parse_asic_meta(meta, hname):
                     switch_type = value
                 elif name == "MaxCores":
                     max_cores = value
+                elif name == "DeploymentId":
+                    deployment_id = value
                 elif name == 'MacSecProfile':
                     macsec_profile = parse_macsec_profile(value)
 
-    return sub_role, switch_id, switch_type, max_cores, macsec_profile
+    return sub_role, switch_id, switch_type, max_cores, deployment_id, macsec_profile
 
 def parse_deviceinfo(meta, hwsku):
     port_speeds = {}
@@ -1384,7 +1387,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
             elif child.tag == str(QName(ns, "PngDec")):
                 (neighbors, devices, port_speed_png) = parse_asic_png(child, asic_name, hostname)
             elif child.tag == str(QName(ns, "MetadataDeclaration")):
-                (sub_role, switch_id, switch_type, max_cores, macsec_profile) = parse_asic_meta(child, asic_name)
+                (sub_role, switch_id, switch_type, max_cores, deployment_id, macsec_profile) = parse_asic_meta(child, asic_name)
             elif child.tag == str(QName(ns, "LinkMetadataDeclaration")):
                 linkmetas = parse_linkmeta(child, hostname)
             elif child.tag == str(QName(ns, "DeviceInfos")):
@@ -1957,7 +1960,7 @@ def parse_asic_sub_role(filename, asic_name):
     root = ET.parse(filename).getroot()
     for child in root:
         if child.tag == str(QName(ns, "MetadataDeclaration")):
-            sub_role, _, _, _, _= parse_asic_meta(child, asic_name)
+            sub_role, _, _, _, _, _= parse_asic_meta(child, asic_name)
             return sub_role
 
 def parse_asic_switch_type(filename, asic_name):

--- a/src/sonic-config-engine/tests/multi_npu_data/sample-minigraph.xml
+++ b/src/sonic-config-engine/tests/multi_npu_data/sample-minigraph.xml
@@ -1465,6 +1465,11 @@
             <a:Reference i:nil="true"/>
             <a:Value>FrontEnd</a:Value>
           </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>DeploymentId</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>1</a:Value>
+          </a:DeviceProperty>
         </a:Properties>
       </a:DeviceMetadata>
       <a:DeviceMetadata>
@@ -1475,6 +1480,11 @@
             <a:Reference i:nil="true"/>
             <a:Value>FrontEnd</a:Value>
           </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>DeploymentId</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>1</a:Value>
+          </a:DeviceProperty>
         </a:Properties>
       </a:DeviceMetadata>
       <a:DeviceMetadata>
@@ -1484,6 +1494,11 @@
             <a:Name>SubRole</a:Name>
             <a:Reference i:nil="true"/>
             <a:Value>FrontEnd</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>DeploymentId</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>1</a:Value>
           </a:DeviceProperty>
         </a:Properties>
       </a:DeviceMetadata>
@@ -1495,6 +1510,11 @@
             <a:Reference i:nil="true"/>
             <a:Value>FrontEnd</a:Value>
           </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>DeploymentId</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>1</a:Value>
+          </a:DeviceProperty>
         </a:Properties>
       </a:DeviceMetadata>
       <a:DeviceMetadata>
@@ -1504,6 +1524,11 @@
             <a:Name>SubRole</a:Name>
             <a:Reference i:nil="true"/>
             <a:Value>BackEnd</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>DeploymentId</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>1</a:Value>
           </a:DeviceProperty>
         </a:Properties>
       </a:DeviceMetadata>
@@ -1515,6 +1540,12 @@
             <a:Reference i:nil="true"/>
             <a:Value>BackEnd</a:Value>
           </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>DeploymentId</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>1</a:Value>
+          </a:DeviceProperty>
+
         </a:Properties>
       </a:DeviceMetadata>
     </Devices>

--- a/src/sonic-config-engine/tests/test_multinpu_cfggen.py
+++ b/src/sonic-config-engine/tests/test_multinpu_cfggen.py
@@ -304,6 +304,7 @@ class TestMultiNpuCfgGen(TestCase):
                 self.assertEqual(output['localhost']['sub_role'], 'FrontEnd')
             else:
                 self.assertEqual(output['localhost']['sub_role'], 'BackEnd')
+            self.assertEqual(output['localhost']['deployment_id'], "1")
 
     def test_global_asic_acl(self):
         argument = "-m {} -p {}  --var-json \"ACL_TABLE\"".format(self.sample_graph, self.sample_port_config)


### PR DESCRIPTION
What I did:
Added Support for deployment_id parsing for Device Asic metadata. 

Why I did:-
Deployment Id is used in BGP docker for FRR template generation. For multi-asic platforms running in namespace without deployment id  as key in DEVICE_METADATA FRR template generation fails. This change is needed after this https://github.com/Azure/sonic-buildimage/pull/10154 where if deployment_id is none we don't update DEVICE_METADA dictionary. 

How I verify:-
Added unit-test.