### PR TITLE
[multi-asic][Mellanox] platform-api changes to support multi-asic

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,6 +31,7 @@ try:
     from functools import reduce
     from .utils import extract_RJ45_ports_index
     from .utils import extract_cpo_ports_index
+    from .utils import extract_asic_id_map
     from . import module_host_mgmt_initializer
     from . import utils
     from .device_data import DeviceDataManager
@@ -38,6 +39,7 @@ try:
     import select
     import threading
     import time
+    from pathlib import Path
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
@@ -125,6 +127,8 @@ class Chassis(ChassisBase):
         # Build the CPO port list from platform.json and hwsku.json
         self._cpo_port_inited = False
         self._cpo_port_list = None
+        # Mapping from SFP index to ASIC ID
+        self._asic_id_map = None
 
         self.liquid_cooling = None
 
@@ -277,6 +281,13 @@ class Chassis(ChassisBase):
     # SFP methods
     ##############################################
 
+    def _get_asic_id_by_sfp_index(self, sfp_index):
+        if not DeviceDataManager.is_multi_asic_platform():
+            return 'asic0'
+        if not self._asic_id_map:
+            self._asic_id_map = extract_asic_id_map(DeviceDataManager.get_asic_count())
+        return f'asic{self._asic_id_map.get(sfp_index)}'
+
     def _import_sfp_module(self):
         if not self.sfp_module:
             from . import sfp as sfp_module
@@ -296,12 +307,13 @@ class Chassis(ChassisBase):
 
                     if not self._sfp_list[index]:
                         sfp_module = self._import_sfp_module()
+                        asic_id = self._get_asic_id_by_sfp_index(index)
                         if self.RJ45_port_list and index in self.RJ45_port_list:
-                            self._sfp_list[index] = sfp_module.RJ45Port(index)
+                            self._sfp_list[index] = sfp_module.RJ45Port(index, asic_id=asic_id)
                         elif self.cpo_port_list and index in self.cpo_port_list:
-                            self._sfp_list[index] = sfp_module.CpoPort(index)
+                            self._sfp_list[index] = sfp_module.CpoPort(index, asic_id=asic_id)
                         else:
-                            self._sfp_list[index] = sfp_module.SFP(index)
+                            self._sfp_list[index] = sfp_module.SFP(index, asic_id=asic_id)
                         self.sfp_initialized_count += 1
 
     def initialize_sfp(self):
@@ -315,24 +327,26 @@ class Chassis(ChassisBase):
                     if not self._sfp_list:
                         sfp_module = self._import_sfp_module()
                         for index in range(sfp_count):
+                            asic_id = self._get_asic_id_by_sfp_index(index)
                             if self.RJ45_port_list and index in self.RJ45_port_list:
-                                sfp_object = sfp_module.RJ45Port(index)
+                                sfp_object = sfp_module.RJ45Port(index, asic_id=asic_id)
                             elif self.cpo_port_list and index in self.cpo_port_list:
-                                sfp_object = sfp_module.CpoPort(index)
+                                sfp_object = sfp_module.CpoPort(index, asic_id=asic_id)
                             else:
-                                sfp_object = sfp_module.SFP(index)
+                                sfp_object = sfp_module.SFP(index, asic_id=asic_id)
                             self._sfp_list.append(sfp_object)
                         self.sfp_initialized_count = sfp_count
                     elif self.sfp_initialized_count != len(self._sfp_list):
                         sfp_module = self._import_sfp_module()
                         for index in range(len(self._sfp_list)):
                             if self._sfp_list[index] is None:
+                                asic_id = self._get_asic_id_by_sfp_index(index)
                                 if self.RJ45_port_list and index in self.RJ45_port_list:
-                                    self._sfp_list[index] = sfp_module.RJ45Port(index)
+                                    self._sfp_list[index] = sfp_module.RJ45Port(index, asic_id=asic_id)
                                 elif self.cpo_port_list and index in self.cpo_port_list:
-                                    self._sfp_list[index] = sfp_module.CpoPort(index)
+                                    self._sfp_list[index] = sfp_module.CpoPort(index, asic_id=asic_id)
                                 else:
