### PR TITLE
[srv6] add support for SRv6 uA into bgpcfgd.

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_srv6.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_srv6.py
@@ -5,6 +5,7 @@ from swsscommon import swsscommon
 
 supported_SRv6_behaviors = {
     'uN',
+    'uA',
     'uDT46',
 }
 
@@ -68,13 +69,6 @@ class SRv6Mgr(Manager):
                 self.directory.subscribe([(self.db_name, "SRV6_MY_LOCATORS", locator_name)], self.on_deps_change)
             return False
 
-        locator = self.directory.get(self.db_name, "SRV6_MY_LOCATORS", locator_name)
-        locator_prefix = IPv6Network(locator.prefix)
-        sid_prefix = IPv6Network(ip_prefix)
-        if not locator_prefix.supernet_of(sid_prefix):
-            log_err("Found a SRv6 SID config entry that does not match the locator prefix: {} | {}; locator {}".format(key, data, locator))
-            return False
-
         if 'action' not in data:
             log_err("Found a SRv6 SID config entry that does not specify action: {} | {}".format(key, data))
             return False
@@ -82,13 +76,33 @@ class SRv6Mgr(Manager):
         if data['action'] not in supported_SRv6_behaviors:
             log_err("Found a SRv6 SID config entry associated with unsupported action: {} | {}".format(key, data))
             return False
+            
+        locator = self.directory.get(self.db_name, "SRV6_MY_LOCATORS", locator_name)
+        locator_prefix = IPv6Network(locator.prefix)
+        sid_prefix = IPv6Network(ip_prefix)
+        locator_block = locator_prefix.supernet(new_prefix=locator.block_len)
+        if not locator_block.supernet_of(sid_prefix):
+            log_err("Found a SRv6 SID config entry that does not match the locator block: {} | {}; locator {}".format(key, data, locator))
+            return False
 
+        if data['action'] == 'uN' and not locator_prefix.supernet_of(sid_prefix):
+            log_err("Found a SRv6 SID config entry that does not match the locator prefix: {} | {}; locator {}".format(key, data, locator))
+            return False
+        
         sid = SID(locator_name, ip_prefix, data) # the information in data will be parsed into SID's attributes
 
         cmd_list = ['segment-routing', 'srv6', 'static-sids']
         sid_cmd = 'sid {} locator {} behavior {}'.format(ip_prefix, locator_name, sid.action)
         if sid.decap_vrf != DEFAULT_VRF:
             sid_cmd += ' vrf {}'.format(sid.decap_vrf)
+        if sid.action == 'uA':
+            if sid.interface:
+                sid_cmd += ' interface {}'.format(sid.interface)
+            else:
+                log_err("Found a SRv6 SID config entry that does not specify interface for action uA: {} | {}".format(key, data))
+                return False
+            if sid.adj:
+                sid_cmd += ' nexthop {}'.format(sid.adj)
         cmd_list.append(sid_cmd)
 
         self.cfg_mgr.push_list(cmd_list)
@@ -148,4 +162,5 @@ class SID:
 
         self.action = data['action']
         self.decap_vrf = data['decap_vrf'] if 'decap_vrf' in data else DEFAULT_VRF
-        self.adj = data['adj'].split(',') if 'adj' in data else []
+        self.interface = data['interface'] if 'interface' in data else None
+        self.adj = data['adj'] if 'adj' in data else None

--- a/src/sonic-bgpcfgd/tests/test_srv6.py
+++ b/src/sonic-bgpcfgd/tests/test_srv6.py
@@ -158,7 +158,12 @@ def test_uA_add_del():
     op_test(sid_mgr, 'SET', ("loc1|FCBB:BBBB:1:FE01::/64", {
         'action': 'uA',
         'interface': 'Ethernet0'
-    }), expected_ret=False, expected_cmds=[])
+    }), expected_ret=True, expected_cmds=[
+        'segment-routing',
+        'srv6',
+        'static-sids',
+        'sid fcbb:bbbb:1:fe01::/64 locator loc1 behavior uA interface Ethernet0'
+    ])
 
     print(loc_mgr.directory.data)
     assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1:fe01::\\64")

--- a/src/sonic-bgpcfgd/tests/test_srv6.py
+++ b/src/sonic-bgpcfgd/tests/test_srv6.py
@@ -91,6 +91,78 @@ def test_uN_add():
     print(loc_mgr.directory.data)
     assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1::\\48")
 
