### PR TITLE
[Nokia-7215-A1] Fix for FW and memory test cases

### DIFF
--- a/device/nokia/arm64-nokia_ixs7215_52xb-r0/installer.conf
+++ b/device/nokia/arm64-nokia_ixs7215_52xb-r0/installer.conf
@@ -1,1 +1,1 @@
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="default_hugepagesz=32M hugepages=4 loglevel=4"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="default_hugepagesz=32M hugepages=4 loglevel=4 efi_pstore.pstore_disable=1" 

--- a/platform/marvell-prestera/sonic-platform-nokia/7215-a1/sonic_platform/component.py
+++ b/platform/marvell-prestera/sonic-platform-nokia/7215-a1/sonic_platform/component.py
@@ -186,7 +186,25 @@ class Component(ComponentBase):
         if self.index == 1:
             cmdstatus, uboot_version = cmd.getstatusoutput('cat /proc/device-tree/chosen/u-boot,version')
             return uboot_version or "V1.1"
+        
+    def get_available_firmware_version(self, image_path):
+        """
+        Retrieves the available firmware version of the component
 
+        Note: the firmware version will be read from image
+
+        Args:
+            image_path: A string, path to firmware image
+
+        Returns:
+            A string containing the available firmware version of the component
+        """
+        if image_path:    
+            image_name = ntpath.basename(image_path)
+            return image_name
+
+        return 'NA'
+    
     def install_firmware(self, image_path):
         """
         Installs firmware to the component
@@ -263,3 +281,23 @@ class Component(ComponentBase):
                     print("ERROR: Failed to upgrade U-BOOT: command={}, rc={}",format(e.cmd),format(e.returncode))
 
                 return success_flag
+
+    def update_firmware(self, image_path):
+        """
+        Updates firmware of the component
+
+        This API performs firmware update: it assumes firmware installation and loading in a single call.
+        In case platform component requires some extra steps (apart from calling Low Level Utility)
+        to load the installed firmware (e.g, reboot, power cycle, etc.) - this will be done automatically by API
+
+        Args:
+            image_path: A string, path to firmware image
+
+        Returns:
+            Boolean False if image_path doesn't exist instead of throwing an exception error
+            Nothing when the update is successful
+
+        Raises:
+            RuntimeError: update failed
+        """
+        return self.install_firmware(image_path)


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix OC test cases to get 100% pass

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
1) Add missing API's to fix firmware testcases
2) Add additional cmdline arg to fix memory exhaustion testcase

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