-                                    self._sfp_list[index] = sfp_module.SFP(index)
+                                    self._sfp_list[index] = sfp_module.SFP(index, asic_id=asic_id)
                         self.sfp_initialized_count = len(self._sfp_list)
 
     def get_num_sfps(self):
@@ -359,6 +373,54 @@ class Chassis(ChassisBase):
         
         return num_sfps
 
+    def get_sfp_ready_file(self):
+        SFP_READY_HOST_FILE = '/tmp/nv-syncd-shared/sfp_ready'
+        SFP_READY_CONTAINER_FILE = '/tmp/sfp_ready'
+        return SFP_READY_HOST_FILE if utils.is_host() else SFP_READY_CONTAINER_FILE
+
+    def wait_sfp_eeprom_ready(self):
+        if DeviceDataManager.is_simx_platform():
+            return True
+
+        eeprom_checks = []
+        for sfp in self._sfp_list:
+            if not sfp:
+                continue
+            sfp_idx = sfp.sdk_index
+            if self.RJ45_port_list and sfp_idx in self.RJ45_port_list or self.cpo_port_list and sfp_idx in self.cpo_port_list:
+                continue
+            eeprom_checks.append(lambda sfp=sfp: sfp.check_eeprom_ready_if_present())
+
+        return utils.wait_until_conditions(eeprom_checks, 10, interval=1)
+
+    def wait_sfp_ready_for_use(self):
+        sfp_ready_file = self.get_sfp_ready_file()
+        if os.path.exists(sfp_ready_file):
+            return True
+
+        if not DeviceDataManager.wait_sysfs_ready(self.get_num_sfps()):
+            logger.log_error('SFPs are not ready for usage')
+            return False
+
+        if not self.wait_sfp_eeprom_ready():
+            logger.log_error('SFPs are not ready for usage due to eeprom not ready')
+            return False
+
+        Path(sfp_ready_file).touch(exist_ok=True)
+
+        logger.log_notice('SFPs are ready for usage')
+        return True
+
+    def sfp_wait_ready_and_initialize_legacy(self):
+        self.initialize_sfp()
+        self.wait_sfp_ready_for_use()
+
+    def sfp_wait_ready_and_initialize(self):
+        if DeviceDataManager.is_module_host_management_mode():
+            self.module_host_mgmt_initializer.initialize(self)
+        else:
+            self.sfp_wait_ready_and_initialize_legacy()
+
     def get_all_sfps(self):
         """
         Retrieves all sfps available on this chassis
@@ -367,10 +429,7 @@ class Chassis(ChassisBase):
             A list of objects derived from SfpBase representing all sfps
             available on this chassis
         """    
-        if DeviceDataManager.is_module_host_management_mode():
-            self.module_host_mgmt_initializer.initialize(self)
-        else:
-            self.initialize_sfp()
+        self.sfp_wait_ready_and_initialize()
         return self._sfp_list
 
     def get_sfp(self, index):
@@ -387,10 +446,7 @@ class Chassis(ChassisBase):
             An object dervied from SfpBase representing the specified sfp
         """
         index = index - 1
-        if DeviceDataManager.is_module_host_management_mode():
-            self.module_host_mgmt_initializer.initialize(self)
-        else:
-            self.initialize_single_sfp(index)
+        self.sfp_wait_ready_and_initialize()
         return super(Chassis, self).get_sfp(index)
 
     def get_port_or_cage_type(self, index):
@@ -440,11 +496,10 @@ class Chassis(ChassisBase):
                       indicates that fan 0 has been removed, fan 2
                       has been inserted and sfp 11 has been removed.
         """
+        self.sfp_wait_ready_and_initialize()
         if DeviceDataManager.is_module_host_management_mode():
-            self.module_host_mgmt_initializer.initialize(self)
             return self.get_change_event_for_module_host_management_mode(timeout)
         else:
-            self.initialize_sfp()
             return self.get_change_event_legacy(timeout)
             
     def get_change_event_for_module_host_management_mode(self, timeout):
@@ -474,6 +529,11 @@ class Chassis(ChassisBase):
             for s in self._sfp_list:
                 fds = s.get_fds_for_poling()
                 for fd_type, fd in fds.items():
