### PR TITLE
[caclmgrd][dualtor] add iptables rule for dualtor gRPC to allow packets

### DIFF
--- a/src/sonic-host-services/scripts/caclmgrd
+++ b/src/sonic-host-services/scripts/caclmgrd
@@ -56,6 +56,7 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
     ACL_RULE = "ACL_RULE"
     DEVICE_METADATA_TABLE = "DEVICE_METADATA"
     MUX_CABLE_TABLE = "MUX_CABLE_TABLE"
+    CONFIG_MUX_CABLE = "MUX_CABLE"
 
     ACL_TABLE_TYPE_CTRLPLANE = "CTRLPLANE"
 
@@ -272,6 +273,39 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
                                                      (docker_mgmt_ipv6, self.namespace_mgmt_ipv6))
 
         return allow_internal_docker_ip_cmds
+
+    def get_loopback_ip_from_loopback_table(self, loopback_table):
+
+        if loopback_table:
+            for key, _ in loopback_table.items():
+                if not _ip_prefix_in_key(key):
+                    continue
+
+                iface_name, iface_cidr = key
+                if iface_name.startswith("Loopback3"):
+                    ip_ntwrk = ipaddress.ip_network(iface_cidr, strict=False)
+                    if isinstance(ip_ntwrk, ipaddress.IPv4Network):
+                        ip_addr = ip_ntwrk.network_address
+                        return ip_addr
+
+        return None
+
+    def generate_fwd_traffic_from_host_to_soc(self, namespace):
+
+        fwd_dualtor_grpc_traffic_from_host_to_soc_cmds = []
+        if self.DualToR:
+            loopback_table = self.config_db_map[DEFAULT_NAMESPACE].get_table('LOOPBACK_INTERFACE')
+            loopback_address = self.get_loopback_ip_from_loopback_table(loopback_table)
+            if loopback_address is not None:
+                mux_table = self.config_db_map[DEFAULT_NAMESPACE].get_table(self.CONFIG_MUX_CABLE)
+                mux_table_keys = mux_table.keys()
+                for key in mux_table_keys:
+                    kvp = mux_table.get(key)
+                    if 'cable_type' in kvp and kvp['cable_type'] == 'active-active':
+                        fwd_dualtor_grpc_traffic_from_host_to_soc_cmds.append(self.iptables_cmd_ns_prefix[namespace] + 
+                                "iptables -t nat -A POSTROUTING --destination {} -j SNAT --to-source {}".format(kvp['soc_ipv4'], loopback_address))
+
+        return fwd_dualtor_grpc_traffic_from_host_to_soc_cmds
 
     def generate_fwd_traffic_from_namespace_to_host_commands(self, namespace, acl_source_ip_map):
         """
@@ -673,6 +707,13 @@ class ControlPlaneAclManager(daemon_base.DaemonBase):
             self.log_info("  " + cmd)
 
         self.run_commands(iptables_cmds)
+
+        if self.DualToR:
+            dualtor_iptables_cmds = self.generate_fwd_traffic_from_host_to_soc(namespace)
+            for cmd in dualtor_iptables_cmds:
+                self.log_info("  " + cmd)
+            self.run_commands(dualtor_iptables_cmds)
+
 
     def check_and_update_control_plane_acls(self, namespace, num_changes):
         """


### PR DESCRIPTION
getting forwarded from loopback IP

Signed-off-by: vaibhav-dahiya <vdahiya@microsoft.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

