### PR TITLE
[broadcom] Package and load bcmgenl

### DIFF
--- a/platform/broadcom/saibcm-modules/debian/opennsl-modules.init
+++ b/platform/broadcom/saibcm-modules/debian/opennsl-modules.init
@@ -46,6 +46,7 @@ function load_kernel_modules()
 {
     if [[ $is_ltsw_chip -eq 1 ]]; then
         modprobe psample
+        modprobe linux_bcmgenl
         modprobe linux_ngbde
         modprobe linux_ngknet
         modprobe linux_ngknetcb
@@ -53,6 +54,7 @@ function load_kernel_modules()
         modprobe linux-kernel-bde dmasize=$dmasize maxpayload=128 debug=4 dma_debug=1 usemsi=$usemsi
         modprobe linux-user-bde
         modprobe psample
+        modprobe linux-bcm-genl
 
         modprobe linux-bcm-knet use_rx_skb=1 rx_buffer_size=9238 debug=0x5020 default_mtu=9100
         modprobe linux-knet-cb
@@ -66,9 +68,11 @@ function remove_kernel_modules()
         rmmod linux_ngknetcb
         rmmod linux_ngknet
         rmmod linux_ngbde
+        rmmod linux_bcmgenl
         rmmod psample
     else
         rmmod psample
+        rmmod linux-bcm-genl
         rmmod linux-knet-cb
         rmmod linux-bcm-knet
         rmmod linux-user-bde

--- a/platform/broadcom/saibcm-modules/debian/opennsl-modules.install
+++ b/platform/broadcom/saibcm-modules/debian/opennsl-modules.install
@@ -1,8 +1,10 @@
 systems/linux/user/x86-smp_generic_64-2_6/linux-bcm-knet.ko lib/modules/6.1.0-29-2-amd64/extra
 systems/linux/user/x86-smp_generic_64-2_6/linux-kernel-bde.ko lib/modules/6.1.0-29-2-amd64/extra
 systems/linux/user/x86-smp_generic_64-2_6/linux-user-bde.ko lib/modules/6.1.0-29-2-amd64/extra
+systems/linux/user/x86-smp_generic_64-2_6/linux-bcm-genl.ko lib/modules/6.1.0-29-2-amd64/extra
 systems/linux/user/x86-smp_generic_64-2_6/linux-knet-cb.ko lib/modules/6.1.0-29-2-amd64/extra
 systemd/opennsl-modules.service lib/systemd/system
 sdklt/build/bde/linux_ngbde.ko lib/modules/6.1.0-29-2-amd64/extra
+sdklt/build/bcmgenl/linux_bcmgenl.ko lib/modules/6.1.0-29-2-amd64/extra
 sdklt/build/knet/linux_ngknet.ko lib/modules/6.1.0-29-2-amd64/extra
 sdklt/build/knetcb/linux_ngknetcb.ko lib/modules/6.1.0-29-2-amd64/extra


### PR DESCRIPTION
#### Why I did it

This module is needed for sflow on Broadcom SAI. Without it orchagent will crash.

Fixes #18248.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

See the linked issue.

#### How to verify it

 1. Enable sflow (`sudo config feature state sflow enabled`)
 2. Orchagent does not crash.
 3. `/proc/bcm/genl/psample/rate` has data in it.

#### Which release branch to backport (provide reason below if selected)

The issue was introduced in saibcm-module from 10.x branches, so it needs to be backported to the following:

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [x] 202311
- [x] 202405
- [x] 202411

#### Tested branch (Please provide the tested image version)

- [x] 202411

#### Description for the changelog

 - orchagent no longer crashes when enabling sflow on Broadcom devices.

#### Link to config_db schema for YANG module changes
N/A


#### A picture of a cute animal (not mandatory but encouraged)
![image](https://github.com/user-attachments/assets/9910bb7e-e5c0-4ce4-a304-3366af1e7e48)

