### PR TITLE
Add key for software BFD remote db.

### DIFF
--- a/src/sonic-bgpcfgd/bfdmon/bfdmon.py
+++ b/src/sonic-bgpcfgd/bfdmon/bfdmon.py
@@ -140,7 +140,7 @@ class BfdFrrMon:
                 self.status_table, self.local_v4_peers, self.local_v6_peers))
 
             if self.remote_table:
-                self.remote_table.set("", values)
+                self.remote_table.set("dash_ha", values)
                 syslog.syslog(syslog.LOG_INFO,
                     "{} table in DPU_STATE_DB updated. v4_peers: {}, v6_peers: {}".format(
                     self.remote_status_table, self.local_v4_peers, self.local_v6_peers))


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Hamgrd requires key in  DPU_STATE_DB for DASH_BFD_PROBE_STATE


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add 'dash_ha' as key for DASH_BFD_PROBE_STATE 

#### How to verify it
Tested on Smartswitch HA testbed, DASH_BFD_PROBE_STATE is properly populated with 'dash_ha' as key in DPU_STATE_DB.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202506

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

