### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,19 @@ sudo pip3 install j2cli
  * Install [Docker](https://docs.docker.com/engine/install/) and configure your system to allow running the 'docker' command without 'sudo':
     * Add current user to the docker group: `sudo gpasswd -a ${USER} docker`
     * Log out and log back in so that your group membership is re-evaluated
+    * The image build followed after the platform configuration fails with containerd running on cgroupv2. 
+    It should be changed to run with cgroupv1. 
+    For .deb based distros edit grub (/etc/default/grub) to have `systemd.unified_cgroup_hierarchy=0` in `GRUB_CMDLINE_LINUX`
+    For EL distros updated the kernel with:
+    ```
+    sudo apt install -y grubby && \
+     sudo grubby \
+     --update-kernel=ALL \
+     --args="systemd.unified_cgroup_hierarchy=0"
+    ```
+  
+ * Platform configuration step fails due to sairedis being missing (https://github.com/Azure/sonic-sairedis/issues/697#issuecomment-731498253).
+ This can be circumvented by cloning the sonic-sairedis (/Azure/sonic-sairedis.git) into the cloned "sonic-buildimage" directory and running a recursive submodule update within the directory (`git submodule update --init --recursive`)
 
 ## Clone or fetch the code repository with all git submodules
 To clone the code repository recursively, assuming git version 1.9 or newer:


### PR DESCRIPTION
make configure and docker image build has been failing for me. The configure step failed due to sairedis being missing and docker image build with the builder images fails in hosts running containerd with cgroupv2. These need to be indicated within the readme until they are fixed elseway anyone trying to use it will have problems.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

