### PR TITLE
Add build flag to skip build checks

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -587,6 +587,7 @@ SONIC_BUILD_INSTRUCTION :=  $(MAKE) \
                            LEGACY_SONIC_MGMT_DOCKER=$(LEGACY_SONIC_MGMT_DOCKER) \
                            SONIC_PTF_ENV_PY_VER=$(SONIC_PTF_ENV_PY_VER) \
 						   ENABLE_MULTIDB=$(ENABLE_MULTIDB) \
+                           SONIC_BUILD_NOCHECK=$(SONIC_BUILD_NOCHECK) \
                            $(SONIC_OVERRIDE_BUILD_VARS)
 
 .PHONY: sonic-slave-build sonic-slave-bash init reset

--- a/rules/config
+++ b/rules/config
@@ -326,3 +326,6 @@ SONIC_PTF_ENV_PY_VER = py3
 
 # Add timeout on some process which may hangs
 BUILD_PROCESS_TIMEOUT ?= 0
+
+# Add 'nocheck' to default DEB_BUILD_OPTIONS to speed up builds
+SONIC_BUILD_NOCHECK ?= n

--- a/slave.mk
+++ b/slave.mk
@@ -330,8 +330,13 @@ ifeq ($(CONFIGURED_PLATFORM),vs)
 export BUILD_MULTIASIC_KVM
 endif
 
-ifeq ($(CROSS_BUILD_ENVIRON),y)
+ifeq ($(SONIC_BUILD_NOCHECK),y)
 DEB_BUILD_OPTIONS_GENERIC += nocheck
+else ifeq ($(CROSS_BUILD_ENVIRON),y)
+DEB_BUILD_OPTIONS_GENERIC += nocheck
+endif
+
+ifeq ($(CROSS_BUILD_ENVIRON),y)
 export $(dpkg-architecture -a$(CONFIGURED_ARCH))
 ifeq ($(ENABLE_PY2_MODULES),n)
 ANT_DEB_CROSS_PROFILES=nopython2
@@ -486,6 +491,7 @@ $(info "LEGACY_SONIC_MGMT_DOCKER"        : "$(LEGACY_SONIC_MGMT_DOCKER)")
 $(info "INCLUDE_EXTERNAL_PATCHES"        : "$(INCLUDE_EXTERNAL_PATCHES)")
 $(info "PTF_ENV_PY_VER"                  : "$(PTF_ENV_PY_VER)")
 $(info "ENABLE_MULTIDB"                  : "$(ENABLE_MULTIDB)")
+$(info "SONIC_BUILD_NOCHECK"             : "$(SONIC_BUILD_NOCHECK)")
 $(info )
 else
 $(info SONiC Build System for $(CONFIGURED_PLATFORM):$(CONFIGURED_ARCH))


### PR DESCRIPTION
Part of the standard process for building a debian package is to run `make check` which usually runs some self tests of the package being built. We already know to skip this when cross compiling, add an additional SONIC_BUILD_NOCHECK that allows the `make check` step to be skipped even when building natively.

There are merits to having the checks run by default and this does not change any behaviour in that respect. It does however provide developers with an escape hatch to speed up local builds.

#### Why I did it

Local builds were slower than necessary

##### Work item tracking

#### How I did it

#### How to verify it

build normally or set `SONIC_BUILD_NOCHECK=y` on the make command line

#### Which release branch to backport (provide reason below if selected)

Not necessary to backport

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

- [x] master marvell-prestera
- [x] vs

#### Description for the changelog

Developers can specify  `SONIC_BUILD_NOCHECK=y` on the make command line to skip some self tests when building debian packages (sets `DEB_BUILD_OPTIONS=nocheck` under the hood).

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

````
               ,-.      .-,
               |-.\ __ /.-|
               \  `    `  /
                /_     _ \
              <  _`q  p _  >
              <.._=/  \=_. >
                 {`\()/`}`\
                 {      }  \
                 |{    }    \
                 \ '--'   .- \
                 |-      /    \
                 | | | | |     ;
                 | | |.;.,..__ |
               .-"";`         `|
              /    |           /
              `-../____,..---'`
````