### PR TITLE
[Nokia-7215] Enhance Watchdog service

### DIFF
--- a/platform/marvell-armhf/sonic-platform-nokia/7215/service/cpu_wdt.service
+++ b/platform/marvell-armhf/sonic-platform-nokia/7215/service/cpu_wdt.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=CPU WDT
+Conflicts=watchdog-control.service
 After=nokia-7215init.service
 [Service]
 ExecStart=/usr/local/bin/cpu_wdt.py

--- a/platform/marvell-armhf/sonic-platform-nokia/debian/sonic-platform-nokia-7215.postinst
+++ b/platform/marvell-armhf/sonic-platform-nokia/debian/sonic-platform-nokia-7215.postinst
@@ -7,6 +7,8 @@ sh /usr/sbin/nokia-7215_plt_setup.sh
 systemctl enable nokia-7215init.service
 systemctl start nokia-7215init.service
 
+systemctl mask --now watchdog-control.service
+
 systemctl enable cpu_wdt.service
 systemctl start cpu_wdt.service
 


### PR DESCRIPTION
Mask Watchdog-control.service and make sure only one watchdog service starts on this platform

This is a backport PR for Master PR #18850 
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To resolve conflict between ordering of the 2 watchdog services.
1) watchdog-control.service -- common service designed to disable watchdog on all platforms
2) cpu_wdt.service -- enable Watchdog on nokia-7215 platform.

Is some cases service 1 was started after service 2 leaving the watchdog on the box disabled

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Enhance service file to assure cpu_wdt.service always starts after watchdog-control.service

#### How to verify it
1) Try multiple upgrades and install scenario to make sure watchdog is always in enabled state 
2) Try multiple reboots to make sure watchdog is always in enabled state 


```
admin@sonic:~$ systemctl status watchdog-control.service 
â— watchdog-control.service
     Loaded: masked (Reason: Unit watchdog-control.service is masked.)
     Active: inactive (dead)
admin@sonic:~$ 
admin@sonic:~$ 
admin@sonic:~$ systemctl status cpu_wdt.service
â— cpu_wdt.service - CPU WDT
     Loaded: loaded (/etc/systemd/system/cpu_wdt.service; enabled; vendor prese>
     Active: active (running) since Mon 2024-05-20 14:57:15 UTC; 4min 57s ago
   Main PID: 635 (cpu_wdt.py)
      Tasks: 1 (limit: 4915)
     Memory: 13.9M
     CGroup: /system.slice/cpu_wdt.service
             â””â”€635 /usr/bin/python /usr/local/bin/cpu_wdt.py

admin@sonic:~$ 
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205
- [ ] 202211
- [x] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

