### PR TITLE
[build] Fix TRUSTED_GPG_URLS bug

### DIFF
--- a/rules/config
+++ b/rules/config
@@ -245,7 +245,7 @@ SECURE_UPGRADE_PROD_TOOL_ARGS ?=
 PACKAGE_URL_PREFIX ?= https://packages.trafficmanager.net/packages
 
 # TRUSTED_GPG_URLS - the trusted gpgs, separated by comma
-TRUSTED_GPG_URLS = https://packages.trafficmanager.net/debian/public_key.gpg,https://packages.microsoft.com/keys/microsoft.asc
+TRUSTED_GPG_URLS = https://packages.microsoft.com/keys/microsoft.asc
 
 # SONIC_VERSION_CONTROL_COMPONENTS - Valid values: none|all|components..., the components consist of one or multiple: deb,py2,py3,web,git,docker, seperated by comma
 #   none  : disable the version control

--- a/src/sonic-build-hooks/Makefile
+++ b/src/sonic-build-hooks/Makefile
@@ -32,7 +32,7 @@ $(SONIC_BUILD_HOOKS_TARGET): $(DEPENDS)
 	@cp debian/* $(DEBIAN_DIR)/
 	@cp scripts/* $(SCRIPTS_PATH)/
 	@cp hooks/* $(HOOKS_PATH)/
-	@for url in $$(echo $(TRUSTED_GPG_URLS) | sed 's/[,;]/ /g'); do wget -q "$$url" -P "$(TRUSTED_GPG_PATH)/"; done
+	@set -e; for url in $$(echo $(TRUSTED_GPG_URLS) | sed 's/[,;]/ /g'); do wget -q "$$url" -P "$(TRUSTED_GPG_PATH)/"; done
 	@for f in $(SYMBOL_LINKS); do ln -s $(SYMBOL_LINKS_SRC_DIR)/$$f $(SYMBOL_LINK_PATH)/$$f; done
 	@$(BUILD_COMMAND)
 


### PR DESCRIPTION
#### Why I did it

There are two bugs in the `TRUSTED_GPG_URLS` flow:

1. The sonic-build-hooks Makefile logic that downloads the URLs in TRUSTED_GPG_URLS only reports a failure if the _last_ URL in the list fails. Any other failures are silently ignored, and build proceeds.

2. The first URL in the current default flag value, https://packages.trafficmanager.net/debian/public_key.gpg, does not exist and seems like it has been broken for quite some time. This went unnoticed because of the first issue.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

1. Added `set -e` at the beginning of the mini bash script responsible for downloading the URLs in `TRUSTED_GPG_URLS`, so fatal errors are noticed and reported.
2. Removed the broken https://packages.trafficmanager.net/debian/public_key.gpg URL from the default value

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

I've verified this fix under multiple scenarios:

1. Running `make init` with no flags

The single valid URL, https://packages.microsoft.com/keys/microsoft.asc, is downloaded successfully and build reports no errors

2. Running `make init` with `TRUSTED_GPG_URLS='https://packages.trafficmanager.net/debian/public_key.gpg,https://packages.microsoft.com/keys/microsoft.asc'`

Build fails as the first URL is broken. Note that this error was not caught in baseline code. The second URL is not downloaded.

3. Running `make init` with the same URLs in opposite order (broken URL last)

The first URL downloads. The second URL does not. The error is noticed and the build stops.

4. Running `make init` with only the working URL (no other URLs or `,` in the variable)

The key file downloads. Build reports success

5. Running `make init` with only the broken URL

The 404 error is noticed and build aborts.

6. Running `make init` with a URL that contains a non-existent domain

The connection failure is recognized and build fails.

7. Running `make init` with `TRUSTED_GPG_URLS=''`

No GPG keys are downloaded and the build proceeds

8. Performing a full build with no `TRUSTED_GPG_URLS` flag provided

Build was successful.

9. Performing a full build with `TRUSTED_GPG_URLS=''` set at each step

Build was successful.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

Needs to be backported as it's a build bug

- [x] 202505
- [x] 202411
- [x] 202405 

#### Tested branch (Please provide the tested image version)

master @ d5bb5397693621f690e859f796bb72eecafd1b64

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

[build] Fix TRUSTED_GPG_URLS bug

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
