### PR TITLE
[202311][orchagent.sh] mask SIGHUP before starting orchagent

### DIFF
--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -82,4 +82,7 @@ if [[ x"${LOCALHOST_SUBTYPE}" == x"SmartSwitch" ]]; then
     ORCHAGENT_ARGS+=" -q tcp://127.0.0.1:8100"
 fi
 
+# Mask SIGHUP signal to avoid orchagent termination by logrotate before orchagent registers its handler.
+trap '' SIGHUP
+
 exec /usr/bin/orchagent ${ORCHAGENT_ARGS}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

BACKPORT of - https://github.com/sonic-net/sonic-buildimage/pull/22207

#### Why I did it

FIXES https://github.com/sonic-net/sonic-buildimage/issues/21962

logrotate uses SIGHUP to let orchagent reopen SAI Redis recording. If SIGHUP is sent by logrotate before orchagent register its handler the default action takes place - termination. If we mask the signal in the start script orchagent inherits masked signals and will ignore SIGHUP until signal handler is registered.

This is a rare race condition observed during 1000 warm-reboot testing.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Mask SIGHUP

#### How to verify it

Place sleep inside orchagent before signal handler for SIGHUP is registered. Send SIGHUP as if it would be sent from logrotate script, ensure no orchagent termination.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202405
- [ ] 202411

Request to backport to all active branches.

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

