### PR TITLE
[202411] Add platform_wait symlinks for SimX platforms

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700_simx-r0/platform_wait
+++ b/device/mellanox/x86_64-mlnx_msn2700_simx-r0/platform_wait
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn2700-r0/platform_wait

--- a/device/mellanox/x86_64-mlnx_msn3700_simx-r0/platform_wait
+++ b/device/mellanox/x86_64-mlnx_msn3700_simx-r0/platform_wait
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn2700-r0/platform_wait

--- a/device/mellanox/x86_64-mlnx_msn4700_simx-r0/platform_wait
+++ b/device/mellanox/x86_64-mlnx_msn4700_simx-r0/platform_wait
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn2700-r0/platform_wait

--- a/device/mellanox/x86_64-nvidia_sn4280_simx-r0/platform_wait
+++ b/device/mellanox/x86_64-nvidia_sn4280_simx-r0/platform_wait
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn2700-r0/platform_wait

--- a/device/mellanox/x86_64-nvidia_sn4800_simx-r0/platform_wait
+++ b/device/mellanox/x86_64-nvidia_sn4800_simx-r0/platform_wait
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn2700-r0/platform_wait

--- a/device/mellanox/x86_64-nvidia_sn5400_simx-r0/platform_wait
+++ b/device/mellanox/x86_64-nvidia_sn5400_simx-r0/platform_wait
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn2700-r0/platform_wait

--- a/device/mellanox/x86_64-nvidia_sn5600_simx-r0/platform_wait
+++ b/device/mellanox/x86_64-nvidia_sn5600_simx-r0/platform_wait
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn2700-r0/platform_wait

--- a/device/mellanox/x86_64-nvidia_sn5640_simx-r0/platform_wait
+++ b/device/mellanox/x86_64-nvidia_sn5640_simx-r0/platform_wait
@@ -1,0 +1,1 @@
+../x86_64-mlnx_msn2700-r0/platform_wait


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add platform_wait for simx, so thermal_updater will check and wait until sysfs ready. If no such file, and read sysfs directly, will report error as:
ERR pmon#thermalctld: Failed to read from file /sys/module/sx_core/asic0/module0/present - FileNotFoundError(2, 'No such file or directory')

#### How I did it
Add platform_wait for simx.

#### How to verify it
After apply it, no such error happen anymore.

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->
- [x] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)
202505