### PR TITLE
Add empty pytest configuration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+# Configuration is deliberately left empty.
+# Presence of the file ensures pytest will select this directory as the rootdir.
+# Otherwise pytest may keep going up the directory tree and find another
+# configuration file.
+[pytest]


### PR DESCRIPTION
#### Why I did it

Pytest in sonic-buildimage and submodules relies on default value of `norecursedirs` setting.
Without the configuration file, pytest may find another one in one of the parent directories and run with an incompatible setting of `norecursedirs` causing test collection failures.

##### Work item tracking

- Microsoft ADO **(number only)**:

#### How I did it

Create an emtpy `pytest.ini` configuration file. 

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

* Ensure pytest runs with default value of `norecursedirs`

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

