### PR TITLE
[yang][dhcp_server] Update yang model for dhcp_server to include always_send config

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/dhcp_server_ipv4.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/dhcp_server_ipv4.json
@@ -60,7 +60,8 @@
     },
     "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_ALWAYS_SEND_INVALID": {
         "desc": "Add option with always send invalid.",
-        "eStrKey": "Pattern"
+        "eStrKey": "InvalidValue",
+        "eStr": ["False"]
     },
     "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_TYPE_VALID_VALUE_UINT8": {
         "desc": "Add uint8 type of DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS."

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/dhcp_server_ipv4.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/dhcp_server_ipv4.json
@@ -406,7 +406,7 @@
                         "id": 60,
                         "type": "string",
                         "value": "dummy_value",
-                        "always_send": "dummy"
+                        "always_send": "False"
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-dhcp-server-ipv4.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dhcp-server-ipv4.yang
@@ -162,10 +162,8 @@ module sonic-dhcp-server-ipv4 {
 
                 leaf always_send {
                     description "Always send option or not";
-                    type string {
-                        pattern "(true|false)";
-                    }
-                    default "true";
+                    type boolean;
+                    default true;
                 }
             }
             /* end of DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS_LIST */


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add a field `always_send` in DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS table

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
1. Add a field `always_send` in DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS table
2. Update UTs

#### How to verify it
UT passed

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

