### PR TITLE
[Mellanox] Feed module info to hw-management

### DIFF
--- a/platform/mellanox/hw-management/0001-Make-SONiC-determine-reboot-cause-service-start-afte.patch
+++ b/platform/mellanox/hw-management/0001-Make-SONiC-determine-reboot-cause-service-start-afte.patch
@@ -9,11 +9,11 @@ Subject: [PATCH 1/2] Make SONiC determine-reboot-cause service start after
  1 file changed, 1 insertion(+)
 
 diff --git a/debian/hw-management.hw-management.service b/debian/hw-management.hw-management.service
-index bdc79d2e..6ae63a95 100755
+index 27273174..cd7fb7e2 100755
 --- a/debian/hw-management.hw-management.service
 +++ b/debian/hw-management.hw-management.service
-@@ -4,6 +4,7 @@ Documentation=man:hw-management.service(8)
- Wants=hw-management-sync.service
+@@ -3,6 +3,7 @@ Description=Chassis HW management service of Nvidia systems
+ Documentation=man:hw-management.service(8)
  Wants=hw-management-sysfs-monitor.service
  Wants=hw-management-fast-sysfs-monitor.service
 +Before=determine-reboot-cause.service
@@ -21,5 +21,5 @@ index bdc79d2e..6ae63a95 100755
  [Service]
  Type=oneshot
 -- 
-2.48.1
+2.49.0
 

--- a/platform/mellanox/hw-management/0002-Make-system-health-service-starts-after-hw-managemen.patch
+++ b/platform/mellanox/hw-management/0002-Make-system-health-service-starts-after-hw-managemen.patch
@@ -10,11 +10,11 @@ On SN2410, it can fail to read the file led_status_capability if it starts from 
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/debian/hw-management.hw-management.service b/debian/hw-management.hw-management.service
-index 6ae63a95..634b4014 100755
+index cd7fb7e2..e6f96743 100755
 --- a/debian/hw-management.hw-management.service
 +++ b/debian/hw-management.hw-management.service
-@@ -4,7 +4,7 @@ Documentation=man:hw-management.service(8)
- Wants=hw-management-sync.service
+@@ -3,7 +3,7 @@ Description=Chassis HW management service of Nvidia systems
+ Documentation=man:hw-management.service(8)
  Wants=hw-management-sysfs-monitor.service
  Wants=hw-management-fast-sysfs-monitor.service
 -Before=determine-reboot-cause.service
@@ -23,5 +23,5 @@ index 6ae63a95..634b4014 100755
  [Service]
  Type=oneshot
 -- 
-2.48.1
+2.49.0
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -45,6 +45,19 @@ try:
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
+try:
+    import sys
+    sys.path.append('/run/hw-management/bin')
+    import hw_management_independent_mode_update
+except ImportError:
+    # Only mock if running under pytest (check if pytest is imported)
+    if 'pytest' in sys.modules:
+        from unittest import mock
+        hw_management_independent_mode_update = mock.MagicMock()
+        hw_management_independent_mode_update.vendor_data_set_module = mock.MagicMock()
+    else:
+        raise
+
 # Define the sdk constants
 SX_PORT_MODULE_STATUS_INITIALIZING = 0
 SX_PORT_MODULE_STATUS_PLUGGED = 1
@@ -426,6 +439,10 @@ class SFP(NvidiaSFPCommon):
         self.sn = None
         self.temp_high_threshold = None
         self.temp_critical_threshold = None
+        self.retry_read_threshold = 5
+        self.retry_read_vendor = 0
+        self.manufacturer = None
+        self.part_number = None
 
     def __str__(self):
         return f'SFP {self.sdk_index}'
@@ -867,12 +884,55 @@ class SFP(NvidiaSFPCommon):
         sn = self._get_serial()
         if sn != self.sn:
             self.reinit()
+            # Clear cached vendor info so a new module will be re-read
+            self.manufacturer = None
+            self.part_number = None
             self.sn = self._get_serial()
+            if self.sn is not None:
+                self.retry_read_threshold = 5
+                self.retry_read_vendor = 5
+            else:
+                self.retry_read_threshold = 0
+                self.retry_read_vendor = 0
             self.temp_high_threshold = None
             self.temp_critical_threshold = None
             return True
         return False
