### PR TITLE
[initramfs] Add initramfs hook to log more info for blockdev wait issue in booting

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -166,6 +166,8 @@ sudo cp files/initramfs-tools/arista-convertfs $FILESYSTEM_ROOT/etc/initramfs-to
 sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/arista-convertfs
 sudo cp files/initramfs-tools/arista-hook $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/arista-hook
 sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/arista-hook
+sudo cp files/initramfs-tools/arista-wait-blockdev $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/arista-wait-blockdev
+sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/arista-wait-blockdev
 sudo cp files/initramfs-tools/mke2fs $FILESYSTEM_ROOT/etc/initramfs-tools/hooks/mke2fs
 sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/hooks/mke2fs
 sudo cp files/initramfs-tools/setfacl $FILESYSTEM_ROOT/etc/initramfs-tools/hooks/setfacl

--- a/files/initramfs-tools/arista-wait-blockdev
+++ b/files/initramfs-tools/arista-wait-blockdev
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+case $1 in
+    prereqs)
+        exit 0
+        ;;
+esac
+
+info() { printf "%04.2f: $@\n" "$(cut -f1 -d' ' /proc/uptime)"; }
+warn() { info "Warning: $@"; }
+
+set -e
+
+aboot_flag=''
+root_val=''
+
+# Extract kernel parameters
+set -- $(cat /proc/cmdline)
+for x in "$@"; do
+    case "$x" in
+        Aboot=*)
+            aboot_flag="${x#Aboot=}"
+            ;;
+        root=UUID=*)
+            root_val="${x#root=UUID=}"
+            ;;
+        systemd.unit=kdump-tools.service)
+            # In kdump environment, skip hooks
+            exit 0
+            ;;
+    esac
+done
+
+[ -z "$aboot_flag" ] && exit 0
+[ -z "$root_val" ] && exit 0
+
+wait_blockdev_retry_count=1
+while [ "$wait_blockdev_retry_count" -le 10 ]; do
+    info "Waiting for UUID=${root_val}: attempt ${wait_blockdev_retry_count}"
+    if blkid --uuid $root_val > /dev/null 2>&1; then
+        info "Finished waiting for UUID=${root_val}"
+        exit 0
+    fi
+    wait_blockdev_retry_count=$((wait_blockdev_retry_count + 1))
+    sleep 1
+done
+warn "Failed to wait for UUID=${root_val}"
+ls /dev
+dmesg | tail -n 100
+blkid

--- a/files/initramfs-tools/arista-wait-blockdev
+++ b/files/initramfs-tools/arista-wait-blockdev
@@ -9,8 +9,6 @@ esac
 info() { printf "%04.2f: $@\n" "$(cut -f1 -d' ' /proc/uptime)"; }
 warn() { info "Warning: $@"; }
 
-set -e
-
 aboot_flag=''
 root_val=''
 
@@ -35,7 +33,7 @@ done
 [ -z "$root_val" ] && exit 0
 
 wait_blockdev_retry_count=1
-while [ "$wait_blockdev_retry_count" -le 10 ]; do
+while [ "$wait_blockdev_retry_count" -le 30 ]; do
     info "Waiting for UUID=${root_val}: attempt ${wait_blockdev_retry_count}"
     if blkid --uuid $root_val > /dev/null 2>&1; then
         info "Finished waiting for UUID=${root_val}"
@@ -48,3 +46,4 @@ warn "Failed to wait for UUID=${root_val}"
 ls /dev
 dmesg | tail -n 100
 blkid
+exit 0


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This change helps to the debug the issue when the block device for /host sometimes fails to initialize in booting.
When the issue happened before, the issue was not persistent so hard to reproduce, and the watchdog was triggered so there was no enough log to understand the cause.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add an Arista-specific initramfs hook to wait for block dev for /host
 - Skip it for non-Arista hardware
 - Skip it if UUID is not in /proc/cmdline
 - Skip if in kdump enviroment
 - Wait for the device based on UUID and the timeout is around 10 seconds
 - If failed, print the last 100 lines of dmesg, ls /dev and blkid to the console. 

#### How to verify it
Verified that the expected debug info can be printed on a device with modified wrong UUID
Verified that the normal device can boot without issue.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

