### PR TITLE
[T2] Fix syntax error in prefix_list script

### DIFF
--- a/dockers/docker-fpm-frr/base_image_files/prefix_list
+++ b/dockers/docker-fpm-frr/base_image_files/prefix_list
@@ -38,7 +38,7 @@ check_spine_router() {
     subtype=$(sonic-cfggen -d -v DEVICE_METADATA.localhost.subtype)
 
     # only supported on UpstreamLC or UpperSpineRouter
-    if [[ ("$type" == "SpineRouter" && "$subtype" == "UpstreamLC") || "$type" == "UpperSpineRouter" ]]
+    if [[ ("$type" == "SpineRouter" && "$subtype" == "UpstreamLC") || "$type" == "UpperSpineRouter" ]]; then
         exit 0
     fi
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR introduce a syntax error https://github.com/sonic-net/sonic-buildimage/pull/22337, `then` part missed in prefix_list script, which would cause syntax error
```
admin@sonic:~$ prefix_list status
/usr/bin/prefix_list: line 43: syntax error near unexpected token `fi'
/usr/bin/prefix_list: line 43: `    fi'
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Fix syntax error

#### How to verify it
Run cli and no error
```
admin@sonic:~$ prefix_list status
Operation is only supported on Upstream SpineRouter.
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

