### PR TITLE
Added missing sai_interface_type_auto_detect on Arista-7060CX-32S-Q32 to fix oper down and Syncd crash on cold boot

### DIFF
--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t0.config.bcm
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/th-a7060-cx32s-32x40G-t0.config.bcm
@@ -447,5 +447,7 @@ serdes_preemphasis_108=0x145c00
 serdes_driver_current_109=0x4
 serdes_preemphasis_109=0x145c00
 
+sai_interface_type_auto_detect=0
+
 mmu_init_config="MSFT-TH-Tier0"
 phy_an_lt_msft=1


### PR DESCRIPTION
fixes: #23943 

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix a bug on the Arista-7060CX-32S-Q32
##### Work item tracking
- Microsoft ADO **(number only)**: 34827366

#### How I did it
Added a missing configuration line

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
I tested this by manually adding
```
sai_interface_type_auto_detect=0
```
to the `th-a7060-cx32s-32x40G-t0.config.bcm` file on an Arista-7060CX-32S-Q32 (the same one that was used to originally repro in #23943) running 202505 then did a cold reboot.

After boot all ports were operationally up and there were no SYNCD dumps seen in syslog

Also, tested warmboot from 202411->202505 and 202505->202505 with the fix in place and there were no SYNCD dumps seen in syslog and the interfaces came up.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202505.21

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added missing sai_interface_type_auto_detect option on Arista-7060CX-32S to resolve syncd crash
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

