### PR TITLE
Reapply "We should check service enabled instead exists (#24754)" (#24794)

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -619,7 +619,7 @@ check_add_bgp_dependency
 check_ports_present
 PORTS_PRESENT=$?
 
-if [[ $PORTS_PRESENT == 0 ]] && [[ $(check_service_enabled "teamd$DEV") == "true" ]]; then
+if [[ $PORTS_PRESENT == 0 ]] && [[ $(check_service_enabled "teamd${DEV:+@$DEV}") == "true" ]]; then
     MULTI_INST_DEPENDENT="teamd"
 fi
 


### PR DESCRIPTION
#### Why I did it
If teamd feature is disabled,
```
sudo config feature state teamd disabled
```

swss service should not wait on team container at all. Currently there is a process
```
python3 /usr/bin/docker-wait-any -s swss -d syncd teamd
```

However, a thread inside /usr/bin/docker-wait-any is actually crashed, and the behavior is same as ignoring teamd. It still keep the whole system working.

The root fix should check service enabled instead exists, so it will not wait-any on teamd at all. After this PR,

```
python3 /usr/bin/docker-wait-any -s swss -d syncd
```


##### Work item tracking
- Microsoft ADO **(number only)**:
- Fixing https://github.com/sonic-net/sonic-buildimage/issues/24730


#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

