### PR TITLE
[Mellanox] Add SAI API headers versions to get_component_versions

### DIFF
--- a/platform/mellanox/component-versions/create_component_versions.sh
+++ b/platform/mellanox/component-versions/create_component_versions.sh
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +19,21 @@
 echo "SDK $1" > temp_versions_file
 echo $2 | sed -r 's/([0-9]*)\.([0-9]*)\.([0-9]*)/FW \2\.\3/g' >> temp_versions_file
 echo "SAI $3" >> temp_versions_file
+
+SAI_API_VERSION_PATH="../../../src/sonic-sairedis/SAI/inc/saiversion.h"
+if [ -f "$SAI_API_VERSION_PATH" ]; then
+    SAI_MAJOR=$(grep "SAI_MAJOR" "$SAI_API_VERSION_PATH" | grep -oE "[0-9]+")
+    SAI_MINOR=$(grep "SAI_MINOR" "$SAI_API_VERSION_PATH" | grep -oE "[0-9]+")
+    SAI_REVISION=$(grep "SAI_REVISION" "$SAI_API_VERSION_PATH" | grep -oE "[0-9]+")
+    if [ -n "$SAI_MAJOR" ] && [ -n "$SAI_MINOR" ] && [ -n "$SAI_REVISION" ]; then
+        echo "SAI_API_HEADERS $SAI_MAJOR.$SAI_MINOR.$SAI_REVISION" >> temp_versions_file
+    else
+        echo "SAI_API_HEADERS N/A" >> temp_versions_file
+    fi
+else
+    echo "SAI_API_HEADERS N/A" >> temp_versions_file
+fi
+
 echo "HW_MANAGEMENT $4" >> temp_versions_file
 echo "MFT $5-$6" >> temp_versions_file
 echo "KERNEL $7" >> temp_versions_file

--- a/platform/mellanox/get_component_versions/get_component_versions.j2
+++ b/platform/mellanox/get_component_versions/get_component_versions.j2
@@ -32,6 +32,7 @@ from tabulate import tabulate
 
 COMPONENT_VERSIONS_FILE = "/etc/mlnx/component-versions"
 HEADERS = ["COMPONENT", "COMPILATION", "ACTUAL"]
+SAI_API_TABLE_HEADERS = ["COMPONENT", "SONIC_SAI", "VENDOR_SAI"]
 
 {% if sonic_asic_platform == "mellanox" %}
 
@@ -40,6 +41,7 @@ COMMANDS_FOR_ACTUAL = {
     "HW_MANAGEMENT": [["dpkg", "-l"], ["grep", "hw"], ".*1\\.mlnx\\.([0-9.]*)"],
     "SDK": [["docker", "exec", "-it", "syncd", "bash", "-c", 'dpkg -l | grep sdk'], ".*1\\.mlnx\\.([0-9.]*)"],
     "SAI": [["docker", "exec", "-it", "syncd", "bash", "-c", 'dpkg -l | grep mlnx-sai'], ".*1\\.mlnx\\.([A-Za-z0-9.]*)"],
+    "SAI_API_HEADERS": [["docker", "exec", "syncd", "dpkg", "-s", "mlnx-sai"], "X-Sai-Headers-Version: ([0-9.]+)"],
     "FW": [["mlxfwmanager", "--query"], "FW * [0-9]{2}\\.([0-9.]*)"],
     "KERNEL": [["uname", "-r"], "([0-9][0-9.-]*)-.*"]
 }
@@ -48,6 +50,7 @@ UNAVAILABLE_COMPILED_VERSIONS = {
     "SDK": "N/A",
     "FW": "N/A",
     "SAI": "N/A",
+    "SAI_API_HEADERS": "N/A",
     "HW_MANAGEMENT": "N/A",
     "MFT": "N/A",
     "KERNEL": "N/A",
@@ -146,8 +149,8 @@ def get_current_version(comp):
         return "N/A"
 
 
-def format_output_table(table):
-    return tabulate(table, HEADERS)
+def format_output_table(table, headers=HEADERS):
+    return tabulate(table, headers)
 
 
 def main():
@@ -158,6 +161,14 @@ def main():
 
     compiled_versions = parse_compiled_components_file()
     simx_compiled_ver = compiled_versions.pop("SIMX")
+
+    # Handle SAI_API_HEADERS versions
+    sai_api_headers_table = []
+    if "SAI_API_HEADERS" in compiled_versions:
+        sai_api_version_in_sai = get_current_version("SAI_API_HEADERS")
+        sai_api_version_in_sonic = compiled_versions["SAI_API_HEADERS"]
+        sai_api_headers_table.append(["SAI_API_HEADERS", sai_api_version_in_sonic, sai_api_version_in_sai])
+        compiled_versions.pop("SAI_API_HEADERS")
 
     # Add compiled versions to table
     output_table = []
@@ -178,6 +189,10 @@ def main():
         output_table.append([comp, "-", platform_versions[comp]])
 
     print(format_output_table(output_table))
+
+    if sai_api_headers_table:
+        print("\n")
+        print(format_output_table(sai_api_headers_table, SAI_API_TABLE_HEADERS))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Improve get_component_versions​ to present the SAI API headers version.
For debugging and compatibility validation, it is important to know:​
- The SAI API version that SONiC was compiled against​.
- The SAI API version implemented by the vendor’s installed SAI library at runtime.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- The SAI API version that SONiC was compiled against:
During compilation, create_component_versions.sh extracts the version​
from src/sonic-sairedis/SAI/inc/saiversion.h and save it into temp component-versions file.
- The SAI API version implemented by the vendor’s installed SAI library at runtime:
During runtime, using syncd:dpkg -s mlnx-sai

#### How to verify it
run: get_component_versions.py

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

