### PR TITLE
Fix setting the hostname from a DHCPv6 response

### DIFF
--- a/files/dhcp/sethostname6
+++ b/files/dhcp/sethostname6
@@ -1,14 +1,14 @@
 case $reason in
     BOUND6|RENEW6|REBIND6|REBOOT)
-        current_dhcp6_fqdn=`hostname`
-        if [ "$current_dhcp6_fqdn" != "$new_dhcp6_fqdn" ] && [ -n "$new_dhcp6_fqdn" ]
+        current_fqdn_fqdn=`hostname`
+        if [ "$current_fqdn_fqdn" != "$new_fqdn_fqdn" ] && [ -n "$new_fqdn_fqdn" ]
         then
-            echo $new_dhcp6_fqdn > /etc/hostname
+            echo $new_fqdn_fqdn > /etc/hostname
             hostname -F /etc/hostname
-            sed -i "/\s$current_dhcp6_fqdn$/d" /etc/hosts
-            sed -i "/\s$new_dhcp6_fqdn$/d" /etc/hosts
-            echo "127.0.0.1 $new_dhcp6_fqdn" >> /etc/hosts
-            echo ":: $new_dhcp6_fqdn" >> /etc/hosts
+            sed -i "/\s$current_fqdn_fqdn$/d" /etc/hosts
+            sed -i "/\s$new_fqdn_fqdn$/d" /etc/hosts
+            echo "127.0.0.1 $new_fqdn_fqdn" >> /etc/hosts
+            echo ":: $new_fqdn_fqdn" >> /etc/hosts
         fi
         ;;
 esac


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The FQDN in a DHCPv6 response is sent via option 39, which is encoded to include some additional information about who can update the hostname of devices. This means that the `dhcp6_fqdn` option used here is just a string of hex-encoded bytes, not the actual hostname. The actual decoded hostname is accessible via `fqdn_fqdn`.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Update the `sethostname6` script to use `new_fqdn_fqdn` instead of `new_dhcp6_fqdn`.

#### How to verify it

Enable ZTP and get a DHCPv6 response containing hostname information (via option 39).

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

