### PR TITLE
[dhcp] Fix that /etc/hosts is not appended with the same record

### DIFF
--- a/files/dhcp/sethostname
+++ b/files/dhcp/sethostname
@@ -1,12 +1,40 @@
 case $reason in
     BOUND|RENEW|REBIND|REBOOT)
-        current_host_name=`hostname -s`
-        if [ "$current_host_name" != "$new_host_name" ] && [ -n "$new_host_name" ]
-        then
-            echo $new_host_name > /etc/hostname
-            hostname -F /etc/hostname
-            sed -i "/\s$current_host_name$/d" /etc/hosts
-            echo "127.0.0.1 $new_host_name" >> /etc/hosts
+        if [ -n "${new_host_name:-}" ]; then
+            # Check hostname for dots. Fall back to adding
+            # new_domain_name or $(hostname -d).
+            if [ "${new_host_name%.*}" != "$new_host_name" ]; then
+                # It has dots. Assume FQDN.
+                my_hostname=${new_host_name%%.*}
+                my_domain=${new_host_name#*.}
+                my_fqdn=${my_hostname}.${my_domain}
+            elif [ -n "${new_domain_name:-}" ]; then
+                # No dots in new_host_name, and
+                # new_domain_name exists. Add it.
+                my_hostname=$new_host_name
+                my_domain=$new_domain_name
+                my_fqdn=${my_hostname}.${my_domain}
+            else
+                # No domain supplied. Take pre-existing domain.
+                my_hostname=$new_host_name
+                my_domain=$(hostname -d 2>/dev/null || true)
+                if [ -n "$my_domain" ]; then
+                    my_fqdn=${my_hostname}.${my_domain}
+                else
+                    my_fqdn=$my_hostname  # alas, no domain at all
+                fi
+            fi
+
+            current_fqdn=$(hostname -f)  # might be short if no domain was set
+            if [ "$current_fqdn" != "$my_fqdn" ]; then
+                # Set the host name as received from DHCP; might be FQDN.
+                echo $new_host_name > /etc/hostname
+                hostname -F /etc/hostname
+                # Store both the determined FQDN and the short hostname in
+                # /etc/hosts.
+                echo "127.0.0.1 $my_fqdn $my_hostname" >> /etc/hosts
+                sed -i "/\s$current_fqdn\s\+${current_fqdn%%.*}$/d" /etc/hosts
+            fi
         fi
         ;;
 esac

--- a/files/dhcp/sethostname6
+++ b/files/dhcp/sethostname6
@@ -1,14 +1,40 @@
 case $reason in
     BOUND6|RENEW6|REBIND6|REBOOT)
-        current_dhcp6_fqdn=`hostname`
-        if [ "$current_dhcp6_fqdn" != "$new_dhcp6_fqdn" ] && [ -n "$new_dhcp6_fqdn" ]
-        then
-            echo $new_dhcp6_fqdn > /etc/hostname
-            hostname -F /etc/hostname
-            sed -i "/\s$current_dhcp6_fqdn$/d" /etc/hosts
-            sed -i "/\s$new_dhcp6_fqdn$/d" /etc/hosts
-            echo "127.0.0.1 $new_dhcp6_fqdn" >> /etc/hosts
-            echo ":: $new_dhcp6_fqdn" >> /etc/hosts
+        if [ -n "${dhcp6_new_host_name:-}" ]; then
+            # Check hostname for dots. Fall back to adding
+            # dhcp6_new_domain_name or $(hostname -d).
+            if [ "${dhcp6_new_host_name%.*}" != "$dhcp6_new_host_name" ]; then
+                # It has dots. Assume FQDN.
+                my_hostname=${dhcp6_new_host_name%%.*}
+                my_domain=${dhcp6_new_host_name#*.}
+                my_fqdn=${my_hostname}.${my_domain}
+            elif [ -n "${dhcp6_new_domain_name:-}" ]; then
+                # No dots in dhcp6_new_host_name, and
+                # dhcp6_new_domain_name exists. Add it.
+                my_hostname=$dhcp6_new_host_name
+                my_domain=$dhcp6_new_domain_name
+                my_fqdn=${my_hostname}.${my_domain}
+            else
+                # No domain supplied. Take pre-existing domain.
+                my_hostname=$dhcp6_new_host_name
+                my_domain=$(hostname -d 2>/dev/null || true)
+                if [ -n "$my_domain" ]; then
+                    my_fqdn=${my_hostname}.${my_domain}
+                else
+                    my_fqdn=$my_hostname  # alas, no domain at all
+                fi
+            fi
+
+            current_fqdn=$(hostname -f)  # might be short if no domain was set
+            if [ "$current_fqdn" != "$my_fqdn" ]; then
+                # Set the host name as received from DHCP; might be FQDN.
+                echo $dhcp6_new_host_name > /etc/hostname
+                hostname -F /etc/hostname
+                # Store both the determined FQDN and the short hostname in
+                # /etc/hosts.
+                echo "127.0.0.1 $my_fqdn $my_hostname" >> /etc/hosts
+                sed -i "/\s$current_fqdn\s\+${current_fqdn%%.*}$/d" /etc/hosts
+            fi
         fi
         ;;
 esac


### PR DESCRIPTION
#### Work item tracking

Ticket: #20579
Alternative-PR: #20404

#### Why I did it

When a dhcp server hands out a fully qualified hostname in option 12, the previous sethostname script would keep appending to /etc/hosts.

#### How I did it

Replace DHCP sethostname and sethostname6 so that:

- hostname takes precedence if it is a FQDN
- if domain name is set and hostname is not FQDN, combine them
- if only hostname is set, merge it with a previously set domain name

Then set both the FQDN and the short hostname in /etc/hosts:

```
127.0.0.1 shortname.domain.com shortname
```

And make sure that the old one is removed when the hostname is updated through DHCP.

#### How to verify it

```
$ reason=BOUND new_host_name=leaf1 sh -x sethostname
$ reason=BOUND new_host_name=leaf2 new_domain_name=domain.com sh -x sethostname
$ reason=BOUND new_host_name=leaf3.domain.com sh -x sethostname
```
Check that `/etc/hosts` and `/etc/hostname` are as expected.

#### Description for the changelog

Rework how dhcp client sets hostname from dhcp host and domain options and keep it from adding duplicates to /etc/hosts.