### PR TITLE
Fix qos template generation of pfc_to_queue_map

### DIFF
--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -454,15 +454,13 @@
             "pfcwd_sw_enable" : "{{ LOSSLESS_TC|join(',') }}",
 {% endif %}
 {% endif %}
-{% if port not in PORT_DPC %}
-            "tc_to_pg_map"    : "AZURE",
-{% else %}
-            "tc_to_pg_map"    : "AZURE_DPC",
+{% if port not in PORT_SERVICE %}
+            "pfc_to_queue_map": "AZURE",
 {% endif %}
-{% if port in PORT_SERVICE %}
-            "pfc_to_queue_map": ""
+{% if port not in PORT_DPC %}
+            "tc_to_pg_map"    : "AZURE"
 {% else %}
-            "pfc_to_queue_map": "AZURE"
+            "tc_to_pg_map"    : "AZURE_DPC"
 {% endif %}
         }{% if not loop.last %},{% endif %}
 


### PR DESCRIPTION
A change in PR#24085 causes service ports to have config:
  "pfc_to_queue_map": ""

This fails yang validation with error:
  "Data Loading Failed:Invalid length for map name."

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

