### PR TITLE
Fix dash-ha issue in multi-asic platform

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -691,6 +691,15 @@ sudo ln -s /dev/null $FILESYSTEM_ROOT/etc/systemd/system/dash-ha@dpu4.service
 sudo ln -s /dev/null $FILESYSTEM_ROOT/etc/systemd/system/dash-ha@dpu5.service
 sudo ln -s /dev/null $FILESYSTEM_ROOT/etc/systemd/system/dash-ha@dpu6.service
 sudo ln -s /dev/null $FILESYSTEM_ROOT/etc/systemd/system/dash-ha@dpu7.service
+sudo ln -s /dev/null $FILESYSTEM_ROOT/etc/systemd/system/dash-ha@0.service
+sudo ln -s /dev/null $FILESYSTEM_ROOT/etc/systemd/system/dash-ha@1.service
+sudo ln -s /dev/null $FILESYSTEM_ROOT/etc/systemd/system/dash-ha@2.service
+sudo ln -s /dev/null $FILESYSTEM_ROOT/etc/systemd/system/dash-ha@3.service
+sudo ln -s /dev/null $FILESYSTEM_ROOT/etc/systemd/system/dash-ha@4.service
+sudo ln -s /dev/null $FILESYSTEM_ROOT/etc/systemd/system/dash-ha@5.service
+sudo ln -s /dev/null $FILESYSTEM_ROOT/etc/systemd/system/dash-ha@6.service
+sudo ln -s /dev/null $FILESYSTEM_ROOT/etc/systemd/system/dash-ha@7.service
+
 # According to the issue: https://github.com/systemd/systemd/issues/19106, To disable ManageForeignRoutingPolicyRules to avoid the ip rules being deleted by systemd-networkd
 sudo sed -i 's/#ManageForeignRoutingPolicyRules=yes/ManageForeignRoutingPolicyRules=no/g' $FILESYSTEM_ROOT/etc/systemd/networkd.conf
 


### PR DESCRIPTION
#### Why I did it
This is to address issue #24005. dash-ha service should not be automatically started in multi-asic system.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Symlink dash-ha service in asic namespace to /dev/null

#### How to verify it
Use multi-asic-t1 kvmtest to verify the behaviour change.

Here are the messages from syslog prior to the change.
```
2025 Sep 25 09:48:45.811921 sonic WARNING systemd[1]: Dependency failed for dash-ha@1.service - DASH HA container
2025 Sep 25 09:48:45.811982 sonic NOTICE systemd[1]: dash-ha@1.service: Job dash-ha@1.service/start failed with result 'dependency'.
```
Then the service got disabled when minigraph was loaded
```
2025 Sep 25 09:52:51.410605 vlab-08 INFO featured: Running cmd: '['sudo', 'systemctl', '
stop', 'dash-ha@0.service']'
2025 Sep 25 09:52:51.441165 vlab-08 INFO featured: Running cmd: '['sudo', 'systemctl', '
disable', 'dash-ha@0.service']'
```

With this PR, above messages are not seen in multi-asic-t1 kvmtest syslog. The only messages related to dash-ha are below
```
2025 Sep 18 19:40:49.452353 vlab-08 INFO featured: Updating feature 'dash-ha' systemd co
nfig file related to auto-restart ...
2025 Sep 18 19:40:49.452420 vlab-08 INFO featured: Feature 'dash-ha' systemd config file
 related to auto-restart is updated!
2025 Sep 18 19:40:49.452446 vlab-08 INFO featured: Updating feature 'dash-ha@0' systemd
config file related to auto-restart ...
2025 Sep 18 19:40:49.452470 vlab-08 INFO featured: Feature 'dash-ha@0' systemd config fi
le related to auto-restart is updated!
2025 Sep 18 19:40:50.164825 vlab-08 INFO featured: Feature dash-ha is stopped and disabled
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

