### PR TITLE
Fix BUFFER_PROFILE case for Arista-7060X6-64PE-B-C448O16, Arista-7060X6-64PE-B-C512S2

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/buffers_defaults_t0.j2
@@ -27,72 +27,72 @@
             "pool": "egress_lossy_pool",
             "size": "1778"
         },
-        "QUEUE0_DOWNLINK_LOSSY_PROFILE": {
+        "queue0_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
         },
-        "QUEUE1_DOWNLINK_LOSSY_PROFILE": {
+        "queue1_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE2_DOWNLINK_LOSSY_PROFILE": {
+        "queue2_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE3_DOWNLINK_LOSSY_PROFILE": {
+        "queue3_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE4_DOWNLINK_LOSSY_PROFILE": {
+        "queue4_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
         },
-        "QUEUE5_DOWNLINK_LOSSY_PROFILE": {
+        "queue5_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-3"
         },
-        "QUEUE6_DOWNLINK_LOSSY_PROFILE": {
+        "queue6_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
         },
-        "QUEUE0_UPLINK_LOSSY_PROFILE": {
+        "queue0_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
         },
-        "QUEUE1_UPLINK_LOSSY_PROFILE": {
+        "queue1_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE2_UPLINK_LOSSY_PROFILE": {
+        "queue2_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE3_UPLINK_LOSSY_PROFILE": {
+        "queue3_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE4_UPLINK_LOSSY_PROFILE": {
+        "queue4_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
         },
-        "QUEUE5_UPLINK_LOSSY_PROFILE": {
+        "queue5_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-3"
         },
-        "QUEUE6_UPLINK_LOSSY_PROFILE": {
+        "queue6_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
@@ -119,47 +119,47 @@
           and DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name]
           and DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type in ('LeafRouter', 'SpineRouter') %}
             "{{ port }}|0": {
-                "profile": "QUEUE0_UPLINK_LOSSY_PROFILE"
+                "profile": "queue0_uplink_lossy_profile"
             },
             "{{ port }}|1": {
-                "profile": "QUEUE1_UPLINK_LOSSY_PROFILE"
+                "profile": "queue1_uplink_lossy_profile"
             },
             "{{ port }}|2": {
-                "profile": "QUEUE2_UPLINK_LOSSY_PROFILE"
+                "profile": "queue2_uplink_lossy_profile"
             },
             "{{ port }}|3": {
-                "profile": "QUEUE3_UPLINK_LOSSY_PROFILE"
+                "profile": "queue3_uplink_lossy_profile"
             },
             "{{ port }}|4": {
-                "profile": "QUEUE4_UPLINK_LOSSY_PROFILE"
+                "profile": "queue4_uplink_lossy_profile"
             },
             "{{ port }}|5": {
-                "profile": "QUEUE5_UPLINK_LOSSY_PROFILE"
+                "profile": "queue5_uplink_lossy_profile"
             },
             "{{ port }}|6": {
-                "profile": "QUEUE6_UPLINK_LOSSY_PROFILE"
+                "profile": "queue6_uplink_lossy_profile"
             }
         {% else %}
             "{{ port }}|0": {
-                "profile": "QUEUE0_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue0_downlink_lossy_profile"
             },
             "{{ port }}|1": {
-                "profile": "QUEUE1_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue1_downlink_lossy_profile"
             },
             "{{ port }}|2": {
-                "profile": "QUEUE2_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue2_downlink_lossy_profile"
             },
             "{{ port }}|3": {
-                "profile": "QUEUE3_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue3_downlink_lossy_profile"
             },
             "{{ port }}|4": {
-                "profile": "QUEUE4_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue4_downlink_lossy_profile"
             },
             "{{ port }}|5": {
-                "profile": "QUEUE5_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue5_downlink_lossy_profile"
             },
             "{{ port }}|6": {
-                "profile": "QUEUE6_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue6_downlink_lossy_profile"
             }
         {% endif %}
     {%- if not loop.last -%},{% endif %}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/buffers_defaults_t1.j2
@@ -27,72 +27,72 @@
             "pool": "egress_lossy_pool",
             "size": "1778"
         },
-        "QUEUE0_DOWNLINK_LOSSY_PROFILE": {
+        "queue0_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
         },
-        "QUEUE1_DOWNLINK_LOSSY_PROFILE": {
+        "queue1_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE2_DOWNLINK_LOSSY_PROFILE": {
+        "queue2_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE3_DOWNLINK_LOSSY_PROFILE": {
+        "queue3_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE4_DOWNLINK_LOSSY_PROFILE": {
+        "queue4_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
         },
-        "QUEUE5_DOWNLINK_LOSSY_PROFILE": {
+        "queue5_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-3"
         },
-        "QUEUE6_DOWNLINK_LOSSY_PROFILE": {
+        "queue6_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
         },
-        "QUEUE0_UPLINK_LOSSY_PROFILE": {
+        "queue0_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
         },
-        "QUEUE1_UPLINK_LOSSY_PROFILE": {
+        "queue1_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE2_UPLINK_LOSSY_PROFILE": {
+        "queue2_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE3_UPLINK_LOSSY_PROFILE": {
+        "queue3_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE4_UPLINK_LOSSY_PROFILE": {
+        "queue4_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
         },
-        "QUEUE5_UPLINK_LOSSY_PROFILE": {
+        "queue5_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-3"
         },
-        "QUEUE6_UPLINK_LOSSY_PROFILE": {
+        "queue6_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
@@ -119,47 +119,47 @@
           and DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name]
           and DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type in ('LeafRouter', 'SpineRouter') %}
             "{{ port }}|0": {
-                "profile": "QUEUE0_UPLINK_LOSSY_PROFILE"
+                "profile": "queue0_uplink_lossy_profile"
             },
             "{{ port }}|1": {
-                "profile": "QUEUE1_UPLINK_LOSSY_PROFILE"
+                "profile": "queue1_uplink_lossy_profile"
             },
             "{{ port }}|2": {
-                "profile": "QUEUE2_UPLINK_LOSSY_PROFILE"
+                "profile": "queue2_uplink_lossy_profile"
             },
             "{{ port }}|3": {
-                "profile": "QUEUE3_UPLINK_LOSSY_PROFILE"
+                "profile": "queue3_uplink_lossy_profile"
             },
             "{{ port }}|4": {
-                "profile": "QUEUE4_UPLINK_LOSSY_PROFILE"
+                "profile": "queue4_uplink_lossy_profile"
             },
             "{{ port }}|5": {
-                "profile": "QUEUE5_UPLINK_LOSSY_PROFILE"
+                "profile": "queue5_uplink_lossy_profile"
             },
             "{{ port }}|6": {
-                "profile": "QUEUE6_UPLINK_LOSSY_PROFILE"
+                "profile": "queue6_uplink_lossy_profile"
             }
         {% else %}
             "{{ port }}|0": {
-                "profile": "QUEUE0_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue0_downlink_lossy_profile"
             },
             "{{ port }}|1": {
-                "profile": "QUEUE1_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue1_downlink_lossy_profile"
             },
             "{{ port }}|2": {
-                "profile": "QUEUE2_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue2_downlink_lossy_profile"
             },
             "{{ port }}|3": {
-                "profile": "QUEUE3_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue3_downlink_lossy_profile"
             },
             "{{ port }}|4": {
-                "profile": "QUEUE4_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue4_downlink_lossy_profile"
             },
             "{{ port }}|5": {
-                "profile": "QUEUE5_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue5_downlink_lossy_profile"
             },
             "{{ port }}|6": {
-                "profile": "QUEUE6_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue6_downlink_lossy_profile"
             }
         {% endif %}
     {%- if not loop.last -%},{% endif %}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t0.j2
@@ -27,72 +27,72 @@
             "pool": "egress_lossy_pool",
             "size": "1778"
         },
-        "QUEUE0_DOWNLINK_LOSSY_PROFILE": {
+        "queue0_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
         },
-        "QUEUE1_DOWNLINK_LOSSY_PROFILE": {
+        "queue1_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE2_DOWNLINK_LOSSY_PROFILE": {
+        "queue2_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE3_DOWNLINK_LOSSY_PROFILE": {
+        "queue3_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE4_DOWNLINK_LOSSY_PROFILE": {
+        "queue4_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
         },
-        "QUEUE5_DOWNLINK_LOSSY_PROFILE": {
+        "queue5_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-3"
         },
-        "QUEUE6_DOWNLINK_LOSSY_PROFILE": {
+        "queue6_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
         },
-        "QUEUE0_UPLINK_LOSSY_PROFILE": {
+        "queue0_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
         },
-        "QUEUE1_UPLINK_LOSSY_PROFILE": {
+        "queue1_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE2_UPLINK_LOSSY_PROFILE": {
+        "queue2_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE3_UPLINK_LOSSY_PROFILE": {
+        "queue3_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE4_UPLINK_LOSSY_PROFILE": {
+        "queue4_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
         },
-        "QUEUE5_UPLINK_LOSSY_PROFILE": {
+        "queue5_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-3"
         },
-        "QUEUE6_UPLINK_LOSSY_PROFILE": {
+        "queue6_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
@@ -119,47 +119,47 @@
           and DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name]
           and DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type in ('LeafRouter', 'ToRRouter') %}
             "{{ port }}|0": {
-                "profile": "QUEUE0_UPLINK_LOSSY_PROFILE"
+                "profile": "queue0_uplink_lossy_profile"
             },
             "{{ port }}|1": {
-                "profile": "QUEUE1_UPLINK_LOSSY_PROFILE"
+                "profile": "queue1_uplink_lossy_profile"
             },
             "{{ port }}|2": {
-                "profile": "QUEUE2_UPLINK_LOSSY_PROFILE"
+                "profile": "queue2_uplink_lossy_profile"
             },
             "{{ port }}|3": {
-                "profile": "QUEUE3_UPLINK_LOSSY_PROFILE"
+                "profile": "queue3_uplink_lossy_profile"
             },
             "{{ port }}|4": {
-                "profile": "QUEUE4_UPLINK_LOSSY_PROFILE"
+                "profile": "queue4_uplink_lossy_profile"
             },
             "{{ port }}|5": {
-                "profile": "QUEUE5_UPLINK_LOSSY_PROFILE"
+                "profile": "queue5_uplink_lossy_profile"
             },
             "{{ port }}|6": {
-                "profile": "QUEUE6_UPLINK_LOSSY_PROFILE"
+                "profile": "queue6_uplink_lossy_profile"
             }
         {% else %}
             "{{ port }}|0": {
-                "profile": "QUEUE0_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue0_downlink_lossy_profile"
             },
             "{{ port }}|1": {
-                "profile": "QUEUE1_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue1_downlink_lossy_profile"
             },
             "{{ port }}|2": {
-                "profile": "QUEUE2_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue2_downlink_lossy_profile"
             },
             "{{ port }}|3": {
-                "profile": "QUEUE3_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue3_downlink_lossy_profile"
             },
             "{{ port }}|4": {
-                "profile": "QUEUE4_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue4_downlink_lossy_profile"
             },
             "{{ port }}|5": {
-                "profile": "QUEUE5_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue5_downlink_lossy_profile"
             },
             "{{ port }}|6": {
-                "profile": "QUEUE6_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue6_downlink_lossy_profile"
             }
         {% endif %}
     {%- if not loop.last -%},{% endif %}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t1.j2
@@ -27,72 +27,72 @@
             "pool": "egress_lossy_pool",
             "size": "1778"
         },
-        "QUEUE0_DOWNLINK_LOSSY_PROFILE": {
+        "queue0_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
         },
-        "QUEUE1_DOWNLINK_LOSSY_PROFILE": {
+        "queue1_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE2_DOWNLINK_LOSSY_PROFILE": {
+        "queue2_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE3_DOWNLINK_LOSSY_PROFILE": {
+        "queue3_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE4_DOWNLINK_LOSSY_PROFILE": {
+        "queue4_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
         },
-        "QUEUE5_DOWNLINK_LOSSY_PROFILE": {
+        "queue5_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-3"
         },
-        "QUEUE6_DOWNLINK_LOSSY_PROFILE": {
+        "queue6_downlink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
         },
-        "QUEUE0_UPLINK_LOSSY_PROFILE": {
+        "queue0_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
         },
-        "QUEUE1_UPLINK_LOSSY_PROFILE": {
+        "queue1_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE2_UPLINK_LOSSY_PROFILE": {
+        "queue2_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE3_UPLINK_LOSSY_PROFILE": {
+        "queue3_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-7"
         },
-        "QUEUE4_UPLINK_LOSSY_PROFILE": {
+        "queue4_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
         },
-        "QUEUE5_UPLINK_LOSSY_PROFILE": {
+        "queue5_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "-3"
         },
-        "QUEUE6_UPLINK_LOSSY_PROFILE": {
+        "queue6_uplink_lossy_profile": {
             "pool": "egress_lossy_pool",
             "size": "1778",
             "dynamic_th": "0"
@@ -119,47 +119,47 @@
           and DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name]
           and DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type in ('LeafRouter', 'ToRRouter') %}
             "{{ port }}|0": {
-                "profile": "QUEUE0_UPLINK_LOSSY_PROFILE"
+                "profile": "queue0_uplink_lossy_profile"
             },
             "{{ port }}|1": {
-                "profile": "QUEUE1_UPLINK_LOSSY_PROFILE"
+                "profile": "queue1_uplink_lossy_profile"
             },
             "{{ port }}|2": {
-                "profile": "QUEUE2_UPLINK_LOSSY_PROFILE"
+                "profile": "queue2_uplink_lossy_profile"
             },
             "{{ port }}|3": {
-                "profile": "QUEUE3_UPLINK_LOSSY_PROFILE"
+                "profile": "queue3_uplink_lossy_profile"
             },
             "{{ port }}|4": {
-                "profile": "QUEUE4_UPLINK_LOSSY_PROFILE"
+                "profile": "queue4_uplink_lossy_profile"
             },
             "{{ port }}|5": {
-                "profile": "QUEUE5_UPLINK_LOSSY_PROFILE"
+                "profile": "queue5_uplink_lossy_profile"
             },
             "{{ port }}|6": {
-                "profile": "QUEUE6_UPLINK_LOSSY_PROFILE"
+                "profile": "queue6_uplink_lossy_profile"
             }
         {% else %}
             "{{ port }}|0": {
-                "profile": "QUEUE0_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue0_downlink_lossy_profile"
             },
             "{{ port }}|1": {
-                "profile": "QUEUE1_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue1_downlink_lossy_profile"
             },
             "{{ port }}|2": {
-                "profile": "QUEUE2_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue2_downlink_lossy_profile"
             },
             "{{ port }}|3": {
-                "profile": "QUEUE3_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue3_downlink_lossy_profile"
             },
             "{{ port }}|4": {
-                "profile": "QUEUE4_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue4_downlink_lossy_profile"
             },
             "{{ port }}|5": {
-                "profile": "QUEUE5_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue5_downlink_lossy_profile"
             },
             "{{ port }}|6": {
-                "profile": "QUEUE6_DOWNLINK_LOSSY_PROFILE"
+                "profile": "queue6_downlink_lossy_profile"
             }
         {% endif %}
     {%- if not loop.last -%},{% endif %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The convention for buffer profiles is that they're lower case, which some test cases expect.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

