### PR TITLE
[Mellanox][Smartswitch] Add warning log for DPU going down

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
@@ -115,11 +115,13 @@ class DpuCtlPlat():
         if use_print:
             self.logger_info = print_with_time
             self.logger_error = print_with_time 
+            self.logger_warning = print_with_time
             self.logger_debug = print_with_time
             return
         self.logger_debug = logger.log_debug
         self.logger_info = logger.log_info
         self.logger_error = logger.log_error
+        self.logger_warning = logger.log_warning
 
     def log_debug(self, msg=None):
         # Print only in verbose mode
@@ -130,6 +132,9 @@ class DpuCtlPlat():
 
     def log_error(self, msg=None):
         self.logger_error(f"{self.dpu_name}: {msg}")
+
+    def log_warning(self, msg=None):
+        self.logger_warning(f"{self.dpu_name}: {msg}")
 
     def run_cmd_output(self, cmd, raise_exception=True):
         try:
@@ -196,7 +201,8 @@ class DpuCtlPlat():
         except (FileNotFoundError, PermissionError) as inotify_exc:
             raise type(inotify_exc)(f"{self.dpu_name}:{str(inotify_exc)}")
         if not dpu_shtdn_rdy:
-            self.log_error(f"Going Down Unsuccessful")
+            # Log level warning since we have a fallback to force power off
+            self.log_warning(f"Going Down Unsuccessful")
             return False
         return True
 

--- a/platform/mellanox/mlnx-platform-api/tests/test_dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_dpuctlplat.py
@@ -78,6 +78,7 @@ class TestDpuCtlPlatInit:
         assert dpuctl_obj.logger_info != print
         assert dpuctl_obj.logger_error != print
         assert dpuctl_obj.logger_debug != print
+        assert dpuctl_obj.logger_warning != print
 
     def test_get_pci_dev_path(self, dpuctl_obj):
         """Test PCI device path retrieval"""


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Since we have a fallback mechanism to force power off if regular power off fails, the going down message severity is changed from error to warning. If force power off also fails we have an error log added to the syslog

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Change log level for the log message

#### How to verify it
Manual verification for log level in the syslog
`tail -f /var/log/syslog | grep "chassisd"`
should yield
`WARN pmon#chassisd[49]: dpu0: Going Down Unsuccessful`
unit test is updated
`tests/test_dpuctlplat.py::TestDpuCtlPlatInit::test_setup_logger PASSED       [ 45%]`


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505
- [X] 202506

#### Tested branch (Please provide the tested image version)
- [X] 202506
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

