### PR TITLE
Passing -M option to orchange to enable SAI MACSec POST

### DIFF
--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 HWSKU_DIR=/usr/share/sonic/hwsku
+PLATFORM_ENV_CONF=/usr/share/sonic/platform/platform_env.conf
 SWSS_VARS_FILE=/usr/share/sonic/templates/swss_vars.j2
 
 # Retrieve SWSS vars from sonic-cfggen
@@ -136,7 +137,8 @@ fi
 # - FIPS is enabled in SONiC (either in /proc/cmdline or /etc/fips/fips_enable); AND
 # - MACSec is enabled on platform.
 if grep -q "sonic_fips=1" /proc/cmdline || grep -q "1" /etc/fips/fips_enable ; then
-    if grep -q "macsec_enabled=1" /usr/share/sonic/platform/platform_env.conf 2>/dev/null ; then
+    [ -f $PLATFORM_ENV_CONF ] && . $PLATFORM_ENV_CONF
+    if [[ $macsec_enabled -eq 1 ]]; then
         ORCHAGENT_ARGS+=" -M"
     fi
 fi


### PR DESCRIPTION
Passing -M option to orchange to enable SAI MACSec POST when:
- FIPS is enabled in SONiC; AND
- MACSec is enabled on platform.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
 https://github.com/sonic-net/sonic-swss/pull/3836 adds `-M` option to orchagent to enable SAI MACSec POST. This PR passes the option to orchagent when:
- FIPS is enabled in SONiC; AND
- MACSec is enabled on platform.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