-            
+
+    def get_vendor_info(self):
+        """Get SFP vendor info (manufacturer and part number).
+        Reads fields via xcvr_eeprom to avoid manual offset logic.
+        Uses cache to avoid redundant reads.
+        Returns:
+            tuple: (manufacturer, part_number) or (None, None) if read fails
+        """
+        try:
+            display_idx = self.sdk_index + 1
+            if self.manufacturer is not None and self.part_number is not None:
+                return self.manufacturer, self.part_number
+
+            api = self.get_xcvr_api()
+            if not api or api.xcvr_eeprom is None:
+                return None, None
+
+            try:
+                manufacturer = api.xcvr_eeprom.read(consts.VENDOR_NAME_FIELD)
+                part_number = api.xcvr_eeprom.read(consts.VENDOR_PART_NO_FIELD)
+                logger.log_info(f"SFP {display_idx} vendor info read: manufacturer='{manufacturer}', part_number='{part_number}'")
+            except Exception as e:
+                logger.log_error(f"SFP {display_idx} vendor info read failed: {e}")
+                manufacturer = None
+                part_number = None
+
+            if manufacturer and part_number:
+                self.manufacturer = manufacturer
+                self.part_number = part_number
+                return manufacturer, part_number
+
+            return None, None
+        except Exception:
+            return None, None
+
     def get_temperature_info(self):
         """Get SFP temperature info in a fast way. This function is faster than calling following functions one by one: get_temperature, get_temperature_warning_threshold, get_temperature_critical_threshold.
 
@@ -880,6 +940,30 @@ class SFP(NvidiaSFPCommon):
             tuple: (temperature, warning_threshold, critical_threshold)
         """
         try:
+            sn_changed = self.reinit_if_sn_changed()
+            if self.retry_read_vendor > 0:
+                try:
+                    manufacturer, part_number = self.get_vendor_info()
+                    if manufacturer and part_number:
+                        vendor_info = {'manufacturer': manufacturer, 'part_number': part_number}
+                        hw_management_independent_mode_update.vendor_data_set_module(
+                            0,  # ASIC index always 0 for now
+                            self.sdk_index + 1,
+                            vendor_info
+                        )
+                        logger.log_notice(f'Module {self.sdk_index + 1} vendor info updated - '
+                                          f'manufacturer: {manufacturer} part_number: {part_number}')
+                        self.retry_read_vendor = 0
+                    else:
+                        self.retry_read_vendor -= 1
+                        if self.retry_read_vendor == 0:
+                            logger.log_notice(f"SFP {self.sdk_index + 1}: vendor info unavailable after retries")
+                except Exception as e:
+                    logger.log_warning(f'Failed to publish vendor info for SFP {self.sdk_index + 1} - {e}')
+                    self.retry_read_vendor -= 1
+                    if self.retry_read_vendor == 0:
+                        logger.log_notice(f"SFP {self.sdk_index + 1}: vendor info unavailable after retries")
+
             sw_control = self.is_sw_control()
             if not sw_control:
                 return sw_control, None, None, None

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
@@ -27,14 +27,17 @@ sys.path.append('/run/hw-management/bin')
 try:
     import hw_management_independent_mode_update
 except ImportError:
-    # For unit test only
-    from unittest import mock
-    hw_management_independent_mode_update = mock.MagicMock()
-    hw_management_independent_mode_update.module_data_set_module_counter = mock.MagicMock()
-    hw_management_independent_mode_update.thermal_data_set_asic = mock.MagicMock()
-    hw_management_independent_mode_update.thermal_data_set_module = mock.MagicMock()
-    hw_management_independent_mode_update.thermal_data_clean_asic = mock.MagicMock()
-    hw_management_independent_mode_update.thermal_data_clean_module = mock.MagicMock()
+    # Only mock if running under pytest (check if pytest is imported)
+    if 'pytest' in sys.modules:
+        from unittest import mock
+        hw_management_independent_mode_update = mock.MagicMock()
+        hw_management_independent_mode_update.module_data_set_module_counter = mock.MagicMock()
+        hw_management_independent_mode_update.thermal_data_set_asic = mock.MagicMock()
+        hw_management_independent_mode_update.thermal_data_set_module = mock.MagicMock()
+        hw_management_independent_mode_update.thermal_data_clean_asic = mock.MagicMock()
+        hw_management_independent_mode_update.thermal_data_clean_module = mock.MagicMock()
+    else:
+        raise
 
 
 SFP_TEMPERATURE_SCALE = 1000

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
@@ -32,7 +32,6 @@ sys.path.insert(0, modules_path)
 from sonic_platform.sfp import SFP, RJ45Port, CpoPort, CPO_TYPE, cmis_api, SX_PORT_MODULE_STATUS_INITIALIZING, SX_PORT_MODULE_STATUS_PLUGGED, SX_PORT_MODULE_STATUS_UNPLUGGED, SX_PORT_MODULE_STATUS_PLUGGED_WITH_ERROR, SX_PORT_MODULE_STATUS_PLUGGED_DISABLED
 from sonic_platform.chassis import Chassis
 
