### PR TITLE
marvell-prestera: raise syncd nice 8 priority

### DIFF
--- a/platform/marvell-prestera/docker-syncd-mrvl-prestera/supervisord.conf
+++ b/platform/marvell-prestera/docker-syncd-mrvl-prestera/supervisord.conf
@@ -31,7 +31,7 @@ stderr_syslog=true
 dependent_startup=true
 
 [program:syncd]
-command=/usr/bin/syncd_start.sh
+command=/usr/bin/nice -n -8 /usr/bin/syncd_start.sh
 priority=3
 autostart=false
 autorestart=false


### PR DESCRIPTION
#### Why I did it
Fix for issue   https://github.com/sonic-net/sonic-buildimage/issues/24771
syncd supervisor-proc-exit-listener FATAL under startup and high CPU loading

##### Work item tracking
NO

#### How I did it
Raise nice priority for the Marvell-prestera platform (only) for time-consumptive syncd 

#### How to verify it
Refer  https://github.com/sonic-net/sonic-buildimage/issues/24771

#### Which release branch to backport (provide reason below if selected)
NO

#### Tested branch (Please provide the tested image version)
#### Description for the changelog
#### Link to config_db schema for YANG module changes
#### A picture of a cute animal (not mandatory but encouraged)

