### PR TITLE
[SNMP] Fix IPv6 link local failed when enable management VRF

### DIFF
--- a/src/snmpd/patch-5.9.3+dfsg/0014-SNMP-ipv6-link-local-under-MGMT-VRF.patch
+++ b/src/snmpd/patch-5.9.3+dfsg/0014-SNMP-ipv6-link-local-under-MGMT-VRF.patch
@@ -1,0 +1,55 @@
+From cd79a528dee3348c65cbf501cec4010e2e22d717 Mon Sep 17 00:00:00 2001
+From: mhchann <mhchann082@gmail.com>
+Date: Mon, 30 Jun 2025 16:37:28 +0800
+Subject: [PATCH 1/1] 0014-SNMP-ipv6-link-local-under-MGMT-VRF
+
+---
+ include/net-snmp/library/snmp_transport.h | 4 ++++
+ snmplib/transports/snmpUDPIPv6Domain.c    | 9 +++++++++
+ 2 files changed, 13 insertions(+)
+
+diff --git a/include/net-snmp/library/snmp_transport.h b/include/net-snmp/library/snmp_transport.h
+index d005d45..966287b 100644
+--- a/include/net-snmp/library/snmp_transport.h
++++ b/include/net-snmp/library/snmp_transport.h
+@@ -169,6 +169,10 @@ typedef struct netsnmp_transport_s {
+     netsnmp_tmStateReference *tmStateRef;
+ #endif
+ 
++#if defined(HAVE_STRUCT_SOCKADDR_IN6_SIN6_SCOPE_ID)
++    uint32_t        sin6_scope_id;
++#endif
++
+     /* tunneled transports */
+     struct netsnmp_transport_s * base_transport;
+ 
+diff --git a/snmplib/transports/snmpUDPIPv6Domain.c b/snmplib/transports/snmpUDPIPv6Domain.c
+index e2f2b03..0c5e300 100644
+--- a/snmplib/transports/snmpUDPIPv6Domain.c
++++ b/snmplib/transports/snmpUDPIPv6Domain.c
+@@ -130,6 +130,11 @@ netsnmp_udp6_recv(netsnmp_transport *t, void *buf, int size,
+         }
+         *opaque = (void *) from;
+         *olength = sizeof(struct sockaddr_in6);
++#if defined(HAVE_STRUCT_SOCKADDR_IN6_SIN6_SCOPE_ID)
++        if (((struct sockaddr_in6 *) (*opaque))->sin6_scope_id != t->sin6_scope_id) {
++            ((struct sockaddr_in6 *) (*opaque))->sin6_scope_id = t->sin6_scope_id;
++        }
++#endif
+     }
+     return rc;
+ }
+@@ -316,6 +321,10 @@ netsnmp_udp6_transport_bind(netsnmp_transport *t,
+                     errno, strerror(errno)));
+         goto err;
+     }
++#if defined(HAVE_STRUCT_SOCKADDR_IN6_SIN6_SCOPE_ID)
++    else
++        t->sin6_scope_id = addr->sin6_scope_id; /* Record the scope id when socket binding */
++#endif
+ 
+     return 0;
+ 
+-- 
+2.25.1
+

--- a/src/snmpd/patch-5.9.3+dfsg/series
+++ b/src/snmpd/patch-5.9.3+dfsg/series
@@ -3,3 +3,4 @@
 0012-agent-Makefile.in-Unbreak-the-enable-minimalist-buil.patch  
 0013-enable-parallel-build-for-net-snmp.patch  
 cross-compile-changes.patch 
+0014-SNMP-ipv6-link-local-under-MGMT-VRF.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix issue #23117
When SNMP binds to `eth0` using a link-local address (`<link-local>%eth0`), there's a mismatch in interface scope handling:
1. SNMP correctly binds its socket to `eth0`
2. When `recvfrom()` retrieves the sender's address, the kernel returns the link-local address scoped to the `mgmt` interface (`<remote_addr>%mgmt`) instead of `eth0`
3. SNMP tries to send responses using `<remote_addr>%mgmt` as the destination, but this creates a routing/interface mismatch since the original socket was bound to `eth0`

The problem occurs because `eth0` is enslaved to the `mgmt` interface. In Linux networking, when an interface is enslaved, the kernel may report the master interface (`mgmt`) in address resolution rather than the actual physical interface (`eth0`) where the packet was received.

#### How I did it
Involving and correcting the IPv6 scope ID at the transport layer:
* Add a `sin6_scope_id` field to the `netsnmp_transport_s` structure to remember the original scope ID used during socket binding
* In `netsnmp_udp6_transport_bind()`, capture and store the scope ID from the bind address (`addr->sin6_scope_id`) into the transport structure (`t->sin6_scope_id`)
* Correct scope id on receive. In `netsnmp_udp6_recv()`, after receiving a packet via `recvfrom()`, if received address's scope ID differ from the stored original scope ID, override the received scope ID with the original one

This ensures that when SNMP later uses the received address for `sendto()` operations, it uses the same interface scope (`%eth0`) that was originally bound, rather than the master interface scope (`%mgmt`) returned by the kernel due to interface enslaving.


#### How to verify it
snmp can work with ipv6 link local even eth0 under mgmg VRF 
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

