### PR TITLE
Update media_settings.json for LPO module on Arista-7060x6

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe/media_settings.json
+++ b/device/arista/x86_64-arista_7060x6_64pe/media_settings.json
@@ -2,7 +2,7 @@
     "PORT_MEDIA_SETTINGS": {
         "1": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -132,7 +132,7 @@
         },
         "2": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -262,7 +262,7 @@
         },
         "3": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -392,7 +392,7 @@
         },
         "4": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -522,7 +522,7 @@
         },
         "5": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -652,7 +652,7 @@
         },
         "6": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -782,7 +782,7 @@
         },
         "7": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffd",
                         "lane1": "0xfffffffd",
@@ -912,7 +912,7 @@
         },
         "8": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffd",
                         "lane1": "0xfffffffd",
@@ -1042,7 +1042,7 @@
         },
         "9": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -1172,7 +1172,7 @@
         },
         "10": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -1302,7 +1302,7 @@
         },
         "11": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -1432,7 +1432,7 @@
         },
         "12": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -1562,7 +1562,7 @@
         },
         "13": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -1692,7 +1692,7 @@
         },
         "14": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -1822,7 +1822,7 @@
         },
         "15": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -1952,7 +1952,7 @@
         },
         "16": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -2082,7 +2082,7 @@
         },
         "17": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -2212,7 +2212,7 @@
         },
         "18": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -2342,7 +2342,7 @@
         },
         "19": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -2472,7 +2472,7 @@
         },
         "20": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -2602,7 +2602,7 @@
         },
         "21": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -2732,7 +2732,7 @@
         },
         "22": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -2862,7 +2862,7 @@
         },
         "23": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -2992,7 +2992,7 @@
         },
         "24": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -3122,7 +3122,7 @@
         },
         "25": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -3252,7 +3252,7 @@
         },
         "26": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -3382,7 +3382,7 @@
         },
         "27": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -3512,7 +3512,7 @@
         },
         "28": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -3642,7 +3642,7 @@
         },
         "29": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -3772,7 +3772,7 @@
         },
         "30": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -3902,7 +3902,7 @@
         },
         "31": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                    "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -4032,7 +4032,7 @@
         },
         "32": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                    "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -4162,7 +4162,7 @@
         },
         "33": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -4292,7 +4292,7 @@
         },
         "34": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -4422,7 +4422,7 @@
         },
         "35": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -4552,7 +4552,7 @@
         },
         "36": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -4682,7 +4682,7 @@
         },
         "37": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                    "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -4812,7 +4812,7 @@
         },
         "38": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                    "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -4942,7 +4942,7 @@
         },
         "39": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -5072,7 +5072,7 @@
         },
         "40": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -5202,7 +5202,7 @@
         },
         "41": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -5332,7 +5332,7 @@
         },
         "42": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -5462,7 +5462,7 @@
         },
         "43": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -5592,7 +5592,7 @@
         },
         "44": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -5722,7 +5722,7 @@
         },
         "45": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -5852,7 +5852,7 @@
         },
         "46": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -5982,7 +5982,7 @@
         },
         "47": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -6112,7 +6112,7 @@
         },
         "48": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -6242,7 +6242,7 @@
         },
         "49": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -6372,7 +6372,7 @@
         },
         "50": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -6502,7 +6502,7 @@
         },
         "51": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -6632,7 +6632,7 @@
         },
         "52": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -6762,7 +6762,7 @@
         },
         "53": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -6892,7 +6892,7 @@
         },
         "54": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -7022,7 +7022,7 @@
         },
         "55": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -7152,7 +7152,7 @@
         },
         "56": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -7282,7 +7282,7 @@
         },
         "57": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -7412,7 +7412,7 @@
         },
         "58": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -7542,7 +7542,7 @@
         },
         "59": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -7672,7 +7672,7 @@
         },
         "60": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -7802,7 +7802,7 @@
         },
         "61": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -7932,7 +7932,7 @@
         },
         "62": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -8062,7 +8062,7 @@
         },
         "63": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -8192,7 +8192,7 @@
         },
         "64": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",

--- a/device/arista/x86_64-arista_7060x6_64pe_b/media_settings.json
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/media_settings.json
@@ -2,7 +2,7 @@
     "PORT_MEDIA_SETTINGS": {
         "1": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -132,7 +132,7 @@
         },
         "2": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -262,7 +262,7 @@
         },
         "3": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -392,7 +392,7 @@
         },
         "4": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -522,7 +522,7 @@
         },
         "5": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -652,7 +652,7 @@
         },
         "6": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -782,7 +782,7 @@
         },
         "7": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffd",
                         "lane1": "0xfffffffd",
