### PR TITLE
[202511][healthd] Add stuck process cleanup flow

### DIFF
--- a/src/system-health/health_checker/service_checker.py
+++ b/src/system-health/health_checker/service_checker.py
@@ -389,7 +389,7 @@ class ServiceChecker(HealthChecker):
                 # it not always possible to get process cmdline in supervisor.conf. E.g, cmdline of orchagent is "/usr/bin/orchagent",
                 # however, in supervisor.conf it is "/usr/bin/orchagent.sh"
                 cmd = 'docker exec {} bash -c "supervisorctl status"'.format(container_name)
-                process_status = utils.run_command(cmd)
+                process_status = utils.run_command(cmd, timeout=15)
                 if process_status is None:
                     for process_name in critical_process_list:
                         self.set_object_not_ok('Process', '{}:{}'.format(container_name, process_name), "Process '{}' in container '{}' is not running".format(process_name, container_name))

--- a/src/system-health/health_checker/utils.py
+++ b/src/system-health/health_checker/utils.py
@@ -1,15 +1,58 @@
+import os
+import signal
+import logging
 import subprocess
 
+from logging.handlers import SysLogHandler
+from sonic_py_common.syslogger import SysLogger
 
-def run_command(command):
+
+logger = SysLogger(
+    log_identifier='healthd#utils',
+    log_facility=SysLogHandler.LOG_DAEMON,
+    log_level=logging.INFO,
+    enable_runtime_config=False
+)
+
+
+def run_command(command, timeout=None):
     """
     Utility function to run an shell command and return the output.
     :param command: Shell command string.
     :return: Output of the shell command.
     """
     try:
