### PR TITLE
[ci] refine slave image tag strategy

### DIFF
--- a/.azure-pipelines/docker-sonic-slave-template.yml
+++ b/.azure-pipelines/docker-sonic-slave-template.yml
@@ -55,8 +55,8 @@ jobs:
       build_options="$(VERSION_CONTROL_OPTIONS)"
       image_tag=$(BLDENV=${{ parameters.dist }} make -f Makefile.work showtag $build_options PLATFORM=generic PLATFORM_ARCH=${{ parameters.arch }} | grep sonic-slave | tail -n 1)
       image_latest=$(echo $(echo $image_tag | awk -F: '{print$1}'):latest)
-      image_branch=$(echo $(echo $image_latest | awk -F: '{print$1}'):$(Build.SourceBranchName))
-      image_branch_arch=$(echo $(echo $image_latest_arch | awk -F: '{print$1}'):$(Build.SourceBranchName)-${{ parameters.arch }})
+      image_branch=$(echo $(echo $image_tag | awk -F: '{print$1}'):$(Build.SourceBranchName))
+      image_branch_arch=$(echo $(echo $image_tag | awk -F: '{print$1}'):$(Build.SourceBranchName)-${{ parameters.arch }})
       docker rmi $image_tag || true
 
       if [[ "$(Build.Reason)" =~ [a-zA-Z]*CI ]] && docker pull ${{ parameters.registry_url }}/${image_tag};then


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
current naming convention:
master:
 - amd64
    - sonic-slave-{debian}-amd64:latest
    - sonic-slave-{debian}-amd64:master
 - armhf:
    - sonic-slave-{debian}-armhf:latest
    - sonic-slave-{debian}-armhf:master
 - arm64:
    - sonic-slave-{debian}-arm64:latest
    - sonic-slave-{debian}-arm64:master
202511:
- amd64
    - sonic-slave-{debian}-amd64:202511
 - armhf:
    - sonic-slave-{debian}-armhf:202511
 - arm64:
    - sonic-slave-{debian}-arm64:202511

At the moment, most of the pipelines are pulling sonic-slave-bookworm:latest, which hasn't been updated more than two months. 
To make the slave image management easier, the new naming convention will tag images as following:
<img width="352" height="557" alt="image" src="https://github.com/user-attachments/assets/12fad99f-8c00-4f01-96e4-331a8e9dd16b" />

all the slave images will have the same image-name 'sonic-slave-{debian}, but different tags
In submodule pipelines, we can pull images using SONIC_SLAVE:arch-branch   (SONIC_SLAVE=sonic-slave-{debian})

##### Work item tracking
- Microsoft ADO **(number only)**: 36254894
#### How I did it

#### How to verify it


#### A picture of a cute animal (not mandatory but encouraged)

