### PR TITLE
Patch PTF gnxi for telemetry tests failures in mgmt IPv6 only setups

### DIFF
--- a/dockers/docker-ptf/gnxi-patches/0008-Fix-ipv6-addr-port-format-for-grpc.patch
+++ b/dockers/docker-ptf/gnxi-patches/0008-Fix-ipv6-addr-port-format-for-grpc.patch
@@ -1,0 +1,24 @@
+From a3b6293c8f9f5e0368a174711c981e9992a315d8 Mon Sep 17 00:00:00 2001
+From: markxiao <markxiao@arista.com>
+Date: Thu, 30 Oct 2025 13:54:47 -0700
+Subject: [PATCH] Fix IPv6 addr + port format for grpc
+
+---
+ gnmi_cli_py/py_gnmicli.py | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/gnmi_cli_py/py_gnmicli.py b/gnmi_cli_py/py_gnmicli.py
+index a17e8c3..b7d1165 100644
+--- a/gnmi_cli_py/py_gnmicli.py
++++ b/gnmi_cli_py/py_gnmicli.py
+@@ -290,6 +290,10 @@ def _create_stub(creds, target, port, host_override):
+   Returns:
+     a gnmi_pb2_grpc object representing a gNMI Stub.
+   """
++  # Handle IPv6 addr + port by wrapping addr in brackets
++  if ':' in target:
++    target = '[' + target + ']'
++
+   if creds:
+     if host_override:
+       channel = gnmi_pb2_grpc.grpc.secure_channel(target + ':' + port, creds, ((

--- a/dockers/docker-ptf/gnxi-patches/series
+++ b/dockers/docker-ptf/gnxi-patches/series
@@ -5,3 +5,4 @@
 0005-Enhance-gnmi_cli_py-4.patch
 0006-Add-support-for-extensive-configurations.patch
 0007-Fix-py_gnmicli.py-POLL-mode.patch
+0008-Fix-ipv6-addr-port-format-for-grpc.patch


### PR DESCRIPTION
py_gnmicli.py from gnxi library in PTF container doesn't handle IPv6 + port properly e.g. [addr]:port when passing it to grpc functions.

Fixes: https://github.com/sonic-net/sonic-buildimage/issues/24400

#### Why I did it

Telemetry tests failed for mgmt IPv6 only setups

#### How I did it

Patch gnxi library for PTF container, add square brackets to IPv6 address before combining with port.

#### How to verify it

Telemetry tests should pass.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

- [x] 202505

#### Description for the changelog

Fix IPv6 addr + port format for grpc.