### PR TITLE
[nvidia-bluefield] Add SAI API headers versions to get_component_versions

### DIFF
--- a/platform/mellanox/component-versions/create_component_versions.sh
+++ b/platform/mellanox/component-versions/create_component_versions.sh
@@ -20,7 +20,7 @@ echo "SDK $1" > temp_versions_file
 echo $2 | sed -r 's/([0-9]*)\.([0-9]*)\.([0-9]*)/FW \2\.\3/g' >> temp_versions_file
 echo "SAI $3" >> temp_versions_file
 
-SAI_API_VERSION_PATH="../../../src/sonic-sairedis/SAI/inc/saiversion.h"
+SAI_API_VERSION_PATH="/sonic/src/sonic-sairedis/SAI/inc/saiversion.h"
 if [ -f "$SAI_API_VERSION_PATH" ]; then
     SAI_MAJOR=$(grep "SAI_MAJOR" "$SAI_API_VERSION_PATH" | grep -oE "[0-9]+")
     SAI_MINOR=$(grep "SAI_MINOR" "$SAI_API_VERSION_PATH" | grep -oE "[0-9]+")

--- a/platform/mellanox/get_component_versions/get_component_versions.j2
+++ b/platform/mellanox/get_component_versions/get_component_versions.j2
@@ -63,6 +63,7 @@ COMMANDS_FOR_ACTUAL = {
     "MFT": [["dpkg", "-l"], ["grep", "mft "], "mft *([0-9.-]*)"],
     "SDK": [["docker", "exec", "syncd", "bash", "-c", 'dpkg -l | grep sdn'], "sdn-appliance *([0-9.-]*mlnx1)"],
     "SAI": [["docker", "exec", "syncd", "bash", "-c", 'dpkg -l | grep mlnx-sai'], ".*1\\.mlnx\\.([A-Za-z0-9.]*)"],
+    "SAI_API_HEADERS": [["docker", "exec", "syncd", "dpkg", "-s", "mlnx-sai"], "X-Sai-Headers-Version: ([0-9.]+)"],
     "FW": [["mlxfwmanager", "--query"], "FW * [0-9]{2}\\.([0-9.]*)"],
     "KERNEL": [["uname", "-r"], "(.*)-[a-z0-9]+$"],
     "BFSOC": [["dpkg", "-l"], ["grep", "mlxbf-bootimages"], "mlxbf-bootimages *([0-9.-]*)"]
@@ -72,6 +73,7 @@ UNAVAILABLE_COMPILED_VERSIONS = {
     "SDK": "N/A",
     "FW": "N/A",
     "SAI": "N/A",
+    "SAI_API_HEADERS": "N/A",
     "MFT": "N/A",
     "KERNEL": "N/A",
     "BFSOC": "N/A",

--- a/platform/nvidia-bluefield/component-versions/create_component_versions.sh
+++ b/platform/nvidia-bluefield/component-versions/create_component_versions.sh
@@ -20,7 +20,7 @@ echo "SDK $SDK_VERSION" > temp_versions_file
 echo "FW $BF3_FW_VERSION" >> temp_versions_file
 echo "SAI $DPU_SAI_VERSION" >> temp_versions_file
 
-SAI_API_VERSION_PATH="../../../src/sonic-sairedis/SAI/inc/saiversion.h"
+SAI_API_VERSION_PATH="/sonic/src/sonic-sairedis/SAI/inc/saiversion.h"
 if [ -f "$SAI_API_VERSION_PATH" ]; then
     SAI_MAJOR=$(grep "SAI_MAJOR" "$SAI_API_VERSION_PATH" | grep -oE "[0-9]+")
     SAI_MINOR=$(grep "SAI_MINOR" "$SAI_API_VERSION_PATH" | grep -oE "[0-9]+")

--- a/platform/nvidia-bluefield/component-versions/create_component_versions.sh
+++ b/platform/nvidia-bluefield/component-versions/create_component_versions.sh
@@ -19,6 +19,21 @@
 echo "SDK $SDK_VERSION" > temp_versions_file
 echo "FW $BF3_FW_VERSION" >> temp_versions_file
 echo "SAI $DPU_SAI_VERSION" >> temp_versions_file
+
+SAI_API_VERSION_PATH="../../../src/sonic-sairedis/SAI/inc/saiversion.h"
+if [ -f "$SAI_API_VERSION_PATH" ]; then
+    SAI_MAJOR=$(grep "SAI_MAJOR" "$SAI_API_VERSION_PATH" | grep -oE "[0-9]+")
+    SAI_MINOR=$(grep "SAI_MINOR" "$SAI_API_VERSION_PATH" | grep -oE "[0-9]+")
+    SAI_REVISION=$(grep "SAI_REVISION" "$SAI_API_VERSION_PATH" | grep -oE "[0-9]+")
+    if [ -n "$SAI_MAJOR" ] && [ -n "$SAI_MINOR" ] && [ -n "$SAI_REVISION" ]; then
+        echo "SAI_API_HEADERS $SAI_MAJOR.$SAI_MINOR.$SAI_REVISION" >> temp_versions_file
+    else
+        echo "SAI_API_HEADERS N/A" >> temp_versions_file
+    fi
+else
+    echo "SAI_API_HEADERS N/A" >> temp_versions_file
+fi
+
 echo "BFSOC $BFSOC_VERSION-$BFSOC_REVISION" >> temp_versions_file
 echo "MFT $MFT_VERSION-$MFT_REVISION" >> temp_versions_file
 echo "KERNEL $KVERSION_SHORT" >> temp_versions_file


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
For compatibility as we show the SAI API headers version for mellanox platform.
https://github.com/sonic-net/sonic-buildimage/pull/24662

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Get the SAI API headers version from mlnx-sai dpkg as done for mellanox platform.

#### How to verify it
run: get_component_versions.py

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

