### PR TITLE
Add a systemd service to execute commands after certain events

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -500,6 +500,11 @@ sudo cp $IMAGE_CONFIGS/corefile_uploader/core_uploader.py $FILESYSTEM_ROOT/usr/b
 sudo cp $IMAGE_CONFIGS/corefile_uploader/core_analyzer.rc.json $FILESYSTEM_ROOT_ETC_SONIC/
 sudo chmod og-rw $FILESYSTEM_ROOT_ETC_SONIC/core_analyzer.rc.json
 
+# Copy script hook systemd files
+sudo cp $IMAGE_CONFIGS/script-execution-hooks/post-syncd-start.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
+sudo cp $IMAGE_CONFIGS/script-execution-hooks/post-syncd-start.timer $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
+sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable post-syncd-start.timer
+
 if [[ $CONFIGURED_ARCH == amd64 ]]; then
     # Install rasdaemon package
     # NOTE: Can be installed from debian directly when we move to trixie

--- a/files/image_config/script-execution-hooks/post-syncd-start.service
+++ b/files/image_config/script-execution-hooks/post-syncd-start.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Timer to run a set of commands after syncd has been initialized
+Requisite=syncd.service swss.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/true

--- a/files/image_config/script-execution-hooks/post-syncd-start.timer
+++ b/files/image_config/script-execution-hooks/post-syncd-start.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Timer to run a set of commands after syncd has been initialized
+StopPropagatedFrom=syncd.service swss.service
+
+[Timer]
+OnActiveSec=3min
+
+[Install]
+WantedBy=syncd.service


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Add a systemd service that will allow users (or people building custom SONiC images) to execute arbitrary commands/scripts after certain SONiC events. For instance, the one included here will start running after syncd has been up for 3 minutes. This event/service could be used as a marker to say that the system has been up and is in a steady state.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