-        process = subprocess.Popen(command, shell=True, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        return process.communicate()[0]
+        process = subprocess.Popen(
+            command,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            start_new_session=True
+        )
+        return process.communicate(timeout=timeout)[0]
+    except subprocess.TimeoutExpired as err:
+        logger.log_warning("Failed to run command: {}".format(str(err)))
+
+        # The child process is not killed if the timeout expires,
+        # so in order to cleanup properly a well-behaved application
+        # should kill the child process and finish communication
+
+        logger.log_notice("Initiate stuck process cleanup: pid={}".format(process.pid))
+
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except Exception as e:
+            logger.log_error("Failed to kill process group: {}".format(str(e)))
+
+        try:
+            process.communicate(timeout=1)
+        except Exception as e:
+            logger.log_error("Failed to wait for process: {}".format(str(e)))
+
+        logger.log_notice("Cleanup is done: rc={}".format(process.returncode))
+
+        return None
     except Exception:
         return None
 

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -17,7 +17,7 @@ import importlib.util
 import importlib.machinery
 from swsscommon import swsscommon
 
-from mock import Mock, MagicMock, patch
+from mock import Mock, MagicMock, patch, call
 from sonic_py_common import device_info
 
 from .mock_connector import MockConnector
@@ -646,6 +646,40 @@ def test_utils():
 
     output = utils.run_command('ls')
     assert output
+
+
+@patch('health_checker.utils.logger.log_warning')
+@patch('health_checker.utils.logger.log_notice')
+@patch('health_checker.utils.logger.log_error')
+@patch('os.killpg')
+@patch('subprocess.Popen')
+def test_utils_timeout(mock_popen, mock_killpg, mock_log_error, mock_log_notice, mock_log_warning):
+    # Mock the spawned process
+    from subprocess import TimeoutExpired
+    mock_process = MagicMock()
+    mock_process.pid = 1234
+    mock_process.communicate.side_effect = [
+        TimeoutExpired(cmd='cmd', timeout=0.01), # first call triggers timeout
+        ('', '')                                 # second call during cleanup
+    ]
+    mock_popen.return_value = mock_process
+
+    # Execute with a timeout to trigger the TimeoutExpired path
+    output = utils.run_command('cmd', timeout=0.01)
+
+    # Expectations
+    assert output is None
+
+    assert mock_process.communicate.call_count == 2
+    mock_process.communicate.assert_has_calls([call(timeout=0.01), call(timeout=1)])
+
+    from signal import SIGKILL
+    mock_killpg.assert_called_once()
+    mock_killpg.assert_called_with(mock_process.pid, SIGKILL)
+
+    assert mock_log_notice.call_count == 2  # cleanup + done
+    mock_log_warning.assert_called_once() # command timeout
+    mock_log_error.assert_not_called() # no errors
 
 
 @patch('swsscommon.swsscommon.ConfigDBConnector.connect', MagicMock())


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

**Stuck process cleanup flow:**

```
LOG:

root@sonic:/home/admin# tail -F /var/log/syslog | grep healthd
2026 Jan  5 09:33:54.957660 sonic NOTICE healthd[320495]: Processing stats: started
2026 Jan  5 09:33:54.958102 sonic NOTICE healthd[320495]: Processing stats: done
2026 Jan  5 09:33:54.958170 sonic NOTICE healthd[320495]: System health takes 4.862624168395996 seconds for one iteration
2026 Jan  5 09:33:55.234547 sonic NOTICE healthd#sysmonitor[320503]: Received event:gnmi.service from source:sysbus time:2026-01-05 09:33:55
2026 Jan  5 09:33:55.263004 sonic NOTICE healthd: System is ready
2026 Jan  5 09:33:55.959102 sonic NOTICE healthd[320495]: Running checks: done
2026 Jan  5 09:33:55.959335 sonic NOTICE healthd[320495]: Running checks: started
2026 Jan  5 09:33:55.959499 sonic NOTICE healthd#manager[320495]: Running default system checks
2026 Jan  5 09:33:55.959662 sonic NOTICE healthd#service_checker[320495]: Checking services: started
2026 Jan  5 09:33:55.990947 sonic NOTICE healthd#service_checker[320495]: Checking docker image(docker-sonic-telemetry): started
2026 Jan  5 09:33:56.002126 sonic WARNING healthd: Failed to get image 'docker-sonic-telemetry'. Error: '404 Client Error for http+docker://localhost/v1.43/images/docker-sonic-telemetry/json: Not Found ("No such image: docker-sonic-telemetry:latest")'
2026 Jan  5 09:33:56.002251 sonic NOTICE healthd#service_checker[320495]: Checking docker image(docker-sonic-telemetry): done
2026 Jan  5 09:33:56.002531 sonic NOTICE healthd#service_checker[320495]: Checking docker image(docker-sonic-gnmi): started
2026 Jan  5 09:33:56.013274 sonic NOTICE healthd#service_checker[320495]: Checking docker image(docker-sonic-gnmi): done
2026 Jan  5 09:33:56.014791 sonic NOTICE healthd#service_checker[320495]: Fetching current running docker containers: started
2026 Jan  5 09:33:56.066840 sonic NOTICE healthd#service_checker[320495]: Fetching container(sysmgr) critical processes list: started
2026 Jan  5 09:33:56.066975 sonic NOTICE healthd#service_checker[320495]: Fetching container(sysmgr) critical processes list: done
2026 Jan  5 09:33:56.067038 sonic NOTICE healthd#service_checker[320495]: Fetching current running docker containers: done
2026 Jan  5 09:33:56.068401 sonic NOTICE healthd#service_checker[320495]: Checking container(eventd) process existence: started
2026 Jan  5 09:33:56.369585 sonic NOTICE healthd#service_checker[320495]: Checking container(eventd) process existence: done
2026 Jan  5 09:33:56.369688 sonic NOTICE healthd#service_checker[320495]: Checking container(teamd) process existence: started
2026 Jan  5 09:33:56.715451 sonic NOTICE healthd#service_checker[320495]: Checking container(teamd) process existence: done
2026 Jan  5 09:33:56.715559 sonic NOTICE healthd#service_checker[320495]: Checking container(bgp) process existence: started
2026 Jan  5 09:33:57.052417 sonic NOTICE healthd#service_checker[320495]: Checking container(bgp) process existence: done
2026 Jan  5 09:33:57.052586 sonic NOTICE healthd#service_checker[320495]: Checking container(swss) process existence: started
2026 Jan  5 09:33:57.370682 sonic NOTICE healthd#sysmonitor[320503]: Received event:gnmi.service from source:sysbus time:2026-01-05 09:33:57
2026 Jan  5 09:33:57.402789 sonic NOTICE healthd: System is not ready - one or more services are not up
2026 Jan  5 09:33:57.421043 sonic NOTICE healthd#service_checker[320495]: Checking container(swss) process existence: done
2026 Jan  5 09:33:57.421165 sonic NOTICE healthd#service_checker[320495]: Checking container(restapi) process existence: started
2026 Jan  5 09:33:57.791013 sonic NOTICE healthd#service_checker[320495]: Checking container(restapi) process existence: done
2026 Jan  5 09:33:57.791088 sonic NOTICE healthd#service_checker[320495]: Checking container(database) process existence: started
2026 Jan  5 09:33:58.119424 sonic NOTICE healthd#service_checker[320495]: Checking container(database) process existence: done
2026 Jan  5 09:33:58.119513 sonic NOTICE healthd#service_checker[320495]: Checking container(dhcp_relay) process existence: started
2026 Jan  5 09:33:58.430438 sonic NOTICE healthd#service_checker[320495]: Checking container(dhcp_relay) process existence: done
2026 Jan  5 09:33:58.430518 sonic NOTICE healthd#service_checker[320495]: Checking container(pmon) process existence: started
2026 Jan  5 09:33:58.786535 sonic NOTICE healthd#service_checker[320495]: Checking container(pmon) process existence: done
2026 Jan  5 09:33:58.786663 sonic NOTICE healthd#service_checker[320495]: Checking container(radv) process existence: started
2026 Jan  5 09:33:59.149904 sonic NOTICE healthd#service_checker[320495]: Checking container(radv) process existence: done
2026 Jan  5 09:33:59.149995 sonic NOTICE healthd#service_checker[320495]: Checking container(syncd) process existence: started
2026 Jan  5 09:33:59.452821 sonic NOTICE healthd#service_checker[320495]: Checking container(syncd) process existence: done
2026 Jan  5 09:33:59.598413 sonic NOTICE healthd#sysmonitor[320503]: Received event:gnmi.service from source:sysbus time:2026-01-05 09:33:59
2026 Jan  5 09:33:59.792060 sonic NOTICE healthd#service_checker[320495]: Checking container(snmp) process existence: started
2026 Jan  5 09:34:00.128402 sonic NOTICE healthd#service_checker[320495]: Checking container(snmp) process existence: done
2026 Jan  5 09:34:00.128487 sonic NOTICE healthd#service_checker[320495]: Checking container(mgmt-framework) process existence: started
2026 Jan  5 09:34:00.433243 sonic NOTICE healthd#service_checker[320495]: Checking container(mgmt-framework) process existence: done
2026 Jan  5 09:34:00.433350 sonic NOTICE healthd#service_checker[320495]: Checking container(lldp) process existence: started
2026 Jan  5 09:34:00.810458 sonic NOTICE healthd#service_checker[320495]: Checking container(lldp) process existence: done
2026 Jan  5 09:34:00.810610 sonic NOTICE healthd#service_checker[320495]: Checking container(gnmi) process existence: started
2026 Jan  5 09:34:01.706165 sonic NOTICE healthd#sysmonitor[320503]: Received event:gnmi.service from source:sysbus time:2026-01-05 09:34:01
2026 Jan  5 09:34:03.942550 sonic NOTICE healthd#sysmonitor[320503]: Received event:gnmi.service from source:sysbus time:2026-01-05 09:34:03
2026 Jan  5 09:34:06.190446 sonic NOTICE healthd#sysmonitor[320503]: Received event:gnmi.service from source:sysbus time:2026-01-05 09:34:06
2026 Jan  5 09:34:08.338363 sonic NOTICE healthd#sysmonitor[320503]: Received event:gnmi.service from source:sysbus time:2026-01-05 09:34:08
2026 Jan  5 09:34:08.366720 sonic NOTICE healthd: System is ready
2026 Jan  5 09:34:15.825068 sonic WARNING healthd#utils[320495]: Failed to run command: Command 'docker exec gnmi bash -c "supervisorctl status"' timed out after 15 seconds
2026 Jan  5 09:34:15.825371 sonic NOTICE healthd#utils[320495]: Initiate stuck process cleanup: pid=331123
2026 Jan  5 09:34:15.826126 sonic NOTICE healthd#utils[320495]: Cleanup is done: rc=-9
2026 Jan  5 09:34:15.826322 sonic NOTICE healthd#service_checker[320495]: Checking services: done
2026 Jan  5 09:34:15.826470 sonic NOTICE healthd#hardware_checker[320495]: Checking hardware: started
2026 Jan  5 09:34:15.828715 sonic NOTICE healthd#hardware_checker[320495]: Checking hardware: done
2026 Jan  5 09:34:15.828821 sonic NOTICE healthd#manager[320495]: Running custom user checks
2026 Jan  5 09:34:15.828905 sonic NOTICE healthd#manager[320495]: Setting chassis led

PS:

root@sonic:/home/admin# ps -aux | grep status
root      347029  0.0  0.0   6980  2184 pts/3    S+   09:37   0:00 grep status
```

#### Why I did it
* Fixed `healthd` stuck on service(s) process state polling during config reload operation

#### Work item tracking
* N/A

#### How I did it
* Added stuck process cleanup flow

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

1. Set minimal polling interval
```
root@sonic:/usr/share/sonic/device/x86_64-mlnx_msn4600c-r0# cat system_health_monitoring_config.json
{
    "services_to_ignore": [],
    "devices_to_ignore": ["psu.voltage"],
    "user_defined_checkers": [],
    "polling_interval": 1,
    "led_color": {
        "fault": "orange",
        "normal": "green",
        "booting": "orange_blink"
    }
}
```

2. Run the script
```
root@sonic:/home/admin# cat repro.sh
#!/bin/bash

declare -i idx=0

while true; do
    echo "=> Reset: ${idx}"
    systemctl reset-failed gnmi
    systemctl restart gnmi
    ((idx++))
done
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master <!-- image version 1 -->
- [x] 202511 <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* N/A

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
* N/A

#### Details if related
* Backport from `master`: https://github.com/sonic-net/sonic-buildimage/pull/25017

#### A picture of a cute animal (not mandatory but encouraged)
```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```