### PR TITLE
Login through RADIUS is not working due to invalid shell

### DIFF
--- a/src/radius/nss/libnss-radius/nss_radius_common.c
+++ b/src/radius/nss/libnss-radius/nss_radius_common.c
@@ -159,11 +159,11 @@ static void init_rnm(RADIUS_NSS_CONF_B * conf) {
     rnm[0].gid   = 999;
     rnm[0].groups = "docker";
     rnm[0].gecos = "remote_user";
-    rnm[0].shell = "/usr/bin/sonic-launch-shell";
+    rnm[0].shell = "/bin/bash";
     rnm[RADIUS_MAX_MPL-1].gid   = 1000;
     rnm[RADIUS_MAX_MPL-1].groups = "admin,sudo,docker";
     rnm[RADIUS_MAX_MPL-1].gecos = "remote_user_su";
-    rnm[RADIUS_MAX_MPL-1].shell = "/usr/bin/sonic-launch-shell";
+    rnm[RADIUS_MAX_MPL-1].shell = "/bin/bash";
 
 }
 

--- a/src/sonic-host-services-data/templates/radius_nss.conf.j2
+++ b/src/sonic-host-services-data/templates/radius_nss.conf.j2
@@ -13,13 +13,13 @@ debug=on
 #
 # User Privilege:
 # Default:
-# user_priv=15;pw_info=remote_user_su;gid=1000;group=sudo,docker;shell=/usr/bin/sonic-launch-shell
-# user_priv=1;pw_info=remote_user;gid=999;group=docker;shell=/usr/bin/sonic-launch-shell
+# user_priv=15;pw_info=remote_user_su;gid=1000;group=sudo,docker;shell=/bin/bash
+# user_priv=1;pw_info=remote_user;gid=999;group=docker;shell=/bin/bash
 
 # Eg:
-# user_priv=15;pw_info=remote_user_su;gid=1000;group=sudo,docker;shell=/usr/bin/sonic-launch-shell
-# user_priv=7;pw_info=netops;gid=999;group=docker;shell=/usr/bin/sonic-launch-shell
-# user_priv=1;pw_info=operator;gid=100;group=docker;shell=/usr/bin/sonic-launch-shell
+# user_priv=15;pw_info=remote_user_su;gid=1000;group=sudo,docker;shell=/bin/bash
+# user_priv=7;pw_info=netops;gid=999;group=docker;shell=/bin/bash
+# user_priv=1;pw_info=operator;gid=100;group=docker;shell=/bin/bash
 #
 
 # many_to_one:

--- a/src/sonic-host-services-data/templates/radius_nss.conf.j2
+++ b/src/sonic-host-services-data/templates/radius_nss.conf.j2
@@ -13,13 +13,13 @@ debug=on
 #
 # User Privilege:
 # Default:
-# user_priv=15;pw_info=remote_user_su;gid=1000;group=sudo,docker;shell=/bin/bash
-# user_priv=1;pw_info=remote_user;gid=999;group=docker;shell=/bin/bash
+# user_priv=15;pw_info=remote_user_su;gid=1000;group=sudo,docker;shell=/usr/bin/sonic-launch-shell
+# user_priv=1;pw_info=remote_user;gid=999;group=docker;shell=/usr/bin/sonic-launch-shell
 
 # Eg:
-# user_priv=15;pw_info=remote_user_su;gid=1000;group=sudo,docker;shell=/bin/bash
-# user_priv=7;pw_info=netops;gid=999;group=docker;shell=/bin/bash
-# user_priv=1;pw_info=operator;gid=100;group=docker;shell=/bin/bash
+# user_priv=15;pw_info=remote_user_su;gid=1000;group=sudo,docker;shell=/usr/bin/sonic-launch-shell
+# user_priv=7;pw_info=netops;gid=999;group=docker;shell=/usr/bin/sonic-launch-shell
+# user_priv=1;pw_info=operator;gid=100;group=docker;shell=/usr/bin/sonic-launch-shell
 #
 
 # many_to_one:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
RADIUS presumes that sonic launch shell (/usr/bin/sonic-launch-shell) is available by default to be authenticated users, which is not the case. This leads to failure in RADIUS authentication.

#### How I did it
Added valid bash shell  (/bin/bash) in RADIUS nss code

#### How to verify it
Verification of remote RADIUS user with valid credentials is authenticated without any failure - PASS


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211

#### Description for the changelog
Fixed RADIUS user authentication issue due to invalid shell (sonic-launch-shell)
Resolves 
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

####   This pull request resolves PR#11352 (https://github.com/sonic-net/sonic-buildimage/issues/11352) under sonic-buildimage repository.
