### PR TITLE
[build] Fix wrong package dependency about thrift

### DIFF
--- a/rules/thrift_0_14_1.mk
+++ b/rules/thrift_0_14_1.mk
@@ -14,7 +14,9 @@ PYTHON3_THRIFT_0_14_1 = python3-thrift_$(THRIFT_0_14_1_VERSION)_$(CONFIGURED_ARC
 $(eval $(call add_derived_package,$(LIBTHRIFT_0_14_1),$(PYTHON3_THRIFT_0_14_1)))
 
 PYTHON_THRIFT_0_14_1 = python-thrift_$(THRIFT_0_14_1_VERSION)_$(CONFIGURED_ARCH).deb
-$(eval $(call add_derived_package,$(LIBTHRIFT_0_14_1),$(PYTHON_THRIFT_0_14_1)))
+# LIBTHRIFT_0_14_1 didn't derive PYTHON_THRIFT_0_14_1
+# Don't uncomment following line until python-thrift_* is built
+# $(eval $(call add_derived_package,$(LIBTHRIFT_0_14_1),$(PYTHON_THRIFT_0_14_1)))
 
 THRIFT_0_14_1_COMPILER = thrift-compiler_$(THRIFT_0_14_1_VERSION)_$(CONFIGURED_ARCH).deb
 $(eval $(call add_derived_package,$(LIBTHRIFT_0_14_1),$(THRIFT_0_14_1_COMPILER)))


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix wrongly added dependency, which caused vs platform build failure.
#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