+                    if fd is None:
+                        self.poll_obj = None
+                        self.registered_fds = {}
+                        logger.log_warning('SFPs are not initialized, too early to get change event')
+                        return True, {'sfp': {}}
                     self.poll_obj.register(fd, select.POLLERR | select.POLLPRI)
                     self.registered_fds[fd.fileno()] = (s.sdk_index, fd, fd_type)
 
@@ -499,7 +559,11 @@ class Chassis(ChassisBase):
                 sfp_index, fd, fd_type = self.registered_fds[fileno]
                 s = self._sfp_list[sfp_index]
                 fd.seek(0)
-                fd_value = int(fd.read().strip())
+                try:
+                    fd_value = int(fd.read().strip())
+                except Exception as e:
+                    logger.log_warning(f'Failed to read value from file {fd_type} for SFP {sfp_index}: {e}')
+                    continue
 
                 # Detecting dummy event
                 if s.is_dummy_event(fd_type, fd_value):
@@ -595,6 +659,13 @@ class Chassis(ChassisBase):
             self.sfp_states_before_first_poll = {}
             for s in self._sfp_list:
                 fd = s.get_fd_for_polling_legacy()
+                if fd is None:
+                    self.poll_obj = None
+                    self.registered_fds = {}
+                    self.sfp_states_before_first_poll = {}
+                    logger.log_warning('SFPs are not initialized, too early to get change event')
+                    return True, {'sfp': {}}
+
                 self.poll_obj.register(fd, select.POLLERR | select.POLLPRI)
                 self.registered_fds[fd.fileno()] = (s.sdk_index, fd)
                 self.sfp_states_before_first_poll[s.sdk_index] = s.get_module_status()
@@ -619,7 +690,12 @@ class Chassis(ChassisBase):
                 
                 sfp_index, fd = self.registered_fds[fileno]
                 fd.seek(0)
-                fd.read()
+                try:
+                    fd.read()
+                except Exception as e:
+                    logger.log_warning(f'Failed to read module sysfs fd for SFP {sfp_index}: {e}')
+                    continue
+
                 s = self._sfp_list[sfp_index]
                 sfp_status = s.get_module_status()
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2020-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +20,7 @@ import glob
 import os
 import time
 import re
+from pathlib import Path
 from enum import Enum
 
 from . import utils
@@ -374,8 +375,8 @@ class DeviceDataManager:
     def is_module_host_management_mode(cls):
         sai_profile_file = '/tmp/sai.profile'
         if not os.path.exists(sai_profile_file):
-            from sonic_py_common import device_info
-            _, hwsku_dir = device_info.get_paths_to_platform_and_hwsku_dirs()
+            asic_id = 0 if cls.is_multi_asic_platform() else None
+            hwsku_dir = utils.get_path_to_hwsku_directory(asic_id=asic_id)
             sai_profile_file = os.path.join(hwsku_dir, 'sai.profile')
         data = utils.read_key_value_file(sai_profile_file, delimeter='=')
         return data.get('SAI_INDEPENDENT_MODULE_MODE') == '1'
@@ -383,22 +384,41 @@ class DeviceDataManager:
     @classmethod
     def wait_platform_ready(cls):
         """
-        Wait for Nvidia platform related services(SDK, hw-management) ready
+        Legacy function for backward compatibility
+        """
+        return True
+
+    @classmethod
+    def check_sysfs_access(cls, path):
+        try:
+            p = Path(path)
+            if not p.exists():
+                return False
+            if p.is_dir():
+                return True
+            with open(path, "rb", buffering=0) as f:
+                f.read(1)
+            return True
+        except:
+            return False
+
+    @classmethod
+    def wait_sysfs_ready(cls, modules_count, timeout=300, interval=1):
+        """
+        Wait for sysfs nodes of modules to be ready before proceeding.
         Returns:
             bool: True if wait success else timeout
         """
-        conditions = []
-        sysfs_nodes = ['power_mode', 'power_mode_policy', 'present', 'reset', 'status', 'statuserror']
+
+        sysfs_nodes = ['present', 'status', 'statuserror']
         if cls.is_module_host_management_mode():
