### PR TITLE
[bgpcfgd]BGP suppress fib pending support for multi-asic

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_db.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_db.py
@@ -23,7 +23,7 @@ class BGPDataBaseMgr(Manager):
         if self.__set_handler_validate(key, data) == True:
             cmd_list = []
             bgp_asn = data["bgp_asn"]
-            state = data["suppress_fib_pending"]
+            state = data["suppress-fib-pending"]
             cmd_list.append("router bgp %s" % bgp_asn)
             if state == "disabled":
                 cmd_list.append("no bgp suppress-fib-pending")
@@ -43,6 +43,6 @@ class BGPDataBaseMgr(Manager):
 
     def __set_handler_validate(self, key, data):
         if data:
-            if ((key == "localhost") and ("bgp_asn" in data) and ("suppress_fib_pending" in data and data["suppress_fib_pending"] in ["enabled","disabled"])):
+            if ((key == "localhost") and ("bgp_asn" in data) and ("suppress-fib-pending" in data and data["suppress-fib-pending"] in ["enabled","disabled"])):
                  return True
         return False

--- a/src/sonic-bgpcfgd/tests/test_db.py
+++ b/src/sonic-bgpcfgd/tests/test_db.py
@@ -30,13 +30,13 @@ def test_set_del_handler():
     assert "test_key2" in m.directory.get_slot(m.db_name, m.table_name)
     assert m.directory.get(m.db_name, m.table_name, "test_key2") == {}
 
-    res = m.set_handler("localhost", {'bgp_asn':'65100','suppress_fib_pending':'enabled'})
+    res = m.set_handler("localhost", {'bgp_asn':'65100','suppress-fib-pending':'enabled'})
     assert res, "Returns always True"
-    assert m.directory.get(m.db_name, m.table_name, "localhost") == {'bgp_asn':'65100','suppress_fib_pending':'enabled'}
+    assert m.directory.get(m.db_name, m.table_name, "localhost") == {'bgp_asn':'65100','suppress-fib-pending':'enabled'}
 
-    res = m.set_handler("localhost", {'bgp_asn':'65100','suppress_fib_pending':'disabled'})
+    res = m.set_handler("localhost", {'bgp_asn':'65100','suppress-fib-pending':'disabled'})
     assert res, "Returns always True"
-    assert m.directory.get(m.db_name, m.table_name, "localhost") == {'bgp_asn':'65100','suppress_fib_pending':'disabled'}
+    assert m.directory.get(m.db_name, m.table_name, "localhost") == {'bgp_asn':'65100','suppress-fib-pending':'disabled'}
 
     # test del_handler
     m.del_handler("test_key")


### PR DESCRIPTION
bgpcfgd support for FRR configuration for suppress-fib-pending configuration.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Before this PR, bgpcfgd did not have support of frr configuration for suppress-fib-pending configuration from config db. The suppress-fib-pending was enabled by default via templates only. This commit adds support for suppress-fib-pending configuation by config db and also fixes the issue (https://github.com/sonic-net/sonic-buildimage/issues/19022) for multi-asic

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Changes include:
- bgpcfgd managers db set handler changes to push command for suppress-fib-pending configuration from config db DEVICE_METADATA
- Unit tests for the changes.

#### How to verify it

- In a multi-asic device configure suppress-fib-pending using the command "sudo config suppress-fib-pending enabled"
- Verify that the the fv "suppress-fib-pending":"enabled" exists in all asic's config db.
- Verify in FRR that "bgp suppress-fib-pending" avaiable under "router bgp <as number>"
- Verify this for disabling suppress-fib-pending by using the command "sudo config suppress-fib-pending disabled"
- Verify that the the fv "suppress-fib-pending":"disabled" exists in all asic's config db.
- In a multi-asic device execute the command "show suppress-fib-pending" and verify that configured value is displayed for all the asics.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
bgpcfgd support for FRR configuration for suppress-fib-pending configuration.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

