### PR TITLE
sonic-cfggen should return boolean values as lowercase true and false

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -27,6 +27,7 @@ import sys
 import yaml
 import ipaddress
 import base64
+import sonic_yang
 
 from collections import OrderedDict
 from config_samples import generate_sample_config, get_available_config
@@ -39,6 +40,7 @@ from swsscommon.swsscommon import ConfigDBConnector, SonicDBConfig, ConfigDBPipe
 from asic_sensors_config import get_asic_sensors_config
 
 PY3x = sys.version_info >= (3, 0)
+YANG_MODELS = "/usr/local/yang-models"
 
 # TODO: Remove STR_TYPE, FILE_TYPE once SONiC moves to Python 3.x
 # TODO: Remove the import SonicYangCfgDbGenerator once SONiC moves to python3.x
@@ -212,7 +214,13 @@ TODO(taoyl): Current version of config db only supports BGP admin states.
         return db_data
 
     @staticmethod
-    def to_serialized(data, lookup_key = None):
+    def to_serialized(data, lookup_key = None, sy = None, path_tokens = None):
+        if path_tokens is None:
+            path_tokens = []
+        if sy is None:
+          sy = sonic_yang.SonicYang(YANG_MODELS, print_log_enabled = False)
+          sy.loadYangModel()
+
         if type(data) is dict:
             if lookup_key is not None:
                 newData = {}
@@ -227,7 +235,25 @@ TODO(taoyl): Current version of config db only supports BGP admin states.
                 new_key = ConfigDBConnector.serialize_key(key)
                 if new_key != key:
                     data[new_key] = data.pop(key)
-                data[new_key] = FormatConverter.to_serialized(data[new_key])
+                path_tokens.append(new_key)
+                data[new_key] = FormatConverter.to_serialized(data[new_key], sy = sy, path_tokens = path_tokens)
+                path_tokens.pop()
+
+        if isinstance(data, bool):
+            data = 'true' if data else 'false'
+
+        # If we have a string that we know looks like true/false, but differs by
+        # Case, look up from the yang schema to see if we should convert into
+        # a properly formatted boolean for yang.
+        if isinstance(data, str) and data.lower() in [ "true", "false" ] and data not in [ "true", "false" ]:
+            try:
+                schema_xpath = sy.configdb_path_to_xpath(sy.configdb_path_join(path_tokens), schema_xpath = True)
+                datatype = sy.get_data_type(schema_xpath)
+                if datatype == "BOOL":
+                    data = 'true' if data.lower() == "true" else 'false'
+            except:
+                pass
+
         return data
 
     @staticmethod
@@ -504,7 +530,8 @@ def main():
 
     if args.var_json is not None and args.var_json in data:
         if args.key is not None:
-            print(json.dumps(FormatConverter.to_serialized(data[args.var_json], args.key), indent=4, cls=minigraph_encoder))
+            print(json.dumps(FormatConverter.to_serialized(data[args.var_json], args.key), indent=4,
+                             cls=minigraph_encoder))
         else:
             print(json.dumps(FormatConverter.to_serialized(data[args.var_json]), indent=4, cls=minigraph_encoder))
 

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -152,6 +152,26 @@ class TestCfgGen(TestCase):
         output = self.run_script(argument)
         self.assertEqual(utils.to_dict(output.strip()), utils.to_dict('{\n    "k11": "v11"\n}'))
 
