### PR TITLE
[Mellanox] [saidump] Install missing rdb-cli tool

### DIFF
--- a/platform/mellanox/docker-syncd-mlnx.mk
+++ b/platform/mellanox/docker-syncd-mlnx.mk
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2016-2023 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2016-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
@@ -1,7 +1,7 @@
 ##
 ## SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
 ## Copyright (c) 2016-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-## Apache-2.0
+## SPDX-License-Identifier: Apache-2.0
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Propagating: https://github.com/sonic-net/sonic-buildimage/pull/20948

**ERR log:**
```
root@sonic:/home/admin# docker exec -ti syncd bash
root@sonic:/# /usr/bin/saidump.sh
/usr/bin/saidump.sh: line 26: rdb-cli: command not found
JSON parsing error: [json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal.
```

#### Why I did it
* To fix dump generation

#### Work item tracking
* N/A

#### How I did it
* Installed missing `rdb-cli` tool to syncd docker

#### How to verify it
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
1. Run script `saidump.sh`
```
root@sonic:/# /usr/bin/saidump.sh
+ save_saidump_by_rdb
+ local filepath=/var/run/redis/sonic-db/database_config.json
++ python3 -c '
import json
with open('\''/var/run/redis/sonic-db/database_config.json'\'') as json_file:
  data = json.load(json_file)
  print(data['\''INSTANCES'\'']['\''redis'\'']['\''hostname'\''], data['\''INSTANCES'\'']['\''redis'\'']['\''port'\''], data['\''INSTANCES'\'']['\''redis'\'']['\''unix_socket_path'\''])'
+ local 'redis_config=127.0.0.1 6379 /var/run/redis/redis.sock'
+ redis_config=(${redis_config// / })
+ local hostname=127.0.0.1
+ local port=6379
++ dirname /var/run/redis/redis.sock
+ local redis_dir=/var/run/redis
+ logger 'saidump.sh: hostname:127.0.0.1, port:6379, redis_dir:/var/run/redis'
+ logger 'saidump.sh: [1] Get the remote backups of RDB file.'
+ redis-cli -h 127.0.0.1 -p 6379 --rdb /var/run/redis/dump.rdb
+ logger 'saidump.sh: [2] Run rdb-cli command to convert the dump files into JSON files.'
+ rdb-cli /var/run/redis/dump.rdb json
+ tee /var/run/redis/dump.json
+ logger 'saidump.sh: [3] Run saidump -r to get the result at standard output from the JSON file.'
+ saidump -r /var/run/redis/dump.json -m 100
+ logger 'saidump.sh: [4] Clear the temporary files.'
+ rm -f /var/run/redis/dump.rdb
+ rm -f /var/run/redis/dump.json
root@sonic:/# echo $?
0
```

#### Which release branch to backport (provide reason below if selected)
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [x] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master <!-- image version 1 -->
- [x] 202405 <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* N/A

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
* N/A

#### A picture of a cute animal (not mandatory but encouraged)
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```