### PR TITLE
[Bug][Build] Fix the variable patterns not replaced issue

### DIFF
--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -471,7 +471,6 @@ EOF
     fi
 
 # Add extra linux command line
-extra_cmdline_linux=%%EXTRA_CMDLINE_LINUX%%
 echo "EXTRA_CMDLINE_LINUX=$extra_cmdline_linux"
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX $extra_cmdline_linux"
 

--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -64,7 +64,6 @@ create_partition()
         # determine ONIE partition type
         onie_partition_type=$(${onie_bin} onie-sysinfo -t)
         # demo partition size in MB
-        demo_part_size="%%ONIE_IMAGE_PART_SIZE%%"
         if [ "$firmware" = "uefi" ] ; then
             create_demo_uefi_partition $blk_dev
         elif [ "$onie_partition_type" = "gpt" ] ; then

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -236,6 +236,9 @@ if [ "$install_env" = "onie" ]; then
     fi
 fi
 
+demo_part_size="%%ONIE_IMAGE_PART_SIZE%%"
+echo "ONIE_IMAGE_PART_SIZE=$demo_part_size"
+
 extra_cmdline_linux=%%EXTRA_CMDLINE_LINUX%%
 echo "EXTRA_CMDLINE_LINUX=$extra_cmdline_linux"
 

--- a/onie-mk-demo.sh
+++ b/onie-mk-demo.sh
@@ -99,6 +99,9 @@ sed -i -e "s/%%DEMO_TYPE%%/$demo_type/g" \
        -e "s/%%EXTRA_CMDLINE_LINUX%%/$EXTRA_CMDLINE_LINUX/" \
        -e "s@%%OUTPUT_RAW_IMAGE%%@$output_raw_image@" \
     $tmp_installdir/install.sh || clean_up 1
+sed -i -e "s/%%ONIE_IMAGE_PART_SIZE%%/$onie_image_part_size/" \
+       -e "s/%%EXTRA_CMDLINE_LINUX%%/$EXTRA_CMDLINE_LINUX/" \
+    $tmp_installdir/default_platform.conf || clean_up 1
 echo -n "."
 cp -r $* $tmp_installdir || clean_up 1
 echo -n "."

--- a/onie-mk-demo.sh
+++ b/onie-mk-demo.sh
@@ -99,9 +99,6 @@ sed -i -e "s/%%DEMO_TYPE%%/$demo_type/g" \
        -e "s/%%EXTRA_CMDLINE_LINUX%%/$EXTRA_CMDLINE_LINUX/" \
        -e "s@%%OUTPUT_RAW_IMAGE%%@$output_raw_image@" \
     $tmp_installdir/install.sh || clean_up 1
-sed -i -e "s/%%ONIE_IMAGE_PART_SIZE%%/$onie_image_part_size/" \
-       -e "s/%%EXTRA_CMDLINE_LINUX%%/$EXTRA_CMDLINE_LINUX/" \
-    $tmp_installdir/default_platform.conf || clean_up 1
 echo -n "."
 cp -r $* $tmp_installdir || clean_up 1
 echo -n "."


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The %%EXTRA_CMDLINE_LINUX%% is not replaced to the real value, it has impact on the kernel parameter settings.
See the log sonic-vs.img.gz.log in the latest master build. In the grub.cfg, the %%EXTRA_CMDLINE_LINUX%% is set in the linux command line.
```
Installing for i386-pc platform.
Installation finished. No error reported.
Switch CPU vendor is: GenuineIntel
Switch CPU cstates are: disabled
EXTRA_CMDLINE_LINUX=%%EXTRA_CMDLINE_LINUX%%
Installed SONiC base image SONiC-OS successfully
ONIE: NOS install successful: file://dev/vdb/onie-installer.bin
```

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

