### PR TITLE
Potential fix for Celestica E1031 device hang

### DIFF
--- a/device/celestica/x86_64-cel_e1031-r0/installer.conf
+++ b/device/celestica/x86_64-cel_e1031-r0/installer.conf
@@ -1,4 +1,4 @@
 CONSOLE_PORT=0x2f8
 CONSOLE_DEV=1
 CONSOLE_SPEED=9600
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="module_blacklist=gpio_ich"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="module_blacklist=gpio_ich processor.max_cstate=1 intel_idle.max_cstate=0"


### PR DESCRIPTION
#### Why I did it
CPU idle kicks in and cause device to become non-responsive.
(Pulling change in #6125 to master and for back porting)

##### Work item tracking
- Microsoft ADO **(number only)**: 24524571

#### How I did it
set CPU max_cstate to 0

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

