### PR TITLE
[Mellanox] Fix thermal_updater polling interval get issue

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
@@ -104,33 +104,35 @@ class ThermalUpdater:
         sfp_poll_interval = 10
         data = utils.load_json_file(TC_CONFIG_FILE, log_func=None)
         if not data:
-            logger.log_notice(f'{TC_CONFIG_FILE} does not exist, use default polling interval')
+            logger.log_error(f'{TC_CONFIG_FILE} does not exist, use default polling interval')
 
         if data:
             dev_parameters = data.get('dev_parameters')
-            if dev_parameters is not None:
+            if not dev_parameters:
+                logger.log_error('dev_parameters not configured or empty, using default intervals')
+            else:
                 # Find ASIC parameter using regex pattern
                 asic_key, asic_parameter = self._find_matching_key(dev_parameters, r'asic\\d*')
                 if asic_parameter is not None:
                     asic_poll_interval_config = asic_parameter.get('poll_time')
                     if asic_poll_interval_config:
-                        asic_poll_interval = int(asic_poll_interval_config) / 2
+                        asic_poll_interval = int(asic_poll_interval_config)
                         logger.log_notice(f'ASIC parameter found with key "{asic_key}", poll_time: {asic_poll_interval_config}, interval: {asic_poll_interval}')
                     else:
-                        logger.log_notice(f'ASIC poll_time not configured in "{asic_key}", using default interval: {asic_poll_interval}')
+                        logger.log_error(f'ASIC poll_time not configured in "{asic_key}", using default interval: {asic_poll_interval}')
                 else:
-                    logger.log_notice(f'ASIC parameter not found (pattern: asic\\d*), using default interval: {asic_poll_interval}')
+                    logger.log_error(f'ASIC parameter not found (pattern: asic\\d*), using default interval: {asic_poll_interval}')
                 # Find Module parameter using regex pattern
                 module_key, module_parameter = self._find_matching_key(dev_parameters, r'module\\d+')
                 if module_parameter is not None:
                     sfp_poll_interval_config = module_parameter.get('poll_time')
                     if sfp_poll_interval_config:
-                        sfp_poll_interval = int(sfp_poll_interval_config) / 2
+                        sfp_poll_interval = int(sfp_poll_interval_config)
                         logger.log_notice(f'Module parameter found with key "{module_key}", poll_time: {sfp_poll_interval_config}, interval: {sfp_poll_interval}')
                     else:
-                        logger.log_notice(f'Module poll_time not configured in "{module_key}", using default interval: {sfp_poll_interval}')
+                        logger.log_error(f'Module poll_time not configured in "{module_key}", using default interval: {sfp_poll_interval}')
                 else:
-                    logger.log_notice(f'Module parameter not found (pattern: module\\d+), using default interval: {sfp_poll_interval}')
+                    logger.log_error(f'Module parameter not found (pattern: module\\d+), using default interval: {sfp_poll_interval}')
 
         if self._update_asic:
             logger.log_notice(f'ASIC polling interval: {asic_poll_interval}')

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
@@ -20,6 +20,7 @@ from .device_data import DeviceDataManager
 from . import utils
 from sonic_py_common import logger
 
+import re
 import sys
 import time
 import os
@@ -88,6 +89,16 @@ class ThermalUpdater:
 
         return result
 
+    def _find_matching_key(self, dev_parameters, pattern):
+        """
+        Find the first key in dev_parameters that matches the given regex pattern.
+        Returns the matching key and its value, or (None, None) if no match found.
+        """
+        for key in dev_parameters.keys():
+            if re.match(pattern, key):
+                return key, dev_parameters[key]
+        return None, None
+
     def load_tc_config(self):
         asic_poll_interval = 1
         sfp_poll_interval = 10
@@ -98,16 +109,28 @@ class ThermalUpdater:
         if data:
             dev_parameters = data.get('dev_parameters')
             if dev_parameters is not None:
-                asic_parameter = dev_parameters.get('asic')
+                # Find ASIC parameter using regex pattern
+                asic_key, asic_parameter = self._find_matching_key(dev_parameters, r'asic\\d*')
                 if asic_parameter is not None:
                     asic_poll_interval_config = asic_parameter.get('poll_time')
                     if asic_poll_interval_config:
                         asic_poll_interval = int(asic_poll_interval_config) / 2
-                module_parameter = dev_parameters.get('module\\d+')
+                        logger.log_notice(f'ASIC parameter found with key "{asic_key}", poll_time: {asic_poll_interval_config}, interval: {asic_poll_interval}')
+                    else:
+                        logger.log_notice(f'ASIC poll_time not configured in "{asic_key}", using default interval: {asic_poll_interval}')
+                else:
+                    logger.log_notice(f'ASIC parameter not found (pattern: asic\\d*), using default interval: {asic_poll_interval}')
+                # Find Module parameter using regex pattern
+                module_key, module_parameter = self._find_matching_key(dev_parameters, r'module\\d+')
                 if module_parameter is not None:
                     sfp_poll_interval_config = module_parameter.get('poll_time')
                     if sfp_poll_interval_config:
                         sfp_poll_interval = int(sfp_poll_interval_config) / 2
