### PR TITLE
[202411] FRR patch in zebra to fix a bug in zebra_ns_link_ifp() (#24311)

### DIFF
--- a/src/sonic-frr/patch/0065-zebra-if-speed-change-check-fix.patch
+++ b/src/sonic-frr/patch/0065-zebra-if-speed-change-check-fix.patch
@@ -1,0 +1,28 @@
+Zebra patch to fix a bug in zebra_ns_link_ifp()
+
+From: dileep <dileep@arista.com>
+
+This function should first check whether the given interface is valid (i.e. an
+RTM_NEWLINK has been processed for the interface and it has a valid ifindex) before
+updating zebra_ns.ifp_tree.
+---
+ zebra/zebra_ns.c |    6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/zebra/zebra_ns.c b/zebra/zebra_ns.c
+index 578dee7b7..12c38e2f8 100644
+--- a/zebra/zebra_ns.c
++++ b/zebra/zebra_ns.c
+@@ -49,6 +49,12 @@ void zebra_ns_link_ifp(struct zebra_ns *zns, struct interface *ifp)
+ 	struct zebra_if *zif;
+ 	struct ifp_tree_link *link, tlink = {};
+ 
++	if (ifp->ifindex == IFINDEX_INTERNAL) {
++		if (IS_ZEBRA_DEBUG_EVENT)
++			zlog_debug("%s: interface %s not ready, ignoring", __func__, ifp->name);
++		return;
++	}
++
+ 	zif = ifp->info;
+ 	assert(zif != NULL);
+ 

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -44,3 +44,4 @@
 0062-zebra-lib-use-internal-rbtree-per-ns.patch
 0063-lib-Return-duplicate-prefix-list-entry-test.patch
 0064-mgmtd-clean-session-config-only-when-it-is-needed.patch
+0065-zebra-if-speed-change-check-fix.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

There is a race condition in zebra after bootup, where if_zebra_speed_update timer fires 15 seconds after interface creation. If speed is available in kernel, it calls if_add_update -> zebra_ns_link_ifp to link the interface to a namespace. But if this happens before RTM_NEWLINK event, it links the default ifindex IFINDEX_INTERNAL 0 and makes following if_lookup_by_index_per_ns fail. If one interface is affected, the BGP neighbor on that interface will remain permanently down. If two are affected, it causes assertion in zebra_ns_link_ifp because it tries to link both interfaces with ifindex 0.

#### How I did it

This workaround just skips linking if the ifindex is IFINDEX_INTERNAL. A complete solution requires careful redesign for the timer.

#### How to verify it

Reboot device with large amount of interfaces, there is 50% of chance that a random BGP neighbor goes down permanently on m1-108 and small chance that zebra asserts on m1-128.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

Probably more branches?

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202505

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
This function should first check whether an interface is valid (i.e. an RTM_NEWLINK has been processed for the interface and it has a valid ifindex) before updating zebra_ns.ifp_tree.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

