### PR TITLE
Revert "Add open telemetry into sonic-mgmt container."

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -111,9 +111,6 @@ RUN python3 -m pip install aiohttp \
                  thrift==0.11.0 \
                  virtualenv \
                  debugpy \
-                 opentelemetry-api==1.33.1 \
-                 opentelemetry-sdk==1.33.1 \
-                 opentelemetry-exporter-otlp==1.33.1 \
     && wget https://github.com/nanomsg/nanomsg/archive/1.2.tar.gz \
     && tar xvfz 1.2.tar.gz \
     && cd nanomsg-1.2      \


### PR DESCRIPTION
Reverts sonic-net/sonic-buildimage#23855

This PR caused dependency conflicts while building docker-sonic-mgmt.

opentelemetry-exporter-otlp-proto-grpc 1.33.1 requires grpcio<2.0.0,>=1.63.2
opentelemetry-proto 1.33.1 requires protobuf<6.0,>=5.0

snappi 1.27.1 requires grpcio~=1.59.0;
snappi 1.27.1 requires protobuf~=4.24.4;
If install the opentelemetry packages after snappi, it will update grpcio=1.70.0, protobuf=5.29.5.

It could break the snappi package. We need to revert this change until there is a better solution.