### PR TITLE
Change /etc/sonic mount in P4RT Docker container from read-only to read-write

### DIFF
--- a/rules/docker-p4rt.mk
+++ b/rules/docker-p4rt.mk
@@ -31,7 +31,7 @@ endif
 
 $(DOCKER_P4RT)_CONTAINER_NAME = p4rt
 $(DOCKER_P4RT)_RUN_OPT += -t
-$(DOCKER_P4RT)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
-$(DOCKER_P4RT)_RUN_OPT += -v /etc/localtime:/etc/localtime:ro 
+$(DOCKER_P4RT)_RUN_OPT += -v /etc/sonic:/etc/sonic:rw
+$(DOCKER_P4RT)_RUN_OPT += -v /etc/localtime:/etc/localtime:ro
 $(DOCKER_P4RT)_GIT_COMMIT = $(shell cd "$($(SONIC_P4RT)_SRC_PATH)" && git log -n 1 --format=format:"%H %s" || echo "Unable to fetch git log for p4rt")
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Changed the filesystem mode to read-write so that we can save copy of the ForwardingPipelineConfig to /etc/sonic/.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Changed the ro mode to rw mode for /etc/sonic.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)



P4rt Docker Build Result:

/kavitha/sonic-buildimage$ NOJESSIE=1 NOSTRETCH=1 NOBUSTER=1 NOBULLSEYE=1 SONIC_BUILD_JOBS=12 INCLUDE_P4RT=y make target/docker-sonic-p4rt.gz
+++ --- Making target/docker-sonic-p4rt.gz --- +++
./scripts/run_with_retry make BLDENV=bookworm -f Makefile.work target/docker-sonic-p4rt.gz
make[1]: Entering directory '/usr/local/google/home/kanasanis/kavitha/sonic-buildimage'
"SECURE_UPGRADE_PROD_SIGNING_TOOL": ""
~/kavitha/sonic-buildimage/src/sonic-build-hooks ~/kavitha/sonic-buildimage
make[2]: Entering directory '/usr/local/google/home/kanasanis/kavitha/sonic-buildimage/src/sonic-build-hooks'
dpkg-deb: warning: root directory tmp/sonic-build-hooks has unusual owner or group 1440321:89939
dpkg-deb: hint: you might need to pass --root-owner-group, see <[https://wiki.debian.org/Teams/Dpkg/RootlessBuilds>](https://wiki.debian.org/Teams/Dpkg/RootlessBuilds%3E) for further details
dpkg-deb: warning: ignoring 1 warning about the control file(s)
dpkg-deb: building package 'sonic-build-hooks' in 'buildinfo/sonic-build-hooks_1.0_all.deb'.
make[2]: Leaving directory '/usr/local/google/home/kanasanis/kavitha/sonic-buildimage/src/sonic-build-hooks'
~/kavitha/sonic-buildimage
Checking sonic-slave-base image: sonic-slave-bookworm:24da1632ba6
Checking sonic-slave-user image: sonic-slave-bookworm-kanasanis:13d708ca9d9
SONiC Build System
 
Build Configuration
"CONFIGURED_PLATFORM"             : "vs"
"CONFIGURED_ARCH"                 : "amd64"
"SONIC_CONFIG_PRINT_DEPENDENCIES" : ""
"SONIC_BUILD_JOBS"                : "12"
"SONIC_CONFIG_MAKE_JOBS"          : "96"
"USE_NATIVE_DOCKERD_FOR_BUILD"    : ""
"SONIC_USE_DOCKER_BUILDKIT"       : ""
"USERNAME"                        : "admin"
"PASSWORD"                        : "YourPaSsWoRd"
"CHANGE_DEFAULT_PASSWORD"         : "n"
"SECURE_UPGRADE_MODE"             : "no_sign"
"SECURE_UPGRADE_DEV_SIGNING_KEY"  : ""
"SECURE_UPGRADE_SIGNING_CERT"     : ""
"SECURE_UPGRADE_PROD_SIGNING_TOOL": ""
"SECURE_UPGRADE_PROD_TOOL_ARGS"   : ""
"ONIE_IMAGE_PART_SIZE"            : ""
"SHUTDOWN_BGP_ON_START"           : ""
"ENABLE_PFCWD_ON_START"           : ""
"SONIC_BUFFER_MODEL"              : ""
"INSTALL_DEBUG_TOOLS"             : ""
"ROUTING_STACK"                   : "frr"
"FRR_USER_UID"                    : "300"
"FRR_USER_GID"                    : "300"
"ENABLE_SYNCD_RPC"                : ""
"SAITHRIFT_V2"                    : ""
"ENABLE_ORGANIZATION_EXTENSIONS"  : "y"
"HTTP_PROXY"                      : ""
"HTTPS_PROXY"                     : ""
"NO_PROXY"                        : ""
"ENABLE_ZTP"                      : ""
"INCLUDE_PDE"                     : ""
"SONIC_DEBUGGING_ON"              : ""
"SONIC_PROFILING_ON"              : ""
"KERNEL_PROCURE_METHOD"           : "build"
"BUILD_TIMESTAMP"                 : "20250912.112723"
"BUILD_LOG_TIMESTAMP"             : "none"
"SONIC_IMAGE_VERSION"             : "alpine_chg.0-dirty-20250912.112723"
"BLDENV"                          : "bookworm"
"VS_PREPARE_MEM"                  : "yes"
"INCLUDE_MGMT_FRAMEWORK"          : "y"
"INCLUDE_ICCPD"                   : "n"
"INCLUDE_STP"                     : ""
"INCLUDE_SYSTEM_TELEMETRY"        : "n"
"INCLUDE_SYSTEM_GNMI"             : "y"
"INCLUDE_SYSTEM_BMP"              : "y"
"INCLUDE_SYSTEM_EVENTD"           : "y"
"ENABLE_HOST_SERVICE_ON_START"    : "y"
"INCLUDE_RESTAPI"                 : "n"
"INCLUDE_SFLOW"                   : "y"
"INCLUDE_NAT"                     : "y"
"INCLUDE_DHCP_RELAY"              : "y"
"INCLUDE_DHCP_SERVER"             : "y"
"INCLUDE_P4RT"                    : "n"
"INCLUDE_VS_DASH_SAI"             : "y"
"INCLUDE_KUBERNETES"              : "n"
"INCLUDE_KUBERNETES_MASTER"       : "n"
"INCLUDE_MACSEC"                  : "y"
"INCLUDE_MUX"                     : "y"
"INCLUDE_TEAMD"                   : "y"
"INCLUDE_DASH_HA"                 : "y"
"INCLUDE_ROUTER_ADVERTISER"       : "y"
"INCLUDE_BOOTCHART                : "y"
"ENABLE_BOOTCHART                 : "n"
"INCLUDE_FIPS"                    : "y"
"ENABLE_TRANSLIB_WRITE"           : ""
"ENABLE_NATIVE_WRITE"             : "y"
"ENABLE_DIALOUT"                  : ""
"ENABLE_AUTO_TECH_SUPPORT"        : "y"
"PDDF_SUPPORT"                    : "y"
"MULTIARCH_QEMU_ENVIRON"          : "n"
"SONIC_VERSION_CONTROL_COMPONENTS": "py2,py3,web,git,docker"
"ENABLE_ASAN"                     : "n"
"DEFAULT_CONTAINER_REGISTRY"      : "publicmirror.azurecr.io/"
"BUILD_MULTIASIC_KVM"             : "n"
"CROSS_BUILD_ENVIRON"             : "n"
"LEGACY_SONIC_MGMT_DOCKER"        : "y"
"INCLUDE_EXTERNAL_PATCHES"        : "n"
"PTF_ENV_PY_VER"                  : "py3"
"ENABLE_MULTIDB"                  : ""
 
mv: cannot move '/etc/apt/sources.list.d/debian.sources' to '/etc/apt/sources.list.d/debian.sources.back': Permission denied
fatal: not a git repository (or any of the parent directories): .git
"SONIC_DPKG_CACHE_METHOD"         : "none"
 
make[1]: Leaving directory '/usr/local/google/home/kanasanis/kavitha/sonic-buildimage'
BLDENV=bookworm make -f Makefile.work docker-cleanup
make[1]: Entering directory '/usr/local/google/home/kanasanis/kavitha/sonic-buildimage'
"SECURE_UPGRADE_PROD_SIGNING_TOOL": ""
~/kavitha/sonic-buildimage/src/sonic-build-hooks ~/kavitha/sonic-buildimage
make[2]: Entering directory '/usr/local/google/home/kanasanis/kavitha/sonic-buildimage/src/sonic-build-hooks'
dpkg-deb: warning: root directory tmp/sonic-build-hooks has unusual owner or group 1440321:89939
dpkg-deb: hint: you might need to pass --root-owner-group, see <[https://wiki.debian.org/Teams/Dpkg/RootlessBuilds>](https://wiki.debian.org/Teams/Dpkg/RootlessBuilds%3E) for further details
dpkg-deb: warning: ignoring 1 warning about the control file(s)
dpkg-deb: building package 'sonic-build-hooks' in 'buildinfo/sonic-build-hooks_1.0_all.deb'.
make[2]: Leaving directory '/usr/local/google/home/kanasanis/kavitha/sonic-buildimage/src/sonic-build-hooks'
~/kavitha/sonic-buildimage
make[1]: Leaving directory '/usr/local/google/home/kanasanis/kavitha/sonic-buildimage'










