### PR TITLE
Remove PFC/TC_TO_PG and PFC_TO_QUEUE map for lossy SKUs

### DIFF
--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -466,6 +466,7 @@
 {% if LOSSLESS_TC|length > 0 %}
             "pfc_to_queue_map": "AZURE"
 {% endif %}
+{% endif %}
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}


### PR DESCRIPTION
#### Why I did it
For LOSSY SKUs, PFC_TO_PG, TC_TO_PG and PFC_TO_QUEUE maps are not valid, so removing them from the default templates.

##### Work item tracking
- Microsoft ADO **(number only)**: 32883774

#### How I did it
Updated qos_config.j2 to remove PFC/TC_TO_PG and PFC_TO_QUEUE maps for lossy SKUs.

#### How to verify it
Verified on lossy SKUs with the latest j2 file.
