### PR TITLE
[Mellanox] Fix chassis test issue

### DIFF
--- a/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
@@ -286,7 +286,8 @@ class TestChassis:
 
     def test_get_port_or_cage_type(self):
         chassis = Chassis()
-        chassis.RJ45_port_list = [0]
+        chassis._RJ45_port_inited = True
+        chassis._RJ45_port_list = [0]
         assert SfpBase.SFP_PORT_TYPE_BIT_RJ45 == chassis.get_port_or_cage_type(1)
 
         exceptionRaised = False


### PR DESCRIPTION
Fix compiling issue
```
=================================== FAILURES =================================== 
____________________ TestChassis.test_get_port_or_cage_type ____________________ 
self = <tests.test_chassis.TestChassis object at 0x7f7e81fecaf0> 
def test_get_port_or_cage_type(self): 
chassis = Chassis() 
> chassis.RJ45_port_list = [0] 
E AttributeError: can't set attribute 
tests/test_chassis.py:289: AttributeError 
=============================== warnings summary ============
```
It was caused by #11336 but the root cause is that the ci/merge flow of PR #11336 and #11436 interleaved.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

