### PR TITLE
[swss][warm-boot] Always load TUNNEL_DECAP config during warm boot if it exists except on broadcom ASICs

### DIFF
--- a/dockers/docker-orchagent/swssconfig.sh
+++ b/dockers/docker-orchagent/swssconfig.sh
@@ -49,6 +49,7 @@ fast_reboot
 [ -f /etc/sonic/sonic-environment ] && . /etc/sonic/sonic-environment
 
 HWSKU=${HWSKU:-`sonic-cfggen -d -v "DEVICE_METADATA['localhost']['hwsku']"`}
+sonic_asic_type=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)
 
 # Apply only TUNNEL_DECAP_TABLE entries
 apply_ipinip_subset() {
@@ -81,8 +82,9 @@ apply_ipinip_subset() {
 SYSTEM_WARM_START=`sonic-db-cli STATE_DB hget "WARM_RESTART_ENABLE_TABLE|system" enable`
 SWSS_WARM_START=`sonic-db-cli STATE_DB hget "WARM_RESTART_ENABLE_TABLE|swss" enable`
 if [[ "$SYSTEM_WARM_START" == "true" ]] || [[ "$SWSS_WARM_START" == "true" ]]; then
-    # On warm boot, only apply TUNNEL_DECAP_TABLE subset on non-Broadcom ASICs
-    if [[ "$ASIC_VENDOR" != "broadcom" ]]; then
+    # On warm boot, only apply TUNNEL_DECAP_TABLE subset on non-Broadcom ASICs to
+    # match ipinip.json.j2 config
+    if [[ "$sonic_asic_type" != "broadcom" ]]; then
         echo "Preparing to apply ipinip.json config for non-broadcom ASIC switch"
         apply_ipinip_subset
     else


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Always load ipinip.json during warm boot if it exists
#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**: 35324334
All logs and experiment results are attached in the ADO.

#### How I did it

#### How to verify it
After warm-boot to 202505, the ipinip changes are present in appl_db

```
docker ps
CONTAINER ID   IMAGE                             COMMAND                  CREATED       STATUS              PORTS     NAMES
a06623573f13   docker-dhcp-relay:latest          "/usr/bin/docker_ini…"   2 hours ago   Up About a minute             dhcp_relay
2aefd24bd4fa   docker-router-advertiser:latest   "/usr/bin/docker-ini…"   2 hours ago   Up About a minute             radv
70ab2eea55dc   docker-syncd-mlnx:latest          "/usr/local/bin/supe…"   2 hours ago   Up About a minute             syncd
47f1adc2a900   docker-eventd:latest              "/usr/local/bin/supe…"   2 hours ago   Up About a minute             eventd
1d62b6ead600   docker-fpm-frr:latest             "/usr/bin/docker_ini…"   2 hours ago   Up About a minute             bgp
13e91c6468d1   docker-teamd:latest               "/usr/local/bin/supe…"   2 hours ago   Up About a minute             teamd
8dac30ec5395   docker-sysmgr:latest              "/usr/local/bin/supe…"   2 hours ago   Up About a minute             sysmgr
fea830472eba   docker-orchagent:latest           "/usr/bin/docker-ini…"   2 hours ago   Up About a minute             swss
25df9919047e   docker-sonic-restapi:latest       "/usr/local/bin/supe…"   2 hours ago   Up About a minute             restapi
58678f7be59b   docker-acms:latest                "/usr/local/bin/supe…"   2 hours ago   Up 2 minutes                  acms
04123d0d724b   docker-database:latest            "/usr/local/bin/dock…"   2 hours ago   Up 2 minutes                  database

redis-cli -n 0 HGETALL "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL"
 1) "dscp_mode"
 2) "pipe"
 3) "ecn_mode"
 4) "copy_from_outer"
 5) "ttl_mode"
 6) "pipe"
 7) "tunnel_type"
 8) "IPINIP"
 9) "decap_dscp_to_tc_map"
10) "AZURE"
redis-cli -n 0 HGETALL "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL"
 1) "dscp_mode"
 2) "pipe"
 3) "ecn_mode"
 4) "copy_from_outer"
 5) "ttl_mode"
 6) "pipe"
 7) "tunnel_type"
 8) "IPINIP"
 9) "decap_dscp_to_tc_map"
10) "AZURE"
```

Set in the asic too (see sairedis)
```
2025-09-30.21:31:47.746420|s|SAI_OBJECT_TYPE_TUNNEL:oid:0x2a0000000005c9|SAI_TUNNEL_ATTR_DECAP_QOS_DSCP_TO_TC_MAP=oid:0x140000000005c0
2025-09-30.21:31:47.748412|s|SAI_OBJECT_TYPE_TUNNEL:oid:0x2a0000000005c9|SAI_TUNNEL_ATTR_DECAP_DSCP_MODE=SAI_TUNNEL_DSCP_MODE_PIPE_MODEL
2025-09-30.21:31:47.754631|s|SAI_OBJECT_TYPE_TUNNEL:oid:0x2a0000000005cb|SAI_TUNNEL_ATTR_DECAP_QOS_DSCP_TO_TC_MAP=oid:0x140000000005c0
2025-09-30.21:31:47.776611|s|SAI_OBJECT_TYPE_TUNNEL:oid:0x2a0000000005cb|SAI_TUNNEL_ATTR_DECAP_DSCP_MODE=SAI_TUNNEL_DSCP_MODE_PIPE_MODEL
```

No new tunnels are created - values are only set
```
2025 Sep 30 21:31:47.777158 bjw-can-2700-2 NOTICE swss#orchagent: :- setTunnelAttribute: Set attribute decap_dscp_to_tc_map with value 5629499534214592
2025 Sep 30 21:31:47.780014 bjw-can-2700-2 NOTICE syncd#SDK: [SAI_UTILS.NOTICE] ./src/mlnx_sai_utils.c[2070]- set_dispatch_attrib_handler: Set DECAP_DSCP_MODE, key:TUNNEL [OID:0x20000002A] [tunnel_entry_db[2]], val:PIPE_MODEL
2025 Sep 30 21:31:47.785386 bjw-can-2700-2 NOTICE swss#orchagent: :- setTunnelAttribute: Set attribute dscp_mode with value pipe
2025 Sep 30 21:31:47.785386 bjw-can-2700-2 NOTICE swss#orchagent: :- doDecapTunnelTask: Skip setting ecn_mode since the SAI attribute SAI_TUNNEL_ATTR_DECAP_ECN_MODE is create only
2025 Sep 30 21:31:47.788322 bjw-can-2700-2 NOTICE swss#orchagent: :- addDecapTunnelTermEntry: Tunnel decap term entry 10.0.0.56 already exists.
2025 Sep 30 21:31:47.788322 bjw-can-2700-2 NOTICE swss#orchagent: :- addDecapTunnelTermEntry: Tunnel decap term entry 10.0.0.58 already exists.
2025 Sep 30 21:31:47.788322 bjw-can-2700-2 NOTICE swss#orchagent: :- addDecapTunnelTermEntry: Tunnel decap term entry 10.0.0.60 already exists.
2025 Sep 30 21:31:47.788322 bjw-can-2700-2 NOTICE swss#orchagent: :- addDecapTunnelTermEntry: Tunnel decap term entry 10.0.0.62 already exists.
2025 Sep 30 21:31:47.788322 bjw-can-2700-2 NOTICE swss#orchagent: :- addDecapTunnelTermEntry: Tunnel decap term entry 10.1.0.32 already exists.
2025 Sep 30 21:31:47.788322 bjw-can-2700-2 NOTICE swss#orchagent: :- addDecapTunnelTermEntry: Tunnel decap term entry 192.168.0.1 already exists.
2025 Sep 30 21:31:47.788322 bjw-can-2700-2 NOTICE swss#orchagent: :- addDecapTunnelTermEntry: Tunnel decap term entry fc00:1::32 already exists.
2025 Sep 30 21:31:47.788322 bjw-can-2700-2 NOTICE swss#orchagent: :- addDecapTunnelTermEntry: Tunnel decap term entry fc00::71 already exists.
2025 Sep 30 21:31:47.788322 bjw-can-2700-2 NOTICE swss#orchagent: :- addDecapTunnelTermEntry: Tunnel decap term entry fc00::75 already exists.
2025 Sep 30 21:31:47.788322 bjw-can-2700-2 NOTICE swss#orchagent: :- addDecapTunnelTermEntry: Tunnel decap term entry fc00::79 already exists.
2025 Sep 30 21:31:47.788322 bjw-can-2700-2 NOTICE swss#orchagent: :- addDecapTunnelTermEntry: Tunnel decap term entry fc00::7d already exists.
2025 Sep 30 21:31:47.788322 bjw-can-2700-2 NOTICE swss#orchagent: :- addDecapTunnelTermEntry: Tunnel decap term entry fc02:1000::1 already exists.
```

Skipped on broadcom
```
2025 Oct  2 01:17:18.105963 bjw2-can-7260-8 INFO swss#supervisord: swssconfig Skip applying ipinip.json config for broadcom ASIC switch after warm-boot
```

pipe mode test on 2700 after warm-boot to 202505
```
  Inner Packet DSCP Value    Expected Egress Queue    Egress Queue Count  Result      Actual Egress Queue
-------------------------  -----------------------  --------------------  --------  ---------------------
                        0                        1                  2000  SUCCESS                       1
                        1                        1                  2000  SUCCESS                       1
                        2                        1                  2000  SUCCESS                       1
                        3                        3                  2000  SUCCESS                       3
                        4                        4                  2000  SUCCESS                       4
                        5                        2                  2000  SUCCESS                       2
                        6                        1                  2000  SUCCESS                       1
                        7                        1                  2000  SUCCESS                       1
                        8                        0                  2000  SUCCESS                       0
                        9                        1                  2000  SUCCESS                       1
                       10                        1                  2000  SUCCESS                       1
                       11                        1                  2000  SUCCESS                       1
                       12                        1                  2000  SUCCESS                       1
                       13                        1                  2000  SUCCESS                       1
                       14                        1                  2000  SUCCESS                       1
                       15                        1                  2000  SUCCESS                       1
                       16                        1                  2000  SUCCESS                       1
                       17                        1                  2000  SUCCESS                       1
                       18                        1                  2000  SUCCESS                       1
                       19                        1                  2000  SUCCESS                       1
                       20                        1                  2000  SUCCESS                       1
                       21                        1                  2000  SUCCESS                       1
                       22                        1                  2000  SUCCESS                       1
                       23                        1                  2000  SUCCESS                       1
                       24                        1                  2000  SUCCESS                       1
                       25                        1                  2000  SUCCESS                       1
                       26                        1                  2000  SUCCESS                       1
                       27                        1                  2000  SUCCESS                       1
                       28                        1                  2000  SUCCESS                       1
                       29                        1                  2000  SUCCESS                       1
                       30                        1                  2000  SUCCESS                       1
                       31                        1                  2000  SUCCESS                       1
                       32                        1                  2000  SUCCESS                       1
                       33                        1                  2000  SUCCESS                       1
                       34                        1                  2000  SUCCESS                       1
                       35                        1                  2000  SUCCESS                       1
                       36                        1                  2000  SUCCESS                       1
                       37                        1                  2000  SUCCESS                       1
                       38                        1                  2000  SUCCESS                       1
                       39                        1                  2000  SUCCESS                       1
                       40                        1                  2000  SUCCESS                       1
                       41                        1                  2000  SUCCESS                       1
                       42                        1                  2000  SUCCESS                       1
                       43                        1                  2000  SUCCESS                       1
                       44                        1                  2000  SUCCESS                       1
                       45                        1                  2000  SUCCESS                       1
                       46                        5                  2000  SUCCESS                       5
                       47                        1                  2000  SUCCESS                       1
                       48                        6                  2000  SUCCESS                       6
                       49                        1                  2000  SUCCESS                       1
                       50                        1                  2000  SUCCESS                       1
                       51                        1                  2000  SUCCESS                       1
                       52                        1                  2000  SUCCESS                       1
                       53                        1                  2000  SUCCESS                       1
                       54                        1                  2000  SUCCESS                       1
                       55                        1                  2000  SUCCESS                       1
                       56                        1                  2000  SUCCESS                       1
                       57                        1                  2000  SUCCESS                       1
                       58                        1                  2000  SUCCESS                       1
                       59                        1                  2000  SUCCESS                       1
                       60                        1                  2000  SUCCESS                       1
                       61                        1                  2000  SUCCESS                       1
                       62                        1                  2000  SUCCESS                       1
                       63                        1                  2000  SUCCESS                       1
PASSED
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

