### PR TITLE
[dhcprelay] Don't build flaky unit tests

### DIFF
--- a/rules/dhcprelay.mk
+++ b/rules/dhcprelay.mk
@@ -10,6 +10,7 @@ ifneq ("$(wildcard $(SRC_PATH)/dhcprelay/dhcp6relay)","")
 else
   $(SONIC_DHCPRELAY)_SRC_PATH = $(SRC_PATH)/dhcprelay
 endif
+$(SONIC_DHCPRELAY)_DEB_BUILD_OPTIONS = nocheck
 SONIC_DPKG_DEBS += $(SONIC_DHCPRELAY)
 
 SONIC_DHCPRELAY_DBG = sonic-$(SONIC_DHCPRELAY_PKG_NAME)-dbgsym_$(SONIC_DHCPRELAY_VERSION)_$(CONFIGURED_ARCH).deb


### PR DESCRIPTION
The dhcp6relay unit tests can trigger an endless loop of failures in some build environments:

  make[2]: Leaving directory '/sonic/src/dhcprelay'
     dh_auto_test
      make -j20 test
  make[2]: Entering directory '/sonic/src/dhcprelay'
  sudo ASAN_OPTIONS=detect_leaks=0 ./build-test/dhcp6relay-test --gtest_output=xml:build-test/dhcp6relay-test-test-result.xml || true
  gcovr -r ./ --html --html-details -o build-test/dhcp6relay-test-code-coverage.html
  gcovr -r ./ --xml-pretty -o build-test/dhcp6relay-test-code-coverage.xml
  AddressSanitizer:DEADLYSIGNAL
  AddressSanitizer:DEADLYSIGNAL
  ...

Technically this is an AddressSanitizer bug. It's been seen with GCC 11.4.0 and GCC 13.2.0 but other versions (and clang) may be affected. It is possible to run the unit tests on affected systems by setting the number of ASLR bits to 28 (e.g. `sudo sysctl -w vm.mmap_rnd_bits=28`) but doing so requires being able to adjust this setting in the first place and would mean the SONiC build process affects the build machine which is not desirable. The best thing sonic-build-image can do is to disable the unit tests for the dhcprelay package.

Fixes #19007

#### Why I did it

Local builds would sporadically stall and/or fill up my disk.

##### Work item tracking

#### How I did it

Set `nocheck` in the DEB_BUILD_OPTIONS for the sonic-dhcprelay package.

#### How to verify it

```
rm target/debs/bookworm/sonic-dhcp6relay_1.0.0-0_amd64.deb target/debs/bookworm/sonic-dhcp6relay-dbgsym_1.0.0-0_amd64.deb
make SONIC_BUILD_JOBS=4 NOJESSIE=1 NOSTRETCH=1 NOBUSTER=1 NOBULLSEYE=1 NOBOOKWORM=0 NOTRIXIE=1 target/debs/bookworm/sonic-dhcp6relay_1.0.0-0_amd64.deb
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

- [x] master (marvell-prestera)

#### Description for the changelog

Fix an issue where builds on some systems could hit and endless loop and eventually fill the disk with log output.

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

