### PR TITLE
Added patch to avoid zebra crash when eth1-midplane flaps for chassis

### DIFF
--- a/src/sonic-frr/patch/0055-zebra-Fix-crash-on-macvlan-link-down-up.patch
+++ b/src/sonic-frr/patch/0055-zebra-Fix-crash-on-macvlan-link-down-up.patch
@@ -1,0 +1,33 @@
+From bbe3646519822410212159850436cdc7499e6fdf Mon Sep 17 00:00:00 2001
+From: Abhishek Dosi <abdosi@microsoft.com>
+Date: Thu, 24 Jul 2025 01:51:14 +0000
+Subject: [PATCH] zebra: Fix crash on macvlan link down/up
+
+Signed-off-by: Abhishek Dosi <abdosi@microsoft.com>
+---
+ zebra/zebra_vxlan.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/zebra/zebra_vxlan.c b/zebra/zebra_vxlan.c
+index c6ff5089c..bafd40456 100644
+--- a/zebra/zebra_vxlan.c
++++ b/zebra/zebra_vxlan.c
+@@ -4783,6 +4783,15 @@ void zebra_vxlan_macvlan_up(struct interface *ifp)
+ 	zif = ifp->info;
+ 	assert(zif);
+ 	link_ifp = zif->link;
++	if (!link_ifp) {
++		if (IS_ZEBRA_DEBUG_VXLAN)
++			zlog_debug(
++				"macvlan parent link is not found. Parent index %d ifp %s",
++				zif->link_ifindex,
++				ifindex2ifname(zif->link_ifindex,
++					       ifp->vrf->vrf_id));
++		return;
++	}
+ 	link_zif = link_ifp->info;
+ 	assert(link_zif);
+ 
+-- 
+2.25.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -52,3 +52,4 @@
 0052-bgpd-backpressure-log-error-for-evpn-when-route-inst.patch
 0053-Patch-to-send-tag-value-associated-with-route-via-ne.patch
 0054-make-route-node-lock-atomic.patch
+0055-zebra-Fix-crash-on-macvlan-link-down-up.patch


### PR DESCRIPTION
What I did:
Added patch to avoid zebra crash when eth1-midplane flaps for chassis 
eth1-midplane is binded to macvlan interface causing this crash.

How I did:

Take FRR patch for similar issue seen:
https://github.com/FRRouting/frr/pull/15010/files

Backtrace of crash is similar as reported in FRR
MSFT ADO: 33915620


