### PR TITLE
The hostname-config.sh script rewrites the hostname and appends

### DIFF
--- a/files/image_config/hostname/hostname-config.sh
+++ b/files/image_config/hostname/hostname-config.sh
@@ -17,6 +17,12 @@ if [ $CURRENT_HOSTNAME == $HOSTNAME ] ;  then
     exit 0
 fi
 
+# Create /etc/hosts file if the file is not existed
+if [ ! -f "/etc/hosts" ]; then
+    echo "127.0.0.1       localhost" > /etc/hosts
+    sync;sync;sync;
+fi
+
 # Remove the old hostname entry from hosts file.
 # But, 'localhost' entry is used by multiple applications. Don't remove it altogether.
 # Edit contents of /etc/hosts and put in /etc/hosts.new
@@ -31,3 +37,4 @@ echo "127.0.0.1 $HOSTNAME" >> /etc/hosts.new
 # Swap file: hosts.new and hosts
 mv -f /etc/hosts     /etc/hosts.old
 mv -f /etc/hosts.new /etc/hosts
+sync;sync;sync;


### PR DESCRIPTION
#### Why I did it
The hostname-config.sh script rewrites the hostname and appends the 127.0.0.1 new hostname mapping to the /etc/hosts list. However, it does not handle the case where the file does not exist, resulting in the hostname not being updated in /etc/hosts.

When /etc/hosts is missing, it causes the sudo command to be blocked for a while and displays an "unable to resolve host" error message.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
This patch adds a workaround in hostname-config.sh to create a default /etc/hosts if it does not exist, ensuring the hostname is updated properly.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog


#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

