### PR TITLE
Add midplane ipv4 field/attribute to DPU section in yang model

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-smart-switch.yang
+++ b/src/sonic-yang-models/yang-models/sonic-smart-switch.yang
@@ -145,6 +145,11 @@ module sonic-smart-switch {
 					type inet:ipv6-address;
 				}
 				
+				leaf midplane_ipv4 {
+					description "Midplane IPv4 address from minigraph";
+					type inet:ipv4-address;
+				}
+
 				leaf dpu_id {
 					description "ID of the DPU from minigraph";
 					type string {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
DPU Table needs to support additional midplane_ipv4 field

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added field to yang model

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
-->

- [x] 20250505.08

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add midplane ipv4 field/attribute to DPU section in yang model
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