+def test_uA_add_del():
+    loc_mgr, sid_mgr = constructor()
+    assert loc_mgr.set_handler("loc1", {'prefix': 'fcbb:bbbb:1::'})
+
+    op_test(sid_mgr, 'SET', ("loc1|FCBB:BBBB:1:FE01::/64", {
+        'action': 'uA',
+        'interface': 'Ethernet0',
+        'adj': '2001:db8::1'
+    }), expected_ret=True, expected_cmds=[
+        'segment-routing',
+        'srv6',
+        'static-sids',
+        'sid fcbb:bbbb:1:fe01::/64 locator loc1 behavior uA interface Ethernet0 nexthop 2001:db8::1'
+    ])
+
+    print(loc_mgr.directory.data)
+    assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1:fe01::\\64")
+
+    # test the deletion
+    op_test(sid_mgr, 'DEL', ("loc1|FCBB:BBBB:1:FE01::/64",),
+            expected_ret=True, expected_cmds=[
+            'segment-routing',
+            'srv6',
+            'static-sids',
+            'no sid fcbb:bbbb:1:fe01::/64 locator loc1 behavior uA interface Ethernet0 nexthop 2001:db8::1'
+    ])
+    print(loc_mgr.directory.data)
+    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1:fe01::\\64")
+
+    op_test(sid_mgr, 'SET', ("loc1|FCBB:BBBB:FE01::/48", {
+        'action': 'uA',
+        'interface': 'Ethernet0',
+        'adj': '2001:db8::1'
+    }), expected_ret=True, expected_cmds=[
+        'segment-routing',
+        'srv6',
+        'static-sids',
+        'sid fcbb:bbbb:fe01::/48 locator loc1 behavior uA interface Ethernet0 nexthop 2001:db8::1'
+    ])
+
+    print(loc_mgr.directory.data)
+    assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:fe01::\\48")
+
+    # test the deletion
+    op_test(sid_mgr, 'DEL', ("loc1|FCBB:BBBB:FE01::/48",),
+            expected_ret=True, expected_cmds=[
+            'segment-routing',
+            'srv6',
+            'static-sids',
+            'no sid fcbb:bbbb:fe01::/48 locator loc1 behavior uA interface Ethernet0 nexthop 2001:db8::1'
+    ])
+    print(loc_mgr.directory.data)
+    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:fe01::\\48")
+
+    # test missing interface
+    op_test(sid_mgr, 'SET', ("loc1|FCBB:BBBB:1:FE01::/64", {
+        'action': 'uA',
+        'adj': '2001:db8::1'
+    }), expected_ret=False, expected_cmds=[])
+
+    print(loc_mgr.directory.data)
+    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1:fe01::\\64")
+
+    # test missing adj (adj is optional)
+    op_test(sid_mgr, 'SET', ("loc1|FCBB:BBBB:1:FE01::/64", {
+        'action': 'uA',
+        'interface': 'Ethernet0'
+    }), expected_ret=False, expected_cmds=[])
+
+    print(loc_mgr.directory.data)
+    assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1:fe01::\\64")
+
 def test_uDT46_add_vrf1():
     loc_mgr, sid_mgr = constructor()
     assert loc_mgr.set_handler("loc1", {'prefix': 'fcbb:bbbb:1::'})


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Need to support uA action for SRv6 SID.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
add uA action in sonic-bgpcfgd/bgpcfgd/managers_srv6.py

#### How to verify it
build an SONiC image with the above change and a SDK with uA support.
Here is the configuration and sairedis.rec log:

