### PR TITLE
modified:   src/iccpd/src/iccp_ifm.c

### DIFF
--- a/src/iccpd/src/iccp_ifm.c
+++ b/src/iccpd/src/iccp_ifm.c
@@ -571,8 +571,8 @@ static void do_ndisc_learn_from_kernel(struct ndmsg *ndm, struct rtattr *tb[], i
         else
         {
             /* update ND */
-            if (ndisc_info->op_type != ndisc_info->op_type
-                || strcmp(ndisc_info->ifname, ndisc_info->ifname) != 0 || memcmp(ndisc_info->mac_addr, ndisc_info->mac_addr, ETHER_ADDR_LEN) != 0)
+            if (ndisc_info->op_type != ndisc_msg->op_type
+                || strcmp(ndisc_info->ifname, ndisc_msg->ifname) != 0 || memcmp(ndisc_info->mac_addr, ndisc_msg->mac_addr, ETHER_ADDR_LEN) != 0)
             {
                 neigh_update = 1;
                 ndisc_info->op_type = ndisc_msg->op_type;


### PR DESCRIPTION
Code fixes for UPDATE scenario in do_ndisc_learn_from_kernel()

The function **do_ndisc_learn_from_kernel()** is having a logic to update ND by comparing members of **ndisc_info** and **ndisc_msg**. But the "if" condition is wrongly written in such a way it is comparing the members of **ndisc_info** itself which will always return FALSE. Due to this bug in code, MC-LAG Peer update will be skipped for ND and resulting in ND-ARP mismatch between MC-LAG Peers

Fix is applicable to 
- [X] 202305
- [X] 202311
- [X] 202405
- [X] 202411
- [X] 202505
- [X] 202511
- [X] master