-            sysfs_nodes.extend(['control', 'frequency', 'frequency_support', 'hw_present', 'hw_reset',
-                                'power_good', 'power_limit', 'power_on', 'temperature/input'])
-        else:
-            conditions.append(lambda: utils.read_int_from_file('/var/run/hw-management/config/asics_init_done') == 1)
-        sfp_count = cls.get_sfp_count()
-        for sfp_index in range(sfp_count):
+            sysfs_nodes.extend(['control', 'power_on'])
+
+        conditions = []
+        for sfp_index in range(modules_count):
             for sysfs_node in sysfs_nodes:
-                conditions.append(lambda: os.path.exists(f'/sys/module/sx_core/asic0/module{sfp_index}/{sysfs_node}'))
-        return utils.wait_until_conditions(conditions, 300, 1)
+                conditions.append(lambda idx=sfp_index, node=sysfs_node: cls.check_sysfs_access(f'/sys/module/sx_core/asic0/module{idx}/{node}'))
+        return utils.wait_until_conditions(conditions, timeout, interval)
 
     @classmethod
     @utils.read_only_cache()
@@ -425,3 +445,14 @@ class DeviceDataManager:
             return None
 
         return sfp_data.get('fw_control_ports')
+
+    @classmethod
+    @utils.read_only_cache()
+    def get_asic_count(cls):
+        from sonic_py_common import device_info
+        return device_info.get_num_npus()
+
+    @classmethod
+    @utils.read_only_cache()
+    def is_multi_asic_platform(cls):
+        return cls.get_asic_count() > 1

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module_host_mgmt_initializer.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module_host_mgmt_initializer.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -60,6 +61,14 @@ class ModuleHostMgmtInitializer:
                 if not self.initialized:
                     with self.lock:
                         if not self.initialized:
+                            from sonic_platform.device_data import DeviceDataManager
+                            logger.log_notice('Waiting for modules to be ready...')
+                            sfp_count = chassis.get_num_sfps()
+                            if not DeviceDataManager.wait_sysfs_ready(sfp_count):
+                                logger.log_error('Modules are not ready')
+                            else:
+                                logger.log_notice('Modules are ready')
+
                             logger.log_notice('Starting module initialization for module host management...')
                             initialization_owner = True
                             self.remove_module_ready_file()

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/pcie.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/pcie.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,6 +40,27 @@ PCIE_OPERATION_DETACHING = "detaching"
 
 
 class Pcie(PcieUtil):
+
+    def pcie_check_dpu(self, bus, dev, fn):
+        # Special handling for Bluefield Devices
+        # Ideally even with BIOS updates, the PCI ID for bluefield devices should not change.
+        try:
+            # Connect to STATE_DB to check for detached devices
+            if not self.state_db:
+                import swsscommon
+                self.state_db = swsscommon.swsscommon.DBConnector("STATE_DB", 0)
+            key_dict = f"{PCIE_DETACH_INFO_TABLE}|0000:{bus}:{dev}.{fn}"
+            detach_info_dict = dict(self.state_db.hgetall(key_dict))
+            if detach_info_dict and detach_info_dict.get("dpu_state") == PCIE_OPERATION_DETACHING:
+                # Do not add this device to confInfo list
+                return None
+            elif self.check_pcie_sysfs(bus=int(bus, base=16), device=int(dev, base=16), func=int(fn, base=16)):
+                return "Passed"
+            return "Failed"
+        except Exception as e:
+            self.logger.log_error(f"Error: {e}")
+            return None
+
     # check the current PCIe device with config file and return the result
     # use bus from _device_id_to_bus_map instead of from yaml file
     def get_pcie_check(self):
@@ -52,29 +73,13 @@ class Pcie(PcieUtil):
             bus_conf = item_conf["bus"]
             pcie_device_id = f"0000:{bus_conf}:{dev_conf}.{fn_conf}"
             if pcie_device_id in self.dpu_pcie_devices:
-                # Special handling for Bluefield Devices
-                # Ideally even with BIOS updates, the PCI ID for bluefield devices should not change.
-                try:
-                    # Connect to STATE_DB to check for detached devices
-                    if not os.environ.get('UNITTEST'):
-                        import swsscommon
-                        self.state_db = swsscommon.swsscommon.DBConnector("STATE_DB", 0)
-                    key_dict = f"{PCIE_DETACH_INFO_TABLE}|0000:{bus_conf}:{dev_conf}.{fn_conf}"
-                    detach_info_dict = dict(self.state_db.hgetall(key_dict))
-                    if detach_info_dict and detach_info_dict.get("dpu_state") == PCIE_OPERATION_DETACHING:
-                        # Do not add this device to confInfo list
-                        continue
-                    elif self.check_pcie_sysfs(bus=int(bus_conf, base=16), device=int(dev_conf, base=16), func=int(fn_conf, base=16)):
-                        # Add device to confInfo list if not present in state_db
-                        item_conf["result"] = "Passed"
-                    else:
-                        item_conf["result"] = "Failed"
+                status = self.pcie_check_dpu(bus_conf, dev_conf, fn_conf)
+                if status:
+                    item_conf["result"] = status
                     return_confInfo.append(item_conf)
-                    continue
-                except Exception as e:
-                    self.logger.log_error(f"Error: {e}")
-                    pass
-            bus_conf = self._device_id_to_bus_map.get(str(id_conf))
+                continue
+
+            bus_conf = self._device_id_to_bus_map.get(f"{id_conf}:{dev_conf}")
             if bus_conf and self.check_pcie_sysfs(bus=int(bus_conf, base=16), device=int(dev_conf, base=16),
                                                   func=int(fn_conf, base=16)):
                 item_conf["result"] = "Passed"
@@ -118,16 +123,17 @@ class Pcie(PcieUtil):
             #   2 hex digit of id
             #   dot '.'
             #   1 digit of fn
-            pattern_for_device_folder = re.search(r'....:(..):..\..', folder)
+            pattern_for_device_folder = re.search(r'....:(..):(..)\..', folder)
             if pattern_for_device_folder:
                 bus = pattern_for_device_folder.group(1)
+                dev = pattern_for_device_folder.group(2)
                 with open(os.path.join('/sys/bus/pci/devices', folder, 'device'), 'r') as device_file:
                     # The 'device' file contain an hex repesantaion of the id key in the yaml file.
                     # Example of the file contact:
                     # 0x6fe2
                     # We will strip the new line character, and remove the 0x prefix that is not needed.
                     device_id = device_file.read().strip().replace('0x', '')
