### PR TITLE
Automatically enable tunnel_qos_remap on T1 and T0 in DualToR deployment

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -895,6 +895,7 @@ def parse_meta(meta, hname):
     kube_data = {}
     macsec_profile = {}
     redundancy_type = None
+    downstream_redundancy_types = None
     qos_profile = None
 
     device_metas = meta.find(str(QName(ns, "Devices")))
@@ -941,32 +942,12 @@ def parse_meta(meta, hname):
                     macsec_profile = parse_macsec_profile(value)
                 elif name == "RedundancyType":
                     redundancy_type = value
+                elif name == "DownstreamRedundancyTypes":
+                    downstream_redundancy_types = value
                 elif name == "SonicQosProfile":
                     qos_profile = value
-    return syslog_servers, dhcp_servers, dhcpv6_servers, ntp_servers, tacacs_servers, mgmt_routes, erspan_dst, deployment_id, region, cloudtype, resource_type, downstream_subrole, switch_id, switch_type, max_cores, kube_data, macsec_profile, redundancy_type, qos_profile
+    return syslog_servers, dhcp_servers, dhcpv6_servers, ntp_servers, tacacs_servers, mgmt_routes, erspan_dst, deployment_id, region, cloudtype, resource_type, downstream_subrole, switch_id, switch_type, max_cores, kube_data, macsec_profile, downstream_redundancy_types, redundancy_type, qos_profile
 
-
-def parse_system_defaults(meta):
-    system_default_values = {}
-
-    system_defaults = meta.find(str(QName(ns1, "SystemDefaults")))
-    
-    if system_defaults is None:
-        return system_default_values
-    
-    for system_default in system_defaults.findall(str(QName(ns1, "SystemDefault"))):
-        name = system_default.find(str(QName(ns1, "Name"))).text
-        value = system_default.find(str(QName(ns1, "Value"))).text
-
-        # Tunnel Qos remapping 
-        if name == "TunnelQosRemapEnabled":
-            if value.lower() == "true":
-                status = "enabled"
-            else:
-                status = "disabled"
-            system_default_values["tunnel_qos_remap"] = {"status": status}
-
-    return system_default_values
 
 def parse_linkmeta(meta, hname):
     link = meta.find(str(QName(ns, "Link")))
@@ -1369,6 +1350,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     static_routes = {}
     system_defaults = {}
     macsec_profile = {}
+    downstream_redundancy_types = None
     redundancy_type = None
     qos_profile = None
 
@@ -1401,13 +1383,11 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
             elif child.tag == str(QName(ns, "UngDec")):
                 (u_neighbors, u_devices, _, _, _, _, _, _) = parse_png(child, hostname, None)
             elif child.tag == str(QName(ns, "MetadataDeclaration")):
-                (syslog_servers, dhcp_servers, dhcpv6_servers, ntp_servers, tacacs_servers, mgmt_routes, erspan_dst, deployment_id, region, cloudtype, resource_type, downstream_subrole, switch_id, switch_type, max_cores, kube_data, macsec_profile, redundancy_type, qos_profile) = parse_meta(child, hostname)
+                (syslog_servers, dhcp_servers, dhcpv6_servers, ntp_servers, tacacs_servers, mgmt_routes, erspan_dst, deployment_id, region, cloudtype, resource_type, downstream_subrole, switch_id, switch_type, max_cores, kube_data, macsec_profile, downstream_redundancy_types, redundancy_type, qos_profile) = parse_meta(child, hostname)
             elif child.tag == str(QName(ns, "LinkMetadataDeclaration")):
                 linkmetas = parse_linkmeta(child, hostname)
             elif child.tag == str(QName(ns, "DeviceInfos")):
                 (port_speeds_default, port_descriptions, sys_ports) = parse_deviceinfo(child, hwsku)
-            elif child.tag == str(QName(ns, "SystemDefaultsDeclaration")):
-                system_defaults = parse_system_defaults(child)
         else:
             if child.tag == str(QName(ns, "DpgDec")):
                 (intfs, lo_intfs, mvrf, mgmt_intf, voq_inband_intfs, vlans, vlan_members, dhcp_relay_table, pcs, pc_members, acls, vni, tunnel_intfs, dpg_ecmp_content, static_routes, tunnel_intfs_qos_remap_config) = parse_dpg(child, asic_name)
@@ -1422,8 +1402,6 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
                 linkmetas = parse_linkmeta(child, hostname)
             elif child.tag == str(QName(ns, "DeviceInfos")):
                 (port_speeds_default, port_descriptions, sys_ports) = parse_deviceinfo(child, hwsku)
-            elif child.tag == str(QName(ns, "SystemDefaultsDeclaration")):
-                system_defaults = parse_system_defaults(child)
 
     select_mmu_profiles(qos_profile, platform, hwsku)
     # set the host device type in asic metadata also
@@ -1460,10 +1438,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
                 'ip': kube_data.get('ip', '')
             }
         }
