### PR TITLE
Add default buffer configs for egress_lossless_profile 

### DIFF
--- a/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/buffers_defaults_t2.j2
+++ b/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/buffers_defaults_t2.j2
@@ -23,6 +23,11 @@
             "size":"0",
             "dynamic_th":"3"
         },
+        "egress_lossless_profile": {
+            "pool":"ingress_pool",
+            "size":"0",
+            "dynamic_th":"-1"
+        },
         "egress_lossy_profile": {
             "pool":"ingress_pool",
             "size":"0",


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Default buffer configuration was missing for egress_lossless_profile causing yang validation failure on the platform

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added default configuration for egress_lossless_profile as part of BUFFER_PROFILE configuration

#### How to verify it
Verify that yang validation does not fail when egress_lossless_profile is used in the configuration

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

