### PR TITLE
[minigraph] allow LibraPeeringLink to be dualtor indication as well

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -999,7 +999,7 @@ def parse_linkmeta(meta, hname):
             value = device_property.find(str(QName(ns1, "Value"))).text
             if name == "FECDisabled":
                 fec_disabled = value
-            elif name == "GeminiPeeringLink":
+            elif name in [ "GeminiPeeringLink", "LibraPeeringLink" ]:
                 has_peer_switch = True
             elif name == "UpperTOR":
                 upper_tor_hostname = value


### PR DESCRIPTION
#### Why I did it
Active-active dualtor has new indicator for peering link.

#### How I did it
allow LibraPeeringLink to be dualtor indication as well.

#### How to verify it
Tested on the dut with the new peering link type.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