-    
-    if len(system_defaults) > 0:
-        results['SYSTEM_DEFAULTS'] = system_defaults
-    
+
     results['PEER_SWITCH'], mux_tunnel_name, peer_switch_ip = get_peer_switch_info(linkmetas, devices)
 
     if bool(results['PEER_SWITCH']):
@@ -1472,7 +1447,20 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
             print("Warning: more than one peer switch was found. Only the first will be parsed: {}".format(results['PEER_SWITCH'].keys()[0]))
 
         results['DEVICE_METADATA']['localhost']['peer_switch'] = list(results['PEER_SWITCH'].keys())[0]
+    
+    # Enable tunnel_qos_remap if downstream_redundancy_types(T1) or redundancy_type(T0) = Gemini/Libra
+    enable_tunnel_qos_map = False
+    if results['DEVICE_METADATA']['localhost']['type'].lower() == 'leafrouter' and ('gemini' in str(downstream_redundancy_types).lower() or 'libra' in str(downstream_redundancy_types).lower()):
+        enable_tunnel_qos_map = True
+    elif results['DEVICE_METADATA']['localhost']['type'].lower() == 'torrouter' and ('gemini' in str(redundancy_type).lower() or 'libra' in str(redundancy_type).lower()):
+        enable_tunnel_qos_map = True
 
+    if enable_tunnel_qos_map:
+        system_defaults['tunnel_qos_remap'] = {"status": "enabled"}
+
+    if len(system_defaults) > 0:
+        results['SYSTEM_DEFAULTS'] = system_defaults
+    
     # for this hostname, if sub_role is defined, add sub_role in 
     # device_metadata
     if sub_role is not None:
