### PR TITLE
Keep eth1 for multi-asic disaggregated chassis platforms

### DIFF
--- a/src/sonic-device-data/Makefile
+++ b/src/sonic-device-data/Makefile
@@ -52,6 +52,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 			num_columns=$$(echo $$last_line | awk '{print NF}'); \
 			i=0; \
 			if [ -f $$(dirname $$d)/chassisdb.conf ] && ! grep -q '^disaggregated_chassis=1' $$(dirname $$d)/platform_env.conf; then \
+				echo "Reserve midplane interface for $$(dirname $$d)"; \
 				i=$$(($$i+1)); \
 			fi; \
 			while IFS= read -r line; do \
@@ -70,7 +71,6 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 		if [ -f device/x86_64-kvm_x86_64-r0/$$(basename $$d)/context_config.json ]; then \
 			rm device/x86_64-kvm_x86_64-r0/$$(basename $$d)/context_config.json; \
 		fi; \
-		i=0; \
 		if [ -f $$(dirname $$d)/chassisdb.conf ]; then \
 			# Append Cpu0 Port in lanemap.ini
 			if [ -f device/x86_64-kvm_x86_64-r0/$$(basename $$d)/lanemap.ini ]; then \
@@ -79,6 +79,10 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 			if [ -f device/x86_64-kvm_x86_64-r0/$$(basename $$d)/coreportindexmap.ini ]; then \
 				echo "Cpu0:0,0" >> device/x86_64-kvm_x86_64-r0/$$(basename $$d)/coreportindexmap.ini; \
 			fi; \
+		fi; \
+		i=0; \
+		if [ -f $$(dirname $$d)/chassisdb.conf ] && ! grep -q '^disaggregated_chassis=1' $$(dirname $$d)/platform_env.conf; then \
+			echo "Reserve midplane interface for $$(dirname $$d)"; \
 			i=$$(($$i+1)); \
 		fi; \
 		subdirs="0 1 2"; \

--- a/src/sonic-device-data/Makefile
+++ b/src/sonic-device-data/Makefile
@@ -55,7 +55,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 				echo "Reserve midplane interface for $$(dirname $$d)"; \
 				i=$$(($$i+1)); \
 			fi; \
-			while IFS= read -r line; do \
+			while IFS= read -r line || [ -n "$$line" ]; do \
 				if ! grep -q "^#" <<< "$$line"; then \
 					i=$$(($$i+1)); \
 					lanes=$$(echo "$$line" | awk '{print $$2}'); \
@@ -97,7 +97,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 				if [ -f device/x86_64-kvm_x86_64-r0/$$(basename $$d)/$$(basename $$subdir)/port_config.ini ]; then \
 					last_line=$$(tail -n 1 device/x86_64-kvm_x86_64-r0/$$(basename $$d)/$$(basename $$subdir)/port_config.ini); \
 					num_columns=$$(echo $$last_line | awk '{print NF}'); \
-					while IFS= read -r line; do \
+					while IFS= read -r line || [ -n "$$line" ]; do \
 						if ! grep -q "^#" <<< "$$line"; then \
 							i=$$(($$i+1)); \
 							lanes=$$(echo "$$line" | awk '{print $$2}'); \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
My original PR #24198 only fixed the eth1 problem for single-asic disaggregated chassis platform but it didn't resolve the problem for multi-asic platforms.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Applied the same logic change in #24198 for multi-asic scenario.

#### How to verify it

Build a new sonic-device-data deb package and install it on a device. Then, check the HwSKU directory.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202503

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

