### PR TITLE
[SmartSwitch] Force sync DPU hardware time during bfb install 

### DIFF
--- a/platform/mellanox/sonic-bfb-installer.sh
+++ b/platform/mellanox/sonic-bfb-installer.sh
@@ -329,7 +329,12 @@ bfb_install_call() {
     remove_cx_pci_device "$rshim" "$dpu"
 
     # Create config file with NPU time for DPU time synchronization
-    local config_file=$(mktemp "${WORK_DIR}/bf_cfg.XXXXX")
+    local config_file
+    config_file=$(mktemp "${WORK_DIR}/bf_cfg.XXXXX") || {
+        log_error "$rid: Failed to create temporary config file in ${WORK_DIR}"
+        return 1
+    }
+    trap "rm -f '$config_file'; stop_rshim_daemon $rid" EXIT
     if [ -n "$appendix" ]; then
         cat "$appendix" > "$config_file"
     fi
@@ -359,8 +364,6 @@ bfb_install_call() {
     if [ $exit_status -ne 0 ] || [ $verbose = true ]; then
         cat "$result_file"
     fi
-
-    rm -f "$config_file"
 
     # Stop rshim application and reset DPU
     stop_rshim_daemon "$rid"

--- a/platform/nvidia-bluefield/installer/install.sh.j2
+++ b/platform/nvidia-bluefield/installer/install.sh.j2
@@ -99,14 +99,22 @@ if [ -e /etc/bf.cfg ]; then
 	. /etc/bf.cfg
 fi
 
-if [ -n "$NPU_TIME" ]; then
+if [[ "$NPU_TIME" =~ ^[0-9]+$ ]]; then
 	log "Setting system time from NPU: $NPU_TIME"
-	date -s "@$NPU_TIME"
-	log "System time set to: $(date)"
-	if [ -e /dev/rtc0 ]; then
-		hwclock --systohc --utc
-		log "Hardware clock synced from system time"
+	if date -s "@$NPU_TIME" > /dev/null 2>&1; then
+		log "System time set to: $(date)"
+		if [ -e /dev/rtc0 ]; then
+			if hwclock --systohc --utc > /dev/null 2>&1; then
+				log "Hardware clock synced from system time"
+			else
+				log "WARNING: Failed to sync hardware clock from system time (rc=$?)"
+			fi
+		fi
+	else
+		log "WARNING: Failed to set system time from NPU_TIME=$NPU_TIME (rc=$?)"
 	fi
+else
+	log "Invalid NPU_TIME value '$NPU_TIME'; expected positive integer Unix timestamp. Skipping time update."
 fi
 
 # Flags that can be overwritten by the bf.cfg


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
DPU hardware clock is not guaranteed to be close to the current time on the NPU. Because of this chrony slew often does not correct the DPU time during short tests. By forcing the DPU to be in sync with the NPU on startup it will converge earlier and reduce exceptions caused by the incorrect clock.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Create a configuration NPU_TIME to share with the DPU to set its hardware clock on startup.

#### How to verify it

Before change:
root@sonic-npu:/var/log# date
Tue Dec  9 02:59:32 AM UTC 2025

admin@sonic-dpu:~$ date
Mon Jun 2 06:50:47 AM UTC 2025

After change:
root@sonic-npu:/var/log# date
Tue Dec  9 03:07:46 AM UTC 2025

admin@sonic-dpu:~$ date
Tue Dec  9 03:07:39 AM UTC 2025

After dpuctl dpu-reset:


admin@sonic-npu:~$ date
Tue Dec  9 03:20:01 AM UTC 2025

admin@sonic-dpu:~$ date


#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202511

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Force sync DPU hardware time during bfb instal

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