@@ -1874,14 +1862,28 @@ def get_tunnel_entries(tunnel_intfs, tunnel_intfs_qos_remap_config, lo_intfs, tu
             break
 
     tunnels = {}
+
+    default_qos_map_for_mux_tunnel = {
+        "decap_dscp_to_tc_map": "AZURE_TUNNEL",
+        "decap_tc_to_pg_map": "AZURE_TUNNEL",
+        "encap_tc_to_dscp_map": "AZURE_TUNNEL",
+        "encap_tc_to_queue_map": "AZURE_TUNNEL"
+    }
+
     for type, tunnel_dict in tunnel_intfs.items():
         for tunnel_key, tunnel_attr in tunnel_dict.items():
             tunnel_attr['dst_ip'] = lo_addr
 
             if (tunnel_qos_remap.get('status') == 'enabled') and (mux_tunnel_name == tunnel_key) and (peer_switch_ip is not None):
                 tunnel_attr['src_ip'] = peer_switch_ip
+                # The DSCP mode must be pipe if remap is enabled
+                tunnel_attr['dscp_mode'] = "pipe"
                 if tunnel_key in tunnel_intfs_qos_remap_config[type]:
                     tunnel_attr.update(tunnel_intfs_qos_remap_config[type][tunnel_key].items())
+                # Use default value if qos remap attribute is missing
+                for k, v in default_qos_map_for_mux_tunnel.items():
+                    if k not in tunnel_attr:
+                        tunnel_attr[k] = v
 
             tunnels[tunnel_key] = tunnel_attr
 

--- a/src/sonic-config-engine/tests/sample-arista-7050cx3-dualtor-minigraph.xml
+++ b/src/sonic-config-engine/tests/sample-arista-7050cx3-dualtor-minigraph.xml
@@ -2334,19 +2334,16 @@
             <a:Reference i:nil="true"/>
             <a:Value>10.20.6.16</a:Value>
          </a:DeviceProperty>
+         <a:DeviceProperty>
+            <a:Name>RedundancyType</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>Gemini</a:Value>
+         </a:DeviceProperty>
         </a:Properties>
       </a:DeviceMetadata>
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <SystemDefaultsDeclaration>
-          <a:SystemDefaults xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-                  <a:SystemDefault>
-                          <a:Name>TunnelQosRemapEnabled</a:Name>
-                          <a:Value>True</a:Value>
-                  </a:SystemDefault>
-          </a:SystemDefaults>
-  </SystemDefaultsDeclaration>
   <LinkMetadataDeclaration>
     <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:LinkMetadata>

--- a/src/sonic-config-engine/tests/sample-arista-7260-dualtor-minigraph.xml
+++ b/src/sonic-config-engine/tests/sample-arista-7260-dualtor-minigraph.xml
@@ -4600,19 +4600,16 @@
             <a:Reference i:nil="true"/>
             <a:Value>10.20.6.16</a:Value>
          </a:DeviceProperty>
+         <a:DeviceProperty>
+            <a:Name>RedundancyType</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>Gemini</a:Value>
+         </a:DeviceProperty>
         </a:Properties>
       </a:DeviceMetadata>
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <SystemDefaultsDeclaration>
-          <a:SystemDefaults xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-                  <a:SystemDefault>
-                          <a:Name>TunnelQosRemapEnabled</a:Name>
-                          <a:Value>True</a:Value>
-                  </a:SystemDefault>
-          </a:SystemDefaults>
-  </SystemDefaultsDeclaration>
   <LinkMetadataDeclaration>
     <Link xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
       <a:LinkMetadata>

--- a/src/sonic-config-engine/tests/sample-arista-7260-t1-minigraph.xml
+++ b/src/sonic-config-engine/tests/sample-arista-7260-t1-minigraph.xml
@@ -2481,19 +2481,16 @@
             <a:Reference i:nil="true"/>
             <a:Value>10.20.6.16</a:Value>
          </a:DeviceProperty>
+         <a:DeviceProperty>
+            <a:Name>DownstreamRedundancyTypes</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>Gemini</a:Value>
+         </a:DeviceProperty>
         </a:Properties>
       </a:DeviceMetadata>
     </Devices>
     <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
   </MetadataDeclaration>
-  <SystemDefaultsDeclaration>
-          <a:SystemDefaults xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-                  <a:SystemDefault>
-                          <a:Name>TunnelQosRemapEnabled</a:Name>
-                          <a:Value>True</a:Value>
-                  </a:SystemDefault>
-          </a:SystemDefaults>
-  </SystemDefaultsDeclaration>
   <Hostname>str-7260cx3-acs-7</Hostname>
   <HwSku>Arista-7260CX3-C64</HwSku>
 </DeviceMiniGraph>

--- a/src/sonic-config-engine/tests/simple-sample-graph-case-remap-disabled.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case-remap-disabled.xml
@@ -474,14 +474,6 @@
  </Devices>
  <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
 </MetadataDeclaration>
-<SystemDefaultsDeclaration>
-  <a:SystemDefaults xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
-    <a:SystemDefault>
-      <a:Name>TunnelQosRemapEnabled</a:Name>
-      <a:Value>False</a:Value>
-    </a:SystemDefault>
-  </a:SystemDefaults>
-</SystemDefaultsDeclaration>
   <DeviceInfos>
     <DeviceInfo>
       <EthernetInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">

--- a/src/sonic-config-engine/tests/simple-sample-graph-case-remap-enabled-no-tunnel-attributes.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case-remap-enabled-no-tunnel-attributes.xml
@@ -127,7 +127,7 @@
         </PortChannel>
       </PortChannelInterfaces>
       <TunnelInterfaces>
-        <TunnelInterface Name="MuxTunnel0" Type="IPInIP" AttachTo="Loopback0" DifferentiatedServicesCodePointMode="uniform" EcnEncapsulationMode="standard" EcnDecapsulationMode="copy_from_outer" TtlMode="pipe" DecapDscpToTcMap="AZURE_TUNNEL" DecapTcToPgMap="AZURE_TUNNEL" EncapTcToQueueMap="AZURE_TUNNEL" EncapTcToDscpMap="AZURE_TUNNEL"/>
+        <TunnelInterface Name="MuxTunnel0" Type="IPInIP" AttachTo="Loopback0" DifferentiatedServicesCodePointMode="uniform" EcnEncapsulationMode="standard" EcnDecapsulationMode="copy_from_outer" TtlMode="pipe"/>
       </TunnelInterfaces>
       <VlanInterfaces>
         <VlanInterface>

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -382,7 +382,7 @@ class TestCfgGenCaseInsensitive(TestCase):
                 "tunnel_type": "IPINIP",
                 "src_ip": "25.1.1.10",
                 "dst_ip": "10.1.0.32",
-                "dscp_mode": "uniform",
+                "dscp_mode": "pipe",
                 "encap_ecn_mode": "standard",
                 "ecn_mode": "copy_from_outer",
                 "ttl_mode": "pipe",
@@ -399,6 +399,14 @@ class TestCfgGenCaseInsensitive(TestCase):
             expected_tunnel
         )
 
+        # Validate extra config for mux tunnel is generated automatically when tunnel_qos_remap = enabled
+        sample_graph_enabled_remap = os.path.join(self.test_dir, 'simple-sample-graph-case-remap-enabled-no-tunnel-attributes.xml')
+        argument = '-m "' + sample_graph_enabled_remap + '" -p "' + self.port_config + '" -v "TUNNEL"'
+        output = self.run_script(argument)
+        self.assertEqual(
+            utils.to_dict(output.strip()),
+            expected_tunnel
+        )
 
     def test_minigraph_mux_cable_table(self):
         argument = '-m "' + self.sample_graph + '" -p "' + self.port_config + '" -v "MUX_CABLE"'


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR is to backport PR #11056 and PR11045 into `master` branch.
This PR is to enable `tunnel_qos_remap` on `T1` and `T0` in DualToR deployment.
On T1, we check the property `DownstreamRedundancyTypes`. On T0, we check the property `RedundancyType`.
`tunnel_qos_remap` is set to `enabled` if `gemini` is in  `DownstreamRedundancyTypes` (on T1) or `RedundancyType` (on T0).
#### How I did it
The change is implemented in `minigraph.py`.

#### How to verify it
Verified by `test_minigraph_case.py` and 'test_j2files.py`.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

