### PR TITLE
[Arista] Fix sensors.conf for Moby

### DIFF
--- a/device/arista/x86_64-arista_7060x6_16pe_384c/sensors.conf
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c/sensors.conf
@@ -1,14 +1,40 @@
+bus "i2c-16" "SCD 0000:03:00.0 SMBus master 1 bus 3"
 bus "i2c-19" "SCD 0000:06:00.0 SMBus master 0 bus 0"
+bus "i2c-35" "SCD 0000:06:00.0 SMBus master 2 bus 4"
+bus "i2c-37" "SCD 0000:05:00.0 SMBus master 0 bus 0"
+
+chip "k10temp-pci-00c3"
+    label temp1 "Cpu temp sensor"
 
 chip "max6581-i2c-19-4d"
+    label temp1 "Switch Card temp sensor"
+    label temp2 "TH5 PCB Left"
+    label temp3 "TH5 PCB Right"
+    label temp4 "Inlet Ambiant Air"
     ignore temp5
     ignore temp6
+    label temp7 "TH5 Diode 1"
+    label temp8 "TH5 Diode 2"
 
 chip "nvme-pci-0400"
-    # TODO: sensors complaining about tempX_min and tempX_max
     ignore temp2
     ignore temp3
     ignore temp4
     ignore temp5
     ignore temp6
     ignore temp7
+
+chip "pmbus-i2c-35-10"
+    label temp1 "Power supply 1 internal sensor"
+    ignore temp2
+
+chip "pmbus-i2c-35-12"
+    label temp1 "Power supply 2 internal sensor"
+    ignore temp2
+
+chip "tmp75-i2c-16-48"
+    label temp1 "Outlet"
+
+chip "tmp75-i2c-37-4a"
+    label temp1 "Port Card"
+

--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/sensors.conf
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/sensors.conf
@@ -1,14 +1,1 @@
-bus "i2c-19" "SCD 0000:06:00.0 SMBus master 0 bus 0"
-
-chip "max6581-i2c-19-4d"
-    ignore temp5
-    ignore temp6
-
-chip "nvme-pci-0400"
-    # TODO: sensors complaining about tempX_min and tempX_max
-    ignore temp2
-    ignore temp3
-    ignore temp4
-    ignore temp5
-    ignore temp6
-    ignore temp7
+../x86_64-arista_7060x6_16pe_384c/sensors.conf


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add labels for sensors of Moby by sensors.conf

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it
Verified that labels shown in 'sensors' output is matching the output of 'show platform temperature'

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

