### PR TITLE
Fix static ecmp route not working when config nexthop with dev_name

### DIFF
--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -1425,7 +1425,7 @@ def hdl_static_route(daemon, cmd_str, op, st_idx, args, data):
     if op == CachedDataWithOp.OP_DELETE:
         ip_nh_set = IpNextHopSet(af)
     else:
-        arg_list = lambda v: v.split(',') if len(v.strip()) != 0 else None
+        arg_list = lambda v: [None if x.strip() == '' else x.strip() for x in v.split(',')] if len(v.strip()) != 0 else None
         bkh_list = arg_list(args[2])
         nh_list = arg_list(args[3])
         track_list = arg_list(args[5])


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix issue #22870
When config two or more static ecmp route with empty nexthop ip, the empty strings in comma-separated values cause `IpNextHop` object creation failures.

#### How I did it
Modify `arg_list` to convert empty strings to None
This ensures ',' becomes [None, None] instead of ['', ''], allowing the `IpNextHop` constructor to handle missing values properly.

#### How to verify it
config two static route with empty nexthop ip address, and show route table.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

