### PR TITLE
[Nokia-7215] Update Switch create timeout

### DIFF
--- a/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/sai.profile
+++ b/device/nokia/armhf-nokia_ixs7215_52x-r0/Nokia-7215/sai.profile
@@ -2,5 +2,5 @@ mode=1
 hwId=et6448m
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/profile.ini
 switchProfile=/usr/share/sonic/hwsku/SAI-M0-48x1G-4x10G.xml
-createSwitchTimeout=90
+createSwitchTimeout=120
 customEVlanUpdate=1


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Update Switch create timeout for Nokia-7215 based on statistics from OC test results
Backport PR for #21297 
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it
OC test results uploaded to Kusto:
Kusto report ID's
M0: 41dcfde5-91ad-4da2-a20e-1c478d28a26a
Mx: 643a70a1-a84e-4d05-82ac-5a1cb18dc038

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