+    def test_boolean_case_1(self):
+        # Detect boolean field and value isn't of proper YANG case
+        argument = ['-a', '{"MGMT_VRF_CONFIG":{"vrf_global":{"mgmtVrfEnabled":"TRUe"}}}', '--print-data']
+        output = self.run_script(argument)
+        self.assertEqual(utils.to_dict(output.strip()), utils.to_dict('{"MGMT_VRF_CONFIG":{"vrf_global":{"mgmtVrfEnabled":"true"}}}'))
+
+    def test_boolean_case_2(self):
+        # Detect field is passed as boolean, make sure it doesn't translate into Python "True"
+        argument = ['-a', '{"MGMT_VRF_CONFIG":{"vrf_global":{"mgmtVrfEnabled":true}}}', '--print-data']
+        output = self.run_script(argument)
+        self.assertEqual(utils.to_dict(output.strip()), utils.to_dict('{"MGMT_VRF_CONFIG":{"vrf_global":{"mgmtVrfEnabled":"true"}}}'))
+
+    def test_boolean_case_3(self):
+        # Field looks like a boolean, but its really a string field in YANG, nothing should actually be converted
+        # in this string, note the pythonic True and False with capital first letters.
+        data = '{"FEATURE":{"bgp":{"auto_restart":"enabled","check_up_status":"false","has_global_scope":"false","has_per_asic_scope":"true","delayed":"false","has_global_scope":"False","has_per_asic_scope":"True","delayed":"False","high_mem_alert":"disabled","set_owner":"local","state":"enabled"}}}'
+        argument = ['-a', data, '--print-data']
+        output = self.run_script(argument)
+        self.assertEqual(utils.to_dict(output.strip()), utils.to_dict(data))
+
     def test_var_json_data(self, **kwargs):
         graph_file = kwargs.get('graph_file', self.sample_graph_simple)
         tag_mode = kwargs.get('tag_mode', 'untagged')

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -335,7 +335,7 @@ class TestJ2Files(TestCase):
         with open(sample_output_file) as sample_output_fd:
             sample_output_json = json.load(sample_output_fd)
 
-        self.assertTrue(json.dumps(sample_output_json, sort_keys=True) == json.dumps(output_json, sort_keys=True))
+        self.assertEqual(json.dumps(sample_output_json, sort_keys=True), json.dumps(output_json, sort_keys=True))
 
     def test_t1_smartswitch_dpu_template(self):
         argument = ['-k', 'SS-DPU-1x400Gb', '--preset', 't1-smartswitch', '-p', self.t1_ss_dpu_port_config]
@@ -347,7 +347,7 @@ class TestJ2Files(TestCase):
         with open(sample_output_file) as sample_output_fd:
             sample_output_json = json.load(sample_output_fd)
 
-        self.assertTrue(json.dumps(sample_output_json, sort_keys=True) == json.dumps(output_json, sort_keys=True))
+        self.assertEqual(json.dumps(sample_output_json, sort_keys=True), json.dumps(output_json, sort_keys=True))
 
     def test_qos_arista7050_render_template(self):
         self._test_qos_render_template('arista', 'x86_64-arista_7050_qx32s', 'Arista-7050-QX-32S', 'sample-arista-7050-t0-minigraph.xml', 'qos-arista7050.json')

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/test_SonicYang.json
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/test_SonicYang.json
@@ -25,11 +25,11 @@
    ],
    "data_type" : [
       {
-         "data_type" : "LY_TYPE_STRING",
+         "data_type" : "STRING",
          "xpath" : "/test-port:test-port/test-port:PORT/test-port:PORT_LIST/test-port:port_name"
       },
       {
-         "data_type" : "LY_TYPE_LEAFREF",
+         "data_type" : "LEAFREF",
          "xpath" : "/test-vlan:test-vlan/test-vlan:VLAN_INTERFACE/test-vlan:VLAN_INTERFACE_LIST/test-vlan:vlanid"
       }
    ],
