### PR TITLE
frr development workflow improvement for sonic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,9 @@ src/**/debian/build/
 src/**/debian/files
 src/**/debian/stamp-autotools-files
 
+# checksum file to detect sonic-frr patch-set changes
+src/sonic-frr/.sonic-frr-patch-*.sha1
+
 # .o files
 src/**/*.o
 

--- a/src/sonic-frr/Makefile
+++ b/src/sonic-frr/Makefile
@@ -4,42 +4,60 @@ SHELL = /bin/bash
 
 MAIN_TARGET = $(FRR)
 DERIVED_TARGET = $(FRR_PYTHONTOOLS) $(FRR_DBG) $(FRR_SNMP) $(FRR_SNMP_DBG)
-SUFFIX = $(shell date +%Y%m%d\.%H%M%S)
-STG_BRANCH = stg_temp.$(SUFFIX)
+STG_PATCHED_BRANCH = $(FRR_TAG)-patched
+PATCHSET_SHA_FILE = ../.sonic-frr-patch-$(STG_PATCHED_BRANCH).sha1
 DPLANE_FPM_SONIC_MODULE = dplane_fpm_sonic/dplane_fpm_sonic.c
 
 # DEBEMAIL required by gpb dch
 export DEBEMAIL := sonicproject@googlegroups.com
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
-	# Build the package
+
+	# Prepare source tree.
+
 	pushd ./frr
-	git fetch origin tag $(FRR_TAG)
-	# Create a branch out of tag as stg needs a branch.
-	# Prefix branch name with "build-" to avoid conflicts with tag name
-	git checkout -B build-$(FRR_TAG) refs/tags/$(FRR_TAG)
+
+	# Rebuild the patched branch only when it is missing or patch inputs changed.
+	current_patch_hash=$$(cat ../patch/series ../patch/*.patch 2>/dev/null | sha1sum | awk '{print $$1}')
+	recorded_patch_hash="$$(cat $(PATCHSET_SHA_FILE) 2>/dev/null || true)"
+	patched_branch_exists=no
+	if git rev-parse --verify --quiet "refs/heads/$(STG_PATCHED_BRANCH)" >/dev/null; then
+		patched_branch_exists=yes
+	fi
+	if [[ "$$patched_branch_exists" == "no" || "$$current_patch_hash" != "$$recorded_patch_hash" ]]; then
+		git fetch origin tag $(FRR_TAG)
+		# Create a branch out of tag as stg needs a branch.
+		# Prefix branch name with "build-" to avoid conflicts with tag name.
+		git checkout -B build-$(FRR_TAG) refs/tags/$(FRR_TAG)
 ifeq ($(CROSS_BUILD_ENVIRON), y)
-	git reset --hard
+		git reset --hard
 endif
-	stg branch --create $(STG_BRANCH) build-$(FRR_TAG)
-	stg import -s ../patch/series
-	gbp dch --ignore-branch --new-version=$(FRR_VERSION)-sonic-$(FRR_SUBVERSION) --dch-opt="--force-bad-version" --commit --git-author
+		if [[ "$$patched_branch_exists" == "yes" ]]; then
+			stg branch --delete --force $(STG_PATCHED_BRANCH)
+		fi
+		stg branch --create $(STG_PATCHED_BRANCH) build-$(FRR_TAG)
+		stg import -s ../patch/series
+		gbp dch --ignore-branch --new-version=$(FRR_VERSION)-sonic-$(FRR_SUBVERSION) --dch-opt="--force-bad-version" --commit --git-author
+		echo "$$current_patch_hash" > $(PATCHSET_SHA_FILE)
+	else
+		# Reuse existing patched branch.
+		git checkout $(STG_PATCHED_BRANCH)
+	fi
+
+	# Copy the sonic dplane module source file.
 	cp ../$(DPLANE_FPM_SONIC_MODULE) zebra/
+
+	# Clean artifacts in frr/debian directory from previous run.
+	fakeroot debian/rules clean
+
+	# Build the package.
 
 ifeq ($(CROSS_BUILD_ENVIRON), y)
 	CFLAGS="-I $$CROSS_PERL_CORE_PATH" dpkg-buildpackage -rfakeroot -b -d -us -uc -Ppkg.frr.nortrlib -a$(CONFIGURED_ARCH) -Pcross,nocheck -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)
 else
 	dpkg-buildpackage -rfakeroot -b -us -uc -Ppkg.frr.nortrlib -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)
 endif
-	stg undo || true
-	git clean -xfdf
-	git checkout build-$(FRR_TAG)
-	stg branch --delete --force $(STG_BRANCH)
-	git checkout refs/tags/$(FRR_TAG)
-	git branch -D build-$(FRR_TAG)
-ifeq ($(CROSS_BUILD_ENVIRON), y)
-	git reset --hard
-endif
+
 	popd
 	mv $(DERIVED_TARGET) $* $(DEST)/
 


### PR DESCRIPTION
#### Why I Did It

The standard build system is inconvenient for developers because:
- Source code hard to browse because it is unpatched after every build.
- Local changes in `src/sonic-frr/frr` are wiped out on each build.

#### How I Did It

Modified `src/sonic-frr/Makefile` to automatically:
- Apply SONiC patches once on the first build.
- Preserve the patched source tree across all subsequent builds.
- Clean only Debian build artifacts between runs (not source edits).
- Auto-detect first-time vs incremental builds.
- Auto-detect changes in sonic frr patches. 

#### How to Verify It

**First build** (creates patched branch `$(FRR_BRANCH)-$(FRR_TAG)-patched`):
```bash
make target/debs/bookworm/frr_10.3-sonic-0_amd64.deb
```

**Edit source code:**
```bash
cd src/sonic-frr/frr
vim zebra/main.c
```

**Rebuild** (preserves your changes):
```bash
make target/debs/bookworm/frr_10.3-sonic-0_amd64.deb
```

#### How It Works

**When building for the first time, or when patch inputs changed:**
The system computes a fingerprint of the patch files.
If no patched branch exists, or the fingerprint differs from the previously recorded one, 
the patched branch `$(FRR_BRANCH)-$(FRR_TAG)-patched` is rebuilt from a clean FRR base.
SONiC patches are reapplied and package metadata is refreshed.
The new fingerprint is saved in a hidden file for future builds.

**When building again with unchanged patch inputs:**
The current fingerprint matches the saved one.
The existing patched branch is reused as-is.


#### Key changes from previous revision:

The build now uses a patchset fingerprint to decide whether the patched FRR branch can be reused.

#### Compatibility

- ✅ Works with bookworm, bullseye, and buster.
- ✅ Compatible with cross-compilation (`CROSS_BUILD_ENVIRON=y`).
- ✅ Output packages are identical to original builds.
- ✅ Applies only to `sonic-frr`, doesn't affect other submodules.

#### Tested Branch

- [x] 202505

#### Description for the Changelog

Preserve sonic-frr source tree across builds for developer workflow.