### PR TITLE
[202511][cherry-pick][FPM]: Cherry-pick Fix dplane_fpm_sonic for multiple SRv6 nexthops

### DIFF
--- a/src/sonic-frr/dplane_fpm_sonic/dplane_fpm_sonic.c
+++ b/src/sonic-frr/dplane_fpm_sonic/dplane_fpm_sonic.c
@@ -2460,6 +2460,7 @@ static int fpm_nl_enqueue(struct fpm_nl_ctx *fnc, struct zebra_dplane_ctx *ctx)
 	ssize_t rv;
 	uint64_t obytes, obytes_peak;
 	enum dplane_op_e op = dplane_ctx_get_op(ctx);
+	struct nexthop *nexthop;
 
 	/*
 	 * If we were configured to not use next hop groups, then quit as soon


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->


This is a manual cherry-pick of PRs #23893 and #24602 for SONiC 202511

#### Why I did it
The automated cherry-pick was failing because of a circular dependency between the two PRs.

#### How I did it

git cherry-pick 4794f1d502d1c3683f93583a4f96772defba73bc bcd35f45944792620c171004e4ffdf4e1ebac4b9

