### PR TITLE
[bgpcfgd] Revert BGP suppress fib pending config change (PR #23187)

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_db.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_db.py
@@ -19,20 +19,6 @@ class BGPDataBaseMgr(Manager):
 
     def set_handler(self, key, data):
         """ Implementation of 'SET' command for this class """
-
-        if self.__set_handler_validate(key, data) == True:
-            cmd_list = []
-            bgp_asn = data["bgp_asn"]
-            state = data["suppress-fib-pending"]
-            cmd_list.append("router bgp %s" % bgp_asn)
-            if state == "disabled":
-                cmd_list.append("no bgp suppress-fib-pending")
-            else:
-                cmd_list.append("bgp suppress-fib-pending")
-            cmd_list.append("exit")
-
-            self.cfg_mgr.push_list(cmd_list)
-
         self.directory.put(self.db_name, self.table_name, key, data)
 
         return True
@@ -40,9 +26,3 @@ class BGPDataBaseMgr(Manager):
     def del_handler(self, key):
         """ Implementation of 'DEL' command for this class """
         self.directory.remove(self.db_name, self.table_name, key)
-
-    def __set_handler_validate(self, key, data):
-        if data:
-            if ((key == "localhost") and ("bgp_asn" in data) and ("suppress-fib-pending" in data and data["suppress-fib-pending"] in ["enabled","disabled"])):
-                 return True
-        return False

--- a/src/sonic-bgpcfgd/tests/test_db.py
+++ b/src/sonic-bgpcfgd/tests/test_db.py
@@ -30,14 +30,6 @@ def test_set_del_handler():
     assert "test_key2" in m.directory.get_slot(m.db_name, m.table_name)
     assert m.directory.get(m.db_name, m.table_name, "test_key2") == {}
 
-    res = m.set_handler("localhost", {'bgp_asn':'65100','suppress-fib-pending':'enabled'})
-    assert res, "Returns always True"
-    assert m.directory.get(m.db_name, m.table_name, "localhost") == {'bgp_asn':'65100','suppress-fib-pending':'enabled'}
-
-    res = m.set_handler("localhost", {'bgp_asn':'65100','suppress-fib-pending':'disabled'})
-    assert res, "Returns always True"
-    assert m.directory.get(m.db_name, m.table_name, "localhost") == {'bgp_asn':'65100','suppress-fib-pending':'disabled'}
-
     # test del_handler
     m.del_handler("test_key")
     assert "test_key" not in m.directory.get_slot(m.db_name, m.table_name)


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To address issue: https://github.com/sonic-net/sonic-buildimage/issues/24679

The suppress-fib-pending is always enabled in FRR during system start/boot up (via bgp config templates) for both single asic and multi-asic systems. When this config is changed after BGP sessions are up, the sessions are reset. This is traffic disruptive.

To avoid this trafic distruption, "suppress-fib-pending" config changes done during runtime are not sent to FRR. This is intentional and as per design. 

Therefore these changes are reverted and the "suppress-fib-pending" config changes will not be sent to FRR for both single asic and multi-asic systems.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

By reverting the commit 1b2cead9b550ed15a786b81a60813fb24220888e. (PR #23187)

#### How to verify it

- After BGP sessions are up and routes are learned, change the suppress-fib-pending config.
- Observe: BGP sessions are not restarted.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 --> master
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Revert "[bgpcfgd]BGP suppress fib pending support for multi-asic (#23187)"

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

