### PR TITLE
Remove logging flags for p4rt_app.

### DIFF
--- a/dockers/docker-sonic-p4rt/p4rt.sh
+++ b/dockers/docker-sonic-p4rt/p4rt.sh
@@ -16,7 +16,7 @@ readonly X509=$(echo ${P4RT_VARS} | jq -r '.x509')
 readonly P4RT=$(echo ${P4RT_VARS} | jq -r '.p4rt')
 readonly CERTS=$(echo ${P4RT_VARS} | jq -r '.certs')
 
-P4RT_ARGS=" --alsologtostderr --logbuflevel=-1"
+P4RT_ARGS=""
 
 if [ -n "${CERTS}" ]; then
     readonly SERVER_CRT=$(echo ${CERTS} | jq -r '.server_crt // empty')


### PR DESCRIPTION
### Why I did it
We are migrating from GLOG to absl/log in sonic-pins and absl/log does not use
these flags. By default, it already outputs to stderr.

### How to verify it
With this arguments, the p4rt docker is crashing while loading the sonic-vs image.
After removing the arguments, we are able to make the p4rt docker up without any crash.

### Which release branch to backport (provide reason below if selected)

- [ ]  201811
- [ ]  201911
- [ ]  202006
- [ ]  202012
- [ ]  202106
- [ ]  202111
- [ ]  202205
- [ ]  202211

### Description for the changelog

### A picture of a cute animal (not mandatory but encouraged)
