### PR TITLE
[PDDF] Avoid missing num_* field crashing pddf_chassis.py

### DIFF
--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_chassis.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_chassis.py
@@ -74,47 +74,47 @@ class PddfChassis(ChassisBase):
 
 
         # FANs
-        for i in range(self.platform_inventory['num_fantrays']):
+        for i in range(self.platform_inventory.get('num_fantrays', 0)):
             fandrawer = FanDrawer(i, self.pddf_obj, self.plugin_data)
             self._fan_drawer_list.append(fandrawer)
             self._fan_list.extend(fandrawer._fan_list)
 
         # PSUs
-        for i in range(self.platform_inventory['num_psus']):
+        for i in range(self.platform_inventory.get('num_psus', 0)):
             psu = Psu(i, self.pddf_obj, self.plugin_data)
             self._psu_list.append(psu)
 
         # OPTICs
-        for index in range(self.platform_inventory['num_ports']):
+        for index in range(self.platform_inventory.get('num_ports', 0)):
             sfp = Sfp(index, self.pddf_obj, self.plugin_data)
             self._sfp_list.append(sfp)
 
         # THERMALs
-        for i in range(self.platform_inventory['num_temps']):
+        for i in range(self.platform_inventory.get('num_temps', 0)):
             thermal = Thermal(i, self.pddf_obj, self.plugin_data)
             self._thermal_list.append(thermal)
 
         if voltage_sensor_present:
             # VOLTAGE SENSORs
-            for i in range(self.platform_inventory['num_voltage_sensors']):
+            for i in range(self.platform_inventory.get('num_voltage_sensors', 0)):
                 voltage = VoltageSensor(i, self.pddf_obj, self.plugin_data)
                 self._voltage_sensor_list.append(voltage)
 
         if current_sensor_present:
             # CURRENT SENSORs
-            for i in range(self.platform_inventory['num_current_sensors']):
+            for i in range(self.platform_inventory.get('num_current_sensors', 0)):
                 current = CurrentSensor(i, self.pddf_obj, self.plugin_data)
                 self._current_sensor_list.append(current)
 
         if asicthermal_present:
             # ASIC Thermal
-            for i in range(self.platform_inventory['num_asic_temps']):
+            for i in range(self.platform_inventory.get('num_asic_temps', 0)):
                 asicthermal = AsicThermal(i, self.pddf_obj)
                 self._thermal_list.append(asicthermal)
 
         if component_present:
             # Components (Programmables)
-            for i in range(self.platform_inventory['num_components']):
+            for i in range(self.platform_inventory.get('num_components', 0)):
                 component = Component(i, self.pddf_obj, self.plugin_data)
                 self._component_list.append(component)
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
#Fixes https://github.com/sonic-net/sonic-buildimage/issues/24325
- Avoid pddf_chassis.py requiring the following fields defined in pddf-device.json
   - num_fantrays
   - num_psus
   - num_ports
   - num_temps
   - num_voltage_sensors
   - num_current_sensors
   - num_asic_temps
   - num_components

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Default to 0 whenever a num_* field is missing.

#### How to verify it
- Tested equivalent change on NH-4010 

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

