### PR TITLE
Bullseye is EOL, use the archive repo

### DIFF
--- a/scripts/build_mirror_config.sh
+++ b/scripts/build_mirror_config.sh
@@ -25,7 +25,7 @@ if [ "$ARCHITECTURE" == "armhf" ]; then
     DEFAULT_MIRROR_SECURITY_URLS=http://deb.debian.org/debian-security/
 fi
 
-if [ "$DISTRIBUTION" == "buster" ]; then
+if [ "$DISTRIBUTION" == "buster" ] || [ "$DISTRIBUTION" == "bullseye" ]; then
     DEFAULT_MIRROR_URLS=http://archive.debian.org/debian/
 fi
 


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The bullseye-backports section of the repo has been removed from the main repo.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

Verified by attempting to build slave container:

```
#13 0.522 Get:1 http://archive.debian.org/debian bullseye InRelease [116 kB]
#13 0.538 Get:2 http://archive.debian.org/debian bullseye-updates InRelease [44.0 kB]
#13 0.538 Get:3 http://archive.debian.org/debian bullseye-backports InRelease [48.9 kB]
#13 0.568 Get:4 http://debian-archive.trafficmanager.net/debian-security bullseye-security InRelease [27.2 kB]
#13 0.737 Get:5 http://archive.debian.org/debian bullseye/contrib Sources [43.2 kB]
#13 0.915 Get:6 http://archive.debian.org/debian bullseye/main Sources [8500 kB]
#13 1.037 Get:7 http://debian-archive.trafficmanager.net/debian-security bullseye-security/contrib Sources [1128 B]
#13 1.065 Get:8 http://debian-archive.trafficmanager.net/debian-security bullseye-security/main Sources [250 kB]
#13 1.133 Get:9 http://debian-archive.trafficmanager.net/debian-security bullseye-security/non-free Sources [1352 B]
#13 1.134 Get:10 http://debian-archive.trafficmanager.net/debian-security bullseye-security/main amd64 Packages [389 kB]
#13 1.157 Get:11 http://debian-archive.trafficmanager.net/debian-security bullseye-security/contrib amd64 Packages [2880 B]
#13 1.157 Get:12 http://debian-archive.trafficmanager.net/debian-security bullseye-security/non-free amd64 Packages [1184 B]
#13 1.280 Get:13 http://archive.debian.org/debian bullseye/non-free Sources [81.0 kB]
#13 1.605 Get:14 http://archive.debian.org/debian bullseye/contrib amd64 Packages [50.4 kB]
#13 1.609 Get:15 http://archive.debian.org/debian bullseye/main amd64 Packages [8066 kB]
#13 1.662 Get:16 http://archive.debian.org/debian bullseye/non-free amd64 Packages [96.4 kB]
#13 1.662 Get:17 http://archive.debian.org/debian bullseye-updates/main Sources [7908 B]
#13 1.663 Get:18 http://archive.debian.org/debian bullseye-updates/main amd64 Packages [18.8 kB]
#13 1.663 Get:19 http://archive.debian.org/debian bullseye-backports/non-free amd64 Packages [14.4 kB]
#13 1.663 Get:20 http://archive.debian.org/debian bullseye-backports/main amd64 Packages [403 kB]
#13 1.665 Get:21 http://archive.debian.org/debian bullseye-backports/contrib amd64 Packages [6164 B]
#13 2.755 Fetched 18.2 MB in 2s (8066 kB/s)
#13 2.755 Reading package lists...
#13 3.212 Reading package lists...
#13 3.626 Building dependency tree...
#13 3.709 Reading state information...
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

