### PR TITLE
Enhance lldpd.conf.j2 for IPv6 support

### DIFF
--- a/dockers/docker-lldp/lldpd.conf.j2
+++ b/dockers/docker-lldp/lldpd.conf.j2
@@ -5,6 +5,10 @@
 {% if mgmt_if.update({'port_name' : mgmt_name}) %} {% endif %}
 {% if mgmt_if.update({'ipv4' : mgmt_prefix|ip}) %} {% endif %}
 {% endif %}
+{% if mgmt_prefix|ipv6 and (mgmt_if.ipv4 is not defined) %}
+{% if mgmt_if.update({'port_name' : mgmt_name}) %} {% endif %}
+{% if mgmt_if.update({'ipv6' : mgmt_prefix|ip}) %} {% endif %}
+{% endif %}
 {% endfor %}
 {% endif %}
 {% if mgmt_if %}
@@ -16,7 +20,11 @@ configure ports eth0 lldp portidsubtype local {{ MGMT_PORT[mgmt_if.port_name].al
 configure ports eth0 lldp portidsubtype local {{ mgmt_if.port_name }}
 {% endif %}
 {% endif %}
+{% if mgmt_if.ipv4 %}
 configure system ip management pattern {{ mgmt_if.ipv4 }}
+{% elif mgmt_if.ipv6 %}
+configure system ip management pattern {{ mgmt_if.ipv6 }}
+{% endif %}
 {% endif %}
 configure system hostname {{ DEVICE_METADATA['localhost']['hostname'] }}
 {# pause lldpd operations until all interfaces are well configured, resume command will run in lldpmgrd #}

--- a/src/sonic-config-engine/tests/sample_output/py2/lldp_conf/lldpd-ipv6-iface.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/lldp_conf/lldpd-ipv6-iface.conf
@@ -1,2 +1,4 @@
+configure ports eth0 lldp portidsubtype local eth0
+configure system ip management pattern 2603:10e2:0:2902::8
 configure system hostname switch-t0
 pause

--- a/src/sonic-config-engine/tests/sample_output/py3/lldp_conf/lldpd-ipv6-iface.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/lldp_conf/lldpd-ipv6-iface.conf
@@ -1,2 +1,4 @@
+configure ports eth0 lldp portidsubtype local eth0
+configure system ip management pattern 2603:10e2:0:2902::8
 configure system hostname switch-t0
 pause


### PR DESCRIPTION
What I did:
Added support for parsing MGMT interface for ipv6 address also. 
With this we will first try ipv4 address as system management ip and than fallback to ipv6.
Alias will be used if any of ip address is present.

Why I did:
Without parsing ipv6 address in ipv6 only network mgmt port alias does not geta advertised.

How I verify:
Manual Verification


