### PR TITLE
Add SAI_TUNNEL_ATTR_DECAP_QOS_DSCP_TO_TC_MAP for TH5

### DIFF
--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -4,8 +4,12 @@
 
 {# Check if the ASIC is Broadcom #}
 {% set is_broadcom = false %}
+{% set is_tomahawk5 = false %}
 {% if ASIC_VENDOR is defined and "broadcom" in ASIC_VENDOR|lower %}
   {% set is_broadcom = true %}
+  {% if 'Arista-7060X6' in DEVICE_METADATA['localhost']['hwsku'] %}
+    {% set is_tomahawk5 = true %}
+  {% endif %}
 {% endif %}
 
 {% set is_broadcom_t1 = false %}
@@ -92,7 +96,7 @@
 {% endif %}
 {% else %}
             "dscp_mode":"pipe",
-{% if azure_qos_exists %}
+{% if azure_qos_exists and (not is_broadcom or is_tomahawk5) %}
             "decap_dscp_to_tc_map":"AZURE",
 {% endif %}
 {% endif %}
@@ -122,7 +126,7 @@
 {% endif %}
 {% else %}
             "dscp_mode":"pipe",
-{% if azure_qos_exists %}
+{% if azure_qos_exists and (not is_broadcom or is_tomahawk5) %}
             "decap_dscp_to_tc_map":"AZURE",
 {% endif %}
 {% endif %}
@@ -159,7 +163,7 @@
 {% endif %}
 {% else %}
             "dscp_mode":"pipe",
-{% if azure_qos_exists %}
+{% if azure_qos_exists and (not is_broadcom or is_tomahawk5) %}
             "decap_dscp_to_tc_map":"AZURE",
 {% endif %}
 {% endif %}
@@ -189,7 +193,7 @@
 {% endif %}
 {% else %}
             "dscp_mode":"pipe",
-{% if azure_qos_exists %}
+{% if azure_qos_exists and (not is_broadcom or is_tomahawk5) %}
             "decap_dscp_to_tc_map":"AZURE",
 {% endif %}
 {% endif %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This fixes test_dscp_to_queue_mapping_uniform_mode for TH5. This attr is required for setting the custom qos map for ipinip tunnels.

Manually backported to 202505: https://github.com/sonic-net/sonic-buildimage/pull/24838

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it
Automated and manual testing

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

