### PR TITLE
[Nokia-7215-A1] Update platform to add DC PSU support

### DIFF
--- a/platform/marvell/sonic-platform-nokia/7215-a1/service/cpu_wdt.service
+++ b/platform/marvell/sonic-platform-nokia/7215-a1/service/cpu_wdt.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=CPU WDT
+Conflicts=watchdog-control.service
 After=nokia-7215init.service
 [Service]
 ExecStart=/usr/local/bin/cpu_wdt.py

--- a/platform/marvell/sonic-platform-nokia/7215-a1/sonic_platform/chassis.py
+++ b/platform/marvell/sonic-platform-nokia/7215-a1/sonic_platform/chassis.py
@@ -98,7 +98,7 @@ class Chassis(ChassisBase):
                 self._fan_list.append(fan)
 
         for i in range(MAX_7215_PSU):
-            psu = Psu(i)
+            psu = Psu(i, self.get_model())
             self._psu_list.append(psu)
 
         for i in range(MAX_7215_THERMAL):

--- a/platform/marvell/sonic-platform-nokia/7215-a1/sonic_platform/eeprom.py
+++ b/platform/marvell/sonic-platform-nokia/7215-a1/sonic_platform/eeprom.py
@@ -40,13 +40,13 @@ class Eeprom(TlvInfoDecoder):
             if self.is_psu_eeprom:
                 self.index = psu_index
                 self.part_number = '1'
-                self.model_str = 'PJT-12V100WBBA'
+                self.model_str = 'NA'
                 self.serial_number = 'NA'               
 
             if self.is_fan_eeprom:
                 self.index = fan_index
                 self.part_number = '1'
-                self.model_str = 'FFB0412UHN-BC2EA12'
+                self.model_str = 'NA'
                 self.serial_number = 'NA'                
 
 

--- a/platform/marvell/sonic-platform-nokia/7215-a1/sonic_platform/fan.py
+++ b/platform/marvell/sonic-platform-nokia/7215-a1/sonic_platform/fan.py
@@ -181,7 +181,7 @@ class Fan(FanBase):
         """
         ch_model=self.get_chassis_model()
         #compare first 8 characters of chassis molel string
-        if(ch_model[:8]=='3HE18723'):
+        if(ch_model[:8]=='3HE18723' or ch_model[:8]=='3HE20994' ):
             direction = 'intake'
         else:
             direction = 'exhaust'

--- a/platform/marvell/sonic-platform-nokia/7215-a1/sonic_platform/psu.py
+++ b/platform/marvell/sonic-platform-nokia/7215-a1/sonic_platform/psu.py
@@ -25,12 +25,12 @@ PSU_GPIO_DIR = ["/sys/class/gpio/gpio61/value", "/sys/class/gpio/gpio62/value"]
 class Psu(PsuBase):
     """Nokia platform-specific PSU class for 7215 """
 
-    def __init__(self, psu_index):
+    def __init__(self, psu_index, chassis_model):
         PsuBase.__init__(self)
         # PSU is 1-based in Nokia platforms
         self.index = psu_index + 1
         self._fan_list = []
-        
+        self.chassis_model = chassis_model
 
         # PSU eeprom
         self.eeprom = Eeprom(is_psu=True, psu_index=self.index)
@@ -90,7 +90,16 @@ class Psu(PsuBase):
         active_psus = int(psu1_good) + int(psu2_good)
         
         return active_psus
+    
+    def get_chassis_model(self):
+        """
+        Retrieves the model number of the Fan
 
+        Returns:
+            string: Model number of Fan. Use part number for this.
+        """
+        return self.chassis_model
+    
     def get_name(self):
         """
         Retrieves the name of the device
@@ -118,7 +127,14 @@ class Psu(PsuBase):
         Returns:
             string: Part number of PSU
         """
-        return self.eeprom.modelstr()
+        ch_model=self.get_chassis_model()
+        #compare first 8 characters of chassis molel string
+        if(ch_model[:8]=='3HE18723' or ch_model[:8]=='3HE18724' ):
+            model = 'AC-PSU'
+        else:
+            model = 'DC-PSU'
+
+        return model
 
     def get_serial(self):
         """

--- a/platform/marvell/sonic-platform-nokia/debian/sonic-platform-nokia-7215-a1.postinst
+++ b/platform/marvell/sonic-platform-nokia/debian/sonic-platform-nokia-7215-a1.postinst
@@ -26,6 +26,7 @@ case "$1" in
         systemctl enable nokia-7215init.service
         systemctl start nokia-7215init.service
 
+        systemctl mask --now watchdog-control.service
         systemctl enable cpu_wdt.service
         systemctl start cpu_wdt.service
 


### PR DESCRIPTION
1) Add support for DC PSU
2) Enhance watchdog service

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Add platform support to handle DC PSU
Mask Watchdog-control.service and make sure only one watchdog service
starts on this platform
same as https://github.com/sonic-net/sonic-buildimage/pull/18850

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

1) Build a Marvell-arm64 target for Nokia-7215-A1

2) Run this image on arm64-nokia_ixs7215_52xb-r0 and verify all dockers are up and test basic commands like:

- show version
- show platform summary
- show platform syseeprom
- show platform fan
- show platform psustatus
- show platform firmware status
- show platform temperature
- show platform ssdhealth

3) Verify ports are up using "show interface status" command

4) Run unit tests and OC test cases to get 100% pass.

5) verify only 1 watchdog service is running 
     Try multiple upgrades and install scenario to make sure watchdog is always in enabled state
     Try multiple reboots to make sure watchdog is always in enabled state

6) Verify output of "show platform psu" for different platform variants to confirm it detects the PSU correctly

Run unit tests and OC test cases.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202405

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

