### PR TITLE
Fix golang download url in sonic-slave-buster Dockerfile

### DIFF
--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -483,13 +483,13 @@ RUN eatmydata apt-get install -y kernel-wedge
 # For gobgp and telemetry build
 RUN export VERSION=1.15.15 \
 {%- if CONFIGURED_ARCH == "armhf" and CROSS_BUILD_ENVIRON != "y" %}
- && wget https://storage.googleapis.com/golang/go$VERSION.linux-armv6l.tar.gz \
+ && wget https://go.dev/dl/go$VERSION.linux-armv6l.tar.gz \
  && tar -C /usr/local -xzf go$VERSION.linux-armv6l.tar.gz \
 {%- elif CONFIGURED_ARCH == "arm64" and CROSS_BUILD_ENVIRON != "y" %}
- && wget https://storage.googleapis.com/golang/go$VERSION.linux-arm64.tar.gz \
+ && wget https://go.dev/dl/go$VERSION.linux-arm64.tar.gz \
  && tar -C /usr/local -xzf go$VERSION.linux-arm64.tar.gz \
 {%- else %}
- && wget https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz \
+ && wget https://go.dev/dl/go$VERSION.linux-amd64.tar.gz \
  && tar -C /usr/local -xzf go$VERSION.linux-amd64.tar.gz \
 {%- endif %}
  && echo 'export GOROOT=/usr/local/go' >> /etc/bash.bashrc \


### PR DESCRIPTION
https://storage.googleapis.com/golang no longer allows anonymous access, replace it with https://go.dev/dl/ instead.

#### Why I did it

Builds of sonic-slave-buster docker image fail, as the golang cannot be downloaded using the old url.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Use recommended url for downloading golang.

#### How to verify it

```
docker image list -q -f reference='sonic-slave-buster*' | xargs -r docker rmi
make EXTRA_DOCKER_TARGETS=list BLDENV=buster -f Makefile.work buster
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 202305
- [x] 202311
- [x] 202405
- [x] 202411
- [x] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

`(^._.^)ﾉ`