### PR TITLE
Sync Credo manifest with PR #24762

### DIFF
--- a/files/build/versions/dockers/docker-gbsyncd-credo/versions-deb-bookworm
+++ b/files/build/versions/dockers/docker-gbsyncd-credo/versions-deb-bookworm
@@ -14,9 +14,10 @@ libgpm2==1.20.7-10+b1
 libicu72==72.1-3+deb12u1
 libipt2==2.0.5-1
 libmpfr6==4.2.0-1
-libsaicredo==0.9.9
-libsaicredo-blackhawk==0.9.9
-libsaicredo-owl==0.9.9
+libsaicredo==1.2.4
+libsaicredo-blackhawk==1.2.4
+libsaicredo-crt88322==1.2.4
+libsaicredo-owl==1.2.4
 libsaimetadata==1.0.0
 libsairedis==1.0.0
 libsource-highlight-common==3.1.9-4.2


### PR DESCRIPTION
#### Why I did it
PR [#24762](https://github.com/sonic-net/sonic-buildimage/pull/24762) updated Credo SAI packages to `1.2.4`, but the manifest was not changed.

Fix #24864

#### How I did it
Updated manifest so it matches actual packages used.

#### How to verify it
See updated manifest matches versions used here:
https://github.com/sonic-net/sonic-buildimage/blob/22870352db17651c80094ab66469ca523b5e6cd5/platform/components/docker-gbsyncd-credo.mk#L3-L10

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)
Not run (manifest-only change).