### PR TITLE
Revert "swss.sh should check service enabled instead exists"

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -584,12 +584,15 @@ function check_ports_present()
     return 1
 }
 
-function check_service_enabled()
+function check_service_exists()
 {
-    if systemctl is-enabled "$1" >/dev/null 2>&1; then
+    systemctl list-units --full -all 2>/dev/null | grep -Fq $1
+    if [[ $? -eq 0 ]]; then
         echo true
+        return
     else
         echo false
+        return
     fi
 }
 
@@ -598,7 +601,7 @@ function check_service_enabled()
 DEPENDENT=""
 MULTI_INST_DEPENDENT=""
 
-if [[ $(check_service_enabled radv) == "true" ]]; then
+if [[ $(check_service_exists radv) == "true" ]]; then
     DEPENDENT="$DEPENDENT radv"
 fi
 
@@ -619,7 +622,7 @@ check_add_bgp_dependency
 check_ports_present
 PORTS_PRESENT=$?
 
-if [[ $PORTS_PRESENT == 0 ]] && [[ $(check_service_enabled teamd) == "true" ]]; then
+if [[ $PORTS_PRESENT == 0 ]] && [[ $(check_service_exists teamd) == "true" ]]; then
     MULTI_INST_DEPENDENT="teamd"
 fi
 


### PR DESCRIPTION
Reverts sonic-net/sonic-buildimage#24754 since it's causing pc/test_po_cleanup.py and autorestart/test_container_autorestart.py failure on multi-asic t1

pc/test_po_cleanup.py:
<img width="1252" height="890" alt="image" src="https://github.com/user-attachments/assets/dd8c98be-32ee-4ea0-9d42-e0dc1e74402b" />

autorestart/test_container_autorestart.py:
<img width="870" height="283" alt="image" src="https://github.com/user-attachments/assets/e784e902-4e3d-4cc0-a911-741abfab8af6" />