### PR TITLE
[eventd] Fix off-by-one IPv4 generator in events_publish_tool to prevent AddressValueError during telemetry events cache overflow test

### DIFF
--- a/src/sonic-eventd/tools/events_publish_tool.py
+++ b/src/sonic-eventd/tools/events_publish_tool.py
@@ -64,7 +64,7 @@ def publishBGPEvents(publisher_handle, count, pause):
     param_dict = FieldValueMap()
 
     for _ in range(count):
-        ip = str(ipaddress.IPv4Address(random.randint(0, 2 ** 32)))
+        ip = str(ipaddress.IPv4Address(random.getrandbits(32))) # 0 .. 2**32-1
         ip_addresses.append(ip)
 
     # publish down events


### PR DESCRIPTION
### Description of PR
Summary:
Fixes for `telemetry/test_events.py::test_events_cache_overflow` failures caused by an off-by-one error in the test event publisher inside the `eventd` container.
`events_publish_tool.py` generated IPv4 addresses with:
```python
ip = str(ipaddress.IPv4Address(random.randint(0, 2 ** 32)))
```
`random.randint(a, b)` is inclusive of both ends; super rarely it `returns 2**32`, which is out of range for IPv4 (valid range is `0 .. 2**32-1`), leading to such error:
```
ipaddress.AddressValueError: 4294967296 (>= 2**32) is not permitted as an IPv4 address
```
This PR replaces the call with `random.getrandbits(32)` to produce integers strictly within `0 .. (2**32 - 1)`.

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411
- [x] 202505

### Approach
#### What is the motivation for this PR?
`telemetry/test_events.py::test_events_cache_overflow` publishes ~702k synthetic BGP events to intentionally overflow the cache. The publisher’s off-by-one occasionally generates the integer `2**32`, which the ipaddress module rejects, causing the test to fail. Fixing this makes the test stable.

#### How did you do it?
Replaced the inclusive random range with a 32-bit random integer generator that cannot exceed the IPv4 max:
```
- ip = str(ipaddress.IPv4Address(random.randint(0, 2 ** 32)))
+ ip = str(ipaddress.IPv4Address(random.getrandbits(32)))  # 0 .. 2**32-1
```

#### How did you verify/test it?
Run the `telemetry/test_events.py`


#### Any platform specific information?

#### Supported testbed topology if it's a new test case?

### Documentation