### PR TITLE
Update sensors.conf in x86_64-arista_7280r4{k}_32qf_32df SKUs

### DIFF
--- a/device/arista/x86_64-arista_7280r4_32qf_32df/sensors.conf
+++ b/device/arista/x86_64-arista_7280r4_32qf_32df/sensors.conf
@@ -1,4 +1,7 @@
 chip "nvme-pci-0500"
+    ignore temp2
     ignore temp3
     ignore temp4
+    ignore temp5
+    ignore temp6
     ignore temp7


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Sensorsd picks up non-existent sensors and reports errors.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Updated sensors.conf to ignore all but one temp sensor.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
Check sensord logs and run `sensors`

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

<img width="1500" height="1000" alt="image" src="https://github.com/user-attachments/assets/7e925be3-4a18-4e94-b61d-87c06b123a9b" />
