### PR TITLE
test bgp peer range yang

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1885,6 +1885,20 @@
                 ],
                 "name": "BGPVac",
                 "src_address": "10.1.0.32"
+            },
+            "vnet1|BGPWithVnet": {
+                "ip_range": [
+                    "10.10.0.0/24"
+                ],
+                "name": "BGPWithVnet",
+                "src_address": "10.1.0.32"
+            },
+            "Vrf_blue|BGPWithVrf": {
+                "ip_range": [
+                    "10.11.0.0/24"
+                ],
+                "name": "BGPWithVrf",
+                "src_address": "10.1.0.32"
             }
         },
         "BGP_SENTINELS": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
@@ -190,6 +190,16 @@
     "BGP_PEERRANGE_ALL_VALID": {
         "desc": "Configure BGP peer range table."
     },
+    "BGP_PEERRANGE_VALID_VNET": {
+        "desc": "Configure BGP peer range with a valid vnet."
+    },
+    "BGP_PEERRANGE_VALID_VRF": {
+        "desc": "Configure BGP peer range with a valid vrf."
+    },
+    "BGP_PEERRANGE_INVALID_VNET_OR_VRF": {
+        "desc": "Configure BGP peer range with an invalid vnet or vrf.",
+        "eStrKey" : "InvalidValue"
+    },
     "BGP_ALLOWED_PREFIXES_ALL_VALID": {
         "desc": "Configue BGP allowed prefix list."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
@@ -1686,8 +1686,95 @@
     "BGP_PEERRANGE_ALL_VALID": {
         "sonic-bgp-peerrange:sonic-bgp-peerrange": {
             "sonic-bgp-peerrange:BGP_PEER_RANGE": {
+                "BGP_PEER_RANGE_TEMPLATE_LIST": [
+                    {
+                        "peer_range_name": "BGPSLBPassive",
+                        "name": "BGPSLBPassive",
+                        "src_address": "10.1.0.32",
+                        "peer_asn": "65200",
+                        "ip_range": [
+                            "10.255.0.0/25"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+
+    "BGP_PEERRANGE_VALID_VNET": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10000"
+                    }
+                ]
+            }
+        },
+        "sonic-bgp-peerrange:sonic-bgp-peerrange": {
+            "sonic-bgp-peerrange:BGP_PEER_RANGE": {
                 "BGP_PEER_RANGE_LIST": [
                     {
+                        "vrf_name": "Vnet1",
+                        "peer_range_name": "BGPSLBPassive",
+                        "name": "BGPSLBPassive",
+                        "src_address": "10.1.0.32",
+                        "peer_asn": "65200",
+                        "ip_range": [
+                            "10.255.0.0/25"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+
+    "BGP_PEERRANGE_VALID_VRF": {
+        "sonic-vrf:sonic-vrf":{
+            "sonic-vrf:VRF": {
+                "VRF_LIST": [
+                    {
+                        "name":"Vrf1"
+                    }
+                ]
+            }
+        },
+        "sonic-bgp-peerrange:sonic-bgp-peerrange": {
+            "sonic-bgp-peerrange:BGP_PEER_RANGE": {
+                "BGP_PEER_RANGE_LIST": [
+                    {
+                        "vrf_name": "Vrf1",
+                        "peer_range_name": "BGPSLBPassive",
+                        "name": "BGPSLBPassive",
+                        "src_address": "10.1.0.32",
+                        "peer_asn": "65200",
+                        "ip_range": [
+                            "10.255.0.0/25"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+
+    "BGP_PEERRANGE_INVALID_VNET_OR_VRF": {
+        "sonic-bgp-peerrange:sonic-bgp-peerrange": {
+            "sonic-bgp-peerrange:BGP_PEER_RANGE": {
+                "BGP_PEER_RANGE_LIST": [
+                    {
+                        "vrf_name": "Vnet1",
                         "peer_range_name": "BGPSLBPassive",
                         "name": "BGPSLBPassive",
                         "src_address": "10.1.0.32",

--- a/src/sonic-yang-models/yang-models/sonic-bgp-peerrange.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-peerrange.yang
@@ -11,6 +11,14 @@ module sonic-bgp-peerrange {
         prefix stypes;
     }
 
+    import sonic-vrf {
+        prefix vrf;
+    }
+
+    import sonic-vnet {
+        prefix svnet;
+    }
+
     organization
         "SONiC";
 
@@ -28,6 +36,52 @@ module sonic-bgp-peerrange {
     container sonic-bgp-peerrange {
         container BGP_PEER_RANGE {
             list BGP_PEER_RANGE_LIST {
+                key "vrf_name peer_range_name";
+
+                leaf vrf_name {
+                    type union {
+                        type leafref {
+                            path "/vrf:sonic-vrf/vrf:VRF/vrf:VRF_LIST/vrf:name";
+                        }
+                        type leafref {
+                            path "/svnet:sonic-vnet/svnet:VNET/svnet:VNET_LIST/svnet:name";
+                        }
+                    }
+                    description "vrf or vnet name";
+                }
+
+                leaf peer_range_name {
+                    type string;
+                    description "Peer range name";
+                }
+
+                leaf name {
+                    type string;
+                    must "(current() = current()/../peer_range_name)" {
+                        error-message "Invalid name";
+                    }
+                }
+
+                leaf src_address {
+                    type inet:ip-address;
+                    description "Source address to use for connection";
+                }
+
+                leaf peer_asn {
+                    type uint32 {
+                        range "1..4294967295";
+                    }
+                    description "Peer AS number";
+                }
+
+                leaf-list ip_range {
+                    type stypes:sonic-ip-prefix;
+                    ordered-by user;
+                    description "A range of addresses";
+                }
+            }
+
+            list BGP_PEER_RANGE_TEMPLATE_LIST {
                 key "peer_range_name";
 
                 leaf peer_range_name {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

