### PR TITLE
[202505][Moby] Enable xcvrd SFF manager

### DIFF
--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/pmon_daemon_control.json
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/pmon_daemon_control.json
@@ -1,1 +1,4 @@
-../x86_64-arista_common/pmon_daemon_control.json
+{
+    "skip_fancontrol": true,
+    "enable_xcvrd_sff_mgr": true
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

High power mode is not correctly enabled for non CMIS QSFP modules, and we plan to use an AOI modules in the Moby QSFP port that requires enabling high power mode in 202505.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

This change enables SFF manager so that high power mode can be correctly set for the API opics (and other affected modules). Note that we want to limit the impact in 202505 so we only enable it on Moby.

#### How to verify it

- Confirm the same AOI optics, which couldn't link up, can work with this change
- Run sonicmgmt tests to make sure no regressions are introduced

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

This change only targets 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202505

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

