### PR TITLE
Add additional thermal sensors for Arista-7280_r4[k]_32qf_32df

### DIFF
--- a/device/arista/x86_64-arista_7280r4_32qf_32df/platform.json
+++ b/device/arista/x86_64-arista_7280r4_32qf_32df/platform.json
@@ -125,6 +125,26 @@
             {
                 "name": "Management Card",
                 "controllable": false
+            },
+            {
+                "name": "PCB Temp Near Q3D",
+                "controllable": false
+            },
+            {
+                "name": "D0 Temp diode 0",
+                "controllable": false
+            },
+            {
+                "name": "D0 Temp diode 1",
+                "controllable": false
+            },
+            {
+                "name": "D1 Temp diode 0",
+                "controllable": false
+            },
+            {
+                "name": "D1 Temp diode 1",
+                "controllable": false
             }
         ],
         "sfps": [

--- a/device/arista/x86_64-arista_7280r4k_32qf_32df/platform.json
+++ b/device/arista/x86_64-arista_7280r4k_32qf_32df/platform.json
@@ -125,6 +125,26 @@
             {
                 "name": "Management Card",
                 "controllable": false
+            },
+            {
+                "name": "PCB Temp Near Q3D",
+                "controllable": false
+            },
+            {
+                "name": "D0 Temp diode 0",
+                "controllable": false
+            },
+            {
+                "name": "D0 Temp diode 1",
+                "controllable": false
+            },
+            {
+                "name": "D1 Temp diode 0",
+                "controllable": false
+            },
+            {
+                "name": "D1 Temp diode 1",
+                "controllable": false
             }
         ],
         "sfps": [


### PR DESCRIPTION
#### Why I did it

The additional thermal sensors are required to provide more comprehensive temperature monitoring for the Arista-7280R4-series platforms.

#### How I did it

I added the definitions for five new thermal sensors to the `thermal_sensors` section within the `platform.json` file for both the `x86_64-arista_7280r4_32qf_32df` and `x86_64-arista_7280r4k_32qf_32df` platforms.

The added sensors are:
* "PCB Temp Near Q3D"
* "D0 Temp diode 0"
* "D0 Temp diode 1"
* "D1 Temp diode 0"
* "D1 Temp diode 1"

All new entries are set as `"controllable": false`, as they are read-only sensors.

#### How to verify it

1.  Build and install a SONiC image with this change on an Arista-7280\_r4\[k\]\_32qf\_32df platform.
2.  After the platform initialization, use the SONiC CLI to verify that the new thermal sensors are listed and reporting valid temperature readings.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)
Tested on master

#### Link to config_db schema for YANG module changes
NA

#### A picture of a cute animal (not mandatory but encouraged)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/657753a1-f77a-476d-ac02-7d0e0e208141" />
