### PR TITLE
[YANG] Update range of supported port speeds to support 1.6T ports

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
@@ -196,9 +196,9 @@
                         "name": "Ethernet8",
                         "alias": "eth8",
                         "lanes": "65",
-                        "speed": 800000,
+                        "speed": 1600000,
                         "autoneg": "on",
-                        "adv_speeds": [400000, 800000]
+                        "adv_speeds": [800000, 1600000]
                     }
                 ]
             }
@@ -213,7 +213,7 @@
                         "name": "Ethernet8",
                         "alias": "eth8",
                         "lanes": "65",
-                        "speed": 900000,
+                        "speed": 1700000,
                         "autoneg": "on",
                         "adv_speeds": [25000,40000]
                     }
@@ -266,7 +266,7 @@
                         "lanes": "65",
                         "speed": 25000,
                         "autoneg": "on",
-                        "adv_speeds": [25000,800000]
+                        "adv_speeds": [25000,1600000]
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -99,7 +99,7 @@ module sonic-port{
 				leaf speed {
 					mandatory true;
 					type uint32 {
-						range 1..800000;
+						range 1..1600000;
 					}
 				}
 
@@ -130,7 +130,7 @@ module sonic-port{
 
 					type union {
 						type uint32 {
-							range 1..800000;
+							range 1..1600000;
 						}
 						type string {
 							pattern "all";


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To add support for 1.6T speed for port in the yang
Corresponding issue - [Issue 24222](https://github.com/sonic-net/sonic-buildimage/issues/24222)

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Changed the upperbound for port speed from 800G to 1.6T

#### How to verify it

Set a port speed to 1.6T and run the yang DB validation. e.g. by using dynamic port breakout.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

