### PR TITLE
[Mellanox] Consume SDK artifacts from URL

### DIFF
--- a/platform/mellanox/sdk.mk
+++ b/platform/mellanox/sdk.mk
@@ -1,6 +1,7 @@
 #
-# Copyright (c) 2016-2025 NVIDIA CORPORATION & AFFILIATES.
-# Apache-2.0
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,14 +24,19 @@ MLNX_SDK_ASSETS_RELEASE_TAG = sdk-$(MLNX_SDK_VERSION)-$(BLDENV)-$(CONFIGURED_ARC
 MLNX_SDK_ASSETS_URL = $(MLNX_ASSETS_GITHUB_URL)/releases/download/$(MLNX_SDK_ASSETS_RELEASE_TAG)
 MLNX_SDK_DEB_VERSION = $(subst -,.,$(subst _,.,$(MLNX_SDK_VERSION)))
 
+# Place here URL where alternate SDK assets exist
+MLNX_SDK_ASSETS_BASE_URL =
+
 # Place here URL where SDK sources exist
 MLNX_SDK_SOURCE_BASE_URL =
 
-ifneq ($(MLNX_SDK_SOURCE_BASE_URL), )
-SDK_FROM_SRC = y
-else
-SDK_FROM_SRC = n
+# Use alternate assets URL if provided
+ifneq ($(MLNX_SDK_ASSETS_BASE_URL), )
+MLNX_SDK_ASSETS_URL = $(MLNX_SDK_ASSETS_BASE_URL)
 endif
+
+# Use source build if no assets URL is provided but source URL is available
+SDK_FROM_SRC = $(if $(MLNX_SDK_ASSETS_BASE_URL),n,$(if $(MLNX_SDK_SOURCE_BASE_URL),y,n))
 
 export MLNX_SDK_SOURCE_BASE_URL MLNX_SDK_VERSION MLNX_SDK_ISSU_VERSION MLNX_SDK_DEB_VERSION MLNX_ASSETS_GITHUB_URL MLNX_SDK_DRIVERS_GITHUB_URL
 

--- a/platform/nvidia-bluefield/recipes/sdk.mk
+++ b/platform/nvidia-bluefield/recipes/sdk.mk
@@ -1,6 +1,7 @@
 #
-# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES.
-# Apache-2.0
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,8 +26,14 @@ SDK_COLLECTX_URL = https://linux.mellanox.com/public/repo/doca/1.5.2/debian12/aa
 
 SDK_GH_BASE_URL = https://github.com/Mellanox/sonic-bluefield-packages/releases/download/dpu-sdk-$(SDK_VERSION)-$(BLDENV)/
 
+# Place here URL where alternate SDK assets exist
+SDK_ASSETS_BASE_URL =
+
+# Use alternate assets URL if provided, otherwise use GitHub URL
+SDK_ASSETS_URL = $(if $(SDK_ASSETS_BASE_URL),$(SDK_ASSETS_BASE_URL),$(SDK_GH_BASE_URL))
+
 define make_url_sdk
-	$(1)_URL="$(SDK_GH_BASE_URL)/$(1)"
+	$(1)_URL="$(SDK_ASSETS_URL)/$(1)"
 
 endef
 
@@ -35,8 +42,10 @@ define get_sdk_version_file_gh
 
 endef
 
+# Use source build if source URL is provided and no assets URL is set
+SDK_FROM_SRC = $(if $(SDK_SOURCE_BASE_URL),$(if $(SDK_ASSETS_BASE_URL),n,y),n)
+
 ifneq ($(SDK_SOURCE_BASE_URL), )
-SDK_FROM_SRC = y
 SDK_SOURCE_URL = $(SDK_SOURCE_BASE_URL)/$(subst -,/,$(SDK_VERSION))
 SDK_VERSIONS_FILE = $(PLATFORM_PATH)/sdk-src/VERSIONS
 $(eval $(call get_sdk_version_file_gh, "$(SDK_SOURCE_URL)/VERSIONS_FOR_SONIC_BUILD", $(SDK_VERSIONS_FILE)))


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add another build option (aside consuming source and artifacts from GitHub or building from sources).
The new build option will reduce SONiC Build time when building with SDK prebuilt deb artifacts (sys-sdk).
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added new environment variable for URL to SDK artifacts location and adapt the makefile to utilize it.

#### How to verify it
Run make with MLNX_SDK_ASSETS_BASE_URL assigned to location holding SDK debs, then compare with sha256sum that sys-sdk in the target folder is the same file as in the URL.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

