### PR TITLE
[build] Migrate libyang2 sources download from wget to dget (#13504)

### DIFF
--- a/src/libyang2/Makefile
+++ b/src/libyang2/Makefile
@@ -2,16 +2,6 @@
 SHELL = /bin/bash
 .SHELLFLAGS += -e
 
-LIBYANG_URL = https://sonicstorage.blob.core.windows.net/debian/pool/main/liby/libyang
-
-DSC_FILE = libyang2_$(LIBYANG2_FULLVERSION).dsc
-ORIG_FILE = libyang2_$(LIBYANG2_VERSION).orig.tar.gz
-DEBIAN_FILE = libyang2_$(LIBYANG2_FULLVERSION).debian.tar.xz
-
-DSC_FILE_URL = $(LIBYANG_URL)/$(DSC_FILE)
-ORIG_FILE_URL = $(LIBYANG_URL)/$(ORIG_FILE)
-DEBIAN_FILE_URL = $(LIBYANG_URL)/$(DEBIAN_FILE)
-
 MAIN_TARGET = $(LIBYANG2)
 DERIVED_TARGETS = $(LIBYANG2_DEV) $(LIBYANG2_DBG) $(LIBYANG2_TOOLS) $(LIBYANG2_TOOLS_DBG)
 
@@ -20,10 +10,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -fr ./libyang2-$(LIBYANG2_VERSION)
 
 	# download debian libyang
-	wget -NO "$(DSC_FILE)" $(DSC_FILE_URL)
-	wget -NO "$(ORIG_FILE)" $(ORIG_FILE_URL)
-	wget -NO "$(DEBIAN_FILE)" $(DEBIAN_FILE_URL)
-	dpkg-source -x libyang2_$(LIBYANG2_FULLVERSION).dsc
+	dget https://sonicstorage.blob.core.windows.net/debian/pool/main/liby/libyang/libyang2_$(LIBYANG2_FULLVERSION).dsc
 
 	pushd libyang2-$(LIBYANG2_VERSION)
 	#sed -i 's/set(LIBYANG_MAJOR_SOVERSION 1)/set(LIBYANG_MAJOR_SOVERSION 2)/' CMakeLists.txt


### PR DESCRIPTION
According to its manual page,
"[dget in its] first form, [..] fetches the requested URLs. If this is a .dsc or .changes file, then dget acts as a source-package
 aware form of wget: it also fetches any files referenced in the
.dsc/.changes file.
The downloaded source is then checked with dscverify and, if successful, unpacked by dpkg-source."

Thus, when possible, dget use is preferable to wget so that sources authenticity can be performed automatically by dscverify"

Previous commit in PR https://github.com/sonic-net/sonic-buildimage/pull/13394 has been removed
because it switched the debian repository from its mirror in SONiC at https://sonicstorage.blob.core.windows.net
to debian official repository at https://deb.debian.org/debian/pool/main/liby/libyang2/

This version of the package was in debian testing and after having taken a look at the repo content
at https://deb.debian.org/debian/pool/main/liby/libyang2/ it appears it was removed from the official distribution.
and superseded by a more recent version 2.1.30.

This new commit restores the URL at the mirror
dget https://sonicstorage.blob.core.windows.net/debian/pool/main/liby/libyang/libyang2_2.0.112-6.dsc
to address the following issue https://github.com/sonic-net/sonic-buildimage/issues/13504

Note that debian-keyring must be installed on your system to run this command that performs a signature verification,
what is not the case by default in Ubuntu.
$ sudo apt-get install debian-keyring


#### Which release branch to backport (provide reason below if selected)

all branches using libyang2 sources

#### Description for the changelog

[build] Migrate libyang2 sources download from wget to dget

#### A picture of a cute animal (not mandatory but encouraged)

                      .".
                     /  |
                    /  /
                   / ,"
       .-------.--- /
      "._ __.-/ o. o\  
         "   (    Y  )
              )     /
             /     (
            /       Y
        .-"         |
       /  _     \    \ 
      /    `. ". ) /' )
     Y       )( / /(,/
    ,|      /     )
    ( |     /     /
     " \_  (__   (__        [nabis]
          "-._,)--._,)

