### PR TITLE
yml file changes for Nokia D4 platform

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7220_d4-r0/Nokia-IXR7220-D4-36D/td4_28x100g_8x400g.yml
+++ b/device/nokia/x86_64-nokia_ixr7220_d4-r0/Nokia-IXR7220-D4-36D/td4_28x100g_8x400g.yml
@@ -24,7 +24,6 @@
 device:
     0:
         DEVICE_CONFIG:
-            VARIANT: DNA_6_5_31_7_0
             # CORE CLOCK FREQUENCY
             CORE_CLK_FREQ: CLK_1350MHZ
             # PP CLOCK FREQUENCY
@@ -508,6 +507,20 @@ device:
             THRESHOLD_MODE: LOSSY_AND_LOSSLESS
 ...
 ---
+device:
+    0:
+        TM_ING_PORT_PRI_GRP:
+            ?
+                PORT_ID: [[8, 15], 1, 5, 6, 7, 16, 17, 20, 24,
+                          [28, 35],
+                          [60, 63],
+                          40, 44, 48, 52, 56, 64, 68, 72]
+                TM_PRI_GRP_ID: [3,4]
+            :
+                PFC: 1
+                LOSSLESS: 1
+...
+---
 bcm_device:
     0:
         global:
@@ -537,6 +550,8 @@ bcm_device:
             sai_fast_convergence_support: 1
             sai_modify_hash_flexdigest: 1
             sai_port_phy_time_sync_en: 1
+            egress_pkt_pri_remark_mode: 1
+            sai_mdio_access_clause45: 1
 ...
 ---
 device:


### PR DESCRIPTION
#### Why I did it
Enhance 2 functionalities in newly introduced Nokia-IXR7220-D4-36D platform https://github.com/sonic-net/sonic-buildimage/pull/21853:

- inner vlan tag priority bits preservation in case of double tagged packets
- MDIO clause45.  DNA DEVICE_CONFIG:VARIANT required only for BCM template profiles/CS00012403483


#### How I did it
changes on the broadcom yaml file configuration
#### How to verify it
testcase /sonic-mgmt/acl/test_acl_outer_vlan.py could be used for verification



#### Which release branch to backport (provide reason below if selected)

TD4 functionality is needed on 202505.
- [x] 202505

#### Tested branch (Please provide the tested image version)


#### Description for the changelog
broadcom yaml file configuration changes for Nokia TD4 platform

```
   _____,,;;;`;       ;';;;,,_____
,~(  )  , )~~\|       |/~~( ,  (  )~;
' / / --`--,             .--'-- \ \ `
 /  \    | '             ` |    /  \
```


