### PR TITLE
[docker-pmon] Add ssd and i2c0 for pmon container

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -714,7 +714,10 @@ start() {
 {%- endif %}
 {%- if docker_container_name == "pmon" %}
     -v /usr/share/sonic/firmware:/usr/share/sonic/firmware:rw \
+    $(if [ -e "/dev/i2c-0" ]; then echo "--device=/dev/i2c-0:/dev/i2c-0"; fi) \
     $(if [ -e "/dev/ipmi0" ]; then echo "--device=/dev/ipmi0:/dev/ipmi0"; fi) \
+    $(if [ -e "/dev/sda" ]; then echo "--device=/dev/sda:/dev/sda"; fi) \
+    $(if [ -e "/dev/sdb" ]; then echo "--device=/dev/sdb:/dev/sdb"; fi) \
     $(if [ -e "/dev/watchdog" ]; then echo "--device=/dev/watchdog:/dev/watchdog"; fi) \
     $(for watchdog in /sys/class/watchdog/*; do if [ -d "$watchdog" ]; then device_name=$(basename "$watchdog"); dev_file="/dev/$device_name"; if [ -e "$dev_file" ]; then echo "--device=$dev_file:$dev_file"; fi; fi; done) \
 {%- endif %}


### PR DESCRIPTION
Fix show platform ssd health by providing access to /dev/sda and sdb add access to /dev/i2c0 for PMON container to provide access to i2c devices needed by PMON

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fix errors due to lack of folder access from PMON container 
This regression was introduced by https://github.com/sonic-net/sonic-buildimage/pull/23457

```
1. 
2025 Sep 26 22:05:43.890909 bjw2-can-7215-4 ERR pmon#thermalctld[50]: Caught exception while running thermal policy - FileNotFoundError(2, 'No such file or directory')
2025 Sep 26 22:06:43.891643 bjw2-can-7215-4 ERR pmon#thermalctld[50]: Caught exception while running thermal policy - FileNotFoundError(2, 'No such file or directory')

2. 
Testcase platform_tests/cli/test_show_platform.py::test_show_platform_ssdhealth[ixre-cpm-chassis20] failed with the error:
 
pytest_assert(not is_line_empty, "Invalid data '{}' for '{}'".format(line_data, key))
E           Failed: Invalid data 'N/A' for 'Health'
 
Manual testing confirmed the issue:
 
admin@ixre-cpm-chassis20:~$ show platform ssdhealth
[Error] Cannot read device /dev/sda
Disk Type    : SATA
Device Model : StorFly VSFB25XI240G-NOK
Health       : N/A     <-------------------
Temperature  : 42C
```

After this fix

```
admin@sonic:~$ show platform fan
  Drawer    LED    FAN    Speed    Direction    Presence    Status          Timestamp
--------  -----  -----  -------  -----------  ----------  --------  -----------------
 drawer1  green   Fan1      54%       intake     Present        OK  20251010 16:20:26
 drawer2  green   Fan2      55%       intake     Present        OK  20251010 16:20:26
admin@sonic:~$ 

show platform ssdhealth is fixed with the latest image
admin@sonic:~$ show platform ssdhealth 
Disk Type    : SATA
Device Model : StorFly VSFBM8XI120G-V11
Health       : 99.575%
Temperature  : 50C
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it


#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

