### PR TITLE
[Arista SKUs] Enable kdump by default

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -86,7 +86,8 @@ installer_image_path="$image_path/$installer_image"
 
 boot_config="$target_path/boot-config"
 
-cmdline_allowlist="crashkernel hwaddr_ma1 sonic_fips docker_inram"
+kernel_cmdline_allowlist="crashkernel hwaddr_ma1 sonic_fips docker_inram"
+default_cmdline_blacklist="crashkernel"
 
 # for backward compatibility with the sonic_upgrade= behavior
 install="${install:-${sonic_upgrade:-}}"
@@ -202,6 +203,11 @@ cmdline_clear() {
 
 cmdline_add() {
     echo "$@" >> /tmp/append
+}
+
+cmdline_remove() {
+    # remove all occurences of parameter and its value from the cmdline
+    sed -i "s/\b${1}=[^ ]*\s*//g" /tmp/append
 }
 
 cmdline_has() {
@@ -477,6 +483,17 @@ read_system_eeprom() {
 get_eeprom_value() {
     local key="$1"
     sed -n "s#^$key: *##p" "$target_path/.system-prefdl" || :
+}
+
+write_kdump_cmdline() {
+    local sid="$(cmdline_get sid | sed 's/Ssd$//')"
+    case "$sid" in
+        Wolverine*|Clearwater2*|OtterLake*|QuartzDd*|Redstart8Mk2Quartz4*|CitrineDd*)
+            if ! cmdline_has crashkernel; then
+                cmdline_add crashkernel=0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-16G:448M,16G-32G:768M,32G-:1G
+            fi
+            ;;
+    esac
 }
 
 write_platform_specific_cmdline() {
@@ -802,6 +819,11 @@ write_default_cmdline() {
         # for the Aboot part. Take an educated guess at a right delimiter.
         # Subject to breakage if EOS or SONiC cmdline change.
         cat /proc/cmdline | sed -E 's/^(.*) rw .*$/\1/' | tr ' ' '\n' | cmdline_append
+
+        # Remove any parameters that are inadvertently inherited
+        for field in $default_cmdline_blacklist; do
+            cmdline_remove "$field"
+        done
     fi
 
     cmdline_add "$delimiter"
@@ -822,7 +844,7 @@ write_cmdline() {
     #         this file can be either packaged in the swi or generated from userland
     for cpath in "$image_path/kernel-cmdline" "$image_path/kernel-cmdline-append"; do
         if [ -f "$cpath" ]; then
-            for field in $cmdline_allowlist; do
+            for field in $kernel_cmdline_allowlist; do
                cat "$cpath" | tr ' ' '\n' | grep -E "$field" | tail -n 1 | cmdline_append
             done
         fi
@@ -852,6 +874,7 @@ write_secureboot_configs() {
     # setting panic= has the side effect of disabling the initrd shell on error
     cmdline_add panic=0
     write_cmdline
+    write_kdump_cmdline
 }
 
 write_regular_configs() {
@@ -859,6 +882,7 @@ write_regular_configs() {
     cmdline_add "loop=$image_name/fs.squashfs"
     cmdline_add loopfstype=squashfs
     write_cmdline
+    write_kdump_cmdline
 }
 
 run_kexec() {


### PR DESCRIPTION
This change does two things:

1. Fixes inadvertent inheriting of 'crashkernel=' parameter when eos2sonic script is used for converting a device from Eos to SONiC. This makes sure that we are not working with old kdump configuration as constraints on SONiC maybe different from EOS.

2. Adds 'crashkernel=' parameter to cmdline, which enables kdump by default when the system boots up.

```
on LC

admin@cmp206-5:~$ show reboot history
Name                 Cause                                                                                   Time    User    Comment
-------------------  --------------------------------------------------------------------------------------  ------  ------  -------------------------------------------------------------------------------------------------------------------------------
2025_08_22_21_32_07  Hardware - Other (gpi-2, description: gpi 2 detailed fault, time: 2025-08-22 21:25:00)  N/A     N/A     Unknown (First boot of SONiC version branch.master-ars.ec880b58-buildimage.origin.master-review.485836.16-dbg-2025.08.22.02.31)
admin@cmp206-5:~$ show kdump config
Kdump administrative mode: Enabled     <-------
Kdump operational mode: Ready
Kdump memory reservation: 0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-16G:448M,16G-32G:768M,32G-:1G
Maximum number of Kdump files: 3
Kdump ssh connection string and ssh_path not found

on supervisor

admin@cmp206:~$ show reboot history
Name                 Cause                                                                                             Time    User    Comment
-------------------  ------------------------------------------------------------------------------------------------  ------  ------  -------------------------------------------------------------------------------------------------------------------------------
2025_08_22_21_19_36  Power Loss (powerloss, description: mon 9 detailed fault - powerloss, time: 2025-08-22 21:09:36)  N/A     N/A     Unknown (First boot of SONiC version branch.master-ars.ec880b58-buildimage.origin.master-review.485836.16-dbg-2025.08.22.02.31)
admin@cmp206:~$
admin@cmp206:~$ show kdump config
Kdump administrative mode: Enabled                <-------
Kdump operational mode: Ready
Kdump memory reservation: 0M-2G:256M,2G-4G:320M,4G-8G:384M,8G-16G:448M,16G-32G:768M,32G-:1G
Maximum number of Kdump files: 3
Kdump ssh connection string and ssh_path not found
```

This removes the need to do additional reboot to get kdump to operationally ready state.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

1. SONiC -> SONiC image: On the DUT running SONiC without these changes and having kdump disabled, re-sanitized it with SONiC image containing these changes.

2. EOS -> SONiC image: Used the eos2sonic script to convert DUT from EOS to SONiC. Verified that it doesn't inherit EOS crashkernel parameters and boots up with default parameters from these changes.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

