### PR TITLE
[Mellanox] install pciutils in syncd docker to be able to use asic_detect.sh script

### DIFF
--- a/platform/mellanox/docker-syncd-mlnx-rpc/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx-rpc/Dockerfile.j2
@@ -1,5 +1,6 @@
 ##
-## Copyright (c) 2016-2024 NVIDIA CORPORATION & AFFILIATES.
+## SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+## Copyright (c) 2016-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 ## Apache-2.0
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,7 +47,8 @@ RUN apt-get update        \
     libnanomsg-dev        \
     libthrift-0.17.0      \
     thrift-compiler       \
-    python3-thrift
+    python3-thrift        \
+    pciutils
 
 RUN pip3 install --upgrade pip
 

--- a/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
@@ -1,6 +1,6 @@
 ##
 ## SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-## Copyright (c) 2016-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+## Copyright (c) 2016-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 ## Apache-2.0
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,7 +37,8 @@ RUN apt-get update && \
         python3-pip \
         python3-dev \
         python3-jsonschema \
-        python-is-python3
+        python-is-python3 \
+        pciutils
 
 RUN pip3 install --upgrade pip
 RUN apt-get purge -y python-pip

--- a/platform/nvidia-bluefield/docker-syncd-bluefield/Dockerfile.j2
+++ b/platform/nvidia-bluefield/docker-syncd-bluefield/Dockerfile.j2
@@ -38,7 +38,8 @@ RUN apt-get update && \
         binutils-dev \
         ethtool \
         python3-clang \
-        clang
+        clang \
+        pciutils
 
 RUN pip3 install ctypeslib2 clang==14
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
asic_detect.sh script was added in this PR - https://github.com/sonic-net/sonic-buildimage/pull/23458. 
It uses lspci command, which can be used only if pciutils package is installed. 

Syncd docker started to use asic_detect.sh script by this PR - https://github.com/sonic-net/sonic-sairedis/pull/1633
So, syncd of Mellanox and nvidia-bluefield must have pciutils installed.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added pciutils installation in syncd Dockerfile

#### How to verify it
Make sure pciutils package is installed in Mellanox switch syncd docker

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

