### PR TITLE
Remove ctrmgr_tools.py for backward compatible

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -581,7 +581,7 @@ sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable ctrmgrd.service
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl disable kubelet.service
 {% else %}
 # Some scripts will check one file inside sonic_ctrmgmt_py3_wheel to detect include_kubernetes status
-rm $FILESYSTEM_ROOT/usr/local/bin/ctrmgr_tools.py
+sudo rm $FILESYSTEM_ROOT/usr/local/bin/ctrmgr_tools.py
 {% endif %}
 
 # Copy the buffer configuration template


### PR DESCRIPTION
#### Why I did it
Fixes https://github.com/sonic-net/sonic-buildimage/issues/24319

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

Verified with DUT. Run below commands to and check syslog.
```
ls /usr/local/bin/ctrmgr_tools.py
sudo fast-reboot
```

- Before this PR: script exists, syslog has "ERR ctrmgr_tools.py: Skip to tag feature=syncd image=docker-syncd-.... tag=latest"
- After this PR: script does not exist, syslog has no "ERR ctrmgr_tools.py: Skip to tag feature" pattern around fast-reboot.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

