### PR TITLE
[CEL-SEA2]: fix sonic platform module import issue for sea2

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/services/platform_api/sonic_platform/__init__.py
+++ b/platform/broadcom/sonic-platform-modules-cel/services/platform_api/sonic_platform/__init__.py
@@ -1,2 +1,2 @@
-import chassis
-import platform
+from . import chassis
+from . import platform

--- a/platform/broadcom/sonic-platform-modules-cel/services/platform_api/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-cel/services/platform_api/sonic_platform/chassis.py
@@ -11,7 +11,7 @@
 try:
     import sys
     from sonic_platform_base.chassis_base import ChassisBase
-    from common import Common
+    from sonic_platform.common import Common
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -106,7 +106,7 @@ class Chassis(ChassisBase):
         self._eeprom = Tlv(self._config)
 
     def __initialize_components(self):
-        from component import Component
+        from sonic_platform.component import Component
 
         component_config_path = self._api_common.get_config_path(
             self.COMPONENT_CONFIG)

--- a/platform/broadcom/sonic-platform-modules-cel/services/platform_api/sonic_platform/component.py
+++ b/platform/broadcom/sonic-platform-modules-cel/services/platform_api/sonic_platform/component.py
@@ -10,7 +10,7 @@
 
 try:
     from sonic_platform_base.component_base import ComponentBase
-    from common import Common
+    from sonic_platform.common import Common
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 


### PR DESCRIPTION
#### Why I did it
Fix platform chassis/component error when importing these platform modules.

#### How I did it
Fix the platform module import and dependency issues.

#### How to verify it
Verify the platform in DUT with common show platform commands or import sonic_platform in python3.

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [*] 202106
- [*] 202111
- [*] 202205
