### PR TITLE
YANG: PREFIX_SET entries require `mode` field

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/route_filter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/route_filter.json
@@ -105,5 +105,6 @@
         "desc": "Configure route map table with more than one match tag in list.",
         "eStr": "Too many match_tag elements"
     }
+
 }
 


### PR DESCRIPTION
#### Why I did it

Currently `mode` is not marked as a mandatory field nor has a default value, however without it the FRR configuration is not rendered properly.

This affects unified mode with frr_mgmt_framework_config.

Links to implementation proving YANG model needs update:

https://github.com/sonic-net/sonic-buildimage/blob/0ad420e02c50d7ad140d9e2e86c5a7550cf4fda5/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.route_map.j2#L33

https://github.com/sonic-net/sonic-buildimage/blob/0ad420e02c50d7ad140d9e2e86c5a7550cf4fda5/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.pref_list.j2#L9

https://github.com/sonic-net/sonic-buildimage/blob/0ad420e02c50d7ad140d9e2e86c5a7550cf4fda5/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py#L2219-L2223

##### Work item tracking

#### How I did it

Marked field as default to IPv4 as suggested by @venkatmahalingam 

#### How to verify it

Observe test case passes.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

master as of 20250608

#### Description for the changelog
YANG: PREFIX_SET entries require `mode` field

#### Link to config_db schema for YANG module changes
N/A
#### A picture of a cute animal (not mandatory but encouraged)

Fixes https://github.com/sonic-net/sonic-buildimage/issues/22899
Signed-off-by: Brad House <bhouse@nexthop.ai>