+                        logger.log_notice(f'Module parameter found with key "{module_key}", poll_time: {sfp_poll_interval_config}, interval: {sfp_poll_interval}')
+                    else:
+                        logger.log_notice(f'Module poll_time not configured in "{module_key}", using default interval: {sfp_poll_interval}')
+                else:
+                    logger.log_notice(f'Module parameter not found (pattern: module\\d+), using default interval: {sfp_poll_interval}')
 
         if self._update_asic:
             logger.log_notice(f'ASIC polling interval: {asic_poll_interval}')

--- a/platform/mellanox/mlnx-platform-api/tests/test_thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_thermal_updater.py
@@ -28,7 +28,7 @@ from sonic_platform.thermal_updater import ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD,
 mock_tc_config = """
 {
     "dev_parameters": {
-        "asic": {
+        "asic\\\\d*": {
             "pwm_min": 20,
             "pwm_max": 100,
             "val_min": "!70000",
@@ -48,23 +48,59 @@ mock_tc_config = """
 
 
 class TestThermalUpdater:
-    def test_load_tc_config_non_exists(self):
+    @mock.patch('sonic_platform.thermal_updater.logger')
+    def test_load_tc_config_non_exists(self, mock_logger):
         updater = ThermalUpdater(None)
         updater.load_tc_config()
         assert updater._timer._timestamp_queue.qsize() == 2
 
-    def test_load_tc_config_mocked(self):
+    @mock.patch('sonic_platform.thermal_updater.logger')
+    def test_load_tc_config_mocked(self, mock_logger):
         updater = ThermalUpdater(None)
         mock_os_open = mock.mock_open(read_data=mock_tc_config)
         with mock.patch('sonic_platform.utils.open', mock_os_open):
             updater.load_tc_config()
         assert updater._timer._timestamp_queue.qsize() == 2
+        # Verify that debug logs were called with the correct parameters
+        assert mock_logger.log_notice.call_count >= 2  # At least ASIC and Module parameter logs
 
+    def test_find_matching_key(self):
+        """Test _find_matching_key method for regex pattern matching"""
+        updater = ThermalUpdater(None)
+
+        # Test with asic pattern - should match 'asic\d*' keys
+        dev_parameters = {
+            'asic\\d*': {'poll_time': 3},
+            'module\\d+': {'poll_time': 20},
+            'sensor_amb': {'poll_time': 30}
+        }
+
+        # Test matching asic pattern
+        key, value = updater._find_matching_key(dev_parameters, r'asic\\d*')
+        assert key == 'asic\\d*'
+        assert value == {'poll_time': 3}
+
+        # Test matching module pattern
+        key, value = updater._find_matching_key(dev_parameters, r'module\\d+')
+        assert key == 'module\\d+'
+        assert value == {'poll_time': 20}
+
+        # Test non-matching pattern
+        key, value = updater._find_matching_key(dev_parameters, r'nonexistent')
+        assert key is None
+        assert value is None
+
+        # Test with empty dict
+        key, value = updater._find_matching_key({}, r'asic\\d*')
+        assert key is None
+        assert value is None
+
+    @mock.patch('sonic_platform.thermal_updater.logger')
     @mock.patch('sonic_platform.thermal_updater.ThermalUpdater.update_asic', mock.MagicMock())
     @mock.patch('sonic_platform.thermal_updater.ThermalUpdater.update_module', mock.MagicMock())
     @mock.patch('sonic_platform.thermal_updater.ThermalUpdater.wait_for_sysfs_nodes', mock.MagicMock(return_value=True))
     @mock.patch('sonic_platform.utils.write_file')
-    def test_start_stop(self, mock_write):
+    def test_start_stop(self, mock_write, mock_logger):
         mock_sfp = mock.MagicMock()
         mock_sfp.sdk_index = 1
         updater = ThermalUpdater([mock_sfp])


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The thermal updater's `load_tc_config` method was unable to correctly parse tc_config files that use regex-based parameter.

#### How I did it
1. **Added `_find_matching_key` method**: Implements regex pattern matching to find parameter keys in dictionary.
2. **Updated `load_tc_config` method**:
   - Changed ASIC parameter lookup to use regex pattern `r'asic\\d*'`
   - Changed Module parameter lookup to use regex pattern `r'module\\d+'`
 
#### How to verify it
Test in switch, check if corrected parsed.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->
- [x] 202412
- [x] 202511

#### Tested branch (Please provide the tested image version)
202511
