### PR TITLE
[Nvidia-Bluefield] Change sonic-bfb-installer reboot flow to fix pmon sensor errors

### DIFF
--- a/platform/mellanox/sonic-bfb-installer.sh
+++ b/platform/mellanox/sonic-bfb-installer.sh
@@ -78,6 +78,10 @@ PLATFORM_JSON=/usr/share/sonic/device/$PLATFORM/platform.json
 declare -A rshim2dpu
 declare -r bfsoc_dev_id="15b3:c2d5"
 declare -r cx7_dev_id="15b3:a2dc"
+declare -r REBOOT_HELPER_SCRIPT="/usr/local/bin/reboot_smartswitch_helper"
+
+# Source reboot helper script at initialization if available
+[[ -f "$REBOOT_HELPER_SCRIPT" ]] && source "$REBOOT_HELPER_SCRIPT"
 
 # Local functions to replace dpumap.sh
 rshim2dpu_map() {
@@ -199,6 +203,47 @@ remove_cx_pci_device() {
     fi
 }
 
+# Function to check if CHASSIS_MODULE_TABLE entry exists for a specific DPU
+is_chassis_module_table_present() {
+    local dpu_name=$1
+    local output
+    output=$(sonic-db-cli STATE_DB KEYS "CHASSIS_MODULE_TABLE|${dpu_name}" 2>/dev/null)
+    if [[ -z "$output" ]]; then
+        return 1
+    fi
+    return 0
+}
+
+# Function to execute dpuctl dpu-reset command
+run_dpuctl_reset() {
+    local dpu=$1
+    local use_verbose=$2
+    local reset_cmd="dpuctl dpu-reset --force $dpu"
+    if [[ "$use_verbose" == true ]]; then
+        reset_cmd="$reset_cmd -v"
+    fi
+    eval $reset_cmd
+}
+
+# Function to reset DPU using reboot helper or fallback to dpuctl
+reset_dpu() {
+    local dpu=$1
+    local use_verbose=$2
+    local dpu_upper="${dpu^^}"  # Convert to uppercase (e.g., dpu0 -> DPU0)
+
+    # Check if reboot helper is available and CHASSIS_MODULE_TABLE entry exists for this DPU
+    if [[ -f "$REBOOT_HELPER_SCRIPT" ]] && is_chassis_module_table_present "$dpu_upper"; then
+        log_info "Using reboot helper pre/post shutdown methods while resetting $dpu_upper"
+        module_pre_shutdown "$dpu_upper"
+        run_dpuctl_reset "$dpu" "$use_verbose"
+        module_post_startup "$dpu_upper"
+    else
+        # Fallback to dpuctl
+        log_info "Using dpuctl to reset $dpu"
+        run_dpuctl_reset "$dpu" "$use_verbose"
+    fi
+}
+
 monitor_installation() {
     local -r rid=$1
     local -r pid=$2
@@ -311,11 +356,7 @@ bfb_install_call() {
     stop_rshim_daemon "$rid"
     log_info "$rid: Resetting DPU $dpu"
 
-    local reset_cmd="dpuctl dpu-reset --force $dpu"
-    if [[ $verbose == true ]]; then
-        reset_cmd="$reset_cmd -v"
-    fi
-    eval $reset_cmd
+    reset_dpu "$dpu" "$verbose"
 }
 
 file_cleanup(){


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix transient errors during bfb install on smartswitch platform.

``` 
ERR pmon#sensord: Error getting sensor data: mp2975/#16: Kernel interface error
```
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Use pre-shutdown procedures before doing a reboot

#### How to verify it
Installation of bfb image on dpu from switch shouldn't cause errors
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

