### PR TITLE
Adding the `ttl_mode` attribute for VxLANs

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -2837,7 +2837,8 @@ Single tunnel example:
     "VXLAN_TUNNEL": {
         "vtep1": {
             "src_ip": "10.10.10.10",
-            "dst_ip": "12.12.12.12"
+            "dst_ip": "12.12.12.12",
+            "ttl_mode": "pipe"
         }
     },
     "VXLAN_TUNNEL_MAP": {
@@ -2864,7 +2865,8 @@ Dual tunnel example:
     "VXLAN_TUNNEL": {
         "vtep1": {
             "src_ip": "10.10.10.10",
-            "dst_ip": "12.12.12.12"
+            "dst_ip": "12.12.12.12",
+            "ttl_mode": "uniform"
         },
         "vtep2": {
             "src_ip": "10.20.10.10",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vxlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vxlan.json
@@ -41,5 +41,12 @@
     },
     "VXLAN_TUNNEL_NAME_STRING_VALID_TEST": {
         "desc": "Tunnel name as arbitrary string is valid"
+    },
+    "VXLAN_TUNNEL_VALID_TTL_MODE_TEST": {
+        "desc": "Valid config with 'pipe' and 'uniform' TTL modes"
+    },
+    "VXLAN_TUNNEL_INVALID_TTL_MODE_TEST": {
+        "desc": "Invalid config with an unsupported TTL mode",
+        "eStrKey": "Pattern"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vxlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vxlan.json
@@ -351,5 +351,36 @@
                 ]
             }
         }
+    },
+    "VXLAN_TUNNEL_VALID_TTL_MODE_TEST": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "tunnel_v4-1",
+                        "src_ip": "5.6.7.8",
+                        "ttl_mode": "pipe"
+                    },
+                    {
+                        "name": "tunnel_v4-2",
+                        "src_ip": "1.2.3.4",
+                        "ttl_mode": "uniform"
+                    }
+                ]
+            }
+        }
+    },
+    "VXLAN_TUNNEL_INVALID_TTL_MODE_TEST": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "invalid_tunnel",
+                        "src_ip": "1.2.3.4",
+                        "ttl_mode": "invalid"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-vxlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vxlan.yang
@@ -59,6 +59,13 @@ module sonic-vxlan {
                 leaf dst_ip {
                     type inet:ip-address;
                 }
+
+                leaf ttl_mode {
+                    description "Decap TTL mode";
+                    type string {
+                        pattern "uniform|pipe";
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To allow specifying the decap TTL mode used for each VxLAN tunnel.

##### Work item tracking
- Microsoft ADO **(number only)**: 35743756

#### How I did it
Added the new attribtue `ttl_mode` for each VxLAN, which can be set to `uniform` or `pipe`.
sonic-swss PR: https://github.com/sonic-net/sonic-swss/pull/3963

#### How to verify it
Run the tests modified in this PR, or build an image with these changes and see if this attribute can be set without any errors.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)
Tested on the latest master image.
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [master] <!-- image version 1 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Adding the `ttl_mode` attribute for VxLANs.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#vxlan

