### PR TITLE
Modified platform.conf to support 17.5G emmc

### DIFF
--- a/platform/pensando/platform.conf
+++ b/platform/pensando/platform.conf
@@ -11,19 +11,9 @@ running_cpld_id=
 root_mnt=$R/mnt
 bl_conf_path=$root_mnt
 HOST=/host
-
 image_dir=image-$image_version
-
-INSTALLER_PAYLOAD=fs.zip
-DOCKERFS_DIR=docker
-FILESYSTEM_DOCKERFS=dockerfs.tar.gz
 BL_CONF=boot-$image_dir.conf
-
-DATA_PARTUUID=6ED62003-DD8D-44B8-9538-0A2B7C7E628F
 ROOT_PARTUUID=C7F48DD2-C265-404B-959D-C64D21D49168
-
-ROOT_PARTSIZE=24G
-EMMC_MIN_SIZE=32G
 
 # Sonic kernel version
 KVER=6.1.0-29-2-arm64
@@ -34,9 +24,6 @@ PKG=""
 ACTION=""
 
 root_pn=0
-data_pn=0
-
-REPART_NEEDED=0
 
 set -e
 
@@ -46,10 +33,8 @@ fatal()
     exit 1
 }
 
-check_existing_parts()
+check_running_cpld_id()
 {
-    local nparts i partuuid boot_partsize boot_lastsec data_firstsec emmc_min_size_gb emmc_size
-
     if [ -z "$running_cpld_id" ]; then
         if [ "$install_env" = "onie" ]; then
             running_cpld_id=`printf "%d" \`chroot /mnt/a/rw/ /nic/bin/cpldapp -r 0x80\``
@@ -57,98 +42,44 @@ check_existing_parts()
 	    running_cpld_id=`printf %d \`docker exec $(docker ps -q --filter ancestor="docker-dpu") cpldapp -r 0x80\``
         fi
     fi
+}
+
+check_existing_parts()
+{
+    local nparts i partuuid
+
+    check_running_cpld_id
 
     nparts=$(sgdisk -p /dev/mmcblk0 | grep '^[ ]*[1-9]' | wc -l)
     for i in $(seq $nparts); do
         partuuid=$(sgdisk -i $i /dev/mmcblk0 | awk '/Partition unique GUID/ { print $NF }')
         case "$partuuid" in
-        $DATA_PARTUUID) data_pn=$i; ;;
         $ROOT_PARTUUID) root_pn=$i; ;;
         esac
     done
-
-    emmc_size=$(fdisk -l | grep "/dev/mmcblk0:" | awk '{print $3}')
-    emmc_min_size_gb=${EMMC_MIN_SIZE%G}
-    emmc_size=${emmc_size%.*}
-    if [ $emmc_size -lt $emmc_min_size_gb ]; then
-        ROOT_PARTSIZE=12G
-    fi
-
-    if [ $root_pn -ne 0 ]; then
-        boot_partsize=$(sgdisk -i $root_pn /dev/mmcblk0 | awk -F '[( ]' '/Partition size/ {print int($6)}')
-        boot_lastsec=$(sgdisk -i $root_pn /dev/mmcblk0 | awk '/Last sector/ {print $3}')
-        if [ ${boot_partsize}G = $ROOT_PARTSIZE ]; then
-            echo "SONiC root partitions already present with requested size. No repartition, only formatting"
-        else
-            echo "SONiC root partitions already present with mismatch size ${partsize}G. Repartition needed"
-            REPART_NEEDED=1
-        fi
-    fi
-
-    if [ $data_pn -eq 0 ]; then
-        echo "Data partition not found; Repartition needed"
-        REPART_NEEDED=1
-    elif [ $data_pn -ne $nparts ]; then
-        fatal "Data partition is not the last partition; exiting." >&2
-    else
-        data_firstsec=$(sgdisk -i $data_pn /dev/mmcblk0 | awk '/First sector/ {print $3}')
-        if [ $data_firstsec -ne $((boot_lastsec+1)) ]; then
-            echo "Data partition not contigent with boot partition. Repartition needed"
-            REPART_NEEDED=1
-        fi
-    fi
 }
 
-setup_partitions_multi()
+docker_cleanup()
 {
-    echo "==> Setting up partitions..."
+    # Remove stopped containers
+    echo "Removing stopped containers..."
+    docker container prune -f
 
-    set +e
-    if [ $REPART_NEEDED -eq 0 ]; then
-        mkfs.ext4 -F -q /dev/mmcblk0p$root_pn >/dev/null
-    else
+    # Remove dangling images (untagged, <none>)
+    echo "Removing dangling images..."
+    docker image prune -f
 
-        if [ $root_pn -ne 0 ]; then
-            sgdisk -d $root_pn /dev/mmcblk0 >/dev/null
-        fi
-        [ $data_pn -ne 0 ] && sgdisk -d $data_pn /dev/mmcblk0 >/dev/null
+    # Remove unused images (not used by any container)
+    echo "Removing unused images..."
+    docker image prune -a -f
 
-        if [ $root_pn -eq 0 ]; then
-            root_pn=10
-            data_pn=$(($root_pn + 1))
-        fi
+    # Remove unused volumes (not attached to any container)
+    echo "Removing unused volumes..."
+    docker volume prune -f
 
-        if [ $data_pn -eq 0 ]; then
-            data_pn=$(($root_pn + 1))
-        fi
-
-        sgdisk \
-            -n $root_pn:+0:+$ROOT_PARTSIZE -t $root_pn:8300 \
-            -u $root_pn:$ROOT_PARTUUID -c $root_pn:"SONiC Root Filesystem" \
-            -n $data_pn:+0:0 -t $data_pn:8300 -u $data_pn:$DATA_PARTUUID \
-            -c $data_pn:"Data Filesystem" \
-            /dev/mmcblk0 >/dev/null
-        sgdisk -U R /dev/mmcblk0 >/dev/null
-
-        while true; do
-            partprobe
-            if [ -e $R/dev/mmcblk0p$data_pn ]; then
-                break
-            fi
-            sleep 1
-        done
-
-        echo "==> Creating filesystems"
-        for i in $root_pn $data_pn; do
-            mkfs.ext4 -F -q /dev/mmcblk0p$i >/dev/null
-        done
-    fi
-    set -e
-}
-
-setup_partitions()
-{
-    setup_partitions_multi
+    # Remove unused networks
+    echo "Removing unused networks..."
+    docker network prune -f
 }
 
 cleanup()