-
 class TestSfp:
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_linecard_count', mock.MagicMock(return_value=8))
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_linecard_max_port_count')
@@ -608,14 +607,136 @@ class TestSfp:
         sfp.is_sw_control.side_effect = Exception('')
         assert sfp.get_temperature_info() == (False, None, None, None)
 
+    @mock.patch('time.sleep', mock.MagicMock())
+    def test_get_temperature_info_vendor_retry_loop(self):
+        sfp = SFP(0)
+        sfp.reinit_if_sn_changed = mock.MagicMock(side_effect=[True, False, False])
+        sfp.is_sw_control = mock.MagicMock(return_value=False)
+        sfp.retry_read_vendor = 5
+        # First two attempts fail, third succeeds
+        sfp.get_vendor_info = mock.MagicMock(side_effect=[(None, None), (None, None), ('Mellanox', 'PN-9999')])
+
+        # Attempt 1: reinit sets retry counter, first vendor read fails (counter -> 4)
+        sfp.get_temperature_info()
+        # Attempt 2: retry counter >0, second vendor read fails (counter -> 3)
+        sfp.get_temperature_info()
+        # Attempt 3: retry counter >0, vendor read succeeds, counter cleared
+        sfp.get_temperature_info()
+
+        assert sfp.get_vendor_info.call_count == 3
+        assert sfp.retry_read_vendor == 0
+
     def test_reinit_if_sn_changed(self):
         sfp = SFP(0)
         sfp.get_xcvr_api = mock.MagicMock(return_value=None)
         assert not sfp.reinit_if_sn_changed()
-        
+
         sfp.get_xcvr_api.return_value = mock.MagicMock()
         sfp.get_xcvr_api.return_value.xcvr_eeprom.read = mock.MagicMock(return_value='1234567890')
         assert sfp.reinit_if_sn_changed()
-        
+        assert sfp.retry_read_threshold == 5
+        assert sfp.retry_read_vendor == 5
+
         sfp.get_xcvr_api.return_value.xcvr_eeprom.read.return_value = '1234567891'
         assert sfp.reinit_if_sn_changed()
