### PR TITLE
[YANG] Add constraint for loopback interface name formatting

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-loopback-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-loopback-interface.yang
@@ -35,8 +35,11 @@ module sonic-loopback-interface {
             list LOOPBACK_INTERFACE_LIST {
                 key "name";
 
-                leaf name{
-                    type string;
+                leaf name {
+                    type string {
+                        length 1..128;
+                        pattern 'Loopback[0-9]{1,3}';
+                    };
                 }
 
                 leaf vrf_name {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Loopback interface YANG model was missing the constraint for Loobback interface name formatting (should be LoopbackXXXX)

#### How I did it
Add constraint to YANG model

#### How to verify it
Try configuring Loopback interface name to valid and invalid names

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

