### PR TITLE
Issue 24405: [ztp] Support ZTP on eth0 over v6-only network

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -42,7 +42,7 @@ iface eth0 inet dhcp
 {% endif %}
 {% if ZTP['mode']['ipv6'] == 'true' %}
 iface eth0 inet6 dhcp
-    up sysctl net.ipv6.conf.eth0.accept_ra=1
+    up sysctl net.ipv6.conf.eth0.accept_ra=2
     down sysctl net.ipv6.conf.eth0.accept_ra=0
 {% endif %}
 

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_inband_ip
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_inband_ip
@@ -20,7 +20,7 @@ auto eth0
 allow-hotplug eth0
 iface eth0 inet dhcp
 iface eth0 inet6 dhcp
-    up sysctl net.ipv6.conf.eth0.accept_ra=1
+    up sysctl net.ipv6.conf.eth0.accept_ra=2
     down sysctl net.ipv6.conf.eth0.accept_ra=0
 
 

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_ip
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_nomgmt_ztp_ip
@@ -20,7 +20,7 @@ auto eth0
 allow-hotplug eth0
 iface eth0 inet dhcp
 iface eth0 inet6 dhcp
-    up sysctl net.ipv6.conf.eth0.accept_ra=1
+    up sysctl net.ipv6.conf.eth0.accept_ra=2
     down sysctl net.ipv6.conf.eth0.accept_ra=0
 
 

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_inband_ip
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_inband_ip
@@ -20,7 +20,7 @@ auto eth0
 allow-hotplug eth0
 iface eth0 inet dhcp
 iface eth0 inet6 dhcp
-    up sysctl net.ipv6.conf.eth0.accept_ra=1
+    up sysctl net.ipv6.conf.eth0.accept_ra=2
     down sysctl net.ipv6.conf.eth0.accept_ra=0
 
 

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_ip
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_nomgmt_ztp_ip
@@ -20,7 +20,7 @@ auto eth0
 allow-hotplug eth0
 iface eth0 inet dhcp
 iface eth0 inet6 dhcp
-    up sysctl net.ipv6.conf.eth0.accept_ra=1
+    up sysctl net.ipv6.conf.eth0.accept_ra=2
     down sysctl net.ipv6.conf.eth0.accept_ra=0
 
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

ZTP needs to use Router Advertisements to detect DHCP default routes in V6 networks.

Closes #24405 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Modify the interfaces.j2 template to support ZTP over v6 by using RA messages. This is done by setting accept_ra to 2, which allows the interface to accept RA messages.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Device is configurable using ZTP over ipv6 on eth0.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

ZTP needs to use Router Advertisements to detect DHCP default routes in V6 networks.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

