### PR TITLE
Enhance Rust supervisor-proc-exit-listener-rs script to handle redis-communication failure case gracefully

### DIFF
--- a/src/sonic-supervisord-utilities-rs/src/proc_exit_listener.rs
+++ b/src/sonic-supervisord-utilities-rs/src/proc_exit_listener.rs
@@ -332,11 +332,8 @@ pub fn main_with_parsed_args_and_stdin<S: Read + AsRawFd, P: Poller>(args: Args,
 
         let mut stdin_ready = false;
         for event in events.iter() {
-            match event.token() {
-                STDIN_TOKEN => {
-                    stdin_ready = true;
-                }
-                _ => unreachable!(),
+            if event.token() == STDIN_TOKEN {
+                stdin_ready = true;
             }
         }
 

--- a/src/sonic-supervisord-utilities-rs/src/proc_exit_listener.rs
+++ b/src/sonic-supervisord-utilities-rs/src/proc_exit_listener.rs
@@ -12,7 +12,7 @@ use std::fs::File;
 use std::io::{self, BufRead, BufReader, Read};
 use std::os::unix::io::AsRawFd;
 use std::process;
-use std::sync::{Mutex, OnceLock};
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 use swss_common::{ConfigDBConnector, EventPublisher};
 use syslog::Severity;
@@ -34,9 +34,6 @@ pub const ALERTING_INTERVAL_SECS: u64 = 60;
 const EVENTS_PUBLISHER_SOURCE: &str = "sonic-events-host";
 const EVENTS_PUBLISHER_TAG: &str = "process-exited-unexpectedly";
 
-// Global state variables
-static HEARTBEAT_ALERT_INTERVAL_INITIALIZED: OnceLock<bool> = OnceLock::new();
-static HEARTBEAT_ALERT_INTERVAL_MAPPING: OnceLock<Mutex<HashMap<String, f64>>> = OnceLock::new();
 
 #[derive(Error, Debug)]
 pub enum SupervisorError {
@@ -212,48 +209,32 @@ pub fn get_autorestart_state(container_name: &str, config_db: &dyn ConfigDBTrait
 }
 
 /// Load heartbeat alert intervals from ConfigDB
-pub fn load_heartbeat_alert_interval(config_db: &dyn ConfigDBTrait) -> Result<()> {
+pub fn load_heartbeat_alert_interval(config_db: &dyn ConfigDBTrait) -> HashMap<String, f64> {
+    let mut mapping = HashMap::new();
 
-    let heartbeat_table = config_db.get_table(HEARTBEAT_TABLE_NAME)
-        .map_err(|e| SupervisorError::Database(format!("Failed to get HEARTBEAT table: {}", e)))?;
+    let heartbeat_table = match config_db.get_table(HEARTBEAT_TABLE_NAME) {
+        Ok(table) => table,
+        Err(e) => {
+            warn!("Failed to get HEARTBEAT table: {}", e);
+            return mapping;
+        }
+    };
 
-    if !heartbeat_table.is_empty() {
-        let mapping = HEARTBEAT_ALERT_INTERVAL_MAPPING.get_or_init(|| Mutex::new(HashMap::new()));
-        let mut mapping = mapping.lock().unwrap();
-        
-        for (process, config) in heartbeat_table {
-            if let Some(alert_interval_str) = config.get("alert_interval") {
-                if let Ok(alert_interval_ms) = alert_interval_str.parse::<i64>() {
-                    // Convert from milliseconds to seconds
-                    mapping.insert(process, alert_interval_ms as f64 / 1000.0);
-                }
+    for (process, config) in heartbeat_table {
+        if let Some(alert_interval_str) = config.get("alert_interval") {
+            if let Ok(alert_interval_ms) = alert_interval_str.parse::<i64>() {
+                // Convert from milliseconds to seconds
+                mapping.insert(process, alert_interval_ms as f64 / 1000.0);
             }
         }
     }
 
-    HEARTBEAT_ALERT_INTERVAL_INITIALIZED.set(true).map_err(|_| {
-        SupervisorError::System("Failed to set heartbeat initialized flag".to_string())
-    })?;
-
-    Ok(())
+    mapping
 }
 
 /// Get heartbeat alert interval for process
-pub fn get_heartbeat_alert_interval(process: &str, config_db: &dyn ConfigDBTrait) -> f64 {
-    if HEARTBEAT_ALERT_INTERVAL_INITIALIZED.get().is_none() {
-        if let Err(e) = load_heartbeat_alert_interval(config_db) {
-            warn!("Failed to load heartbeat alert intervals: {}", e);
-        }
-    }
-
-    let mapping = HEARTBEAT_ALERT_INTERVAL_MAPPING.get_or_init(|| Mutex::new(HashMap::new()));
-    if let Ok(mapping) = mapping.lock() {
-        if let Some(&interval) = mapping.get(process) {
-            return interval;
-        }
-    }
-
-    ALERTING_INTERVAL_SECS as f64
+pub fn get_heartbeat_alert_interval(process: &str, heartbeat_intervals: &HashMap<String, f64>) -> f64 {
+    heartbeat_intervals.get(process).copied().unwrap_or(ALERTING_INTERVAL_SECS as f64)
 }
 
 /// Publish events
@@ -319,6 +300,9 @@ pub fn main_with_parsed_args_and_stdin<S: Read + AsRawFd, P: Poller>(args: Args,
     // Process state tracking
     let mut process_under_alerting: HashMap<String, HashMap<String, f64>> = HashMap::new();
     let mut process_heart_beat_info: HashMap<String, HashMap<String, f64>> = HashMap::new();
+
+    // Load heartbeat alert intervals once at startup
+    let heartbeat_intervals = load_heartbeat_alert_interval(config_db);
 
     // Initialize events publisher
     let mut events_handle = EventPublisher::new(EVENTS_PUBLISHER_SOURCE)
@@ -506,7 +490,7 @@ pub fn main_with_parsed_args_and_stdin<S: Read + AsRawFd, P: Poller>(args: Args,
         for (process, process_info) in process_heart_beat_info.iter() {
             if let Some(&last_heart_beat) = process_info.get("last_heart_beat") {
                 let elapsed_secs = current_time - last_heart_beat;
-                let threshold = get_heartbeat_alert_interval(process, config_db);
+                let threshold = get_heartbeat_alert_interval(process, &heartbeat_intervals);
                 if threshold > 0.0 && elapsed_secs >= threshold {
                     let elapsed_mins = (elapsed_secs / 60.0) as u64;
                     generate_alerting_message(process, "stuck", elapsed_mins, Severity::LOG_WARNING);

--- a/src/sonic-supervisord-utilities-rs/src/proc_exit_listener.rs
+++ b/src/sonic-supervisord-utilities-rs/src/proc_exit_listener.rs
@@ -334,6 +334,8 @@ pub fn main_with_parsed_args_and_stdin<S: Read + AsRawFd, P: Poller>(args: Args,
         for event in events.iter() {
             if event.token() == STDIN_TOKEN {
                 stdin_ready = true;
+            } else {
+                error!("Unexpected event token: {:?}, this may indicate invalid logic", event.token());
             }
         }
 

--- a/src/sonic-supervisord-utilities-rs/tests/integration_tests.rs
+++ b/src/sonic-supervisord-utilities-rs/tests/integration_tests.rs
@@ -90,19 +90,17 @@ fn test_heartbeat_alert_interval_functions() {
     // Test loading heartbeat alert intervals (would normally load from ConfigDB)
     // This is a basic test since we can't easily mock ConfigDB
     let config_db = create_test_config_db();
-    let _result = load_heartbeat_alert_interval(&config_db);
-    // This might fail if ConfigDB is not available, which is expected in test environment
+    let heartbeat_intervals = load_heartbeat_alert_interval(&config_db);
+    // This might return empty map if ConfigDB is not available, which is expected in test environment
     
     // Test getting default interval for unknown process
-    let config_db = create_test_config_db();
-    let default_interval = get_heartbeat_alert_interval("unknown_process", &config_db);
+    let default_interval = get_heartbeat_alert_interval("unknown_process", &heartbeat_intervals);
     assert_eq!(default_interval, ALERTING_INTERVAL_SECS as f64);
     
     // Test that the function doesn't panic with various inputs
-    let config_db = create_test_config_db();
-    let _ = get_heartbeat_alert_interval("orchagent", &config_db);
-    let _ = get_heartbeat_alert_interval("", &config_db);
-    let _ = get_heartbeat_alert_interval("very_long_process_name_that_should_not_exist", &config_db);
+    let _ = get_heartbeat_alert_interval("orchagent", &heartbeat_intervals);
+    let _ = get_heartbeat_alert_interval("", &heartbeat_intervals);
+    let _ = get_heartbeat_alert_interval("very_long_process_name_that_should_not_exist", &heartbeat_intervals);
 }
 
 #[test]
@@ -238,10 +236,11 @@ fn test_time_functions() {
     
     // Test heartbeat interval retrieval
     let config_db = create_test_config_db();
-    let interval1 = get_heartbeat_alert_interval("test_process", &config_db);
+    let heartbeat_intervals = load_heartbeat_alert_interval(&config_db);
+    let interval1 = get_heartbeat_alert_interval("test_process", &heartbeat_intervals);
     assert!(interval1 > 0.0);
     
-    let interval2 = get_heartbeat_alert_interval("another_process", &config_db);
+    let interval2 = get_heartbeat_alert_interval("another_process", &heartbeat_intervals);
     assert!(interval2 > 0.0);
     
     // Both should return the default since there's no ConfigDB in test
@@ -268,10 +267,11 @@ fn test_edge_cases_and_boundary_conditions() {
     
     // Test heartbeat interval edge cases
     let config_db = create_test_config_db();
-    let zero_interval = get_heartbeat_alert_interval("", &config_db);
+    let heartbeat_intervals = load_heartbeat_alert_interval(&config_db);
+    let zero_interval = get_heartbeat_alert_interval("", &heartbeat_intervals);
     assert_eq!(zero_interval, ALERTING_INTERVAL_SECS as f64);
     
-    let default_interval = get_heartbeat_alert_interval("nonexistent", &config_db);
+    let default_interval = get_heartbeat_alert_interval("nonexistent", &heartbeat_intervals);
     assert_eq!(default_interval, ALERTING_INTERVAL_SECS as f64);
 }
 
@@ -297,10 +297,11 @@ fn test_function_robustness() {
     
     // Test heartbeat interval function with various inputs
     let config_db = create_test_config_db();
-    let _ = get_heartbeat_alert_interval("test1", &config_db);
-    let _ = get_heartbeat_alert_interval("test2", &config_db);
-    let _ = get_heartbeat_alert_interval("", &config_db);
-    let _ = get_heartbeat_alert_interval("very_long_name", &config_db);
+    let heartbeat_intervals = load_heartbeat_alert_interval(&config_db);
+    let _ = get_heartbeat_alert_interval("test1", &heartbeat_intervals);
+    let _ = get_heartbeat_alert_interval("test2", &heartbeat_intervals);
+    let _ = get_heartbeat_alert_interval("", &heartbeat_intervals);
+    let _ = get_heartbeat_alert_interval("very_long_name", &heartbeat_intervals);
 }
 
 #[test]


### PR DESCRIPTION
#### Why I did it
Enhance Rust supervisor-proc-exit-listener-rs script to handle redis-communication failure case gracefully similar to python version changes: #24393

Remove risky unwrap().

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

