### PR TITLE
ci: validate docker-sonic-mgmt image with PR tests before publishing

### DIFF
--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -96,6 +96,7 @@ stages:
       parameters:
         CHECKOUT_SONIC_MGMT: true
         OVERRIDE_PARAMS:
+          REPO_NAME: "sonic-mgmt"
           SETUP_CONTAINER_PARAMS: "-i ${{ parameters.registry_url }}/docker-sonic-mgmt:lastbuild"
 
 - stage: Publish


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Previously, the newly built docker-sonic-mgmt image was not tested before publishing, creating a gap in catching regressions. 
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

This change introduces a Test stage that validates the built image using sonic-mgmt PR tests before pushing to registry.

- Push lastbuild tag after Build stage
- Add Test stage using newly built docker-sonic-mgmt:lastbuild image
- Add Publish stage to push latest tag only after tests pass
- Fix cp command syntax in artifact staging

This change depends on the merge of https://github.com/sonic-net/sonic-mgmt/pull/21636

#### How to verify it
Created a temp pipeline to verify that new docker-sonic-mgmt image is used for PR testing: https://dev.azure.com/mssonic/build/_build?definitionId=3328&_a=summary

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

