### PR TITLE
[Celestica] Make 'sfputil show presence' 10x faster

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/services/platform_api/sonic_platform/common.py
+++ b/platform/broadcom/sonic-platform-modules-cel/services/platform_api/sonic_platform/common.py
@@ -25,7 +25,6 @@ class Common:
 
     SET_METHOD_IPMI = 'ipmitool'
     NULL_VAL = 'N/A'
-    HOST_CHK_CMD = ["docker"]
     REF_KEY = '$ref:'
 
     def __init__(self, conf=None):
@@ -167,11 +166,7 @@ class Common:
         return True
 
     def is_host(self):
-        try:
-            subprocess.call(self.HOST_CHK_CMD, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        except FileNotFoundError:
-            return False
-        return True
+        return not os.path.isfile('/.dockerenv')
 
     def load_json_file(self, path):
         """


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The is_host function is used when enumerating SFPs which was very slow when detecting if it was running inside docker. The following call makes the detection 10x faster.

#### How I did it
Instead of executing `docker` check for `/.dockerenv` which is present when inside a container. 

#### How to verify it
Before patch:
```
  $ time sudo sfputil show presence
  Port         Presence
  -----------  -----------
  Ethernet0    Present
  Ethernet1    Present
  Ethernet2    Present

  -- snip --

  real    0m13.521s
  user    0m10.239s
  sys     0m4.104s
```
After patch:
```  
  $ time sudo sfputil show presence
  Port         Presence
  -----------  -----------
  Ethernet0    Present
  Ethernet1    Present
  Ethernet2    Present

  -- snip --

  real    0m2.133s
  user    0m1.461s
  sys     0m0.347s
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [x] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202211

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
n/a
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
n/a
#### A picture of a cute animal (not mandatory but encouraged)

![image](https://github.com/sonic-net/sonic-buildimage/assets/7513707/97f49f15-9138-49e4-b417-c7f6eb1fdb40)