@@ -405,8 +336,11 @@ prepare_boot_menu() {
 }
 
 create_partition() {
+    check_running_cpld_id
     check_existing_parts
-    setup_partitions
+
+    echo "Formatting partition p$root_pn"
+    mkfs.ext4 -F -q /dev/mmcblk0p$root_pn >/dev/null
 }
 
 mount_partition() {
@@ -422,5 +356,8 @@ bootloader_menu_config() {
     prepare_boot_menu
     if [ "$install_env" = "onie" ]; then
         chmod -x /bin/onie-nos-mode
+    else
+        docker_cleanup
+        ssh-keygen -A
     fi
 }


### PR DESCRIPTION
- Removed p11 (data_pn) partition and on ONIE only formatting of p10 (root_pn) partition is needed. Repartitioning is handled in ONIE installation on goldfw on pensando DPUs
- Added docker cleanup post installation to free up space
- Added ssh-keygen -A post installation to fix ssh connectivity post sonic installation on DPUs

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Some of DPU board will have only 17.5G of emmc. To support two sonic images on p10 (root_pn) partition, have removed p11 partition and also reduced p4 and p5 partition from 1GB to 16MB which are not getting used for MtFuji smartswitch DPU. These changes are part of ONIE installation via goldfw. The sonic image only need to format p10 partition for sonic installation via ONIE.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

```
ONIE:/ # onie-nos-install /tmp/sonic-pensando-17G.bin
discover: Rescue mode detected. No discover stopped.
ONIE: Executing installer: /tmp/sonic-pensando-17G.bin
Verifying image checksum ... OK.
Preparing image archive ... OK.
Installing SONiC in ONIE
ONIE Installer: platform: arm64-pensando-r0
onie_platform: arm64-elba-asic-flash128-r0
Formatting partition p10
Installing SONiC to /mnt/image-20250500.02
Archive:  fs.zip
   creating: boot/
  inflating: boot/elba-asic-psci.dtb
  inflating: boot/config-6.1.0-29-2-arm64
  inflating: boot/elba-asic-psci-mtfuji.dtb
  inflating: boot/elba-asic-psci-lipari.dtb
  inflating: boot/vmlinuz-6.1.0-29-2-arm64
  inflating: boot/install_file
  inflating: boot/System.map-6.1.0-29-2-arm64
  inflating: boot/initrd.img-6.1.0-29-2-arm64
  inflating: fs.squashfs
ONIE_IMAGE_PART_SIZE=32768
EXTRA_CMDLINE_LINUX=
Sync up cache ...
Setting up U-Boot environment...
Smart Switch -  mtfuji
==> Create bootloader mtfuji config
created //mnt/image-20250500.02/boot/first_boot
uboota.img not present. Skipping uboota installation
1+0 records in
1+0 records out
16 bytes (16B) copied, 0.000053 seconds, 294.8KB/s
1+0 records in
1+0 records out
16 bytes (16B) copied, 0.000043 seconds, 363.4KB/s
boot0.img not present. Skipping boot0 installation
==> Setting u-boot environment for Debian Boot
current env is
set sonic env onie
ONIE: NOS install successful: /tmp/sonic-pensando-17G.bin
ONIE: Rebooting...
[  418.683209] reboot: Restarting system
Boot0 v14, Id 0x82
Boot fwid 0 @ 0x74200000... OK
```
Partition table
```
root@sonic:/home/admin# sgdisk -p /dev/mmcblk0
Disk /dev/mmcblk0: 62095360 sectors, 29.6 GiB
Sector size (logical/physical): 512/512 bytes
Disk identifier (GUID): 50CCAEB7-E971-4B78-A732-7CE6800D6059
Partition table holds up to 128 entries
Main partition table begins at sector 2 and ends at sector 33
First usable sector is 34, last usable sector is 62095326
Partitions will be aligned on 2048-sector boundaries
Total free space is 2014 sectors (1007.0 KiB)

Number  Start (sector)    End (sector)  Size       Code  Name
   1            2048           67583   32.0 MiB    EF02  Kernel Image A
   2           67584          133119   32.0 MiB    EF02  Kernel Image B
   3          133120         2230271   1024.0 MiB  8300  System Image A
   4         2230272         2263039   16.0 MiB    8300  System Image B
   5         2263040         2295807   16.0 MiB    8300  Update Filesystem
   6         2295808         2328575   16.0 MiB    8300  Config0 Filesystem
   7         2328576         2361343   16.0 MiB    8300  Config1 Filesystem
   8         2361344         2885631   256.0 MiB   8300  OBFL Filesystem
   9         2885632         3147775   128.0 MiB   EF02  Reserved
  10         3147776        62095326   28.1 GiB    8300  SONiC Root Filesystem
```