+        assert sfp.retry_read_threshold == 5
+        assert sfp.retry_read_vendor == 5
+
+        # Vendor cache should reset on reinit to allow new modules to be read
+        sfp.sn = 'old_sn'
+        sfp.manufacturer = 'OldVendor'
+        sfp.part_number = 'OldPart'
+        sfp._get_serial = mock.MagicMock(return_value='new_sn')
+        assert sfp.reinit_if_sn_changed()
+        assert sfp.manufacturer is None
+        assert sfp.part_number is None
+        assert sfp.retry_read_vendor == 5
+
+    @mock.patch('time.sleep', mock.MagicMock())
+    def test_get_vendor_info_success_and_cache(self):
+        sfp = SFP(0)
+        mock_api = mock.MagicMock()
+        mock_eeprom = mock.MagicMock()
+        mock_api.xcvr_eeprom = mock_eeprom
+        sfp.get_xcvr_api = mock.MagicMock(return_value=mock_api)
+
+        from sonic_platform_base.sonic_xcvr.fields import consts
+        def mock_read(field):
+            if field == consts.VENDOR_NAME_FIELD:
+                return 'Mellanox'
+            if field == consts.VENDOR_PART_NO_FIELD:
+                return 'PN-1234'
+            return None
+        mock_eeprom.read.side_effect = mock_read
+
+        # First call reads from eeprom
+        manufacturer, part_number = sfp.get_vendor_info()
+        assert manufacturer == 'Mellanox'
+        assert part_number == 'PN-1234'
+        assert mock_eeprom.read.call_count == 2
+
+        # Second call should return cached values without additional reads
+        manufacturer, part_number = sfp.get_vendor_info()
+        assert manufacturer == 'Mellanox'
+        assert part_number == 'PN-1234'
+        assert mock_eeprom.read.call_count == 2
+
+    @mock.patch('time.sleep', mock.MagicMock())
+    def test_get_vendor_info_retry_then_success(self):
+        sfp = SFP(0)
+        mock_api = mock.MagicMock()
+        mock_eeprom = mock.MagicMock()
+        mock_api.xcvr_eeprom = mock_eeprom
+        sfp.get_xcvr_api = mock.MagicMock(return_value=mock_api)
+
+        from sonic_platform_base.sonic_xcvr.fields import consts
+        state = {'fail_reads': 2}
+        def flaky_read(field):
+            if state['fail_reads'] > 0:
+                state['fail_reads'] -= 1
+                raise Exception('EEPROM not ready')
+            if field == consts.VENDOR_NAME_FIELD:
+                return 'Mellanox'
+            if field == consts.VENDOR_PART_NO_FIELD:
+                return 'PN-5678'
+            return None
+        mock_eeprom.read.side_effect = flaky_read
+
+        # First call fails (counter decremented)
+        manufacturer, part_number = sfp.get_vendor_info()
+        assert (manufacturer, part_number) == (None, None)
+        # Second call fails (counter decremented)
+        manufacturer, part_number = sfp.get_vendor_info()
+        assert (manufacturer, part_number) == (None, None)
+        # Third call succeeds (reads both fields)
+        manufacturer, part_number = sfp.get_vendor_info()
+        assert (manufacturer, part_number) == ('Mellanox', 'PN-5678')
+        # Total read invocations: first two calls each raise on first field (2),
+        # third call reads both fields (2) → 4 total
+        assert mock_eeprom.read.call_count == 4
+
+    @mock.patch('time.sleep', mock.MagicMock())
+    def test_get_vendor_info_all_fail(self):
+        sfp = SFP(0)
+        mock_api = mock.MagicMock()
+        mock_eeprom = mock.MagicMock()
+        mock_api.xcvr_eeprom = mock_eeprom
+        sfp.get_xcvr_api = mock.MagicMock(return_value=mock_api)
+        mock_eeprom.read.side_effect = Exception('EEPROM error')
+
+        manufacturer, part_number = sfp.get_vendor_info()
+        assert manufacturer is None
+        assert part_number is None
+
+    def test_get_vendor_info_no_api_or_missing_attr(self):
+        sfp = SFP(0)
+        # No API
+        sfp.get_xcvr_api = mock.MagicMock(return_value=None)
+        assert sfp.get_vendor_info() == (None, None)
+
+        # API without xcvr_eeprom attribute
+        class DummyApi(object):
+            pass
+        sfp.get_xcvr_api.return_value = DummyApi()
+        assert sfp.get_vendor_info() == (None, None)
+


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
At 40°C ambient temperature with current FW+SW, some modules have >7.6% probability of reaching 75°C, which triggers false temperature warnings.
This PR implements vendor-specific temperature threshold support to eliminate false warnings while maintaining accurate temperature telemetry for monitoring purposes.

#### How I did it
Implemented new API for vendor-specific temperature offset adjustments:
1. **New  API**:
   - Add get_vendor_info() API with caching support.

2. **Smart Module Detection**:
   - Cache vendor information (Manufacturer + Part Number) for each module.
   - Skip redundant vendor info updates when the same module is replugged.

#### How to verify it
1. Plug in optical module -> Verify vendor info sent to HW-MGMT.
2. Unplug and replug same module -> Verify no redundant vendor info update.
3. Replace with different module -> Verify new vendor info sent.

#### Which release branch to backport (provide reason below if selected)
- [x] 202412
- [x] 202511

#### Tested branch (Please provide the tested image version)
202412

#### A picture of a cute animal (not mandatory but encouraged)
```bash
    /\_/\  
   ( o.o ) 
    > ^ <
   /|   |\
  (_|   |_)
   Cool Cat~
```