### PR TITLE
[build] don't reinstall golang-src to reduce build time

### DIFF
--- a/sonic-slave-bookworm/Dockerfile.j2
+++ b/sonic-slave-bookworm/Dockerfile.j2
@@ -508,15 +508,14 @@ RUN apt-get install -y kernel-wedge
 {%- endif %}
 
 # For gobgp and telemetry build
-RUN apt-get install -y golang
 {%- if INCLUDE_FIPS == "y" %}
 RUN wget -O golang-go.deb 'https://sonicstorage.blob.core.windows.net/public/fips/bookworm/{{ FIPS_VERSION }}/{{ CONFIGURED_ARCH }}/golang-1.19-go_{{ FIPS_GOLANG_VERSION }}_{{ CONFIGURED_ARCH }}.deb' \
  && wget -O golang-src.deb 'https://sonicstorage.blob.core.windows.net/public/fips/bookworm/{{ FIPS_VERSION }}/{{ CONFIGURED_ARCH }}/golang-1.19-src_{{ FIPS_GOLANG_VERSION }}_all.deb' \
- && dpkg -i golang-go.deb golang-src.deb \
+ && apt-get install -y ./golang-go.deb ./golang-src.deb golang \
  && ln -sf /usr/lib/go-1.19 /usr/local/go \
  && rm golang-go.deb golang-src.deb
 {%- else %}
-RUN apt-get install -y golang-go \
+RUN apt-get install -y golang \
  && ln -sf /usr/lib/go-1.19 /usr/local/go
 {%- endif %}
 

--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -512,13 +512,14 @@ RUN eatmydata apt-get install -y kernel-wedge
 {%- endif %}
 
 # For gobgp and telemetry build
-RUN eatmydata apt-get install -y golang-1.15 && ln -s /usr/lib/go-1.15 /usr/local/go
 {%- if INCLUDE_FIPS == "y" %}
 RUN wget -O golang-go.deb 'https://sonicstorage.blob.core.windows.net/public/fips/bullseye/{{ FIPS_VERSION }}/{{ CONFIGURED_ARCH }}/golang-1.15-go_{{ FIPS_GOLANG_VERSION }}_{{ CONFIGURED_ARCH }}.deb' \
  && wget -O golang-src.deb 'https://sonicstorage.blob.core.windows.net/public/fips/bullseye/{{ FIPS_VERSION }}/{{ CONFIGURED_ARCH }}/golang-1.15-src_{{ FIPS_GOLANG_VERSION }}_{{ CONFIGURED_ARCH }}.deb' \
- && eatmydata dpkg -i golang-go.deb golang-src.deb \
+ && eatmydata apt-get install -y ./golang-go.deb ./golang-src.deb golang-1.15 \
  && ln -sf /usr/lib/go-1.15 /usr/local/go \
  && rm golang-go.deb golang-src.deb
+{%- else %}
+RUN eatmydata apt-get install -y golang-1.15 && ln -s /usr/lib/go-1.15 /usr/local/go
 {%- endif %}
 
 RUN pip3 install --upgrade pip


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Installation of golang takes too much time when `INCLUDE_FIPS` is enabled.
That's because we install `golang` with all dependencies and then reinstall `golang-src` and `golang-go` for FIPS.

```
2024-05-27T01:51:46.1124745Z Step 22/64 : RUN apt-get install -y golang
...
2024-05-27T01:51:47.2233316Z The following additional packages will be installed:
2024-05-27T01:51:47.2234165Z   golang-1.19 golang-1.19-doc golang-1.19-go golang-1.19-src golang-doc
2024-05-27T01:51:47.2234451Z   golang-go golang-src
...
2024-05-27T01:52:13.8455358Z Step 23/64 : RUN wget -O golang-go.deb 'https://sonicstorage.blob.core.windows.net/public/fips/bookworm/1.4.3-preview/amd64/golang-1.19-go_1.19.8-2+fips_amd64.deb'  && wget -O golang-src.deb 'https://sonicstorage.blob.core.windows.net/public/fips/bookworm/1.4.3-preview/amd64/golang-1.19-src_1.19.8-2+fips_all.deb'  && dpkg -i golang-go.deb golang-src.deb  && ln -sf /usr/lib/go-1.19 /usr/local/go  && rm golang-go.deb golang-src.deb
...
2024-05-27T01:52:25.9958314Z Unpacking golang-1.19-go (1.19.8-2+fips) over (1.19.8-2) ...
2024-05-27T01:52:32.2760376Z Preparing to unpack golang-src.deb ...
2024-05-27T01:52:32.2937135Z Unpacking golang-1.19-src (1.19.8-2+fips) over (1.19.8-2) ...
2024-05-27T01:53:22.6439324Z Setting up golang-1.19-src (1.19.8-2+fips) ...
2024-05-27T01:53:22.6627387Z Setting up golang-1.19-go (1.19.8-2+fips) ...
```
`Unpacking golang-1.19-src (1.19.8-2+fips) over (1.19.8-2) ` takes 50 seconds.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Use `apt-get` instead of `dpkg` to install local and remote deb packages in one step.

#### How to verify it

Build time:

```
old:

2024-05-27T01:27:34.1340377Z Unpacking golang-1.15-src (1.15.15-1~deb11u4+fips) over (1.15.15-1~deb11u4) ...
2024-05-27T01:28:13.8588940Z Setting up golang-1.15-src (1.15.15-1~deb11u4+fips) ...

2024-05-27T01:52:32.2937135Z Unpacking golang-1.19-src (1.19.8-2+fips) over (1.19.8-2) ...
2024-05-27T01:53:22.6439324Z Setting up golang-1.19-src (1.19.8-2+fips) ...

new:

2024-05-27T01:20:21.8255774Z Unpacking golang-1.15-src (1.15.15-1~deb11u4+fips) ...
2024-05-27T01:20:23.7776107Z Selecting previously unselected package golang-1.15-go.

2024-05-27T01:48:10.4356465Z Unpacking golang-1.19-src (1.19.8-2+fips) ...
2024-05-27T01:48:12.5296508Z Selecting previously unselected package golang-1.19-go.
```

Size:
```
old:  sonic-slave-bookworm  8.02GB
new:  sonic-slave-bookworm  7.56GB

old:  sonic-slave-bullseye 6.67GB
new: sonic-slave-bullseye 6.31GB
```

Versions:

sonic-slave-bullseye:
```
dpkg -l | grep golang | awk '{print $2,$3}'
golang-1.15 1.15.15-1~deb11u4
golang-1.15-doc 1.15.15-1~deb11u4
golang-1.15-go 1.15.15-1~deb11u4+fips
golang-1.15-src 1.15.15-1~deb11u4+fips
```
sonic-slave-bookworm:
```
dpkg -l | grep golang | awk '{print $2,$3}'
golang:amd64 2:1.19~1
golang-1.19 1.19.8-2
golang-1.19-doc 1.19.8-2
golang-1.19-go 1.19.8-2+fips
golang-1.19-src 1.19.8-2+fips
golang-doc 2:1.19~1
golang-go:amd64 2:1.19~1
golang-src 2:1.19~1
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

