### PR TITLE
Include stp

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -546,6 +546,7 @@ SONIC_BUILD_INSTRUCTION :=  $(MAKE) \
                            INCLUDE_DHCP_RELAY=$(INCLUDE_DHCP_RELAY) \
                            INCLUDE_DHCP_SERVER=$(INCLUDE_DHCP_SERVER) \
                            INCLUDE_MACSEC=$(INCLUDE_MACSEC) \
+                           INCLUDE_STP=$(INCLUDE_STP) \
                            INCLUDE_ICCPD=$(INCLUDE_ICCPD) \
                            SONIC_INCLUDE_RESTAPI=$(INCLUDE_RESTAPI) \
                            SONIC_INCLUDE_MUX=$(INCLUDE_MUX) \


### PR DESCRIPTION
#### Why I did it

STP was not being enabled when building.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Ensure that INCLUDE_STP is passed through from the top-level make similar to how INCLUDE_ICCPD and INCLUDE_MACSEC are handled.

#### How to verify it

Build with INCLUDE_STP=y

#### Which release branch to backport (provide reason below if selected)

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Previously it was not possible to enable STP support in the build. It can now be enabled with `make ... INCLUDE_STP=y`.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

