### PR TITLE
[installer] Use the Grub version comes from SONiC OS

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -432,6 +432,14 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
 if [[ $TARGET_BOOTLOADER == grub ]]; then
     if [[ $CONFIGURED_ARCH == amd64 ]]; then
         GRUB_PKG=grub-pc-bin
+        # GRUB images and modules for grub-install
+        sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install \
+            grub-pc-bin \
+            grub-efi-amd64-bin
+        sudo rm -rf $FILESYSTEM_ROOT/boot/grub
+        sudo mkdir -p $FILESYSTEM_ROOT/boot/grub
+        sudo cp -r $FILESYSTEM_ROOT/usr/lib/grub/i386-pc $FILESYSTEM_ROOT/boot/grub
+        sudo cp -r $FILESYSTEM_ROOT/usr/lib/grub/x86_64-efi $FILESYSTEM_ROOT/boot/grub
     elif [[ $CONFIGURED_ARCH == arm64 ]]; then
         GRUB_PKG=grub-efi-arm64-bin
     fi

--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -259,7 +259,9 @@ demo_install_grub()
 
     # Pretend we are a major distro and install GRUB into the MBR of
     # $blk_dev.
-    grub-install --boot-directory="$onie_initrd_tmp/$demo_mnt" --recheck "$blk_dev" || {
+    grub-install \
+        --directory="$demo_mnt/$image_dir/boot/grub/i386-pc" \
+        --boot-directory="$onie_initrd_tmp/$demo_mnt" --recheck "$blk_dev" || {
         echo "ERROR: grub-install failed on: $blk_dev"
         exit 1
     }
@@ -289,7 +291,9 @@ demo_install_grub()
         [ -f "$core_img" ] && chattr -i $core_img
 
         grub_install_log=$(mktemp)
-        grub-install --force --boot-directory="$onie_initrd_tmp/$demo_mnt" \
+        grub-install \
+            --directory="$demo_mnt/$image_dir/boot/grub/i386-pc" \
+            --force --boot-directory="$onie_initrd_tmp/$demo_mnt" \
             --recheck "$demo_dev" > /$grub_install_log 2>&1 || {
             echo "ERROR: grub-install failed on: $demo_dev"
             cat $grub_install_log && rm -f $grub_install_log
@@ -334,6 +338,7 @@ demo_install_uefi_grub()
 
     grub_install_log=$(mktemp)
     grub-install \
+        --directory="$demo_mnt/$image_dir/boot/grub/x86_64-efi" \
         --no-nvram \
         --bootloader-id="$demo_volume_label" \
         --efi-directory="/boot/efi" \


### PR DESCRIPTION
- Why I did it
The Grub in ONiE OS is always out of date.
Reinstall ONiE and SONiC for upgrading Grub is quite complex and takes a lot of time.

- How I did it
Include Grub libraries to the installer.
Specify the directory of Grub libraries for grub-install.

- How to verify it
Install image from ONiE.
Check the Grub version on the banner of SONiC Grub menu.