### PR TITLE
Secureboot: Fix base paths for kernel module signing and verification

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -737,12 +737,11 @@ if [[ $SECURE_UPGRADE_MODE == 'dev' || $SECURE_UPGRADE_MODE == "prod" ]]; then
         # verifying all EFI files and kernel modules in $OUTPUT_SEC_BOOT_DIR
         sudo ./scripts/secure_boot_signature_verification.sh -e $OUTPUT_SEC_BOOT_DIR \
                                                              -c $SECURE_UPGRADE_SIGNING_CERT \
-                                                             -k $FILESYSTEM_ROOT
+                                                             -k ${FILESYSTEM_ROOT}/usr/lib/modules
 
         # verifying vmlinuz file.
         sudo ./scripts/secure_boot_signature_verification.sh -e $FILESYSTEM_ROOT/boot/vmlinuz-${LINUX_KERNEL_VERSION}-${CONFIGURED_ARCH} \
-                                                             -c $SECURE_UPGRADE_SIGNING_CERT \
-                                                             -k $FILESYSTEM_ROOT
+                                                             -c $SECURE_UPGRADE_SIGNING_CERT
     fi
     echo "Secure Boot support build stage: END."
 fi

--- a/scripts/secure_boot_signature_verification.sh
+++ b/scripts/secure_boot_signature_verification.sh
@@ -68,8 +68,8 @@ if [ -f "$EFI_FILE" ]; then
     verify_efi $CERT_PEM $EFI_FILE
 fi
 
-if [ -d "$KERNEL_MODULES_DIR" ]; then
-    # Condition checking that all the kernel modules in the KERNEL_MODULES_DIR contain a signature.
+if [ ! -z "$KERNEL_MODULES_DIR" -a -d "$KERNEL_MODULES_DIR" ]; then
+    # Condition checking that all the kernel modules in the KERNEL_MODULES_DIR contain a signature if specified.
 
     # find all the kernel modules.
     modules_list=$(sudo find ${KERNEL_MODULES_DIR} -name "*.ko")

--- a/scripts/signing_secure_boot_dev.sh
+++ b/scripts/signing_secure_boot_dev.sh
@@ -116,6 +116,6 @@ mv ${CURR_VMLINUZ}-signed ${CURR_VMLINUZ}
 #########################
 # Kernel Modules signing
 #########################
-./scripts/signing_kernel_modules.sh -l $LINUX_KERNEL_VERSION -c ${PEM_CERT} -p ${PEM_PRIV_KEY} -k ${FS_ROOT}
+./scripts/signing_kernel_modules.sh -l $LINUX_KERNEL_VERSION -c ${PEM_CERT} -p ${PEM_PRIV_KEY} -k ${FS_ROOT}/usr/lib/modules
 
 echo "$0 signing & verifying EFI files and Kernel Modules DONE"


### PR DESCRIPTION
#### Why I did it

Without this change, additional files like `usr/share/vim/vim90/tutor/tutor.ko` end up getting signed which is inappropriate.

This also skips attempting to verify kernel module signatures if the module path is not specified.  Previously it would verify the kernel module signatures twice.

##### Work item tracking

#### How I did it

Updated paths specified to signing and verification scripts.

#### How to verify it
Build with secureboot and observe `usr/share/vim/vim90/tutor/tutor.ko` is no longer signed.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

master as of 20250817

#### Description for the changelog
Secureboot: Fix base paths for kernel module signing and verification

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

Fixes: https://github.com/sonic-net/sonic-buildimage/issues/23406
Signed-off-by: Brad House <bhouse@nexthop.ai>
