### PR TITLE
Dockerfile.j2 slave should include optional vendor-specific file

### DIFF
--- a/sonic-slave-bookworm/Dockerfile.j2
+++ b/sonic-slave-bookworm/Dockerfile.j2
@@ -781,3 +781,8 @@ ENV PATH $PATH:$RUST_ROOT/bin
 
 # Install cargo-tarpaulin for code coverage
 RUN $RUST_ROOT/bin/cargo install --locked cargo-tarpaulin
+
+{# Include vendor-defined rules for slave container if it exists.  Contained in ../files #}
+{% with DEBIAN_VERSION='bookworm' %}
+{% include 'files/sonic-slave-Dockerfile.vendor.j2' ignore missing %}
+{% endwith %}

--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -721,3 +721,8 @@ RUN mkdir -p /.cargo && $RUST_ROOT/bin/rustup target add aarch64-unknown-linux-g
 {% endif -%}
 ENV RUSTUP_HOME $RUST_ROOT
 ENV PATH $PATH:$RUST_ROOT/bin
+
+{# Include vendor-defined rules for slave container if it exists.  Contained in ../files #}
+{% with DEBIAN_VERSION='bullseye' %}
+{% include 'files/sonic-slave-Dockerfile.vendor.j2' ignore missing %}
+{% endwith %}

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -687,3 +687,8 @@ RUN mkdir -p /.cargo && $RUST_ROOT/bin/rustup target add aarch64-unknown-linux-g
 {% endif -%}
 ENV RUSTUP_HOME $RUST_ROOT
 ENV PATH $PATH:$RUST_ROOT/bin
+
+{# Include vendor-defined rules for slave container if it exists.  Contained in ../files #}
+{% with DEBIAN_VERSION='buster' %}
+{% include 'files/sonic-slave-Dockerfile.vendor.j2' ignore missing %}
+{% endwith %}

--- a/sonic-slave-jessie/Dockerfile.j2
+++ b/sonic-slave-jessie/Dockerfile.j2
@@ -363,3 +363,8 @@ RUN python -m pip install git+https://github.com/aristanetworks/swi-tools.git@d5
 ARG bazelisk_url=https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-{{ CONFIGURED_ARCH }}
 RUN curl -fsSL -o /usr/local/bin/bazel ${bazelisk_url} && chmod 755 /usr/local/bin/bazel
 {% endif -%}
+
+{# Include vendor-defined rules for slave container if it exists.  Contained in ../files #}
+{% with DEBIAN_VERSION='jessie' %}
+{% include 'files/sonic-slave-Dockerfile.vendor.j2' ignore missing %}
+{% endwith %}

--- a/sonic-slave-stretch/Dockerfile.j2
+++ b/sonic-slave-stretch/Dockerfile.j2
@@ -437,3 +437,8 @@ LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/bin/node"
 ARG bazelisk_url=https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-{{ CONFIGURED_ARCH }}
 RUN curl -fsSL -o /usr/local/bin/bazel ${bazelisk_url} && chmod 755 /usr/local/bin/bazel
 {% endif -%}
+
+{# Include vendor-defined rules for slave container if it exists.  Contained in ../files #}
+{% with DEBIAN_VERSION='stretch' %}
+{% include 'files/sonic-slave-Dockerfile.vendor.j2' ignore missing %}
+{% endwith %}

--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -770,3 +770,8 @@ RUN mkdir -p /.cargo && $RUST_ROOT/bin/rustup target add aarch64-unknown-linux-g
 {% endif -%}
 ENV RUSTUP_HOME=$RUST_ROOT
 ENV PATH=$PATH:$RUST_ROOT/bin
+
+{# Include vendor-defined rules for slave container if it exists.  Contained in ../files #}
+{% with DEBIAN_VERSION='trixie' %}
+{% include 'files/sonic-slave-Dockerfile.vendor.j2' ignore missing %}
+{% endwith %}


### PR DESCRIPTION
#### Why I did it

There are instances where a vendor may want to add additional packages to the slave docker that aren't suitable for upstreaming such as necessary applications or packages for secureboot signing unique to the vendor environment.

This allows vendors to define their own `sonic-slave-Dockerfile.vendor.j2` file within the toplevel files folder if they want to use this feature.

Since these are things that would never be upstreamed, it eases the maintenance burden of handling merge conflicts as well as should be automatically updated when new slave containers are defined (e.g. bookworm -> trixie).

This follows the precedent where a vendor may define their own config settings in rules/config.user.

##### Work item tracking

#### How I did it

Modified the pre-existing sonic-slave-$version/Dockerfile.j2 to optionally include a vendor-specific file.

#### How to verify it

1. Observe the builds pass without the vendor file.
2. Create a files/sonic-slave-Dockerfile.vendor.j2 to install a custom dependency and observe it is available in the slave container


#### Which release branch to backport (provide reason below if selected)

N/A

#### Tested branch (Please provide the tested image version)

master as of 20251106

#### Description for the changelog

Dockerfile.j2 slave should include optional vendor-specific file

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

Signed-off-by: Brad House <bhouse@nexthop.ai>