### PR TITLE
[Arista-7060X6-64PE-B, Arista-7060X6-16PE-384C-B]: Initialize SmartSAF

### DIFF
--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2-FANOUT/th5-a7060x6-16pe-384c.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2-FANOUT/th5-a7060x6-16pe-384c.config.bcm
@@ -2579,3 +2579,10 @@ device:
             :
                 TRAFFIC_CLASS: OBM_TC_LOSSLESS0
 ...
+# Initialize SmartSAF functionality
+---
+device:
+    0:
+        TM_SMART_STORE_AND_FORWARD_CONFIG:
+            SMART_STORE_AND_FORWARD: 1
+...

--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2-LAB/th5-a7060x6-16pe-384c.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2-LAB/th5-a7060x6-16pe-384c.config.bcm
@@ -2579,3 +2579,10 @@ device:
             :
                 TRAFFIC_CLASS: OBM_TC_LOSSLESS0
 ...
+# Initialize SmartSAF functionality
+---
+device:
+    0:
+        TM_SMART_STORE_AND_FORWARD_CONFIG:
+            SMART_STORE_AND_FORWARD: 1
+...

--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2/th5-a7060x6-16pe-384c.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2/th5-a7060x6-16pe-384c.config.bcm
@@ -2578,3 +2578,10 @@ device:
             :
                 TRAFFIC_CLASS: OBM_TC_LOSSLESS0
 ...
+# Initialize SmartSAF functionality
+---
+device:
+    0:
+        TM_SMART_STORE_AND_FORWARD_CONFIG:
+            SMART_STORE_AND_FORWARD: 1
+...

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/th5-a7060x6-64pe.config.bcm
@@ -3401,3 +3401,10 @@ device:
         TM_SCHEDULER_CONFIG:
             NUM_MC_Q: NUM_MC_Q_2
 ...
+# Initialize SmartSAF functionality
+---
+device:
+    0:
+        TM_SMART_STORE_AND_FORWARD_CONFIG:
+            SMART_STORE_AND_FORWARD: 1
+...

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/th5-a7060x6-64pe.config.bcm
@@ -3416,3 +3416,10 @@ device:
         TM_SCHEDULER_CONFIG:
             NUM_MC_Q: NUM_MC_Q_2
 ...
+# Initialize SmartSAF functionality
+---
+device:
+    0:
+        TM_SMART_STORE_AND_FORWARD_CONFIG:
+            SMART_STORE_AND_FORWARD: 1
+...

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/th5-a7060x6-64pe.config.bcm
@@ -2549,3 +2549,10 @@ device:
             :
                 TRAFFIC_CLASS: OBM_TC_LOSSLESS0
 ...
+# Initialize SmartSAF functionality
+---
+device:
+    0:
+        TM_SMART_STORE_AND_FORWARD_CONFIG:
+            SMART_STORE_AND_FORWARD: 1
+...

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128S2/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128S2/th5-a7060x6-64pe.config.bcm
@@ -1427,3 +1427,10 @@ device:
         DEVICE_CONFIG:
             AUTOLOAD_BOARD_SETTINGS: 0
 ...
+# Initialize SmartSAF functionality
+---
+device:
+    0:
+        TM_SMART_STORE_AND_FORWARD_CONFIG:
+            SMART_STORE_AND_FORWARD: 1
+...

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32O64/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32O64/th5-a7060x6-64pe.config.bcm
@@ -2574,4 +2574,10 @@ device:
                 TRAFFIC_CLASS: OBM_TC_LOSSLESS0
 
 ...
-
+# Initialize SmartSAF functionality
+---
+device:
+    0:
+        TM_SMART_STORE_AND_FORWARD_CONFIG:
+            SMART_STORE_AND_FORWARD: 1
+...

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P64/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P64/th5-a7060x6-64pe.config.bcm
@@ -2319,3 +2319,10 @@ device:
                 TRAFFIC_CLASS: OBM_TC_LOSSLESS0
 
 ...
+# Initialize SmartSAF functionality
+---
+device:
+    0:
+        TM_SMART_STORE_AND_FORWARD_CONFIG:
+            SMART_STORE_AND_FORWARD: 1
+...


### PR DESCRIPTION
Note: this is a manual backport to 202505 for https://github.com/sonic-net/sonic-buildimage/pull/23908

#### Why I did it
To enable the SmartSAF feature on the targer platforms.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added SmartSAF settings to the Broadcom config/SAI profile files.

#### How to verify it
From the DUT's CLI, enter the Broadcom shell: `bcmsh`
Run `ps` and confirm that the cut thru mode for the desired interfaces is `Smart`.
Can also confirm `SMART_STORE_AND_FORWARD=1` by running: `bsh -c "lt traverse -l TM_SMART_STORE_AND_FORWARD_CONFIG"`

#### Which release branch to backport (provide reason below if selected)
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202505

#### Tested branch (Please provide the tested image version)
202412, 202505

#### Description for the changelog
Update the BCM config files for Arista-7060X6-64PE-B, Arista-7060X6-16PE-384C-B  to initialize SmartSAF functionality.