### PR TITLE
[DELL Z9264] corrections to sfp.py

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/sfp.py
@@ -41,6 +41,7 @@ class Sfp(SfpOptoeBase):
 
     def __init__(self, index, sfp_type, eeprom_path):
         SfpOptoeBase.__init__(self)
+        self.port_type = sfp_type
         self.sfp_type = sfp_type
         self.index = index
         self.eeprom_path = eeprom_path


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
I see the following errors with latest build 
root@sonic:~# journalctl -xeu determine-reboot-cause.service
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:   File "/usr/local/bin/determine-reboot-cause", line 257, in main
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:     previous_reboot_cause, additional_reboot_info = determine_reboot_cause()
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:                                                     ^^^^^^^^^^^^^^^^^^^^^^^^
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:   File "/usr/local/bin/determine-reboot-cause", line 185, in determine_reboot_cause
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:     hardware_reboot_cause = find_hardware_reboot_cause()
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:   File "/usr/local/bin/determine-reboot-cause", line 126, in find_hardware_reboot_cause
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:     hardware_reboot_cause_major, hardware_reboot_cause_minor = get_reboot_cause_from_platform()
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:   File "/usr/local/bin/determine-reboot-cause", line 114, in get_reboot_cause_from_platform
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:     platform  = sonic_platform.platform.Platform()
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:   File "/usr/local/lib/python3.11/dist-packages/sonic_platform/platform.py", line 24, in __init__
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:     self._chassis = Chassis()
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:                     ^^^^^^^^^
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:   File "/usr/local/lib/python3.11/dist-packages/sonic_platform/chassis.py", line 59, in __init__
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:     sfp_node = Sfp(index, 'QSFP', eeprom_path)
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:   File "/usr/local/lib/python3.11/dist-packages/sonic_platform/sfp.py", line 47, in __init__
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:     self._initialize_media(delay=False)
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:   File "/usr/local/lib/python3.11/dist-packages/sonic_platform/sfp.py", line 93, in _initialize_media
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:     self.set_media_type()
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:   File "/usr/local/lib/python3.11/dist-packages/sonic_platform/sfp.py", line 271, in set_media_type
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:     self.sfp_type = self.port_type
Oct 29 21:11:18 sonic determine-reboot-cause[1125]:                     ^^^^^^^^^^^^^^
Oct 29 21:11:18 sonic determine-reboot-cause[1125]: AttributeError: 'Sfp' object has no attribute 'port_type'
Oct 29 21:11:18 sonic systemd[1]: determine-reboot-cause.service: Main process exited, code=exited, status=1/FAILURE


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added port_type to sfp class similar to other platforms of DELL

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

root@sonic:~# show version

SONiC Software Version: SONiC.master.970701-d7219965b
SONiC OS Version: 12
Distribution: Debian 12.12
Kernel: 6.1.0-29-2-amd64
Build commit: d7219965b
Build date: Tue Oct 28 13:11:40 UTC 2025
Built by: azureuser@9a2e55bec000000

Platform: x86_64-dellemc_z9264f_c3538-r0
HwSKU: DellEMC-Z9264f-C64
ASIC: broadcom
ASIC Count: 1
Serial Number: 3J98PK2
Model Number: 0WCXFV
Hardware Revision: N/A
Uptime: 11:59:05 up 15:58,  1 user,  load average: 0.94, 1.05, 1.08
Date: Fri 31 Oct 2025 11:59:05

Docker images:


<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

