### PR TITLE
Update WARM START FINALIZER to wait for linkmgrd to reconcile

### DIFF
--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -10,6 +10,7 @@ declare -A RECONCILE_COMPONENTS=( \
                         ["swss"]="orchagent neighsyncd" \
                         ["bgp"]="bgp"                   \
                         ["nat"]="natsyncd"              \
+                        ["mux"]="linkmgrd"              \
                        )
 
 for reconcile_file in $(find /etc/sonic/ -iname '*_reconcile' -type f); do


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Spanning from https://github.com/Azure/sonic-linkmgrd/pull/76, this PR is to update warm restart finalizer to wait for linkmgrd to be reconciled. 

sign-off: Jing Zhang zhangjing@microsoft.com

#### Why I did it
To make sure finalizer save config after linkmgrd's reconciliation. 

#### How I did it
Add linkmgrd to the reconciliation wait list of warmboot finalizer. 

#### How to verify it
Verified on lab device, linkmgrd reconciled as expected. (Otherwise we would see ```Some components didn't finish reconcile: ...``` in syslog.)
```
admin@****************:~$ sudo zgrep "WARMBOOT_FINALIZER" /var/log/syslog --text
Jul 27 23:00:56.819553 **************** NOTICE root: WARMBOOT_FINALIZER : Wait for database to become ready...
Jul 27 23:00:57.488231 **************** NOTICE root: WARMBOOT_FINALIZER : Database is ready...
Jul 27 23:00:57.792936 **************** NOTICE root: WARMBOOT_FINALIZER : Restoring counters folder after warmboot...
Jul 27 23:01:00.899604 **************** NOTICE root: WARMBOOT_FINALIZER : Waiting for components: '  orchagent neighsyncd bgp linkmgrd' to reconcile ...
Jul 27 23:03:17.258042 **************** NOTICE root: WARMBOOT_FINALIZER : Tearing down control plane assistant ...
Jul 27 23:03:20.631575 **************** NOTICE root: WARMBOOT_FINALIZER : Save in-memory database after warm reboot ...
Jul 27 23:03:22.315776 **************** NOTICE root: WARMBOOT_FINALIZER : Finalizing warmboot...
```


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