-                    self._device_id_to_bus_map[device_id] = bus
+                    self._device_id_to_bus_map[f"{device_id}:{dev}"] = bus
 
     def __init__(self, platform_path):
         PcieUtil.__init__(self, platform_path)

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -76,12 +76,14 @@ THERMAL_NAMING_RULE = {
     },
     "chassis thermals": [
         {
-            "name": "ASIC",
+            "name": "ASIC{}",
             "temperature": "input",
             "high_threshold_default": 105,
             "high_critical_threshold_default": 120,
-            "sysfs_folder": "/sys/module/sx_core/asic0/temperature",
-            "scale": 8
+            "sysfs_folder": "/sys/module/sx_core/asic{}/temperature",
+            "scale": 8,
+            "type": "asic_indexable",
+            "start_index": 0
         },
         {
             "name": "Ambient Port Side Temp",
@@ -188,12 +190,37 @@ def initialize_chassis_thermals():
             if discrete_thermals:
                 position += len(discrete_thermals)
                 thermal_list.extend(discrete_thermals)
+        elif thermal_type == 'asic_indexable':
+            is_multi_asic = DeviceDataManager.is_multi_asic_platform()
+            asic_count = DeviceDataManager.get_asic_count()
+            for asic_index in range(asic_count):
+                thermal_list.append(create_asic_thermal(rule, asic_index, position, is_multi_asic))
+                position += 1
         else:
             thermal_object = create_single_thermal(rule, CHASSIS_THERMAL_SYSFS_FOLDER, position)
             if thermal_object:
                 thermal_list.append(thermal_object)
                 position += 1
     return thermal_list
+
+
+def create_asic_thermal(rule, asic_index, position, is_multi_asic):
+    """Create thermal object for a specific ASIC
+
+    Args:
+        rule (dict): Thermal rule
+        asic_index (int): ASIC index (0-based)
+        position (int): Position in thermal list
+        is_multi_asic (bool): Whether the platform is multi ASIC
+
+    Returns:
+        Thermal: ASIC thermal object
+    """
+    rule = copy.deepcopy(rule)
+    name_format = asic_index if is_multi_asic else ''
+    rule['name'] = rule['name'].format(name_format)
+    rule['sysfs_folder'] = rule['sysfs_folder'].format(asic_index)
+    return create_single_thermal(rule, rule['sysfs_folder'], position, check_presence=False)
 
 
 def initialize_psu_thermal(psu_index, presence_cb):
@@ -260,7 +287,7 @@ def create_indexable_thermal(rule, index, sysfs_folder, position, presence_cb=No
         return RemovableThermal(name, temp_file, high_th_file, high_crit_th_file, high_th_default, high_crit_th_default, scale, position, presence_cb)
 
 
-def create_single_thermal(rule, sysfs_folder, position, presence_cb=None):
+def create_single_thermal(rule, sysfs_folder, position, presence_cb=None, check_presence=True):
     temp_file = rule['temperature']
     default_present = rule.get('default_present', True)
     thermal_capability = DeviceDataManager.get_thermal_capability()
@@ -273,15 +300,18 @@ def create_single_thermal(rule, sysfs_folder, position, presence_cb=None):
 
     sysfs_folder = rule.get('sysfs_folder', sysfs_folder)
     temp_file = os.path.join(sysfs_folder, temp_file)
-    _check_thermal_sysfs_existence(temp_file, presence_cb)
+    if check_presence:
+        _check_thermal_sysfs_existence(temp_file, presence_cb)
     if 'high_threshold' in rule:
         high_th_file = os.path.join(sysfs_folder, rule['high_threshold'])
-        _check_thermal_sysfs_existence(high_th_file, presence_cb)
+        if check_presence:
+            _check_thermal_sysfs_existence(high_th_file, presence_cb)
     else:
         high_th_file = None
     if 'high_critical_threshold' in rule:
         high_crit_th_file = os.path.join(sysfs_folder, rule['high_critical_threshold'])
-        _check_thermal_sysfs_existence(high_crit_th_file, presence_cb)
+        if check_presence:
+            _check_thermal_sysfs_existence(high_crit_th_file, presence_cb)
     else:
         high_crit_th_file = None
     high_th_default = rule.get('high_threshold_default')

--- a/platform/mellanox/mlnx-platform-api/tests/test_change_event.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_change_event.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,6 +41,7 @@ class TestChangeEvent:
     @mock.patch('sonic_platform.chassis.extract_RJ45_ports_index', mock.MagicMock(return_value=[]))
     @mock.patch('sonic_platform.chassis.extract_cpo_ports_index', mock.MagicMock(return_value=[]))
     @mock.patch('sonic_platform.sfp.SFP.get_module_status')
+    @mock.patch('sonic_platform.chassis.Chassis.wait_sfp_ready_for_use', mock.MagicMock(return_value=True))
     def test_get_change_event_legacy(self, mock_status, mock_time, mock_create_poll, mock_get_fd):
         c = chassis.Chassis()
         s = c.get_sfp(1)

--- a/platform/mellanox/mlnx-platform-api/tests/test_device_data.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_device_data.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,7 +53,7 @@ class TestDeviceData:
     def test_get_bios_component(self):
         assert DeviceDataManager.get_bios_component() is not None
 
-    @mock.patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', mock.MagicMock(return_value=('', '/tmp')))
+    @mock.patch('sonic_platform.utils.get_path_to_hwsku_directory', mock.MagicMock(return_value='/tmp'))
     @mock.patch('sonic_platform.device_data.utils.read_key_value_file')
     def test_is_module_host_management_mode(self, mock_read):
         mock_read.return_value = {}
@@ -70,20 +70,6 @@ class TestDeviceData:
             }
         }
         assert DeviceDataManager.get_sfp_count() == 3
-
-    @mock.patch('sonic_platform.device_data.time.sleep', mock.MagicMock())
-    @mock.patch('sonic_platform.device_data.DeviceDataManager.get_sfp_count', mock.MagicMock(return_value=3))
-    @mock.patch('sonic_platform.device_data.utils.read_int_from_file', mock.MagicMock(return_value=1))
-    @mock.patch('sonic_platform.device_data.os.path.exists')
-    @mock.patch('sonic_platform.device_data.DeviceDataManager.is_module_host_management_mode')
-    def test_wait_platform_ready(self, mock_is_indep, mock_exists):
-        mock_exists.return_value = True
-        mock_is_indep.return_value = True
-        assert DeviceDataManager.wait_platform_ready()
-        mock_is_indep.return_value = False
-        assert DeviceDataManager.wait_platform_ready()
-        mock_exists.return_value = False
-        assert not DeviceDataManager.wait_platform_ready()
 
     @mock.patch('sonic_py_common.device_info.get_path_to_platform_dir', mock.MagicMock(return_value='/tmp'))
     @mock.patch('sonic_platform.device_data.utils.load_json_file')

--- a/platform/mellanox/mlnx-platform-api/tests/test_module_initializer.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_module_initializer.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -61,6 +61,7 @@ class TestModuleInitializer:
         initializer.wait_module_ready()
         assert not initializer.initialized
 
+    @mock.patch('sonic_platform.device_data.DeviceDataManager.wait_sysfs_ready', mock.MagicMock(return_value=True))
     @mock.patch('sonic_platform.chassis.extract_RJ45_ports_index', mock.MagicMock(return_value=[]))
     @mock.patch('sonic_platform.chassis.extract_cpo_ports_index', mock.MagicMock(return_value=[]))
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_sfp_count', mock.MagicMock(return_value=1))

--- a/platform/mellanox/mlnx-platform-api/tests/test_smartswsitch_thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_smartswsitch_thermal_updater.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -52,6 +52,7 @@ mock_tc_config = """
 
 class TestSmartSwitchThermalUpdater:
     @mock.patch('sonic_platform.utils.write_file')
+    @mock.patch('sonic_platform.smartswitch_thermal_updater.SmartswitchThermalUpdater.wait_for_sysfs_nodes', mock.MagicMock(return_value=True))
     def test_configuration(self, mock_write):
         dpu = mock.MagicMock()
         mock_sfp = mock.MagicMock()

--- a/platform/mellanox/mlnx-platform-api/tests/test_thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_thermal_updater.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -62,6 +62,7 @@ class TestThermalUpdater:
 
     @mock.patch('sonic_platform.thermal_updater.ThermalUpdater.update_asic', mock.MagicMock())
     @mock.patch('sonic_platform.thermal_updater.ThermalUpdater.update_module', mock.MagicMock())
+    @mock.patch('sonic_platform.thermal_updater.ThermalUpdater.wait_for_sysfs_nodes', mock.MagicMock(return_value=True))
     @mock.patch('sonic_platform.utils.write_file')
     def test_start_stop(self, mock_write):
         mock_sfp = mock.MagicMock()


### PR DESCRIPTION
#### Why I did it
This PR adds support for multi-asic Mellanox platforms and aligns with the "Independent syncd startup" introduced in the https://github.com/sonic-net/sonic-buildimage/pull/25064.

Changes:

**SFP**
* ASIC ID is now assigned to the SFP objects.
* SFP initialization now delayed until the relevant sysfs is available and accessible.
* More robust error handling for the sysfs access.

**Thermal**
* Support for multiple ASIC's sensors.
* ThermalUpdater start is delayed until the relevant sysfs is available.

**Utilities and device_data.py**
* New utilities to support the above logic (hwsku parsing, sysfs waiting, etc.)

**Minor refactoring for PCIe check logic.**

**Unit tests alignment.**

#### How I did it
* align chassis, SFP, PCIe, thermal implementation
* updated the tests

#### How to verify it
Run regression tests

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

