### PR TITLE
[Build] don't install firmware-amd-graphics

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -333,7 +333,7 @@ sudo LANG=C chroot $FILESYSTEM_ROOT usermod -aG redis $USERNAME
 if [[ $CONFIGURED_ARCH == amd64 ]]; then
     ## Pre-install hardware drivers
     sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y install      \
-        firmware-linux-nonfree
+        firmware-misc-nonfree
 fi
 
 ## Pre-install the fundamental packages


### PR DESCRIPTION
#### Why I did it

firmware-linux-nonfree is a metapackage.
In fact we install firmware-amd-graphics and firmware-misc-nonfree.
https://packages.debian.org/en/bullseye/firmware-linux-nonfree

#### How I did it

Install only firmware-misc-nonfree instead of firmware-linux-nonfree.

#### How to verify it
