### PR TITLE
[Nvidia] [Smartswitch] Added halt timeout in platform

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn4280-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/platform.json
@@ -700,5 +700,6 @@
             "rshim_bus_info": "0000:02:00.1",
             "bus_info": "0000:02:00.0"
         }
-    }
+    },
+    "dpu_halt_services_timeout": 180
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
During firmware upgrade after sonic to sonic image upgrade, the time taken for halt service to complete is more than 60 seconds (the default time) So this timeout is added to fix the issue

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Update `dpu_halt_services_timeout` in platform.json

#### How to verify it
Use sonic-installer: `sonic-installer install sonic-nvidia-blueifield.bin`
Run reboot : `reboot -d DPU0`
Make sure firmware is updated `mlnxfwmanager`


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

