### PR TITLE
Resolve PWD to pass to docker container

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -69,7 +69,7 @@
 SHELL = /bin/bash
 
 USER := $(shell id -un)
-PWD := $(shell pwd)
+PWD := $(shell realpath $(shell pwd))
 USER_LC := $(shell echo $(USER) | tr A-Z a-z)
 ifneq ($(DEFAULT_CONTAINER_REGISTRY),)
 DOCKER_MACHINE := $(shell docker run --rm $(DEFAULT_CONTAINER_REGISTRY)/debian:buster uname -m)


### PR DESCRIPTION
#### Why I did it

In some environments, the build location may actually be a symlink to a different filesystem, resolving the actual location may resolve build issues related to docker containers, especially if authentication using kernel keyrings is required.

An explicit example where this breakage occurs is in an enterprise environment where /home/$USER may be an automount NFS share using kerberos authentication.  The user then has symlink of /home/$USER/work -> /work/$USER
Which is a local scratch space not on the NFS share (as NFS is slow, no one should be doing builds in NFS).

In this scenario, when /home/$USER/work/sonic-buildimage is passed to docker as the volume to mount as /sonic it fails because from within the container the kernel keyring with the kerberos credentials aren't passed through and it is unable to read the symlink.

##### Work item tracking

#### How I did it

Pre-resolving the symlink before entering the container resolves the build issue.

#### How to verify it

Verify CI/CD still works.

#### Which release branch to backport (provide reason below if selected)

- [x] 202505

#### Tested branch (Please provide the tested image version)
master as of 20251028

#### Description for the changelog
Resolve PWD to pass to docker container

#### Link to config_db schema for YANG module changes
N/A

#### A picture of a cute animal (not mandatory but encouraged)
Signed-off-by: Brad House <bhouse@nexthop.ai>
