### PR TITLE
Add configs to bind gNMI and Telemetry to a VRF

### DIFF
--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -91,6 +91,11 @@ if [[ x"${LOCALHOST_SUBTYPE}" == x"SmartSwitch" ]]; then
     TELEMETRY_ARGS+=" -zmq_port=8100 -max_recv_msg_size=$((32*1024*1024)) -max_send_msg_size=$((32*1024*1024))"
 fi
 
+GNMI_VRF=$(extract_field "$GNMI" '.vrf')
+if [[ -n "$GNMI_VRF" && "$GNMI_VRF" != "null" ]]; then
+    TELEMETRY_ARGS+=" --gnmi_vrf $GNMI_VRF"
+fi
+
 # Add VRF parameter when mgmt-vrf enabled
 MGMT_VRF_ENABLED=`sonic-db-cli CONFIG_DB hget  "MGMT_VRF_CONFIG|vrf_global" "mgmtVrfEnabled"`
 if [[ x"${MGMT_VRF_ENABLED}" == x"true" ]]; then

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -159,5 +159,10 @@ if [ ! -z "$USER_AUTH" ] && [  $USER_AUTH != "null" ]; then
     fi
 fi
 
+GNMI_VRF=$(extract_field "$GNMI" '.vrf')
+if [[ -n "$GNMI_VRF" && "$GNMI_VRF" != "null" ]]; then
+    TELEMETRY_ARGS+=" --gnmi_vrf $GNMI_VRF"
+fi
+
 echo "telemetry args: $TELEMETRY_ARGS"
 exec /usr/sbin/telemetry ${TELEMETRY_ARGS}

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -41,6 +41,7 @@
   * [FABRIC_MONITOR](#fabric-monitor)
   * [FABRIC_PORT](#fabric-port)
   * [FLEX_COUNTER_TABLE](#flex_counter_table)
+  * [GNMI](#gnmi)
   * [GRPCCLIENT](#grpcclient)
   * [Hash](#hash)
   * [KDUMP](#kdump)
@@ -1426,6 +1427,37 @@ The FG_NHG_PREFIX table provides the FG_NHG_PREFIX for which FG behavior is desi
 
 ```
 
+### GNMI
+
+GNMI (gRPC Network Management Interface) related configuration is defined in the **GNMI** table. The GNMI table contains server configuration including certificates, authentication settings, and service parameters. The GNMI_CLIENT_CERT table manages client certificate authentication.
+
+```
+{
+    "GNMI": {
+        "certs": {
+            "ca_crt": "/etc/sonic/credentials/dsmsroot.cer",
+            "server_crt": "/etc/sonic/credentials/server.cer",
+            "server_key": "/etc/sonic/credentials/server.key"
+        },
+        "gnmi": {
+            "client_auth": "true",
+            "log_level": "2",
+            "port": "8080",
+            "save_on_set": "false",
+            "enable_crl": "true",
+            "crl_expire_duration": "86400",
+            "user_auth": "password",
+            "vrf": "mgmt"
+        }
+    },
+    "GNMI_CLIENT_CERT": {
+        "client.sonic.net": {
+            "role": ["admin", "operator"]
+        }
+    }
+}
+```
+
 ### Hash
 
 Generic hash allows user to configure various aspects of hashing algorithm.
@@ -2591,7 +2623,8 @@ and is listed in this table.
             "client_auth": "true",
             "log_level": "2",
             "port": "50051",
-            "save_on_set": "false"
+            "save_on_set": "false",
+            "vrf": "mgmt"
         }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/gnmi.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/gnmi.json
@@ -15,6 +15,10 @@
         "desc": "TABLE_WITH_INCORRECT_SAVE_ON_SET failure",
         "eStrKey": "InvalidValue"
     },
+    "GNMI_TABLE_WITH_INCORRECT_VRF": {
+        "desc": "TABLE_WITH_INCORRECT_VRF failure",
+        "eStrKey": "InvalidValue"
+    },
     "GNMI_TABLE_WITH_VALID_CONFIG": {
         "desc": "TABLE WITH VALID CONFIG."
     },
@@ -27,5 +31,19 @@
     },
     "GNMI_TABLE_WITH_VALID_USER_AUTH": {
         "desc": "TABLE WITH VALID USER_AUTH."
+    },
+    "GNMI_TABLE_WITH_CUSTOM_VRF_INCORRECT": {
+        "desc": "TABLE_WITH_CUSTOM_VRF failure - custom VRFs not supported",
+        "eStrKey": "InvalidValue"
+    },
+    "GNMI_TABLE_WITH_MGMT_VRF_CORRECT": {
+        "desc": "TABLE WITH MGMT VRF ENABLED."
+    },
+    "GNMI_TABLE_WITH_MGMT_VRF_INCORRECT": {
+        "desc": "TABLE WITH MGMT VRF DISABLED - should fail validation.",
+        "eStrKey": "Must"
+    },
+    "GNMI_TABLE_WITH_DEFAULT_VRF_CORRECT": {
+        "desc": "TABLE WITH DEFAULT VRF."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/telemetry.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/telemetry.json
@@ -20,5 +20,19 @@
     },
     "TELEMETRY_TABLE_WITH_VALID_USER_AUTH": {
         "desc": "TABLE WITH VALID USER_AUTH."
+    },
+    "TELEMETRY_TABLE_WITH_INCORRECT_VRF": {
+        "desc": "TABLE_WITH_INCORRECT_VRF failure",
+        "eStrKey": "InvalidValue"
+    },
+    "TELEMETRY_TABLE_WITH_VALID_CONFIG_MGMT_VRF": {
+        "desc": "TABLE WITH VALID CONFIG MGMT VRF."
+    },
+    "TELEMETRY_TABLE_WITH_CUSTOM_VRF_INCORRECT": {
+        "desc": "TABLE_WITH_CUSTOM_VRF failure - custom VRFs not supported",
+        "eStrKey": "InvalidValue"
+    },
+    "TELEMETRY_TABLE_WITH_DEFAULT_VRF_CORRECT": {
+        "desc": "TABLE WITH DEFAULT VRF."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/gnmi.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/gnmi.json
@@ -72,6 +72,55 @@
             }
         }
     },
+    "GNMI_TABLE_WITH_INCORRECT_VRF": {
+        "sonic-gnmi:sonic-gnmi": {
+            "sonic-gnmi:GNMI": {
+                "certs": {
+                    "ca_crt": "/etc/sonic/credentials/dsmsroot.cer",
+                    "server_crt": "/etc/sonic/credentials/server.cer",
+                    "server_key": "/etc/sonic/credentials/server.key"
+                },
+                "gnmi": {
+                    "client_auth": "true",
+                    "log_level": "2",
+                    "port": "50052",
+                    "save_on_set": "false",
+                    "enable_crl": "true",
+                    "crl_expire_duration": "86400",
+                    "vrf": "Vrf-Red"
+                }
+            }
+        }
+    },
+    "GNMI_TABLE_WITH_CUSTOM_VRF_INCORRECT": {
+        "sonic-vrf:sonic-vrf":{
+            "sonic-vrf:VRF": {
+                "VRF_LIST": [
+                    {
+                        "name":"Vrf-Blue"
+                    }
+                ]
+            }
+        },
+        "sonic-gnmi:sonic-gnmi": {
+            "sonic-gnmi:GNMI": {
+                "certs": {
+                    "ca_crt": "/etc/sonic/credentials/dsmsroot.cer",
+                    "server_crt": "/etc/sonic/credentials/server.cer",
+                    "server_key": "/etc/sonic/credentials/server.key"
+                },
+                "gnmi": {
+                    "client_auth": "true",
+                    "log_level": "2",
+                    "port": "50052",
+                    "save_on_set": "false",
+                    "enable_crl": "true",
+                    "crl_expire_duration": "86400",
+                    "vrf": "Vrf-Blue"
+                }
+            }
+        }
+    },
     "GNMI_TABLE_WITH_VALID_CONFIG": {
         "sonic-gnmi:sonic-gnmi": {
             "sonic-gnmi:GNMI": {
@@ -135,6 +184,71 @@
                     "user_auth": "none",
                     "log_level": "2",
                     "port": "50052"
+                }
+            }
+        }
+    },
+    "GNMI_TABLE_WITH_MGMT_VRF_CORRECT": {
+        "sonic-mgmt_vrf:sonic-mgmt_vrf": {
+            "sonic-mgmt_vrf:MGMT_VRF_CONFIG": {
+                "sonic-mgmt_vrf:vrf_global": {
+                    "mgmtVrfEnabled": true
+                }
+            }
+        },
+        "sonic-gnmi:sonic-gnmi": {
+            "sonic-gnmi:GNMI": {
+                "certs": {
+                    "ca_crt": "/etc/sonic/credentials/dsmsroot.cer",
+                    "server_crt": "/etc/sonic/credentials/server.cer",
+                    "server_key": "/etc/sonic/credentials/server.key"
+                },
+                "gnmi": {
+                    "client_auth": "true",
+                    "log_level": "2",
+                    "port": "50052",
+                    "vrf": "mgmt"
+                }
+            }
+        }
+    },
+    "GNMI_TABLE_WITH_MGMT_VRF_INCORRECT": {
+        "sonic-mgmt_vrf:sonic-mgmt_vrf": {
+            "sonic-mgmt_vrf:MGMT_VRF_CONFIG": {
+                "sonic-mgmt_vrf:vrf_global": {
+                    "mgmtVrfEnabled": false
+                }
+            }
+        },
+        "sonic-gnmi:sonic-gnmi": {
+            "sonic-gnmi:GNMI": {
+                "certs": {
+                    "ca_crt": "/etc/sonic/credentials/dsmsroot.cer",
+                    "server_crt": "/etc/sonic/credentials/server.cer",
+                    "server_key": "/etc/sonic/credentials/server.key"
+                },
+                "gnmi": {
+                    "client_auth": "true",
+                    "log_level": "2",
+                    "port": "50052",
+                    "vrf": "mgmt"
+                }
+            }
+        }
+    },
+    "GNMI_TABLE_WITH_DEFAULT_VRF_CORRECT": {
+        "sonic-gnmi:sonic-gnmi": {
+            "sonic-gnmi:GNMI": {
+                "certs": {
+                    "ca_crt": "/etc/sonic/credentials/dsmsroot.cer",
+                    "server_crt": "/etc/sonic/credentials/server.cer",
+                    "server_key": "/etc/sonic/credentials/server.key"
+                },
+                "gnmi": {
+                    "client_auth": "true",
+                    "log_level": "2",
+                    "port": "50052",
+                    "vrf": "default"
                 }
             }
         }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/telemetry.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/telemetry.json
@@ -53,6 +53,25 @@
             }
         }
     },
+    "TELEMETRY_TABLE_WITH_VALID_CONFIG": {
+        "sonic-telemetry:sonic-telemetry": {
+            "sonic-telemetry:TELEMETRY": {
+                "certs": {
+                    "ca_crt": "/etc/sonic/telemetry/dsmsroot.cer",
+                    "server_crt": "/etc/sonic/telemetry/streamingtelemetryserver.cer",
+                    "server_key": "/etc/sonic/telemetry/streamingtelemetryserver.key"
+                },
+                "gnmi": {
+                    "client_auth": "true",
+                    "log_level": "2",
+                    "port": "50051",
+                    "save_on_set": "false",
+                    "enable_crl": "true",
+                    "crl_expire_duration": "86400"
+                }
+            }
+        }
+    },
     "TELEMETRY_TABLE_WITH_INCORRECT_SAVE_ON_SET": {
         "sonic-telemetry:sonic-telemetry": {
             "sonic-telemetry:TELEMETRY": {
@@ -72,7 +91,7 @@
             }
         }
     },
-    "TELEMETRY_TABLE_WITH_VALID_CONFIG": {
+    "TELEMETRY_TABLE_WITH_INCORRECT_VRF": {
         "sonic-telemetry:sonic-telemetry": {
             "sonic-telemetry:TELEMETRY": {
                 "certs": {
@@ -86,7 +105,81 @@
                     "port": "50051",
                     "save_on_set": "false",
                     "enable_crl": "true",
-                    "crl_expire_duration": "86400"
+                    "crl_expire_duration": "86400",
+                    "vrf": "Vrf-Red"
+                }
+            }
+        }
+    },
+    "TELEMETRY_TABLE_WITH_VALID_CONFIG_MGMT_VRF": {
+        "sonic-mgmt_vrf:sonic-mgmt_vrf": {
+            "sonic-mgmt_vrf:MGMT_VRF_CONFIG": {
+                "sonic-mgmt_vrf:vrf_global": {
+                    "mgmtVrfEnabled": "true"
+                }
+            }
+        },
+        "sonic-telemetry:sonic-telemetry": {
+            "sonic-telemetry:TELEMETRY": {
+                "certs": {
+                    "ca_crt": "/etc/sonic/telemetry/dsmsroot.cer",
+                    "server_crt": "/etc/sonic/telemetry/streamingtelemetryserver.cer",
+                    "server_key": "/etc/sonic/telemetry/streamingtelemetryserver.key"
+                },
+                "gnmi": {
+                    "client_auth": "true",
+                    "log_level": "2",
+                    "port": "50051",
+                    "save_on_set": "false",
+                    "enable_crl": "true",
+                    "crl_expire_duration": "86400",
+                    "vrf": "mgmt"
+                }
+            }
+        }
+    },
+    "TELEMETRY_TABLE_WITH_CUSTOM_VRF_INCORRECT": {
+        "sonic-vrf:sonic-vrf":{
+            "sonic-vrf:VRF": {
+                "VRF_LIST": [
+                    {
+                        "name":"Vrf-Blue"
+                    }
+                ]
+            }
+        },
+        "sonic-telemetry:sonic-telemetry": {
+            "sonic-telemetry:TELEMETRY": {
+                "certs": {
+                    "ca_crt": "/etc/sonic/telemetry/dsmsroot.cer",
+                    "server_crt": "/etc/sonic/telemetry/streamingtelemetryserver.cer",
+                    "server_key": "/etc/sonic/telemetry/streamingtelemetryserver.key"
+                },
+                "gnmi": {
+                    "client_auth": "true",
+                    "log_level": "2",
+                    "port": "50051",
+                    "save_on_set": "false",
+                    "enable_crl": "true",
+                    "crl_expire_duration": "86400",
+                    "vrf": "Vrf-Blue"
+                }
+            }
+        }
+    },
+    "TELEMETRY_TABLE_WITH_DEFAULT_VRF_CORRECT": {
+        "sonic-telemetry:sonic-telemetry": {
+            "sonic-telemetry:TELEMETRY": {
+                "certs": {
+                    "ca_crt": "/etc/sonic/telemetry/dsmsroot.cer",
+                    "server_crt": "/etc/sonic/telemetry/streamingtelemetryserver.cer",
+                    "server_key": "/etc/sonic/telemetry/streamingtelemetryserver.key"
+                },
+                "gnmi": {
+                    "client_auth": "true",
+                    "log_level": "2",
+                    "port": "50051",
+                    "vrf": "default"
                 }
             }
         }

--- a/src/sonic-yang-models/yang-models/sonic-gnmi.yang
+++ b/src/sonic-yang-models/yang-models/sonic-gnmi.yang
@@ -8,6 +8,9 @@ module sonic-gnmi {
     import ietf-inet-types {
         prefix inet;
     }
+    import sonic-mgmt_vrf {
+        prefix mvrf;
+    }
 
     organization
         "SONiC";
@@ -17,8 +20,19 @@ module sonic-gnmi {
 
     description "GNMI YANG Module for SONiC OS";
 
+    revision 2025-09-01 {
+        description "Add VRF support for GNMI service";
+    }
     revision 2023-02-10 {
         description "First Revision";
+    }
+
+    typedef vrf-device {
+        description "Represents GNMI VRF device";
+        type enumeration {
+            enum default;
+            enum mgmt;
+        }
     }
 
     container sonic-gnmi {
@@ -93,6 +107,13 @@ module sonic-gnmi {
                         pattern 'password|jwt|cert|none';
                     }
                     description "GNMI service user authorization type.";
+                }
+
+                leaf vrf {
+                    type vrf-device;
+                    must "(current() != 'mgmt')
+                    or (/mvrf:sonic-mgmt_vrf/mvrf:MGMT_VRF_CONFIG/mvrf:vrf_global/mvrf:mgmtVrfEnabled = 'true')";
+                    description "VRF for GNMI. Only 'default' and 'mgmt' are supported.";
                 }
             }
         }

--- a/src/sonic-yang-models/yang-models/sonic-telemetry.yang
+++ b/src/sonic-yang-models/yang-models/sonic-telemetry.yang
@@ -8,6 +8,10 @@ module sonic-telemetry {
     import ietf-inet-types {
         prefix inet;
     }
+    import sonic-mgmt_vrf {
+        prefix mvrf;
+    }
+
 
     organization
         "SONiC";
@@ -17,8 +21,19 @@ module sonic-telemetry {
 
     description "TELEMETRY YANG Module for SONiC OS";
 
+    revision 2025-09-01 {
+        description "Add VRF support for Telemetry service";
+    }
     revision 2022-05-13 {
         description "First Revision";
+    }
+
+    typedef vrf-device {
+        description "Represents GNMI VRF device";
+        type enumeration {
+            enum default;
+            enum mgmt;
+        }
     }
 
     container sonic-telemetry {
@@ -93,6 +108,13 @@ module sonic-telemetry {
                         pattern 'password|jwt|cert|none';
                     }
                     description "Telemetry service user authorization type.";
+                }
+
+                leaf vrf {
+                    type vrf-device;
+                    must "(current() != 'mgmt')
+                    or (/mvrf:sonic-mgmt_vrf/mvrf:MGMT_VRF_CONFIG/mvrf:vrf_global/mvrf:mgmtVrfEnabled = 'true')";
+                    description "VRF for Telemetry. Only 'default' and 'mgmt' are supported.";
                 }
             }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Operators have requested to allow gNMI server to be bound to a particular VRF.

This change introduces a VRF binding option in the gNMI and Telemetry configuration tables. Operators can keep the VRF to the current default, or set it to the mgmt VRF, and the service container init scripts would pass the configured value to the service binary at the startup so that the gRPC listener binds to the given VRF.

The YANG models constrain the allowed values to default and mgmt VRFs, with a validation for the mgmt VRF being already enabled when configured.

Fixes https://github.com/sonic-net/sonic-gnmi/issues/504
Depends on https://github.com/sonic-net/sonic-gnmi/pull/503
Related PRs:
- https://github.com/sonic-net/sonic-gnmi/pull/503
- https://github.com/sonic-net/sonic-mgmt/pull/20456
- https://github.com/sonic-net/sonic-utilities/pull/4395

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Added `vrf` leaf to `sonic-gnmi` and `sonic-telemetry` in `CONFIG_DB`.
- Added an extra `--gnmi_vrf` argument that can be passed during gnmi/telemetry startup via `gnmi-native.sh`/`telemetry.sh`, and used it to bind the gNMI server listener socket.

#### How to verify it
- Added `sonic-mgmt` tests [here](https://github.com/sonic-net/sonic-mgmt/pull/20456) to verify the changes
- Manual verification:
```
$ sudo ss -lntp | grep 50052
LISTEN 0      128        *%Vrf-FOO:50052            *:*    users:(("telemetry",pid=47708,fd=17))
...
...
...
$ sudo ip vrf exec Vrf-FOO gnmic -a 10.250.0.101:50052 -u <user> -p <password> --insecure get --path "/openconfig-interfaces:interfaces/interface[name=Ethernet0]/config/mtu" --encoding json_ietf
[
  {
    "source": "10.250.0.101:50052",
    "timestamp": 1753473776134724917,
    "time": "2025-07-25T13:02:56.134724917-07:00",
    "updates": [
      {
        "Path": "openconfig-interfaces:interfaces/interface[name=Ethernet0]/config/mtu",
        "values": {
          "openconfig-interfaces:interfaces/interface/config/mtu": {
            "openconfig-interfaces:mtu": 9100
          }
        }
      }
    ]
  }
]
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add configs to CONFIG_DB for binding gNMI and Telemetry to VRF

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
- [GNMI](https://github.com/spandan-nexthop/sonic-buildimage/blob/spandan-nexthop.vrf-aware-gnmi/src/sonic-yang-models/doc/Configuration.md#gnmi)
- [Telemetry](https://github.com/spandan-nexthop/sonic-buildimage/blob/spandan-nexthop.vrf-aware-gnmi/src/sonic-yang-models/doc/Configuration.md#telemetry)

#### A picture of a cute animal (not mandatory but encouraged)
![pug](https://github.com/user-attachments/assets/787976bd-0768-49c2-9780-a2a4fec38760)

