### PR TITLE
[Mellanox][202012] Configure buffer for queue 7 on T1 uplink ports in dual ToR scenario

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2
@@ -143,7 +143,11 @@
 {% endfor %}
 {% for port in port_names_active.split(',') %}
 {% if port not in port_names_extra_queues.split(',') %}
+{% if port_names_extra_queues|length > 0 %}
+        "{{ port }}|5-7": {
+{% else %}
         "{{ port }}|5-6": {
+{% endif %}
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         }{% if not loop.last %},{% endif %}
 
@@ -187,7 +191,11 @@
         },
 {% endfor %}
 {% for port in port_names_inactive.split(',') %}
+{% if port_names_extra_queues|length > 0 %}
+        "{{ port }}|5-7": {
+{% else %}
         "{{ port }}|5-6": {
+{% endif %}
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         }{% if not loop.last %},{% endif %}
 
@@ -204,7 +212,11 @@
         },
 {% endfor %}
 {% for port in port_names_inactive.split(',') %}
+{% if port_names_extra_queues|length > 0 %}
+        "{{ port }}|5-7": {
+{% else %}
         "{{ port }}|5-6": {
+{% endif %}
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         }{% if not loop.last %},{% endif %}
 

--- a/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox4600c-t1-dynamic.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox4600c-t1-dynamic.json
@@ -997,28 +997,28 @@
         "Ethernet84|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet0|5-6": {
+        "Ethernet0|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet4|5-6": {
+        "Ethernet4|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet16|5-6": {
+        "Ethernet16|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet20|5-6": {
+        "Ethernet20|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet64|5-6": {
+        "Ethernet64|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet68|5-6": {
+        "Ethernet68|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet80|5-6": {
+        "Ethernet80|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet84|5-6": {
+        "Ethernet84|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
         "Ethernet136|0-1": {
@@ -1538,112 +1538,112 @@
         "Ethernet236|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet8|5-6": {
+        "Ethernet8|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet12|5-6": {
+        "Ethernet12|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet24|5-6": {
+        "Ethernet24|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet28|5-6": {
+        "Ethernet28|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet32|5-6": {
+        "Ethernet32|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet36|5-6": {
+        "Ethernet36|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet40|5-6": {
+        "Ethernet40|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet44|5-6": {
+        "Ethernet44|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet48|5-6": {
+        "Ethernet48|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet52|5-6": {
+        "Ethernet52|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet56|5-6": {
+        "Ethernet56|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet60|5-6": {
+        "Ethernet60|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet72|5-6": {
+        "Ethernet72|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet76|5-6": {
+        "Ethernet76|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet88|5-6": {
+        "Ethernet88|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet92|5-6": {
+        "Ethernet92|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet96|5-6": {
+        "Ethernet96|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet100|5-6": {
+        "Ethernet100|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet104|5-6": {
+        "Ethernet104|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet108|5-6": {
+        "Ethernet108|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet112|5-6": {
+        "Ethernet112|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet116|5-6": {
+        "Ethernet116|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet120|5-6": {
+        "Ethernet120|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet124|5-6": {
+        "Ethernet124|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet128|5-6": {
+        "Ethernet128|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet132|5-6": {
+        "Ethernet132|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet140|5-6": {
+        "Ethernet140|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet160|5-6": {
+        "Ethernet160|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet164|5-6": {
+        "Ethernet164|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet172|5-6": {
+        "Ethernet172|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet192|5-6": {
+        "Ethernet192|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet196|5-6": {
+        "Ethernet196|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet204|5-6": {
+        "Ethernet204|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet224|5-6": {
+        "Ethernet224|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet228|5-6": {
+        "Ethernet228|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet236|5-6": {
+        "Ethernet236|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         }
     }

--- a/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox4600c-t1.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox4600c-t1.json
@@ -773,28 +773,28 @@
         "Ethernet84|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet0|5-6": {
+        "Ethernet0|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet4|5-6": {
+        "Ethernet4|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet16|5-6": {
+        "Ethernet16|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet20|5-6": {
+        "Ethernet20|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet64|5-6": {
+        "Ethernet64|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet68|5-6": {
+        "Ethernet68|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet80|5-6": {
+        "Ethernet80|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet84|5-6": {
+        "Ethernet84|5-7": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
         "Ethernet136|0-1": {
@@ -1314,112 +1314,112 @@
         "Ethernet236|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet8|5-6": {
+        "Ethernet8|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet12|5-6": {
+        "Ethernet12|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet24|5-6": {
+        "Ethernet24|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet28|5-6": {
+        "Ethernet28|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet32|5-6": {
+        "Ethernet32|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet36|5-6": {
+        "Ethernet36|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet40|5-6": {
+        "Ethernet40|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet44|5-6": {
+        "Ethernet44|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet48|5-6": {
+        "Ethernet48|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet52|5-6": {
+        "Ethernet52|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet56|5-6": {
+        "Ethernet56|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet60|5-6": {
+        "Ethernet60|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet72|5-6": {
+        "Ethernet72|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet76|5-6": {
+        "Ethernet76|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet88|5-6": {
+        "Ethernet88|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet92|5-6": {
+        "Ethernet92|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet96|5-6": {
+        "Ethernet96|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet100|5-6": {
+        "Ethernet100|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet104|5-6": {
+        "Ethernet104|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet108|5-6": {
+        "Ethernet108|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet112|5-6": {
+        "Ethernet112|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet116|5-6": {
+        "Ethernet116|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet120|5-6": {
+        "Ethernet120|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet124|5-6": {
+        "Ethernet124|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet128|5-6": {
+        "Ethernet128|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet132|5-6": {
+        "Ethernet132|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet140|5-6": {
+        "Ethernet140|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet160|5-6": {
+        "Ethernet160|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet164|5-6": {
+        "Ethernet164|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet172|5-6": {
+        "Ethernet172|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet192|5-6": {
+        "Ethernet192|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet196|5-6": {
+        "Ethernet196|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet204|5-6": {
+        "Ethernet204|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet224|5-6": {
+        "Ethernet224|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet228|5-6": {
+        "Ethernet228|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet236|5-6": {
+        "Ethernet236|5-7": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         }
     }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Configure buffer for queue 7 on T1 uplink ports in dual ToR scenario
On uplink ports `DSCP 48` => `TC 7` => `queue 7`

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

