### PR TITLE
[build] Disable device-data dpkg cache because it never hit cache.

### DIFF
--- a/rules/sonic-device-data.dep
+++ b/rules/sonic-device-data.dep
@@ -4,7 +4,9 @@ DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/sonic-device-data.mk rules/sonic
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(SPATH)) $(SONIC_DEVICE_FILES_LIST)
 
-$(SONIC_DEVICE_DATA)_CACHE_MODE := GIT_CONTENT_SHA
+# disable cache for device-data, because before PR24967 rcache can't match wcache.
+# After PR24967, when building vs image and rcache triggered, build will fail.
+$(SONIC_DEVICE_DATA)_CACHE_MODE := none
 $(SONIC_DEVICE_DATA)_DEP_FLAGS  := $(SONIC_COMMON_FLAGS_LIST)
 $(SONIC_DEVICE_DATA)_DEP_FILES  := $(DEP_FILES)
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Disable dpkg cache for device-data package.
The cache never hit before #24967 
After #24967 , cache can hit, but it breaks vs image build. Failure is related with multi-asic.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

