### PR TITLE
[build] create a clean_docker_images profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,3 +98,6 @@ clean reset showtag docker-cleanup sonic-slave-build sonic-slave-bash :
 # Freeze the versions, see more detail options: scripts/versions_manager.py freeze -h
 freeze:
 	@scripts/versions_manager.py freeze $(FREEZE_VERSION_OPTIONS)
+
+clean_docker_images:
+	@scripts/clean_docker_images.sh

--- a/scripts/clean_docker_images.sh
+++ b/scripts/clean_docker_images.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+DOCKER_CMD=docker
+if [ ! `which $DOCKER_CMD` ]
+then  echo "no docker command available" >&2
+    exit 1
+fi
+#if "docker ps" cannot be run without error, prepend sudo
+if ( ! $DOCKER_CMD ps >/dev/null 2>&1 );then
+    echo "docker command only usable as root, using sudo" >&2
+    DOCKER_CMD="sudo docker"
+fi
+
+cd $(dirname $0)
+cd ..
+IMAGES_LIST=$($DOCKER_CMD image ls "sonic*" | sed 's/  */\t/g' | cut -f3 | tail -n +2)
+
+if [ -z $IMAGES_LIST ]; then
+    echo "No docker image to delete"
+    exit 0
+fi
+
+echo -n "Run '$DOCKER_CMD image rm -f $(echo $IMAGES_LIST) ' (y/n)?"
+initial_stty_cfg=$(stty -g)
+stty raw -echo
+answer=$( while ! head -c 1 | grep -i '[yn]' ;do true ;done )
+stty $initial_stty_cfg
+if echo "$answer" | grep -iq "^y" ;then
+    $DOCKER_CMD image rm -f $(echo $IMAGES_LIST)
+else
+    echo "Nothing done"
+    exit 0
+fi
+echo -n "Run '$DOCKER_CMD image prune -af' (y/n)?"
+initial_stty_cfg=$(stty -g)
+stty raw -echo
+answer=$( while ! head -c 1 | grep -i '[yn]' ;do true ;done )
+stty $initial_stty_cfg
+if echo "$answer" | grep -iq "^y" ;then
+    $DOCKER_CMD image prune -af
+fi


### PR DESCRIPTION
SONiC image build process generates several docker images. They consume much disk space.
This space might need to be reclaimed once the SONiC image has been built to avoid disk full error messages.
Many of these docker images will not be reused at next build.

- create a shell script to detect docker images generated during build (with a blob pattern) in order to delete them and reclaim disk space
- declare in the Make a profile "clean_image" that points to this script

Issue  #428
for example

#### Which release branch to backport (provide reason below if selected)

all branches are affected

#### A picture of a cute animal (not mandatory but encouraged)

 _______\)%%%%%%%%._ 
`''''-'-;   % % % % %'-._
        :b) \            '-. 
        : :__)'    .'    .' 
        :.::/  '.'   .' 
        o_i/   :    ; 
               :   .' 
                ''`
