### PR TITLE
Remove unwrap() in sonic-ctrmgrd-rs

### DIFF
--- a/src/sonic-ctrmgrd-rs/crates/docker-rs/src/container.rs
+++ b/src/sonic-ctrmgrd-rs/crates/docker-rs/src/container.rs
@@ -16,6 +16,8 @@ pub enum Error {
     IO(#[from] std::io::Error),
     #[error("UTF-8 parsing error")]
     UTF8(#[from] std::str::Utf8Error),
+    #[error("Syslog initialization error: {0}")]
+    Syslog(String),
 }
 
 impl<'a> Container<'a> {

--- a/src/sonic-ctrmgrd-rs/crates/docker-wait-any-rs/src/lib.rs
+++ b/src/sonic-ctrmgrd-rs/crates/docker-wait-any-rs/src/lib.rs
@@ -19,6 +19,8 @@ pub enum Error {
     Join(#[from] tokio::task::JoinError),
     #[error("Device info error")]
     DeviceInfo(#[from] sonic_rs_common::device_info::DeviceInfoError),
+    #[error("Syslog initialization error: {0}")]
+    Syslog(String),
 }
 
 pub trait DockerApi: Send + Sync {

--- a/src/sonic-ctrmgrd-rs/crates/docker-wait-any-rs/src/main.rs
+++ b/src/sonic-ctrmgrd-rs/crates/docker-wait-any-rs/src/main.rs
@@ -33,12 +33,13 @@ struct Cli {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    let identity = CString::new("docker-wait-any-rs").unwrap();
+    let identity = CString::new("docker-wait-any-rs")
+        .map_err(|e| Error::Syslog(format!("invalid identity string: {}", e)))?;
     let syslog = syslog_tracing::Syslog::new(
         identity,
         syslog_tracing::Options::LOG_PID,
         syslog_tracing::Facility::Daemon
-    ).unwrap();
+    ).ok_or_else(|| Error::Syslog("failed to initialize syslog".to_string()))?;
     tracing_subscriber::fmt()
         .with_writer(syslog)
         .with_ansi(false)


### PR DESCRIPTION
#### Why I did it
unwrap() function may crash in runtime.

For constant value which is safe, we use expect() instead of unwrap(), so any future programming mistake on changing the constant value could get better crash message. Current value will not trigger crash.

Handle initialization errors gracefully

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

