### PR TITLE
Secureboot: install secureboot shim/grub if image is built with secureboot

### DIFF
--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -438,21 +438,23 @@ bootloader_menu_config()
 
         echo "firmware=$firmware"
         if [ "$firmware" = "uefi" ] ; then
-            secure_boot_state=0
-            reg_sb_guid=""
+            secure_boot=no
             ENABLED=1
-            echo "checking secure boot state"
-            reg_sb_guid=$(efivar -l | grep "SecureBoot$") || echo "Secure Boot GUID not found in efivar list"
-            echo "Secure Boot GUID=$reg_sb_guid"
-            if [ -n "$reg_sb_guid" ]; then
-                secure_boot_state=$(efivar -d --name $reg_sb_guid) || echo "Could not read Secure Boot state from efivar"
+            # We know this image was built with secureboot support if we have the shim and grub EFI images in the
+            # expected paths.  There is currently no other indicator.  We could detect if Secureboot is enabled
+            # (via $(mokutil --sb | grep "enabled") or $(efivar -l | grep "SecureBoot$"), but that would mean the user
+            # would not be able to enable secureboot at a later point in time without a reinstall from ONIE with
+            # Secureboot enabled which could cause confusion.
+            echo "checking if image was built with secure boot support"
+            if [ -f "$demo_mnt/$image_dir/boot/shimx64.efi" -a -f "$demo_mnt/$image_dir/boot/grubx64.efi" ]; then
+                secure_boot=yes
             fi
-            echo secure_boot_state=$secure_boot_state
-            if expr "$secure_boot_state" : '[[:digit:]]\{1,\}' >/dev/null && [ "$secure_boot_state" -eq "$ENABLED" ]; then
-                echo "UEFI Secure Boot is enabled - Installing shim bootloader"
+            echo secure_boot=$secure_boot
+            if [ "${secure_boot}" = "yes" ]; then
+                echo "UEFI Secure Boot image detected - Installing shim bootloader"
                 demo_install_uefi_shim "$demo_mnt" "$blk_dev"
             else
-                echo "UEFI Secure Boot is disabled - Installing regular grub bootloader"
+                echo "UEFI Secure Boot image not detected - Installing regular grub bootloader"
                 demo_install_uefi_grub "$demo_mnt" "$blk_dev"
             fi
         else


### PR DESCRIPTION
#### Why I did it

During an ONIE install, secureboot shim/grub were only being installed if ONIE was booted in secureboot mode.  This is undesirable as it would prevent the user from enabling secureboot after the fact.  The secureboot signed shim and grub will operate normally with secureboot disabled.

##### Work item tracking

#### How I did it

Update installer script to always install the signed secureboot grub and shim if found in the relevant paths.

#### How to verify it

Build a secureboot enabled image.  Boot into a machine with secureboot disabled in the BIOS.  Install SONiC via ONIE.  Reboot and enable secureboot in the BIOS.  Observe SONiC boots as expected with secureboot enabled.  Prior to this patch it would not.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

master as of 20250817

#### Description for the changelog

Secureboot: install secureboot shim/grub if image is built with secureboot

#### Link to config_db schema for YANG module changes


#### A picture of a cute animal (not mandatory but encouraged)

Fixes: https://github.com/sonic-net/sonic-buildimage/issues/23406
Signed-off-by: Brad House <bhouse@nexthop.ai>