```
[Current thread is 1 (Thread 0x7ff9a94977c0 (LWP 49))]
(gdb) bt thread all
No symbol "thread" in current context.
(gdb) bt
#0  0x00007ff9a9839ebc in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007ff9a97eafb2 in raise () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x00007ff9a9a76fdc in core_handler (signo=11, siginfo=0x7fff5963e5f0, context=<optimized out>) at ../lib/sigevent.c:261
#3  <signal handler called>
#4  zebra_vxlan_macvlan_up (ifp=ifp@entry=0x5627746c9700) at ../zebra/zebra_vxlan.c:4786
#5  0x00005627740d4158 in if_up (ifp=0x5627746c9700, install_connected=install_connected@entry=true) at ../zebra/interface.c:1053
#6  0x00005627740d5c30 in zebra_if_dplane_ifp_handling (ctx=0x7ff998028640) at ../zebra/interface.c:2127
#7  zebra_if_dplane_result (ctx=0x7ff998028640) at ../zebra/interface.c:2221
#8  0x000056277412fe19 in rib_process_dplane_results (thread=<optimized out>) at ../zebra/zebra_rib.c:4810
#9  0x00007ff9a9a88f5d in thread_call (thread=thread@entry=0x7fff5963ed50) at ../lib/thread.c:1990
#10 0x00007ff9a9a41378 in frr_run (master=0x562774488f90) at ../lib/libfrr.c:1198
#11 0x00005627740c8317 in main (argc=7, argv=0x7fff5963f168) at ../zebra/main.c:478
(gdb) frame 4
#4  zebra_vxlan_macvlan_up (ifp=ifp@entry=0x5627746c9700) at ../zebra/zebra_vxlan.c:4786
4786    ../zebra/zebra_vxlan.c: No such file or directory.
(gdb) p *ifp
$1 = {name_entry = {rbt_parent = 0x5627746d1aa0, rbt_left = 0x5627746d2700, rbt_right = 0x562774bfd5c0, rbt_color = 0}, index_entry = {
    rbt_parent = 0x5627746c90c0, rbt_left = 0x0, rbt_right = 0x0, rbt_color = 0}, name = "eth1", '\000' <repeats 11 times>, ifindex = 13,
  oldifindex = 0, link_ifindex = 0, status = 5 '\005', flags = 69699, metric = 0, speed = 10000, mtu = 1500, mtu6 = 1500, ll_type = ZEBRA_LLT_ETHER,
  hw_addr = "z6\3235\213\270", '\000' <repeats 13 times>, hw_addr_len = 6, bandwidth = 0, link_params = 0x0, desc = 0x0, distribute_in = 0x0,
  distribute_out = 0x0, connected = 0x5627746c9820, nbr_connected = 0x5627746c9850, info = 0x5627746c9bf0, ptm_enable = 0 '\000', ptm_status = 2 '\002',
  node = 0x5627746ca070, vrf = 0x5627746a2780, configured = false, qobj_node = {nid = 2603326557693239028, nodehash = {hi = {next = 0x0,
        hashval = 296050420}}, type = 0x562774204160 <qobj_t_interface>}}
(gdb) p ifp->info
$2 = (void *) 0x5627746c9bf0
(gdb) p ifp->info->link
Attempt to dereference a generic pointer.
(gdb) p *(struct interface *)ifp->info->link
Attempt to dereference a generic pointer.
(gdb) p link_ifp
$3 = (struct interface *) 0x0
(gdb) p *zif
$4 = {ifp = 0x5627746c9700, flags = 0, shutdown = 2 '\002', multicast = 0 '\000', mpls = false, linkdown = false, linkdownv6 = false,
  v4mcast_on = false, v6mcast_on = false, rtadv_enable = 0 '\000', ipv4_subnets = 0x5627746c9eb0, nhg_dependents = {rr = {rbt_root = 0x0, count = 0}},
  up_count = 1, up_last = "2025/07/12 08:48:24.64", '\000' <repeats 17 times>, down_count = 1,
  down_last = "2025/07/12 08:48:24.35", '\000' <repeats 17 times>, rtadv = {AdvSendAdvertisements = 0, MaxRtrAdvInterval = 600000,
    MinRtrAdvInterval = 198000, AdvIntervalTimer = 0, AdvManagedFlag = 0, lastadvmanagedflag = {tv_sec = 0, tv_usec = 0}, AdvOtherConfigFlag = 0,
    lastadvotherconfigflag = {tv_sec = 0, tv_usec = 0}, AdvLinkMTU = 0, AdvReachableTime = 0, lastadvreachabletime = {tv_sec = 0, tv_usec = 0},
    AdvRetransTimer = 0, lastadvretranstimer = {tv_sec = 0, tv_usec = 0}, AdvCurHopLimit = 64, lastadvcurhoplimit = {tv_sec = 0, tv_usec = 0},
    AdvDefaultLifetime = -1, prefixes = {{rr = {rbt_root = 0x0, count = 0}}}, AdvHomeAgentFlag = 0, HomeAgentPreference = 0, HomeAgentLifetime = -1,
    AdvIntervalOption = 0, DefaultPreference = 0, AdvRDNSSList = 0x5627746c9e50, AdvDNSSLList = 0x5627746c9e80, UseFastRexmit = true,
    inFastRexmit = 0 '\000', ra_configured = 0 '\000', NumFastReXmitsRemain = 0}, ra_sent = 0, ra_rcvd = 0, irdp = 0x0, ptm_enable = 0 '\000',
  zif_type = ZEBRA_IF_MACVLAN, zif_slave_type = ZEBRA_IF_SLAVE_NONE, l2info = {br = {vlan_aware = 0 '\000'}, vl = {vid = 0}, vxl = {vni = 0, vtep_ip = {
        s_addr = 0}, access_vlan = 0, mcast_grp = {s_addr = 0}, ifindex_link = 0, link_nsid = 0}, gre = {vtep_ip = {s_addr = 0}, vtep_ip_remote = {
        s_addr = 0}, ikey = 0, okey = 0, ifindex_link = 0, link_nsid = 0}}, brslave_info = {bridge_ifindex = 0, br_if = 0x0, ns_id = 0},
  bondslave_info = {bond_ifindex = 0, bond_if = 0x0}, bond_info = {mbr_zifs = 0x0}, es_info = {sysmac = {octet = "\000\000\000\000\000"}, lid = 0,
    esi = {val = "\000\000\000\000\000\000\000\000\000"}, df_pref = 0, flags = 0 '\000', es = 0x0}, vlan_bitmap = {data = 0x0, n = 0, m = 0},
  protodown_rc = 0, mac_list = 0x0, link_nsid = 0, link_ifindex = 3, link = 0x0, speed_update_count = 0 '\000', speed_update = 0x0,
  v6_2_v4_ll_neigh_entry = false, neigh_mac = "\000\000\000\000\000", v6_2_v4_ll_addr6 = {__in6_u = {__u6_addr8 = '\000' <repeats 15 times>,
      __u6_addr16 = {0, 0, 0, 0, 0, 0, 0, 0}, __u6_addr32 = {0, 0, 0, 0}}}, desc = 0x0}


```
