### PR TITLE
Refactor DHCP sethostname|sethostname6 scripts

### DIFF
--- a/files/dhcp/sethostname
+++ b/files/dhcp/sethostname
@@ -1,12 +1,21 @@
 case $reason in
     BOUND|RENEW|REBIND|REBOOT)
-        current_host_name=`hostname -s`
-        if [ "$current_host_name" != "$new_host_name" ] && [ -n "$new_host_name" ]
-        then
-            echo $new_host_name > /etc/hostname
-            hostname -F /etc/hostname
-            sed -i "/\s$current_host_name$/d" /etc/hosts
-            echo "127.0.0.1 $new_host_name" >> /etc/hosts
+        if [ -n "$new_host_name" ]; then
+            current_full_hostname=$(hostname -f)
+
+            desired_full_hostname=$new_host_name
+            if [ "$new_host_name" = "${new_host_name%%.*}" ] && [ -n "$new_domain_name" ]; then
+                desired_full_hostname="${new_host_name}.${new_domain_name}"
+            fi
+
+            if [ "$current_full_hostname" != "$desired_full_hostname" ]; then
+                echo "127.0.0.1 $desired_full_hostname ${desired_full_hostname%%.*}" >> /etc/hosts
+
+                echo "$desired_full_hostname" > /etc/hostname
+                hostname -F /etc/hostname
+
+                sed -i "/\s$current_full_hostname\s\+${current_full_hostname%%.*}$/d" /etc/hosts
+            fi
         fi
         ;;
 esac

--- a/files/dhcp/sethostname6
+++ b/files/dhcp/sethostname6
@@ -1,14 +1,17 @@
 case $reason in
     BOUND6|RENEW6|REBIND6|REBOOT)
-        current_fqdn_fqdn=`hostname`
-        if [ "$current_fqdn_fqdn" != "$new_fqdn_fqdn" ] && [ -n "$new_fqdn_fqdn" ]
-        then
-            echo $new_fqdn_fqdn > /etc/hostname
-            hostname -F /etc/hostname
-            sed -i "/\s$current_fqdn_fqdn$/d" /etc/hosts
-            sed -i "/\s$new_fqdn_fqdn$/d" /etc/hosts
-            echo "127.0.0.1 $new_fqdn_fqdn" >> /etc/hosts
-            echo ":: $new_fqdn_fqdn" >> /etc/hosts
+        if [ -n "$new_fqdn_fqdn" ]; then
+            current_full_hostname=$(hostname -f)
+
+            if [ "$current_full_hostname" != "$new_fqdn_fqdn" ]; then
+                echo "127.0.0.1 $new_fqdn_fqdn ${new_fqdn_fqdn%%.*}" >> /etc/hosts
+                echo "::1 $new_fqdn_fqdn ${new_fqdn_fqdn%%.*}" >> /etc/hosts
+
+                echo "$new_fqdn_fqdn" > /etc/hostname
+                hostname -F /etc/hostname
+
+                sed -i "/\s$current_full_hostname\s\+${current_full_hostname%%.*}$/d" /etc/hosts
+            fi
         fi
         ;;
 esac


### PR DESCRIPTION
#### Why I did it
I noticed that /etc/hosts file is getting constantly filled with new records when dhclient is enabled.
```
root@test:~# cat /etc/hosts | wc -l
246
```

DHCP is providing FQDN, while we check only against short hostname and this will never match.
```
root@test:~# hostname
test.lab.com
root@test:~# hostname -s
test
```

And DHCP offer:
```
root@test:~# tcpdump -i eth0 -n -vv port 67 or port 68
tcpdump: listening on eth0, link-type EN10MB (Ethernet), snapshot length 262144 bytes
...
	    Hostname (12), length 30: "test.lab.com"
...
```

`sethostname6` also uses `hostname` instead of `hostname -s`

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Refactored sethostname and sethostname6 scripts to handle option 15 and not to duplicate new entries

#### How to verify it

- Enable DHCP client on the switch
- Receive offer with FQDN hostname option
- Without this fix everytime new entry will be added to /etc/hosts
- With this fix no new entry will be added

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Tested branch (Please provide the tested image version)
202405

#### Description for the changelog
Refactor sethostname and sethostname6 scripts

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

