### PR TITLE
[Orcas T1][TH5] Setting Broadcom setting for PFCWD counter support per Broadcom CSP case 00012425451

### DIFF
--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2/th5-a7060x6-16pe-384c.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2/th5-a7060x6-16pe-384c.config.bcm
@@ -1410,8 +1410,8 @@ bcm_device:
     0:
         global:
             ftem_mem_entries: 65536
-            #enable port queue drop stats
-            sai_stats_support_mask: 0x800
+            #enable port queue drop stats + enable egress queue drop flex counter
+            sai_stats_support_mask: 0x804
             #disable vxlan tunnel stats
             sai_stats_disable_mask: 0x200
             #For PPIU Mode, Set resources for counters in global mode counters like ACL, etc

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/th5-a7060x6-64pe.config.bcm
@@ -1382,8 +1382,8 @@ bcm_device:
     0:
         global:
             ftem_mem_entries: 65536
-            #enable port queue drop stats
-            sai_stats_support_mask: 0x880
+            #enable port queue drop stats + enable egress queue drop flex counter
+            sai_stats_support_mask: 0x804
             #disable vxlan tunnel stats
             sai_stats_disable_mask: 0x200
             #For PPIU Mode, Set resources for counters in global mode counters like ACL, etc


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Setting Broadcom setting for PFCWD counter support per Broadcom CSP case 00012425451:
```
Set Bit 2 in sai_stats_support_mask. (This is to enable Egress Queue drop flex counter)
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Updated the BCM config file accordingly for all Orcas T1 HWSKUs.

#### How to verify it

Confirmed the failed test `pfcwd/test_pfcwd_cli.py` now can pass with this new setting and the patch provided by Broadcom, which merged to SAI 13.2.1.23. 

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202505

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

