### PR TITLE
Update cisco-8000-smartswitch.ini with latest smartswitch release tag 0.master.1.1

### DIFF
--- a/platform/checkout/cisco-8000-smartswitch.ini
+++ b/platform/checkout/cisco-8000-smartswitch.ini
@@ -1,3 +1,4 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
 ref=0.master.1.1
+


### PR DESCRIPTION
Update cisco-8000-smartswitch.ini with latest smartswitch release tag 0.master.1.1

#### Why I did it
This release has support for hostname:sonic change and ACL-Inner Source Mac Rewrite

##### Work item tracking
- Microsoft ADO **(number only)**:


