### PR TITLE
[202311][Mellanox] implement platform wait in python code (#17398)

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/platform_wait
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/platform_wait
@@ -1,69 +1,32 @@
-#!/bin/bash
+#!/usr/bin/python3
 
-declare -r SYSLOG_LOGGER="/usr/bin/logger"
-declare -r SYSLOG_IDENTIFIER="platform_wait"
-declare -r SYSLOG_ERROR="error"
-declare -r SYSLOG_NOTICE="notice"
-declare -r SYSLOG_INFO="info"
+#
+# Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+# Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
-declare -r HW_MGMT_CONFIG="/var/run/hw-management/config"
+import sys
+from sonic_platform.device_data import DeviceDataManager
+from sonic_py_common.logger import Logger
 
-declare -r MODULE_COUNTER="${HW_MGMT_CONFIG}/module_counter"
-declare -r SFP_COUNTER="${HW_MGMT_CONFIG}/sfp_counter"
 
-declare -r EXIT_SUCCESS="0"
-declare -r EXIT_TIMEOUT="1"
-
-function log_error() {
-    eval "${SYSLOG_LOGGER} -t ${SYSLOG_IDENTIFIER} -p ${SYSLOG_ERROR} $@"
-}
-
-function log_notice() {
-    eval "${SYSLOG_LOGGER} -t ${SYSLOG_IDENTIFIER} -p ${SYSLOG_NOTICE} $@"
-}
-
-function log_info() {
-    eval "${SYSLOG_LOGGER} -t ${SYSLOG_IDENTIFIER} -p ${SYSLOG_INFO} $@"
-}
-
-function wait_for_sfp() {
-    local -r _NUM_MATCH="^[0-9]+$"
-    local -r _NUM_ZERO="0"
-
-    local _MODULE_CNT="0"
-    local _SFP_CNT="0"
-
-    local -i _WDOG_CNT="1"
-    local -ir _WDOG_MAX="300"
-
-    local -r _TIMEOUT="1s"
-
-    while [[ "${_WDOG_CNT}" -le "${_WDOG_MAX}" ]]; do
-        _MODULE_CNT="$(cat ${MODULE_COUNTER} 2>&1)"
-        _SFP_CNT="$(cat ${SFP_COUNTER} 2>&1)"
-
-        if [[ "${_MODULE_CNT}" =~ ${_NUM_MATCH} && "${_SFP_CNT}" =~ ${_NUM_MATCH} ]]; then
-            if [[ "${_SFP_CNT}" -gt "${_NUM_ZERO}" && "${_MODULE_CNT}" -eq "${_SFP_CNT}" ]]; then
-                return "${EXIT_SUCCESS}"
-            fi
-        fi
-
-        let "_WDOG_CNT++"
-        sleep "${_TIMEOUT}"
-    done
-
-    return "${EXIT_TIMEOUT}"
-}
-
-log_info "Wait for SFP interfaces to be ready"
-
-wait_for_sfp
-EXIT_CODE="$?"
-if [[ "${EXIT_CODE}" != "${EXIT_SUCCESS}" ]]; then
-    log_error "SFP interfaces are not ready: timeout"
-    exit "${EXIT_CODE}"
-fi
-
-log_info "SFP interfaces are ready"
-
-exit "${EXIT_SUCCESS}"
+logger = Logger(log_identifier='platform_wait')
+logger.log_notice('Nvidia: Wait for PMON dependencies to be ready')
+if DeviceDataManager.wait_platform_ready():
+    logger.log_notice('Nvidia: PMON dependencies are ready')
+    sys.exit(0)
+else:
+    logger.log_error('Nvidia: PMON dependencies are not ready: timeout')
+    sys.exit(-1)

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
@@ -290,6 +290,30 @@ def wait_until(predict, timeout, interval=1, *args, **kwargs):
     return False
 
 
+def wait_until_conditions(conditions, timeout, interval=1):
+    """
+    Wait until all the conditions become true
+    Args:
+        conditions (list): a list of callable which generate True|False
+        timeout (int): wait time in seconds
+        interval (int, optional):  interval to check the predict. Defaults to 1.
+
+    Returns:
+        bool: True if wait success else False
+    """
+    while timeout > 0:
+        pending_conditions = []
+        for condition in conditions:
+            if not condition():
+                pending_conditions.append(condition)
+        if not pending_conditions:
+            return True
+        conditions = pending_conditions
+        time.sleep(interval)
+        timeout -= interval
+    return False
+
+  
 class TimerEvent:
     def __init__(self, interval, cb, repeat):
         self.interval = interval

--- a/platform/mellanox/mlnx-platform-api/tests/test_device_data.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_device_data.py
@@ -60,6 +60,26 @@ class TestDeviceData:
         mock_read.return_value = {'SAI_INDEPENDENT_MODULE_MODE': '1'}
         assert DeviceDataManager.is_independent_mode()
 
+    @mock.patch('sonic_py_common.device_info.get_path_to_platform_dir', mock.MagicMock(return_value='/tmp'))
+    @mock.patch('sonic_platform.device_data.utils.load_json_file')
+    def test_get_sfp_count(self, mock_load_json):
+        mock_load_json.return_value = {
+            'chassis': {
+                'sfps': [1,2,3]
+            }
+        }
+        assert DeviceDataManager.get_sfp_count() == 3
 
-
-
+    @mock.patch('sonic_platform.device_data.time.sleep', mock.MagicMock())
+    @mock.patch('sonic_platform.device_data.DeviceDataManager.get_sfp_count', mock.MagicMock(return_value=3))
+    @mock.patch('sonic_platform.device_data.utils.read_int_from_file', mock.MagicMock(return_value=1))
+    @mock.patch('sonic_platform.device_data.os.path.exists')
+    @mock.patch('sonic_platform.device_data.DeviceDataManager.is_independent_mode')
+    def test_wait_platform_ready(self, mock_is_indep, mock_exists):
+        mock_exists.return_value = True
+        mock_is_indep.return_value = True
+        assert DeviceDataManager.wait_platform_ready()
+        mock_is_indep.return_value = False
+        assert DeviceDataManager.wait_platform_ready()
+        mock_exists.return_value = False
+        assert not DeviceDataManager.wait_platform_ready()

--- a/platform/mellanox/mlnx-platform-api/tests/test_utils.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_utils.py
@@ -195,6 +195,13 @@ class TestUtils:
         mock_os_open = mock.mock_open(read_data='a=b')
         with mock.patch('sonic_platform.utils.open', mock_os_open):
             assert utils.read_key_value_file('some_file', delimeter='=') == {'a':'b'}
+            
+    @mock.patch('sonic_platform.utils.time.sleep', mock.MagicMock())
+    def test_wait_until_conditions(self):
+        conditions = [lambda: True]
+        assert utils.wait_until_conditions(conditions, 1)
+        conditions = [lambda: False]
+        assert not utils.wait_until_conditions(conditions, 1)
 
     def test_timer(self):
         timer = utils.Timer()


### PR DESCRIPTION
Backport PR https://github.com/sonic-net/sonic-buildimage/pull/17398

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

New implementation of Nvidia platform_wait due to:

1. sysfs deprecated by hw-mgmt
2. new dependencies to SDK
3. For CMIS host management mode

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- wait hw-management ready
- wait SDK sysfs nodes ready

#### How to verify it

manual test
unit test
sonic-mgmt regression

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