@@ -81,37 +81,37 @@
    ],
    "leafref_type" : [
       {
-         "data_type" : "LY_TYPE_UINT16",
+         "data_type" : "UINT16",
          "xpath" : "/test-vlan:test-vlan/VLAN_INTERFACE/VLAN_INTERFACE_LIST[vlanid='111'][ip-prefix='2000:f500:45:6709::/64']/vlanid"
       },
       {
-         "data_type" : "LY_TYPE_STRING",
+         "data_type" : "STRING",
          "xpath" : "/test-interface:test-interface/INTERFACE/INTERFACE_LIST[interface='Ethernet8'][ip-prefix='2000:f500:40:a749::/126']/interface"
       },
       {
-         "data_type" : "LY_TYPE_STRING",
+         "data_type" : "STRING",
          "xpath" : "/test-vlan:test-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlanid='111'][port='Ethernet0']/port"
       },
       {
-         "data_type" : "LY_TYPE_UINT16",
+         "data_type" : "UINT16",
          "xpath" : "/test-vlan:test-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[vlanid='111'][port='Ethernet0']/vlanid"
       }
    ],
    "leafref_type_schema" : [
       {
-         "data_type" : "LY_TYPE_UINT16",
+         "data_type" : "UINT16",
          "xpath" : "/test-vlan:test-vlan/test-vlan:VLAN_INTERFACE/test-vlan:VLAN_INTERFACE_LIST/test-vlan:vlanid"
       },
       {
-         "data_type" : "LY_TYPE_STRING",
+         "data_type" : "STRING",
          "xpath" : "/test-interface:test-interface/test-interface:INTERFACE/test-interface:INTERFACE_LIST/test-interface:interface"
       },
       {
-         "data_type" : "LY_TYPE_STRING",
+         "data_type" : "STRING",
          "xpath" : "/test-vlan:test-vlan/test-vlan:VLAN_MEMBER/test-vlan:VLAN_MEMBER_LIST/test-vlan:port"
       },
       {
-         "data_type" : "LY_TYPE_UINT16",
+         "data_type" : "UINT16",
          "xpath" : "/test-vlan:test-vlan/test-vlan:VLAN_MEMBER/test-vlan:VLAN_MEMBER_LIST/test-vlan:vlanid"
       }
    ],

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/test_sonic_yang.py
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/test_sonic_yang.py
@@ -233,17 +233,15 @@ class Test_SonicYang(object):
     def test_get_data_type(self, yang_s, data):
         for node in data['data_type']:
             xpath = str(node['xpath'])
-            expected = node['data_type']
-            expected_type = yang_s._str_to_type(expected)
-            data_type = yang_s._get_data_type(xpath)
+            expected_type = node['data_type']
+            data_type = yang_s.get_data_type(xpath)
             assert expected_type == data_type
 
     def test_get_leafref_type(self, yang_s, data):
         for node in data['leafref_type']:
             xpath = str(node['xpath'])
-            expected = node['data_type']
-            expected_type = yang_s._str_to_type(expected)
-            data_type = yang_s._get_leafref_type(xpath)
+            expected_type = node['data_type']
+            data_type = yang_s.get_leafref_type(xpath)
             assert expected_type == data_type
 
     def test_get_leafref_path(self, yang_s, data):
@@ -256,9 +254,8 @@ class Test_SonicYang(object):
     def test_get_leafref_type_schema(self, yang_s, data):
         for node in data['leafref_type_schema']:
             xpath = str(node['xpath'])
-            expected = node['data_type']
-            expected_type = yang_s._str_to_type(expected)
-            data_type = yang_s._get_leafref_type_schema(xpath)
+            expected_type = node['data_type']
+            data_type = yang_s.get_leafref_type_schema(xpath)
             assert expected_type == data_type
 
     def test_configdb_path_to_xpath(self, yang_s, data):


### PR DESCRIPTION
#### Why I did it
YANG mandates that boolean values are true and false, having the first letter be capital as is represented by Python would cause yang validation failures inside of libyang.  Because of this, it appears a different yang type in `sonic-types.yang` has a secondary `boolean_types` that is used that allows more formats.

This can be seen, for instance, when setting:
```
"MGMT_VRF_CONFIG": {
  "vrf_global": {
    "mgmtVrfEnabled": "true"
  }
}
```

Then running `config save -y`.  The written value is then "True", if then just running `config replace /etc/sonic/config_db.json` it would result in an error of:

```
Invalid value "True" in "mgmtVrfEnabled" element.
```

##### Work item tracking

#### How I did it

Capture native yang boolean values by looking up the yang schema when writing the config_db.json via sonic-cfggen and ensure they are written as lowercase.

#### How to verify it

See above for reproduction method

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202411

#### Tested branch (Please provide the tested image version)

master as of 20250502

#### Description for the changelog
sonic-cfggen should return boolean values as lowercase true and false

#### Link to config_db schema for YANG module changes
N/A

#### A picture of a cute animal (not mandatory but encouraged)

Fixes https://github.com/sonic-net/sonic-buildimage/issues/22527
Signed-off-by: Brad House <bhouse@nexthop.ai>