### PR TITLE
[build] Use relative path for swss-common when building swss and dash-ha.

### DIFF
--- a/src/sonic-dash-ha.patch/0001-build-use-relative-path-when-building-cargo-dependen.patch
+++ b/src/sonic-dash-ha.patch/0001-build-use-relative-path-when-building-cargo-dependen.patch
@@ -1,0 +1,25 @@
+From 3402023e04bcfce7b94127a287c02b9a53b37d2a Mon Sep 17 00:00:00 2001
+From: Liu Shilong <shilongliu@microsoft.com>
+Date: Wed, 10 Dec 2025 13:44:52 +0800
+Subject: [PATCH] [build] use relative path when building cargo dependency
+ swss-common.
+
+---
+ Cargo.toml | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Cargo.toml b/Cargo.toml
+index 3fc3f23..1bbfe4d 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -97,8 +97,8 @@ swss-serde = { version = "0.1.0", path = "crates/swss-serde" }
+ swbus-actor = { version = "0.1.0", path = "crates/swbus-actor" }
+ sonicdb-derive = { version = "0.1.0", path = "crates/sonicdb-derive" }
+ sonic-dash-api-proto = { version = "0.1.0", path = "crates/sonic-dash-api-proto" }
+-swss-common = { git = "https://github.com/sonic-net/sonic-swss-common.git", branch = "master" }
+-swss-common-testing = { git = "https://github.com/sonic-net/sonic-swss-common.git", branch = "master" }
++swss-common = { path = "../sonic-swss-common/crates/swss-common" }
++swss-common-testing = { path = "../sonic-swss-common/crates/swss-common-testing" }
+ 
+ # Dev dependencies
+ criterion = "0.5"

--- a/src/sonic-dash-ha.patch/series
+++ b/src/sonic-dash-ha.patch/series
@@ -1,0 +1,1 @@
+0001-build-use-relative-path-when-building-cargo-dependen.patch

--- a/src/sonic-swss.patch/0001-build-use-relative-path-when-building-cargo-dependen.patch
+++ b/src/sonic-swss.patch/0001-build-use-relative-path-when-building-cargo-dependen.patch
@@ -1,0 +1,23 @@
+From 53a4bf4324752b7e9e246a7f8a53db189cc938d0 Mon Sep 17 00:00:00 2001
+From: Liu Shilong <shilongliu@microsoft.com>
+Date: Wed, 10 Dec 2025 13:27:33 +0800
+Subject: [PATCH] [build] use relative path when building cargo dependency
+ swss-common.
+
+---
+ Cargo.toml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Cargo.toml b/Cargo.toml
+index a2db894e..7484110a 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -64,7 +64,7 @@ itertools = "0.13"
+ uuid = { version = "1.15", features = ["v4"] }
+ 
+ # SONiC specific dependencies
+-swss-common = { git = "https://github.com/sonic-net/sonic-swss-common.git", branch = "master" }
++swss-common = { path = "../sonic-swss-common/crates/swss-common" }
+ 
+ # Development dependencies
+ tempfile = "3.12"

--- a/src/sonic-swss.patch/0002-Remove-lock-option-when-cargo-build.patch
+++ b/src/sonic-swss.patch/0002-Remove-lock-option-when-cargo-build.patch
@@ -1,0 +1,22 @@
+From ce4922401e30fa0cf54c5ab239850b7ec22e4f38 Mon Sep 17 00:00:00 2001
+From: Liu Shilong <shilongliu@microsoft.com>
+Date: Wed, 10 Dec 2025 17:56:29 +0800
+Subject: [PATCH] Remove --lock option when cargo build.
+
+---
+ debian/rules | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/debian/rules b/debian/rules
+index aa94a614..88cc1cd9 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -42,7 +42,7 @@ override_dh_auto_configure:
+ override_dh_auto_build:
+ 	dh_auto_build
+ 	# Build and test countersyncd Rust project
+-	cargo build --release --locked
++	cargo build --release
+ 
+ override_dh_auto_install:
+ 	dh_auto_install --destdir=debian/swss

--- a/src/sonic-swss.patch/series
+++ b/src/sonic-swss.patch/series
@@ -1,0 +1,2 @@
+0001-build-use-relative-path-when-building-cargo-dependen.patch
+0002-Remove-lock-option-when-cargo-build.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Cargo.lock in swss/dash-ha repo maybe not updated in time.
When building SONiC image, we use relative path to build. It will use submodule reference for swss-common.
When building swss/dash-ha, we use Cargo.lock to build from locked commit.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

