### PR TITLE
[multi-asic] Add --netns option to sonic-db-dump

### DIFF
--- a/src/sonic-py-common/tests/test_sonic_db_dump_load.py
+++ b/src/sonic-py-common/tests/test_sonic_db_dump_load.py
@@ -1,0 +1,83 @@
+import sys
+from sonic_py_common.sonic_db_dump_load import sonic_db_dump_load
+from swsscommon.swsscommon import SonicDBKey
+from unittest.mock import patch
+
+@patch("redisdl.dump")
+@patch("swsscommon.swsscommon.SonicDBConfig.getDbHostname", return_value="127.0.0.1")
+@patch("swsscommon.swsscommon.SonicDBConfig.getDbPort", return_value=6379)
+@patch("swsscommon.swsscommon.SonicDBConfig.getDbId", return_value=0)
+@patch("sys.argv", ["sonic-db-dump", "-n", "APPL_DB"])
+def test_sonic_db_dump(mock_getDbHostname, mock_getDbPort, mock_getDbId, mock_dump):
+    sonic_db_dump_load()
+    mock_dump.assert_called_once_with(sys.stdout, **
+        {
+            "host": "127.0.0.1",
+            "port": 6379,
+            "unix_socket_path": None,
+            "db": 0,
+            "encoding": "utf-8",
+        }
+    )
+    mock_getDbHostname.assert_called_once_with("APPL_DB", SonicDBKey())
+
+
+@patch("redisdl.dump")
+@patch("sonic_py_common.multi_asic.is_multi_asic", return_value=True)
+@patch("swsscommon.swsscommon.SonicDBConfig.getDbHostname", return_value="127.0.0.1")
+@patch("swsscommon.swsscommon.SonicDBConfig.getDbPort", return_value=6379)
+@patch("swsscommon.swsscommon.SonicDBConfig.getDbId", return_value=0)
+@patch("sys.argv", ["sonic-db-dump", "--netns", "asic0", "-n", "APPL_DB"])
+def test_sonic_db_dump_multi_asic(mock_getDbHostname, mock_getDbPort, mock_getDbId, mock_is_multi_asic, mock_dump):
+    sonic_db_dump_load()
+    mock_dump.assert_called_once_with(sys.stdout, **
+        {
+            "host": "127.0.0.1",
+            "port": 6379,
+            "unix_socket_path": None,
+            "db": 0,
+            "encoding": "utf-8",
+        }
+    )
+    mock_getDbHostname.assert_called_once_with("APPL_DB", SonicDBKey("asic0"))
+
+
+@patch("redisdl.load")
+@patch("swsscommon.swsscommon.SonicDBConfig.getDbHostname", return_value="127.0.0.1")
+@patch("swsscommon.swsscommon.SonicDBConfig.getDbPort", return_value=6379)
+@patch("swsscommon.swsscommon.SonicDBConfig.getDbId", return_value=0)
+@patch("sys.argv", ["sonic-db-load", "-n", "APPL_DB"])
+def test_sonic_db_load(mock_getDbHostname, mock_getDbPort, mock_getDbId, mock_load):
+    sonic_db_dump_load()
+    mock_load.assert_called_once_with(sys.stdin, **
+        {
+            "host": "127.0.0.1",
+            "port": 6379,
+            "unix_socket_path": None,
+            "db": 0,
+            "encoding": "utf-8",
+        }
+    )
+    args, kwargs = mock_getDbHostname.call_args
+    assert args[0] == "APPL_DB"
+    assert args[1].netns == ""
+
+
+@patch("redisdl.load")
+@patch("sonic_py_common.multi_asic.is_multi_asic", return_value=True)
+@patch("swsscommon.swsscommon.SonicDBConfig.getDbHostname", return_value="127.0.0.1")
+@patch("swsscommon.swsscommon.SonicDBConfig.getDbPort", return_value=6379)
+@patch("swsscommon.swsscommon.SonicDBConfig.getDbId", return_value=0)
+@patch("sys.argv", ["sonic-db-load", "--netns", "asic0", "-n", "APPL_DB"])
+def test_sonic_db_load_multi_asic(mock_getDbHostname, mock_getDbPort, mock_getDbId, mock_is_multi_asic, mock_load):
+    sonic_db_dump_load()
+    mock_load.assert_called_once_with(sys.stdin, **
+        {
+            "host": "127.0.0.1",
+            "port": 6379,
+            "unix_socket_path": None,
+            "db": 0,
+            "encoding": "utf-8",
+        }
+    )
+    mock_getDbHostname.assert_called_once_with("APPL_DB", SonicDBKey("asic0"))


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

`sonic-db-dump` is used in warm-reboot script implementation. Hence, adding namespace awareness to this tool to support warm-boot on Multi-ASIC.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added `--netns` option.

#### How to verify it

1. `sonic-db-dump -n APPL_DB --netns asic0`

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

