### PR TITLE
[PDDF][GPIO] Skip creating i2c device if topo_info is not present in PORTn-CTRL

### DIFF
--- a/platform/pddf/i2c/utils/pddfparse.py
+++ b/platform/pddf/i2c/utils/pddfparse.py
@@ -373,6 +373,9 @@ class PddfParse():
     def create_xcvr_i2c_device(self, dev, ops):
         create_ret = []
         ret = 0
+        # Check if topo_info is present otherwise return from here
+        if "topo_info" not in dev['i2c']:
+            return create_ret.append(ret)
         if dev['i2c']['topo_info']['dev_type'] in self.data['PLATFORM']['pddf_dev_types']['PORT_MODULE']:
             self.create_device(dev['i2c']['topo_info'], "pddf/devices/xcvr/i2c", ops)
             cmd = "echo '%s' > /sys/kernel/pddf/devices/xcvr/i2c/i2c_name" % (dev['dev_info']['device_name'])


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When xcvr presence/lpmode/reset/interrupt are driven through GPIO devices, GPIO i2c devices are already created as part of GPIO parsing. If we provide same address in topo_info for PORTn-CTRL then it would result in error like below,

    [   48.918145] i2c i2c-66: Failed to register i2c client pddf_xcvr at 0x27 (-16)

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added logic to avoid i2c device creation based on topo_info presence.

#### How to verify it
Verified to check duplicate device creation is skipped by adding following entries in pddf-device.json.

    "GPIO1":
    {
        "dev_info": {"device_type": "GPIO", "device_name": "GPIO1", "device_parent": "MUX1"},
        "i2c":
        {
            "topo_info": {"parent_bus": "0x2", "dev_addr": "0x27", "dev_type": "pca9555"},
            "dev_attr": {"gpio_base": "0x27e8"},
            "ports":
            [
                {"port_num":"0", "direction":"in", "value":"", "edge":"", "active_low":"1"},
                {"port_num":"8", "direction":"in", "value":"", "edge":"", "active_low":""}
            ]
        }
    },

    "PORT1-CTRL":
    {
        "dev_info": { "device_type":"", "device_name":"PORT1-CTRL1", "device_parent":"MUX1", "virt_parent":"PORT1"},
        "i2c":
        {
            "attr_list":
            [
                { "attr_name":"xcvr_present", "attr_devaddr":"0x60", "attr_devtype":"gpio", "attr_devname":"GPIO1", "attr_offset":"0x0", "attr_mask":"0x1", "attr_cmpval":"", "attr_len":"1"},
                { "attr_name":"xcvr_intr_status", "attr_devaddr":"0x60", "attr_devtype":"gpio", "attr_devname":"GPIO1", "attr_offset":"0x8", "attr_mask":"0x1", "attr_cmpval":"", "attr_len":"1"}
            ]
        }
    },

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

