### PR TITLE
Fix SSH crash when started with -C  argument  /usr/sbin/sshd -T -C user=root -C host=nd-e013 -C addr=127.0.0.1 -C lport=22

### DIFF
--- a/src/openssh/patch/0003-Export-remote-info-for-authorization.patch
+++ b/src/openssh/patch/0003-Export-remote-info-for-authorization.patch
@@ -1,40 +1,42 @@
-From 51b3d58afef6796fe0568deb4c3765e24cc828c9 Mon Sep 17 00:00:00 2001
-From: liuh-80 <liuh@microsoft.com>
-Date: Fri, 30 Sep 2022 16:57:03 +0800
+From 191df972f207774f8703ebf7fffea1129c11ca68 Mon Sep 17 00:00:00 2001
+From: ab952469 <asha.behera@broadcom.com>
+Date: Thu, 13 Mar 2025 14:46:03 +0530
 Subject: [PATCH] Export remote info for authorization. authorization.
 
 ---
- auth.c    | 11 +++++++++++
+ auth.c    | 14 ++++++++++++++
  auth.h    |  3 +++
  session.c |  3 +++
  sshd.c    |  5 +++++
- 4 files changed, 22 insertions(+)
+ 4 files changed, 25 insertions(+)
 
 diff --git a/auth.c b/auth.c
-index c3693ba3f..96d551922 100644
+index 6653b9e..d9ceac4 100644
 --- a/auth.c
 +++ b/auth.c
-@@ -764,3 +764,14 @@ auth_authorise_keyopts(struct ssh *ssh, struct passwd *pw,
+@@ -764,3 +764,17 @@ auth_restrict_session(struct ssh *ssh)
  		fatal_f("failed to restrict session");
  	sshauthopt_free(restricted);
  }
 +
 +/* Export remote IP address and port for authorization. */
-+void
++	void
 +export_remote_info(struct ssh *ssh)
 +{
-+	const char *remote_ip = ssh_remote_ipaddr(ssh);
-+	const int remote_port = ssh_remote_port(ssh);
-+	const char remote_addr_port[32 + INET6_ADDRSTRLEN];
-+	snprintf(remote_addr_port, sizeof(remote_addr_port), "%s %d", remote_ip, remote_port);
-+	setenv("SSH_CLIENT_IPADDR_PORT", remote_addr_port, 1);
++	if (ssh != NULL)
++	{
++		const char *remote_ip = ssh_remote_ipaddr(ssh);
++		const int remote_port = ssh_remote_port(ssh);
++		const char remote_addr_port[32 + INET6_ADDRSTRLEN];
++		snprintf(remote_addr_port, sizeof(remote_addr_port), "%s %d", remote_ip, remote_port);
++		setenv("SSH_CLIENT_IPADDR_PORT", remote_addr_port, 1);
++	}
 +}
-\ No newline at end of file
 diff --git a/auth.h b/auth.h
-index 3cfce0eaf..3a34742b1 100644
+index d16dc66..8b87656 100644
 --- a/auth.h
 +++ b/auth.h
-@@ -229,6 +229,9 @@ struct passwd *fakepw(void);
+@@ -241,6 +241,9 @@ FILE	*auth_openprincipals(const char *, struct passwd *, int);
  
  int	 sys_auth_passwd(struct ssh *, const char *);
  
@@ -45,7 +47,7 @@ index 3cfce0eaf..3a34742b1 100644
  krb5_error_code ssh_krb5_cc_gen(krb5_context, krb5_ccache *);
  #endif
 diff --git a/session.c b/session.c
-index a638ceef1..c615cb3d0 100644
+index 768d3b3..40f3c41 100644
 --- a/session.c
 +++ b/session.c
 @@ -619,6 +619,9 @@ do_exec_pty(struct ssh *ssh, Session *s, const char *command)
@@ -59,10 +61,10 @@ index a638ceef1..c615cb3d0 100644
  #ifndef HAVE_OSF_SIA
  		do_login(ssh, s, command);
 diff --git a/sshd.c b/sshd.c
-index 3ef0c1452..2f67a0304 100644
+index dd8fd94..8f184a3 100644
 --- a/sshd.c
 +++ b/sshd.c
-@@ -1737,6 +1737,8 @@ main(int ac, char **av)
+@@ -1735,6 +1735,8 @@ main(int ac, char **av)
  			test_flag = 2;
  			break;
  		case 'C':
@@ -71,7 +73,7 @@ index 3ef0c1452..2f67a0304 100644
  			connection_info = get_connection_info(ssh, 0, 0);
  			if (parse_server_match_testspec(connection_info,
  			    optarg) == -1)
-@@ -2252,6 +2254,9 @@ main(int ac, char **av)
+@@ -2263,6 +2265,9 @@ main(int ac, char **av)
  	 */
  	remote_ip = ssh_remote_ipaddr(ssh);
  
@@ -82,5 +84,5 @@ index 3ef0c1452..2f67a0304 100644
  	audit_connection_from(remote_ip, remote_port);
  #endif
 -- 
-2.35.1.windows.2
+2.7.4
 


### PR DESCRIPTION
Fixes issue https://github.com/sonic-net/sonic-buildimage/issues/21997
#### Why I did it

SSH was crashing due to the patch 0003-Export-remote-info-for-authorization.patch when ssh is started with -C  argumnets .
Running debian packaged sshd with  '-T -C user=root -C host=nd-e013 -C addr=127.0.0.1 -C lport=22' arguments doesn't cause crash.
ssh NULL pointer was being accessed hence crash occured .
We are calling export_remote_info before ssh is assigned using ssh_alloc_session_state API later in code

Recreation of the crash:
 (gdb) file /usr/sbin/sshd
 (gdb) run -T -C user=root -C host=nd-e013 -C addr=127.0.0.1 -C lport=22
 Starting program: /usr/sbin/sshd -T -C user=root -C host=nd-e013 -C addr=127.0.0.1 -C lport=22
 [Thread debugging using libthread_db enabled]
 Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".

 Program received signal SIGSEGV, Segmentation fault.
 ssh_remote_ipaddr (ssh=ssh@entry=0x0) at ../../packet.c:532
 Download failed: Invalid argument.  Continuing without source file ./debian/build-deb/../../packet.c.
 532     ../../packet.c: No such file or directory.
 (gdb) bt
 #0  ssh_remote_ipaddr (ssh=ssh@entry=0x0) at ../../packet.c:532
 #1  0x0000555555572d6e in export_remote_info (ssh=ssh@entry=0x0) at ../../auth.c:1111
 #2  0x00005555555620e2 in main (ac=10, av=0x555555633960) at ../../sshd.c:1672...

#### How I did it

Add NULL check in export_remote_info


#### How to verify it

Start ssh with  arguments and check no crash 
 
admin#  /usr/sbin/sshd -T -C user=root -C host=nd-e013 -C addr=127.0.0.1 -C lport=22
addressfamily any
listenaddress 0.0.0.0:22
listenaddress [::]:22
usepam yes
logingracetime 120
x11displayoffset 10
maxauthtries 6
maxsessions 10
clientaliveinterval 600
....