@@ -912,7 +912,7 @@
         },
         "8": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffd",
                         "lane1": "0xfffffffd",
@@ -1042,7 +1042,7 @@
         },
         "9": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -1172,7 +1172,7 @@
         },
         "10": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -1302,7 +1302,7 @@
         },
         "11": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -1432,7 +1432,7 @@
         },
         "12": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -1562,7 +1562,7 @@
         },
         "13": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -1692,7 +1692,7 @@
         },
         "14": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -1822,7 +1822,7 @@
         },
         "15": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -1952,7 +1952,7 @@
         },
         "16": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -2082,7 +2082,7 @@
         },
         "17": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -2212,7 +2212,7 @@
         },
         "18": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -2342,7 +2342,7 @@
         },
         "19": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -2472,7 +2472,7 @@
         },
         "20": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -2602,7 +2602,7 @@
         },
         "21": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -2732,7 +2732,7 @@
         },
         "22": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -2862,7 +2862,7 @@
         },
         "23": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -2992,7 +2992,7 @@
         },
         "24": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -3122,7 +3122,7 @@
         },
         "25": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -3252,7 +3252,7 @@
         },
         "26": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -3382,7 +3382,7 @@
         },
         "27": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -3512,7 +3512,7 @@
         },
         "28": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -3642,7 +3642,7 @@
         },
         "29": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -3772,7 +3772,7 @@
         },
         "30": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -3902,7 +3902,7 @@
         },
         "31": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                    "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -4032,7 +4032,7 @@
         },
         "32": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                    "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -4162,7 +4162,7 @@
         },
         "33": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -4292,7 +4292,7 @@
         },
         "34": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -4422,7 +4422,7 @@
         },
         "35": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -4552,7 +4552,7 @@
         },
         "36": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -4682,7 +4682,7 @@
         },
         "37": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                    "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -4812,7 +4812,7 @@
         },
         "38": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                    "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -4942,7 +4942,7 @@
         },
         "39": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -5072,7 +5072,7 @@
         },
         "40": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -5202,7 +5202,7 @@
         },
         "41": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -5332,7 +5332,7 @@
         },
         "42": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -5462,7 +5462,7 @@
         },
         "43": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -5592,7 +5592,7 @@
         },
         "44": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -5722,7 +5722,7 @@
         },
         "45": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -5852,7 +5852,7 @@
         },
         "46": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -5982,7 +5982,7 @@
         },
         "47": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -6112,7 +6112,7 @@
         },
         "48": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -6242,7 +6242,7 @@
         },
         "49": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -6372,7 +6372,7 @@
         },
         "50": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -6502,7 +6502,7 @@
         },
         "51": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -6632,7 +6632,7 @@
         },
         "52": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -6762,7 +6762,7 @@
         },
         "53": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -6892,7 +6892,7 @@
         },
         "54": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -7022,7 +7022,7 @@
         },
         "55": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -7152,7 +7152,7 @@
         },
         "56": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -7282,7 +7282,7 @@
         },
         "57": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -7412,7 +7412,7 @@
         },
         "58": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -7542,7 +7542,7 @@
         },
         "59": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -7672,7 +7672,7 @@
         },
         "60": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xfffffffe",
                         "lane1": "0xfffffffe",
@@ -7802,7 +7802,7 @@
         },
         "61": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -7932,7 +7932,7 @@
         },
         "62": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -8062,7 +8062,7 @@
         },
         "63": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",
@@ -8192,7 +8192,7 @@
         },
         "64": {
             "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|800G": {
+                "speed:100GAUI-1-S|800G.*": {
                     "pre3": {
                         "lane0": "0xffffffff",
                         "lane1": "0xffffffff",


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The Vendor PN regex for Pinewave LPO pluggable optic was incorrect and hence, the NPU SI settings were not getting applied.
Also, made the speed regex for 800G Eoptolink module more generic to apply SI settings for Eoptolink 800G LPO module

##### Work item tracking
- Microsoft ADO **(number only)**: 35393055

#### How I did it
Corrected Vendor PN regex for Pinewave LPO pluggable optic and modified speed regex for 800G Eoptolink module

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202503

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

