### PR TITLE
[build] use debian slim docker images

### DIFF
--- a/dockers/docker-base-bookworm/Dockerfile.j2
+++ b/dockers/docker-base-bookworm/Dockerfile.j2
@@ -1,26 +1,12 @@
 {% set prefix = DEFAULT_CONTAINER_REGISTRY %}
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
 {% if CONFIGURED_ARCH == "armhf" and (MULTIARCH_QEMU_ENVIRON == "y" or CROSS_BUILD_ENVIRON == "y") %}
-FROM --platform=linux/arm/v7 {{ prefix }}debian:bookworm
+FROM --platform=linux/arm/v7 {{ prefix }}debian:bookworm-slim
 {% elif CONFIGURED_ARCH == "arm64" and (MULTIARCH_QEMU_ENVIRON == "y" or CROSS_BUILD_ENVIRON == "y") %}
-FROM --platform=linux/arm64 {{ prefix }}debian:bookworm
+FROM --platform=linux/arm64 {{ prefix }}debian:bookworm-slim
 {% else %}
-FROM {{ prefix }}{{DOCKER_BASE_ARCH}}/debian:bookworm
+FROM {{ prefix }}{{DOCKER_BASE_ARCH}}/debian:bookworm-slim
 {% endif %}
-
-# Clean documentation in FROM image
-RUN find /usr/share/doc -depth \( -type f -o -type l \) ! -name copyright | xargs rm || true
-
-# Clean doc directories that are empty or only contain empty directories
-RUN while [ -n "$(find /usr/share/doc -depth -type d -empty -print -exec rmdir {} +)" ]; do :; done && \
-    rm -rf               \
-    /usr/share/man/*     \
-    /usr/share/groff/*   \
-    /usr/share/info/*    \
-    /usr/share/lintian/* \
-    /usr/share/linda/*   \
-    /var/cache/man/*     \
-    /usr/share/locale/*
 
 # Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/dockers/docker-base-bullseye/Dockerfile.j2
+++ b/dockers/docker-base-bullseye/Dockerfile.j2
@@ -1,26 +1,12 @@
 {% set prefix = DEFAULT_CONTAINER_REGISTRY %}
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
 {% if CONFIGURED_ARCH == "armhf" and (MULTIARCH_QEMU_ENVIRON == "y" or CROSS_BUILD_ENVIRON == "y") %}
-FROM {{ prefix }}multiarch/debian-debootstrap:armhf-bullseye
+FROM {{ prefix }}multiarch/debian-debootstrap:armhf-bullseye-slim
 {% elif CONFIGURED_ARCH == "arm64" and (MULTIARCH_QEMU_ENVIRON == "y" or CROSS_BUILD_ENVIRON == "y") %}
-FROM {{ prefix }}multiarch/debian-debootstrap:arm64-bullseye
+FROM {{ prefix }}multiarch/debian-debootstrap:arm64-bullseye-slim
 {% else %}
-FROM {{ prefix }}{{DOCKER_BASE_ARCH}}/debian:bullseye
+FROM {{ prefix }}{{DOCKER_BASE_ARCH}}/debian:bullseye-slim
 {% endif %}
-
-# Clean documentation in FROM image
-RUN find /usr/share/doc -depth \( -type f -o -type l \) ! -name copyright | xargs rm || true
-
-# Clean doc directories that are empty or only contain empty directories
-RUN while [ -n "$(find /usr/share/doc -depth -type d -empty -print -exec rmdir {} +)" ]; do :; done && \
-    rm -rf               \
-    /usr/share/man/*     \
-    /usr/share/groff/*   \
-    /usr/share/info/*    \
-    /usr/share/lintian/* \
-    /usr/share/linda/*   \
-    /var/cache/man/*     \
-    /usr/share/locale/*
 
 # Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/dockers/docker-base-buster/Dockerfile.j2
+++ b/dockers/docker-base-buster/Dockerfile.j2
@@ -1,26 +1,12 @@
 {% set prefix = DEFAULT_CONTAINER_REGISTRY %}
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
 {% if CONFIGURED_ARCH == "armhf" and (MULTIARCH_QEMU_ENVIRON == "y" or CROSS_BUILD_ENVIRON == "y") %}
-FROM {{ prefix }}multiarch/debian-debootstrap:armhf-buster
+FROM {{ prefix }}multiarch/debian-debootstrap:armhf-buster-slim
 {% elif CONFIGURED_ARCH == "arm64" and (MULTIARCH_QEMU_ENVIRON == "y" or CROSS_BUILD_ENVIRON == "y") %}
-FROM {{ prefix }}multiarch/debian-debootstrap:arm64-buster
+FROM {{ prefix }}multiarch/debian-debootstrap:arm64-buster-slim
 {% else %}
-FROM {{ prefix }}{{DOCKER_BASE_ARCH}}/debian:buster
+FROM {{ prefix }}{{DOCKER_BASE_ARCH}}/debian:buster-slim
 {% endif %}
-
-# Clean documentation in FROM image
-RUN find /usr/share/doc -depth \( -type f -o -type l \) ! -name copyright | xargs rm || true
-
-# Clean doc directories that are empty or only contain empty directories
-RUN while [ -n "$(find /usr/share/doc -depth -type d -empty -print -exec rmdir {} +)" ]; do :; done && \
-    rm -rf               \
-    /usr/share/man/*     \
-    /usr/share/groff/*   \
-    /usr/share/info/*    \
-    /usr/share/lintian/* \
-    /usr/share/linda/*   \
-    /var/cache/man/*     \
-    /usr/share/locale/*
 
 # Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
#### Why I did it

To reduce final image size and docker images size.

Almost all SONiC docker images are based on debian image.
But default debian image includes multiple extra files that are normally not necessary within containers:
https://github.com/debuerreotype/debuerreotype/blob/master/scripts/.slimify-excludes

We are trying to remove them from debian image but this solution is incorrect.
It's not possible to remove these files from docker base layer because `--squash` only works with NEW layers:
https://docs.docker.com/reference/cli/docker/image/build/#squash:
"Once the image is built, this flag squashes the new layers into a new image with a single new layer. Squashing doesn't destroy any existing image, rather it creates a new image with the content of the squashed layers."

Instead we should use debian -slim images.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Use debian slim image as base image for docker-base-bookworm, docker-base-bullseye and docker-base-buster.

#### How to verify it

default build:
```
82M docker-base-bookworm.gz
86M docker-base-bullseye.gz
99M docker-config-engine-bookworm.gz
103M docker-config-engine-bullseye.gz
197M docker-dash-engine.gz
102M docker-database.gz
103M docker-dhcp-relay.gz
100M docker-eventd.gz
120M docker-fpm-frr.gz
522M docker-gbsyncd-vs.gz
116M docker-lldp.gz
110M docker-macsec.gz
116M docker-mux.gz
109M docker-nat.gz
112M docker-orchagent.gz
140M docker-platform-monitor.gz
100M docker-router-advertiser.gz
109M docker-sflow.gz
110M docker-snmp.gz
128M docker-sonic-gnmi.gz
126M docker-sonic-mgmt-framework.gz
108M docker-swss-layer-bookworm.gz
112M docker-swss-layer-bullseye.gz
522M docker-syncd-vs.gz
108M docker-teamd.gz
1965594999 target/sonic-vs.img.gz
```

build based on slim images:
```
62M docker-base-bookworm.gz
64M docker-base-bullseye.gz
80M docker-config-engine-bookworm.gz
80M docker-config-engine-bullseye.gz
197M docker-dash-engine.gz
82M docker-database.gz
83M docker-dhcp-relay.gz
80M docker-eventd.gz
98M docker-fpm-frr.gz
502M docker-gbsyncd-vs.gz
97M docker-lldp.gz
90M docker-macsec.gz
97M docker-mux.gz
90M docker-nat.gz
92M docker-orchagent.gz
121M docker-platform-monitor.gz
80M docker-router-advertiser.gz
89M docker-sflow.gz
91M docker-snmp.gz
109M docker-sonic-gnmi.gz
107M docker-sonic-mgmt-framework.gz
89M docker-swss-layer-bookworm.gz
89M docker-swss-layer-bullseye.gz
502M docker-syncd-vs.gz
89M docker-teamd.gz
1921280020 sonic-vs.img.gz
```

Size of final image is reduced by 40M (20M for bookworm-based containers and 20M for bullseye-based).

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

