### PR TITLE
[201911] Updated Broadcom SAI Debian Package

### DIFF
--- a/platform/broadcom/sai.mk
+++ b/platform/broadcom/sai.mk
@@ -1,8 +1,8 @@
-BRCM_SAI = libsaibcm_3.7.6.1-1_amd64.deb
-$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm_3.7.6.1-1_amd64.deb?sv=2015-04-05&sr=b&sig=NQ1hWKi6zjqigwb%2BDhM239G6AhL0HvktYE7FW79VdmY%3D&se=2030-08-03T23%3A01%3A11Z&sp=r"
-BRCM_SAI_DEV = libsaibcm-dev_3.7.6.1-1_amd64.deb
+BRCM_SAI = libsaibcm_3.7.6.1-2_amd64.deb
+$(BRCM_SAI)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm_3.7.6.1-2_amd64.deb?sv=2015-04-05&sr=b&sig=feV68rm1rnQzVyEFQjE5ceusSIqtIzlyUX7mPEmio%2B0%3D&se=2038-12-30T22%3A23%3A47Z&sp=r"
+BRCM_SAI_DEV = libsaibcm-dev_3.7.6.1-2_amd64.deb
 $(eval $(call add_derived_package,$(BRCM_SAI),$(BRCM_SAI_DEV)))
-$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm-dev_3.7.6.1-1_amd64.deb?sv=2015-04-05&sr=b&sig=aUS4ZFCfD%2Bct29T%2B0xJAtFHfmtX1dTTsxKTyNtOw1O4%3D&se=2030-08-03T23%3A02%3A56Z&sp=r"
+$(BRCM_SAI_DEV)_URL = "https://sonicstorage.blob.core.windows.net/packages/bcmsai/3.7/libsaibcm-dev_3.7.6.1-2_amd64.deb?sv=2015-04-05&sr=b&sig=80L3rvMTgilj61D4HCLKOjE2of2SgZF3128JmHYTunc%3D&se=2038-12-30T22%3A24%3A53Z&sp=r"
 
 SONIC_ONLINE_DEBS += $(BRCM_SAI)
 $(BRCM_SAI_DEV)_DEPENDS += $(BRCM_SAI)


### PR DESCRIPTION
What/Why I did:

Update Broadcom SAI debian package. New Package has following changes:

CaseCS00012248135: Fix shows error message "linux-bcm-knet: Fatal error: Incomplete chain" followed by malformed LACP/LLDP packets

How I verify:

Validated by @gechiang 

Qualified it on 7050qx HW SKU (T1-Lag Topo) running the following set of tests:

fib/test_fib.py
decap/test_decap.py
pfcwd/test_pfcwd_all_port_storm.py 
ipfwd/test_dip_sip.py 
everflow/test_everflow_ipv6.py 
everflow/test_everflow_per_interface.py 
lldp/test_lldp.py 
pc/test_lag_2.py 
