### PR TITLE
[auditd] update modules_changes rule

### DIFF
--- a/dockers/docker-auditd-watchdog/watchdog/src/main.rs
+++ b/dockers/docker-auditd-watchdog/watchdog/src/main.rs
@@ -7,8 +7,8 @@ static NSENTER_CMD: &str = "nsenter --target 1 --pid --mount --uts --ipc --net";
 
 // Expected hash values
 static AUDITD_CONF_HASH: &str = "7cdbd1450570c7c12bdc67115b46d9ae778cbd76";
-static AUDITD_RULES_HASH_DEFAULT: &str = "6d911a32e47d3dc8fb9bc3734bb0ebb73ae2ae72";
-static AUDITD_RULES_HASH_NOKIA: &str = "60872dddef053a6ed13997acc5e80ac8eead77f0";
+static AUDITD_RULES_HASH_DEFAULT: &str = "99aa7d071a15eb1f2b9d5f1cce75a37cf6a2483d";
+static AUDITD_RULES_HASH_NOKIA: &str = "b70e0ec6b71b70c2282585685fbe53f5d00f1cd0";
 
 // Helper to run commands
 fn run_command(cmd: &str) -> Result<String, String> {

--- a/dockers/docker-auditd/auditd_config_files/32-modules_changes.rules
+++ b/dockers/docker-auditd/auditd_config_files/32-modules_changes.rules
@@ -2,4 +2,3 @@
 -a always,exit -F arch=b64 -S finit_module -S init_module -S delete_module -F auid>=1000 -F auid!=4294967295 -k modules_changes
 -a always,exit -F arch=b32 -S finit_module -S init_module -S delete_module -F auid>=1000 -F auid!=4294967295 -k modules_changes
 -w /lib/modules/ -F perm=r -F auid>=1000 -F auid!=4294967295 -k modules_changes
-

--- a/dockers/docker-auditd/auditd_config_files/32bit/32-modules_changes.rules
+++ b/dockers/docker-auditd/auditd_config_files/32bit/32-modules_changes.rules
@@ -1,4 +1,3 @@
 -a always,exit -F path=/usr/bin/kmod -F perm=x -F auid>=1000 -F auid!=4294967295 -k modules_changes
 -a always,exit -F arch=b32 -S finit_module -S init_module -S delete_module -F auid>=1000 -F auid!=4294967295 -k modules_changes
 -w /lib/modules/ -F perm=r -F auid>=1000 -F auid!=4294967295 -k modules_changes
-

--- a/dockers/docker-auditd/config_checker.py
+++ b/dockers/docker-auditd/config_checker.py
@@ -19,8 +19,8 @@ CONFIG_FILES = "/usr/share/sonic/auditd_config_files/"
 # Expected hash values
 CONFIG_HASHES = {
     "rules": {
-        "default": "6d911a32e47d3dc8fb9bc3734bb0ebb73ae2ae72",
-        "nokia": "60872dddef053a6ed13997acc5e80ac8eead77f0"
+        "default": "99aa7d071a15eb1f2b9d5f1cce75a37cf6a2483d",
+        "nokia": "b70e0ec6b71b70c2282585685fbe53f5d00f1cd0"
     },
     "auditd_conf": "7cdbd1450570c7c12bdc67115b46d9ae778cbd76"
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix modules_changes rule, the error of the old modules_changes rule was not found initially during manual test because the syntax validation command return exit code 0. The failure was found by checking syslog and `sudo systemctl status auditd` output (`Process: 227593 ExecStartPost=/sbin/augenrules --load (code=exited, status=1/FAILURE)`)

```
2025 Aug  7 12:40:53.474022 vlab-01 INFO augenrules[227633]: There was an error in line 46 of /etc/audit/audit.rules

admin@vlab-01:~$ sudo systemctl status auditd
● auditd.service - Security Auditing Service
     Loaded: loaded (/lib/systemd/system/auditd.service; enabled; preset: enabled)
    Drop-In: /etc/systemd/system/auditd.service.d
             └─log-directory.conf
     Active: active (running) since Thu 2025-08-07 12:40:53 UTC; 1min 47s ago
       Docs: man:auditd(8)
             https://github.com/linux-audit/audit-documentation
    Process: 227553 ExecStart=/sbin/auditd (code=exited, status=0/SUCCESS)
    Process: 227593 ExecStartPost=/sbin/augenrules --load (code=exited, status=1/FAILURE)
```
##### Work item tracking
- Microsoft ADO **(number only)**: 36638669

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