```
{

  "SRV6_MY_LOCATORS": {
    "loc1": {
      "prefix": "FCBB:AAAA:4::"
    },
    "loc2": {
      "prefix": "FCBB:BBBB:4::"
    }
  },
  "SRV6_MY_SIDS": {
    "loc1|FCBB:AAAA:4:fe24::/64": {
      "action": "uA",
      "interface": "Ethernet24",
      "adj": "2001:db8:4:5::5"
    },
    "loc2|FCBB:BBBB:4:fe28::/64": {
      "action": "uA",
      "interface": "Ethernet28",
      "adj": "2001:db8:4:52::5"
    }
  }
}
2025-10-17.18:15:29.185425|c|SAI_OBJECT_TYPE_NEXT_HOP:oid:0x40000000010fd|SAI_NEXT_HOP_ATTR_TYPE=SAI_NEXT_HOP_TYPE_IP|SAI_NEXT_HOP_ATTR_IP=2001:db8:4:5::5|SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID=oid:0x60000000010fb
2025-10-17.18:15:31.310468|c|SAI_OBJECT_TYPE_NEXT_HOP:oid:0x40000000010fe|SAI_NEXT_HOP_ATTR_TYPE=SAI_NEXT_HOP_TYPE_IP|SAI_NEXT_HOP_ATTR_IP=2001:db8:4:52::5|SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID=oid:0x60000000010fc
2025-10-17.18:15:38.456100|c|SAI_OBJECT_TYPE_MY_SID_ENTRY:{"args_len":"0","function_len":"16","locator_block_len":"32","locator_node_len":"16","sid":"fcbb:aaaa:4:fe24::","switch_id":"oid:0x21000000000000","vr_id":"oid:0x3000000000085"}|SAI_MY_SID_ENTRY_ATTR_NEXT_HOP_ID=oid:0x40000000010fd|SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR=SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UA|SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR_FLAVOR=SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD
2025-10-17.18:15:38.636275|c|SAI_OBJECT_TYPE_MY_SID_ENTRY:{"args_len":"0","function_len":"16","locator_block_len":"32","locator_node_len":"16","sid":"fcbb:bbbb:4:fe28::","switch_id":"oid:0x21000000000000","vr_id":"oid:0x3000000000085"}|SAI_MY_SID_ENTRY_ATTR_NEXT_HOP_ID=oid:0x40000000010fe|SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR=SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UA|SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR_FLAVOR=SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD
```
example for two SIDs share same locator
```
{

  "SRV6_MY_LOCATORS": {
    "loc1": {
      "prefix": "FCBB:BBBB:4::"
    }
  },
  "SRV6_MY_SIDS": {
    "loc1|FCBB:BBBB:fe24::/48": {
      "action": "uA",
      "interface": "Ethernet24",
      "adj": "2001:db8:4:5::5"
    },
    "loc1|FCBB:BBBB:fe28::/48": {
      "action": "uA",
      "interface": "Ethernet28",
      "adj": "2001:db8:4:52::5"
    }
  }
}

2025-10-30.18:28:32.078580|c|SAI_OBJECT_TYPE_NEXT_HOP:oid:0x40000000010fd|SAI_NEXT_HOP_ATTR_TYPE=SAI_NEXT_HOP_TYPE_IP|SAI_NEXT_HOP_ATTR_IP=2001:db8:4:5::5|SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID=oid:0x60000000010fb
2025-10-30.18:28:34.581524|c|SAI_OBJECT_TYPE_NEXT_HOP:oid:0x40000000010fe|SAI_NEXT_HOP_ATTR_TYPE=SAI_NEXT_HOP_TYPE_IP|SAI_NEXT_HOP_ATTR_IP=2001:db8:4:52::5|SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID=oid:0x60000000010fc

2025-10-30.18:28:53.839816|c|SAI_OBJECT_TYPE_MY_SID_ENTRY:{"args_len":"0","function_len":"16","locator_block_len":"32","locator_node_len":"0","sid":"fcbb:bbbb:fe24::","switch_id":"oid:0x21000000000000","vr_id":"oid:0x3000000000085"}|SAI_MY_SID_ENTRY_ATTR_NEXT_HOP_ID=oid:0x40000000010fd|SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR=SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UA|SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR_FLAVOR=SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD
2025-10-30.18:28:53.889689|c|SAI_OBJECT_TYPE_MY_SID_ENTRY:{"args_len":"0","function_len":"16","locator_block_len":"32","locator_node_len":"0","sid":"fcbb:bbbb:fe28::","switch_id":"oid:0x21000000000000","vr_id":"oid:0x3000000000085"}|SAI_MY_SID_ENTRY_ATTR_NEXT_HOP_ID=oid:0x40000000010fe|SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR=SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UA|SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR_FLAVOR=SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD

```

If SID prefix does not match block, throw and error and ignore that SID:
```
{

  "SRV6_MY_LOCATORS": {
    "loc1": {
      "prefix": "FCBB:BBBB:4::"
    }
  },
  "SRV6_MY_SIDS": {
    "loc1|FCBB:BBBB:fe24::/48": {
      "action": "uA",
      "interface": "Ethernet24",
      "adj": "2001:db8:4:5::5"
    },
    "loc1|FCBB:BBBA:fe28::/48": {
      "action": "uA",
      "interface": "Ethernet28",
      "adj": "2001:db8:4:52::5"
    }
  }
}

2025 Oct 30 22:15:55.047652 sonic DEBUG bgp#bgpcfgd: CONFIG_DB SRv6 static configuration SRV6_MY_LOCATORS|loc1 is scheduled for updates. ['segment-routing', 'srv6', 'locators', 'locator loc1', 'prefix fcbb:bbbb:4::/48 block-len 32 node-len 16 func-bits 16', 'behavior usid']
2025 Oct 30 22:15:55.047708 sonic ERR bgp#bgpcfgd: Found a SRv6 SID config entry that does not match the locator block: loc1|fcbb:bbba:fe28::/48 | {'action': 'uA', 'adj': '2001:db8:4:52::5', 'interface': 'Ethernet28'}; locator <bgpcfgd.managers_srv6.Locator object at 0x7f4f4d87cb50>
2025 Oct 30 22:15:55.047791 sonic DEBUG bgp#bgpcfgd: CONFIG_DB SRv6 static configuration SRV6_MY_SIDS|loc1|fcbb:bbbb:fe24::/48 is scheduled for updates. ['segment-routing', 'srv6', 'static-sids', 'sid fcbb:bbbb:fe24::/48 locator loc1 behavior uA interface Ethernet24 nexthop 2001:db8:4:5::5']
2025 Oct 30 22:15:55.048082 sonic DEBUG bgp#bgpcfgd: execute command '['vtysh', '-f', '/tmp/tmppjsn4ntp']'.

2025-10-30.22:15:55.100429|c|SAI_OBJECT_TYPE_MY_SID_ENTRY:{"args_len":"0","function_len":"16","locator_block_len":"32","locator_node_len":"0","sid":"fcbb:bbbb:fe24::","switch_id":"oid:0x21000000000000","vr_id":"oid:0x3000000000085"}|SAI_MY_SID_ENTRY_ATTR_NEXT_HOP_ID=oid:0x40000000010fd|SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR=SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UA|SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR_FLAVOR=SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD

```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] 202505
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

