### PR TITLE
[yang] Add IPv6 link-local support for vlan-sub-interface

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vlan_sub_interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vlan_sub_interface.json
@@ -56,6 +56,13 @@
         "eStrKey" : "Pattern",
         "eStr": ["drop|forward"]
     },
+    "VLAN_SUB_INTERFACE_ENABLE_IPV6_LINK_LOCAL": {
+        "desc": "Enable the ipv6 link-local."
+    },
+    "VLAN_SUB_INTERFACE_INVALID_ENABLE_IPV6_LINK_LOCAL": {
+        "desc": "Enable the ipv6 link-local as true.",
+        "eStr": "Invalid value \"true\" in \"ipv6_use_link_local_only\" element."
+    },
     "VLAN_SUB_INTERFACE_SHORT_NAME_FORMAT_VLAN_CHECK_MUST_CONDITION_FALSE_TEST": {
         "desc": "Configure valid short name format vlan sub interface vlan must check condition false.",
         "eStrKey": "Must"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan_sub_interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan_sub_interface.json
@@ -538,6 +538,60 @@
             }
         }
     },
+    "VLAN_SUB_INTERFACE_ENABLE_IPV6_LINK_LOCAL": {
+        "sonic-vlan-sub-interface:sonic-vlan-sub-interface": {
+            "sonic-vlan-sub-interface:VLAN_SUB_INTERFACE": {
+                "VLAN_SUB_INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8.10",
+                        "ipv6_use_link_local_only": "enable"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "admin_status": "up",
+                        "alias": "Ethernet8/1",
+                        "description": "Ethernet8",
+                        "lanes": "45,46,47,48",
+                        "mtu": 9000,
+                        "speed": 100000
+                    }
+                ]
+            }
+        }
+    },
+    "VLAN_SUB_INTERFACE_INVALID_ENABLE_IPV6_LINK_LOCAL": {
+        "sonic-vlan-sub-interface:sonic-vlan-sub-interface": {
+            "sonic-vlan-sub-interface:VLAN_SUB_INTERFACE": {
+                "VLAN_SUB_INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8.10",
+                        "ipv6_use_link_local_only": "true"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "admin_status": "up",
+                        "alias": "Ethernet8/1",
+                        "description": "Ethernet8",
+                        "lanes": "45,46,47,48",
+                        "mtu": 9000,
+                        "speed": 100000
+                    }
+                ]
+            }
+        }
+    },
     "VLAN_SUB_INTERFACE_SHORT_NAME_FORMAT_VLAN_CHECK_MUST_CONDITION_FALSE_TEST": {
         "sonic-vlan-sub-interface:sonic-vlan-sub-interface": {
             "sonic-vlan-sub-interface:VLAN_SUB_INTERFACE": {

--- a/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
@@ -36,6 +36,10 @@ module sonic-vlan-sub-interface {
         description "Initial version";
     }
 
+    revision 2025-12-23 {
+        description "Add leaf ipv6 ipv6_use_link_local_only";
+    }
+
     container sonic-vlan-sub-interface {
         container VLAN_SUB_INTERFACE {
 
@@ -98,6 +102,12 @@ module sonic-vlan-sub-interface {
                     type uint16 {
                         range 1..4094;
                     }
+                }
+
+                leaf ipv6_use_link_local_only {
+                    description "Enable/Disable IPv6 link local address on vlan-sub-interface";
+                    type stypes:mode-status;
+                    default disable;
                 }
             }
 


### PR DESCRIPTION
#### Why I did it
The vlan-sub-interface supports the ipv6_use_link_local_only feature, so the YANG model needs to be revised accordingly.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added validation for the ipv6_use_link_local_only field in the vlan-sub-interface YANG model, and updated the associated test cases.

#### How to verify it
Run the test cases modified in this PR.

#### Which release branch to backport (provide reason below if selected)


#### Tested branch (Please provide the tested image version)

- [x] 202505

#### Description for the changelog

add ipv6_use_link_local_only for vlan_sub_interface

#### Link to config_db schema for YANG module changes


#### A picture of a cute animal (not mandatory but encouraged)

