### PR TITLE
[PDDF] Fix create_gpio_device error

### DIFF
--- a/platform/pddf/i2c/utils/pddfparse.py
+++ b/platform/pddf/i2c/utils/pddfparse.py
@@ -545,13 +545,13 @@ class PddfParse():
                 return create_ret.append(ret)
 
         if 'gpio' in dev:
-            ret = self.create_gpio_device(bdf, dev['gpio'], ops)
+            ret = self.create_multifpgapci_gpio_device(bdf, dev['gpio'], ops)
             if ret != 0:
                 return create_ret.append(ret)
 
         return create_ret.append(ret)
 
-    def create_gpio_device(self, bdf, gpio_dev, ops):
+    def create_multifpgapci_gpio_device(self, bdf, gpio_dev, ops):
         create_ret = []
         ret = 0
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixes https://github.com/sonic-net/sonic-buildimage/issues/24354

See https://github.com/sonic-net/sonic-buildimage/pull/23669#issuecomment-3450190028

```
Oct 27 07:59:31 sonic pddf_util.py[1183]: File "/usr/local/bin/pddfparse.py", line 1898, in dev_parse
Oct 27 07:59:31 sonic pddf_util.py[1183]: return self.gpio_parse(dev, ops)
Oct 27 07:59:31 sonic pddf_util.py[1183]: ^^^^^^^^^^^^^^^^^^^^^^^^^
Oct 27 07:59:31 sonic pddf_util.py[1183]: File "/usr/local/bin/pddfparse.py", line 1694, in gpio_parse
Oct 27 07:59:31 sonic pddf_util.py[1183]: ret = getattr(self, ops['cmd']+"_gpio_device")(dev, ops)
Oct 27 07:59:31 sonic pddf_util.py[1183]: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Oct 27 07:59:31 sonic pddf_util.py[1183]: TypeError: PddfParse.create_gpio_device() missing 1 required positional argument: 'ops'
Oct 27 07:59:31 sonic systemd[1]: pddf-platform-init.service: Main process exited, code=exited, status=1/FAILURE
Oct 27 07:59:31 sonic systemd[1]: pddf-platform-init.service: Failed with result 'exit-code'.
Oct 27 07:59:31 sonic systemd[1]: Failed to start pddf-platform-init.service - PDDF module and device initialization service.
```

https://github.com/sonic-net/sonic-buildimage/pull/23669 introduced a regression which only hit on PDDF platforms which used the previous GPIO component.

This was due to the `create_gpio_device` name of the new and existing method being the same. The new method has a different number of parameters, which led to this error.

The fix is to make unique names for the different versions of `create_gpio_device`.


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

