### PR TITLE
 Fix a bug, need add braces

### DIFF
--- a/src/sonic-frr/dplane_fpm_sonic/dplane_fpm_sonic.c
+++ b/src/sonic-frr/dplane_fpm_sonic/dplane_fpm_sonic.c
@@ -1711,9 +1711,10 @@ static ssize_t fill_seg6ipt_encap_private(char *buffer, size_t buflen,
 
 	srhlen = SRH_BASE_HEADER_LENGTH + SRH_SEGMENT_LENGTH * segs->num_segs;
 
-	if (buflen < (sizeof(struct seg6_iptunnel_encap_pri) + srhlen))
+	if (buflen < (sizeof(struct seg6_iptunnel_encap_pri) + srhlen)) {
 		zlog_err("%s: Buffer too small", __func__);
 		return -1;
+	}
 
 	memset(buffer, 0, buflen);
 


### PR DESCRIPTION
#### Why I did it
This function always returns -1.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
When testing the PhoenixWing project, the srv6 feature was not work.
#### How to verify it
Test srv6 feature.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ x] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

