### PR TITLE
reduce the amount of logmessages

### DIFF
--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -46,6 +46,7 @@ Cmnd_Alias      READ_ONLY_CMDS = /bin/cat /var/log/syslog, /bin/cat /var/log/sys
                                  /usr/local/bin/sfputil show *, \
                                  /usr/local/bin/storyteller *
 
+Defaults!READ_ONLY_CMDS !syslog
 
 Cmnd_Alias      PASSWD_CMDS = /usr/local/bin/config tacacs passkey *, \
                               /usr/local/bin/config radius passkey *, \


### PR DESCRIPTION
SONiC creates huge amount of logmessages caused by automated processes which perform "sudo" with the messages enlisted by the READ_ONLY_CMDS Cmnd_Alias.
This change prevents the logging of messages of the following type:
```
Jan 22 17:34:44.534159 st01-sw1g-r01-u32 NOTICE sudo:    \
       admin : TTY=pts/2 ; PWD=/home/admin ; USER=root ; \
       COMMAND=/usr/bin/docker ps
```
 If you use centralized logging for dozens and hundreds of switches, this always causes you to filter these messages out.
