### PR TITLE
[QoS] Enable DSCP pipe mode on Broadcom T1 SKUs

### DIFF
--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -9,7 +9,7 @@
 {% endif %}
 
 {% set is_broadcom_t1 = false %}
-{% if is_broadcom and (DEVICE_METADATA['localhost']['type'] == "LeafRouter" or DEVICE_METADATA['localhost']['type'] == "BackEndLeafRouter") %}
+{% if is_broadcom and 'LeafRouter' in DEVICE_METADATA['localhost']['type'] %}
     {% set is_broadcom_t1 = true %}
 {% endif %}
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Enable DSCP pipe mode on Broadcom T1 SKUs
#### Why I did it
Add support for DSCP decap pipe mode in Broadcom T1s. Pipe mode support for T0 will be added in a future update.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it
Example T1 BCM device: 

```
admin@str2-7050cx3-acs-03:~$ redis-cli -n 0 hgetall 'TUNNEL_DECAP_TABLE:IPINIP_TUNNEL'
1) "dscp_mode"
2) "pipe"
3) "ecn_mode"
4) "copy_from_outer"
5) "ttl_mode"
6) "pipe"
7) "tunnel_type"
8) "IPINIP"
admin@str2-7050cx3-acs-03:~$ redis-cli -n 0 hgetall 'TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL'
1) "dscp_mode"
2) "pipe"
3) "ecn_mode"
4) "copy_from_outer"
5) "ttl_mode"
6) "pipe"
7) "tunnel_type"
8) "IPINIP"

root@str2-7050cx3-acs-03:/# cat /etc/swss/config.d/ipinip.json
[
    {
        "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL" : {
            "tunnel_type":"IPINIP",
            "dscp_mode":"pipe",
            "ecn_mode":"copy_from_outer",
            "ttl_mode":"pipe"
        },
        "OP": "SET"
    },
    ...
    {
        "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL" : {
            "tunnel_type":"IPINIP",
            "dscp_mode":"pipe",
            "ecn_mode":"copy_from_outer",
            "ttl_mode":"pipe"
        },
        "OP": "SET"
    },
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

