### PR TITLE
Secureboot: SECURE_UPGRADE_MODE should be overwritable

### DIFF
--- a/rules/config
+++ b/rules/config
@@ -243,7 +243,7 @@ SONIC_ENABLE_IMAGE_SIGNATURE ?= n
 # SECURE_UPGRADE_PROD_TOOL_ARGS - Extra arguments options for vendor to use to run his specific prod signing script
 SECURE_UPGRADE_DEV_SIGNING_KEY ?= 
 SECURE_UPGRADE_SIGNING_CERT ?= 
-SECURE_UPGRADE_MODE = "no_sign"
+SECURE_UPGRADE_MODE ?= "no_sign"
 SECURE_UPGRADE_PROD_SIGNING_TOOL ?=
 SECURE_UPGRADE_PROD_TOOL_ARGS ?=
 # PACKAGE_URL_PREFIX - the package url prefix


### PR DESCRIPTION
#### Why I did it

The other secureboot parameters allow overwriting on command line or environment variables, but this was missing for SECURE_UPGRADE_MODE.

#### How I did it

Use `?=` instead of `=`

#### How to verify it

Set using environment variable in build environment and observe is is honored

#### Which release branch to backport (provide reason below if selected)

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

master as of 20250817

#### Description for the changelog

Secureboot: SECURE_UPGRADE_MODE should be overwritable

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

Fixes: https://github.com/sonic-net/sonic-buildimage/issues/23406
Signed-off-by: Brad House <bhouse@nexthop.ai>