### PR TITLE
Revert "[Mellanox] enable 'create_only_config_db_buffers' to optimize counters polling for Mellanox-SN4700-V64 (#22225)"

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/create_only_config_db_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/create_only_config_db_buffers.json
@@ -1,7 +1,0 @@
-{
-    "DEVICE_METADATA": {
-        "localhost": {
-            "create_only_config_db_buffers": "true"
-        }
-    }
-}


### PR DESCRIPTION
This reverts commit d4f2b7b6f833761a468e531a2a1040f8c646684a.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Revert PR https://github.com/sonic-net/sonic-buildimage/pull/22225 because MSFT will integrate config separately by some internal logic

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
remove config file

#### How to verify it
run config reload and check initialization sequence
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

