### PR TITLE
[PINS] P4RT docker improvements

### DIFF
--- a/dockers/docker-sonic-p4rt/p4rt.sh
+++ b/dockers/docker-sonic-p4rt/p4rt.sh
@@ -89,6 +89,10 @@ fi
 # Try to read P4RT unix socket config from ConfigDB.
 readonly UNIX_SOCKET=$(echo ${P4RT} | jq -r '.p4rt_unix_socket // empty')
 if [ ! -z "${UNIX_SOCKET}" ]; then
+    SOCK_DIR="$(dirname "$UNIX_SOCKET")"
+    if [ ! -d "$SOCK_DIR" ]; then
+        mkdir -p "$SOCK_DIR"
+    fi
     P4RT_ARGS+=" --p4rt_unix_socket=${UNIX_SOCKET}"
 fi
 

--- a/rules/docker-p4rt.mk
+++ b/rules/docker-p4rt.mk
@@ -31,7 +31,7 @@ endif
 
 $(DOCKER_P4RT)_CONTAINER_NAME = p4rt
 $(DOCKER_P4RT)_RUN_OPT += -t
-$(DOCKER_P4RT)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
+$(DOCKER_P4RT)_RUN_OPT += -v /etc/sonic:/etc/sonic:rw
 $(DOCKER_P4RT)_RUN_OPT += -v /etc/localtime:/etc/localtime:ro 
 $(DOCKER_P4RT)_GIT_COMMIT = $(shell cd "$($(SONIC_P4RT)_SRC_PATH)" && git log -n 1 --format=format:"%H %s" || echo "Unable to fetch git log for p4rt")
 


### PR DESCRIPTION
#### Why I did it

Two minor fixes for P4RT docker

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
1. The /sock/p4rt.sock is used for communication with the p4rt socket. Creating this fails at the moment because /sock is not present. In docker-p4rt, if a socket is defined in the configuration, create its home directory.
2. /etc/sonic has to be read/write as the docker-p4rt uses it for saving p4rt config and other things.

 ~/bin/keyword_check.sh ../../p4rt.diff 
Keyword check Passed.


#### How to verify it

P4RT docker used to fail during creation because the /sock was not present. After this fix, p4rt comes up.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
P4RT docker related changes to create the directory for p4rt sock and load /etc/sonic into the P4RT docker as read/write


<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

