### PR TITLE
[bgp] Fix the error from mixed internal and external member in bgp peer-group

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
@@ -14,13 +14,18 @@
   neighbor {{ neighbor_addr }} shutdown
 {% endif %}
 !
+{% set skip_internal_group_member_hwskus = ['Arista-7050CX3-32S-C28S4'] %}
 {% if neighbor_addr | ipv4 %}
   address-family ipv4
+{% if bgp_session["asn"] != bgp_asn or CONFIG_DB__DEVICE_METADATA['localhost']['hwsku'] not in skip_internal_group_member_hwskus %}
     neighbor {{ neighbor_addr }} peer-group PEER_V4
+{% endif %}
 !
 {% elif neighbor_addr | ipv6 %}
   address-family ipv6
+{% if bgp_session["asn"] != bgp_asn or CONFIG_DB__DEVICE_METADATA['localhost']['hwsku'] not in skip_internal_group_member_hwskus %}
     neighbor {{ neighbor_addr }} peer-group PEER_V6
+{% endif %}
 !
 {% endif %}
 !


### PR DESCRIPTION




<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The issue is seen on t0-d18u8s4. The peer switches (internal) and t1 switches (external) were added to the same BGP peer group, which is not allowed.

The error is from bgpcfgd:
Peer-group members must be all internal or all external


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Skip adding the internal neighbors (same ASN) to peer group.

#### How to verify it
Tested with sonic-mgmt topo t0-d18u8s4

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

