### PR TITLE
Run staticroutebfd only for chassis-packet platform (T2, remove it from T0/T1)

### DIFF
--- a/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
+++ b/dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
@@ -178,8 +178,7 @@ stderr_syslog=true
 dependent_startup=true
 dependent_startup_wait_for=bgpd:running
 
-{% if DEVICE_METADATA.localhost.frr_mgmt_framework_config is defined and DEVICE_METADATA.localhost.frr_mgmt_framework_config == "true" %}
-{% else %}
+{% if DEVICE_METADATA.localhost.switch_type is defined and DEVICE_METADATA.localhost.switch_type == "chassis-packet" %}
 [program:staticroutebfd]
 command=/usr/local/bin/staticroutebfd
 priority=6
@@ -192,7 +191,10 @@ stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
 dependent_startup_wait_for=bgpd:running
+{% endif %}
 
+{% if DEVICE_METADATA.localhost.frr_mgmt_framework_config is defined and DEVICE_METADATA.localhost.frr_mgmt_framework_config == "true" %}
+{% else %}
 [program:bgpmon]
 command=/usr/local/bin/bgpmon
 priority=6


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Staticroutebfd is not T0/T1 and it creates unnecessary load.

related issue
https://github.com/sonic-net/sonic-buildimage/issues/22725
this PR does not directly solve the above issue, but it will remove unnecessary impact on T0/T1

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
add platform checking in dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2 to start staticroutebfd in T2 only

#### How to verify it
use same condition in 
dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.j2
tested it both in T0/T1 and T2, the staticroutebfd can be launched in T2 and removed from T0/T1.

```
In T2 linecard:
$ grep chassis-packet supervisord.conf.j2 -A 20
{% if DEVICE_METADATA.localhost.switch_type is defined and DEVICE_METADATA.localhost.switch_type == "chassis-packet" %}
[program:staticroutebfd]
command=/usr/local/bin/staticroutebfd
priority=6
autostart=false
autorestart=true
startsecs=0
stdout_logfile=syslog
stderr_logfile=syslog
dependent_startup=true
dependent_startup_wait_for=bgpd:running
{% endif %}

sonic@sfd-t2-lc1:/var/tmp$ docker exec -it bgp1 bash -c "ps -ef"
UID          PID    PPID  C STIME TTY          TIME CMD
root           1       0  0 22:53 pts/0    00:00:00 /usr/bin/python3 /usr/local/bin/supervisord
root          42       1  0 22:53 pts/0    00:00:00 python3 /usr/bin/supervisor-proc-exit-listener --container-name bgp
root          45       1  0 22:53 pts/0    00:00:00 /usr/sbin/rsyslogd -n -iNONE
frr           49       1  0 22:53 pts/0    00:00:00 /usr/lib/frr/zebra -A 127.0.0.1 -s 90000000 -M dplane_fpm_nl -M snmp
frr           64       1  0 22:53 pts/0    00:00:00 /usr/lib/frr/staticd -A 127.0.0.1
frr           65       1  1 22:53 pts/0    00:00:00 /usr/lib/frr/bgpd -A 127.0.0.1 -M snmp
root          67       1  1 22:53 pts/0    00:00:00 /usr/bin/python3 /usr/local/bin/bgpcfgd
root          68       1  0 22:53 pts/0    00:00:00 /usr/bin/python3 /usr/local/bin/bgpmon
root          69       1  0 22:53 pts/0    00:00:00 fpmsyncd
root          70       1  0 22:53 pts/0    00:00:00 /usr/bin/python3 /usr/local/bin/staticroutebfd
root          78      45  0 22:53 pts/0    00:00:00 /usr/bin/rsyslog_plugin -r /etc/rsyslog.d/bgp_regex.json -m sonic-events-bgp
root         107       0 60 22:54 pts/1    00:00:00 ps -ef
sonic@sfd-t2-lc1:/var/tmp$ 

In T0/T1:
root@sonic:/# grep chassis-packet ./usr/share/sonic/templates/supervisord/supervisord.conf.j2 -A 15
{% if DEVICE_METADATA.localhost.switch_type is defined and DEVICE_METADATA.localhost.switch_type == "chassis-packet" %}
[program:staticroutebfd]
command=/usr/local/bin/staticroutebfd
priority=6
autostart=false
autorestart=true
startsecs=0
stdout_logfile=syslog
stderr_logfile=syslog
dependent_startup=true
dependent_startup_wait_for=bgpd:running
{% endif %}

{% if DEVICE_METADATA.localhost.frr_mgmt_framework_config is defined and DEVICE_METADATA.localhost.frr_mgmt_framework_config == "true" %}
{% else %}
[program:bgpmon]
root@sonic:/# 
root@sonic:/# ps -ef
UID          PID    PPID  C STIME TTY          TIME CMD
root           1       0  0 Jun05 pts/0    00:01:36 /usr/bin/python3 /usr/local/bin/supervisord
root          26       1  0 Jun05 pts/0    00:00:15 python3 /usr/bin/supervisor-proc-exit-listener --container-name bgp
root          29       1  0 Jun05 pts/0    00:00:00 /usr/sbin/rsyslogd -n -iNONE
frr           33       1  0 Jun05 pts/0    00:00:06 /usr/lib/frr/zebra -A 127.0.0.1 -s 90000000 -M dplane_fpm_nl -M snmp
frr           48       1  0 Jun05 pts/0    00:00:05 /usr/lib/frr/staticd -A 127.0.0.1
frr           49       1  0 Jun05 pts/0    00:00:15 /usr/lib/frr/bgpd -A 127.0.0.1 -M snmp
root          51       1  0 Jun05 pts/0    00:00:18 /usr/bin/python3 /usr/local/bin/bgpcfgd
root          57       1  0 Jun05 pts/0    00:00:16 /usr/bin/python3 /usr/local/bin/bgpmon
root          58       1  0 Jun05 pts/0    00:00:08 fpmsyncd
root          61      29  0 Jun05 pts/0    00:00:00 /usr/bin/rsyslog_plugin -r /etc/rsyslog.d/bgp_regex.json -m sonic-events-bgp
root       82957       0  0 18:42 pts/1    00:00:00 bash
root       82985   82957  0 18:44 pts/1    00:00:00 ps -ef
root@sonic:/# 


```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

