### PR TITLE
[sonic-cfggen] add additional option to read only specified ConfigDB table

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -331,10 +331,11 @@ def main():
     parser.add_argument("-y", "--yaml", help="yaml file that contains additional variables", action='append', default=[])
     parser.add_argument("-j", "--json", help="json file that contains additional variables", action='append', default=[])
     parser.add_argument("-a", "--additional-data", help="addition data, in json string")
-    parser.add_argument("-d", "--from-db", help="read config from configdb", action='store_true')
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("-d", "--from-db", help="read config from configdb", action='store_true')
+    group.add_argument("-D", "--from-db-table", help="read only specified ConfigDB table(s); repeatable", action='append', default=[])
     parser.add_argument("-H", "--platform-info", help="read platform and hardware info", action='store_true')
     parser.add_argument("-s", "--redis-unix-sock-file", help="unix sock file for redis connection")
-    parser.add_argument("-D", "--from-db-table", help="read only specified ConfigDB table(s); repeatable", action='append', default=[])
     group = parser.add_mutually_exclusive_group()
     group.add_argument("-t", "--template", help="render the data with the template file", action="append", default=[],
                        type=lambda opt_value: tuple(opt_value.split(',')) if ',' in opt_value else (opt_value, sys.stdout))

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -443,7 +443,7 @@ def main():
                 if table_data:
                     deep_update(data, {table_name: table_data})
                 else:
-                    print("Warning: ConfigDB table '{}' not found or empty".format(table_name), file=sys.stderr)
+                    print("Error: ConfigDB table '{}' not found or empty".format(table_name), file=sys.stderr)
                     sys.exit(1)
 
     # the minigraph file must be provided to get the mac address for backend asics

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -334,6 +334,7 @@ def main():
     parser.add_argument("-d", "--from-db", help="read config from configdb", action='store_true')
     parser.add_argument("-H", "--platform-info", help="read platform and hardware info", action='store_true')
     parser.add_argument("-s", "--redis-unix-sock-file", help="unix sock file for redis connection")
+    parser.add_argument("-D", "--from-db-table", help="read only specified ConfigDB table(s); repeatable", action='append', default=[])
     group = parser.add_mutually_exclusive_group()
     group.add_argument("-t", "--template", help="render the data with the template file", action="append", default=[],
                        type=lambda opt_value: tuple(opt_value.split(',')) if ',' in opt_value else (opt_value, sys.stdout))
@@ -423,7 +424,7 @@ def main():
     if args.additional_data is not None:
         deep_update(data, json.loads(args.additional_data))
 
-    if args.from_db:
+    if args.from_db or args.from_db_table:
         use_unix_sock = True if os.getuid() == 0 else False
         if args.namespace is None:
             configdb = ConfigDBPipeConnector(use_unix_socket_path=use_unix_sock, **db_kwargs)
@@ -432,8 +433,18 @@ def main():
             configdb = ConfigDBPipeConnector(use_unix_socket_path=use_unix_sock, namespace=args.namespace, **db_kwargs)
 
         configdb.connect()
-        deep_update(data, FormatConverter.db_to_output(configdb.get_config()))
 
+        if args.from_db:
+            deep_update(data, FormatConverter.db_to_output(configdb.get_config()))
+        else:
+            # Merge only the requested tables
+            for table_name in args.from_db_table:
+                table_data = configdb.get_table(table_name)
+                if table_data:
+                    deep_update(data, {table_name: table_data})
+                else:
+                    print("Warning: ConfigDB table '{}' not found or empty".format(table_name), file=sys.stderr)
+                    sys.exit(1)
 
     # the minigraph file must be provided to get the mac address for backend asics
     # or switch_type chassis_packet


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
sonic-cfggen supports render template from CONFIG DB. However, it always load the whole CONFIG DB which consumes time/memory. A possible way to improve it is having a new option that allows user to specify table name that will be used for rendering If table name is specified, no need load the whole CONFIG DB.


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
New option added:
"-D" "--from-db-table" 
help="read only specified ConfigDB table(s); repeatable"

#### How to verify it
old approach (-d):
```
root@sonic:/etc/sonic# time /usr/local/bin/sonic-cfggen -d -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/sonic-environment.j2,/etc/sonic/file2

real    0m0.369s
user    0m0.291s
sys     0m0.032s
```

new approach (-D table-name)
```
root@sonic:/etc/sonic# time /usr/local/bin/sonic-cfggen -D DEVICE_METADATA -y /etc/sonic/sonic_version.yml -t /usr/share/sonic/templates/sonic-environment.j2,/etc/sonic/file1

real    0m0.279s
user    0m0.234s
sys     0m0.044s
```
<==== less tine spent for execution


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

