### PR TITLE
Fix NH fpga util click 8.0 compatibility

### DIFF
--- a/platform/broadcom/sonic-platform-modules-nexthop/common/nexthop/fpga_cli.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/common/nexthop/fpga_cli.py
@@ -62,6 +62,9 @@ class AlignedOffset(click.ParamType):
     name = "aligned_offset"
 
     def convert(self, value, param, ctx) -> int:
+        if isinstance(value, int):
+            return value
+
         try:
             offset = int(value, 16)
         except ValueError:
@@ -79,6 +82,9 @@ class BitRange(click.ParamType):
 
         Validates that the start and end are within [0, 31] and that start <= end.
         """
+        if isinstance(value, tuple):
+            return value
+
         match = re.search(pattern=r"^(\d+):(\d+)$", string=value)
         if match is None:
             self.fail(
@@ -194,7 +200,7 @@ def write32(pci_address, offset, value, bits):
     default="0:31",
     help="Inclusive range of bits to read from (e.g., '0:31').",
 )
-def read32(offset, pci_address, bits):
+def read32(pci_address, offset, bits):
     """Read 32-bit value from FPGA register.
     
     TARGET_FPGA can be either the FPGA name (e.g., 'CPU_CARD_FPGA') or 


### PR DESCRIPTION
#### Why I did it
`click` version has been upgraded to 8.0 in https://github.com/sonic-net/sonic-buildimage/pull/24678

This PR updates Nexthop's fpga util to be compatible with click 8.0

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Update `convert` methods to handle being called multiple times with non-string input values.

#### How to verify it
Tested on an NH platform

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)
master

#### Description for the changelog
Fix NH fpga util click 8.0 compatibility