### PR TITLE
Remove version restriction for snappi and update OTEL packages to be compatible with snappi.

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -104,8 +104,8 @@ RUN python3 -m pip install aiohttp \
                  scapy==2.5.0 \
                  setuptools-rust \
                  six \
-                 snappi==1.33.0 \
-                 snappi-ixnetwork==1.33.1 \
+                 snappi \
+                 snappi-ixnetwork \
                  matplotlib \
                  seaborn \
                  rich \
@@ -114,9 +114,9 @@ RUN python3 -m pip install aiohttp \
                  thrift==0.11.0 \
                  virtualenv \
                  debugpy \
-                 opentelemetry-api==1.33.1 \
-                 opentelemetry-sdk==1.33.1 \
-                 opentelemetry-exporter-otlp==1.33.1 \
+                 opentelemetry-api==1.27.0 \
+                 opentelemetry-sdk==1.27.0 \
+                 opentelemetry-exporter-otlp==1.27.0 \
     && wget https://github.com/nanomsg/nanomsg/archive/1.2.tar.gz \
     && tar xvfz 1.2.tar.gz \
     && cd nanomsg-1.2      \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The latest OTEL package has dependency on fairly recent gRPC and protobuf packages, which the latest snappi package does not support.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

This commit fix the OTEL package version to a relatively old version, so it doesn't have the dependency on the gRPC and protobuf package. We cannot use newer version than 1.27.0 until snappi packages are updated with more loose dependency.

This change also removes the snappi package version, as we always prefer to use the latest version. This is one of the directions that mgmt container build is moving towards, in order to reduce maintenance effort.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Run pip install locally without error.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

