### PR TITLE
Updated cisco-8000-smartswitch.ini  ref. to release tag 202505.1.0.2

### DIFF
--- a/platform/checkout/cisco-8000-smartswitch.ini
+++ b/platform/checkout/cisco-8000-smartswitch.ini
@@ -1,4 +1,4 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=000000.1.0.0
+ref=202505.1.0.2
 


### PR DESCRIPTION
Updated cisco-8000-smartswitch.ini  ref. to release tag 202505.1.0.2

#### Why I did it
Cisco smartswitch has a new release 202505.1.0.2

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Updated the ref in;  cisco-8000-smartswitch.ini 

#### How to verify it
Did an internal build