### PR TITLE
Fix syslog pollution caused by disabled telemetry image checks

### DIFF
--- a/src/system-health/health_checker/service_checker.py
+++ b/src/system-health/health_checker/service_checker.py
@@ -25,7 +25,6 @@ def check_docker_image(image_name):
         DOCKER_CLIENT.images.get(image_name)
         return True
     except (docker.errors.ImageNotFound, docker.errors.APIError) as err:
-        logger.log_warning("Failed to get image '{}'. Error: '{}'".format(image_name, err))
         return False
 
 class ServiceChecker(HealthChecker):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This is a Quality of Life improvement with no functional changes. The syslog is polluted with a number of "Failed to get Image logs as seen below":
```
Failed to get image 'docker-sonic-telemetry'. Error: '404 Client Error for http+docker://localhost/v1.43/images/docker-sonic-telemetry/json: Not Found ("No such image: docker-sonic-telemetry:latest")'
Failed to get image 'docker-sonic-telemetry'. Error: '404 Client Error for http+docker://localhost/v1.43/images/docker-sonic-telemetry/json: Not Found ("No such image: docker-sonic-telemetry:latest")'
Failed to get image 'docker-sonic-telemetry'. Error: '404 Client Error for http+docker://localhost/v1.43/images/docker-sonic-telemetry/json: Not Found ("No such image: docker-sonic-telemetry:latest")'
Failed to get image 'docker-sonic-telemetry'. Error: '404 Client Error for http+docker://localhost/v1.43/images/docker-sonic-telemetry/json: Not Found ("No such image: docker-sonic-telemetry:latest")'
Failed to get image 'docker-sonic-telemetry'. Error: '404 Client Error for http+docker://localhost/v1.43/images/docker-sonic-telemetry/json: Not Found ("No such image: docker-sonic-telemetry:latest")'
Failed to get image 'docker-sonic-telemetry'. Error: '404 Client Error for http+docker://localhost/v1.43/images/docker-sonic-telemetry/json: Not Found ("No such image: docker-sonic-telemetry:latest")'
Failed to get image 'docker-sonic-telemetry'. Error: '404 Client Error for http+docker://localhost/v1.43/images/docker-sonic-telemetry/json: Not Found ("No such image: docker-sonic-telemetry:latest")'
Failed to get image 'docker-sonic-telemetry'. Error: '404 Client Error for http+docker://localhost/v1.43/images/docker-sonic-telemetry/json: Not Found ("No such image: docker-sonic-telemetry:latest")'
Failed to get image 'docker-sonic-telemetry'. Error: '404 Client Error for http+docker://localhost/v1.43/images/docker-sonic-telemetry/json: Not Found ("No such image: docker-sonic-telemetry:latest")'
Failed to get image 'docker-sonic-telemetry'. Error: '404 Client Error for http+docker://localhost/v1.43/images/docker-sonic-telemetry/json: Not Found ("No such image: docker-sonic-telemetry:latest")'
Failed to get image 'docker-sonic-telemetry'. Error: '404 Client Error for http+docker://localhost/v1.43/images/docker-sonic-telemetry/json: Not Found ("No such image: docker-sonic-telemetry:latest")'
Failed to get image 'docker-sonic-telemetry'. Error: '404 Client Error for http+docker://localhost/v1.43/images/docker-sonic-telemetry/json: Not Found ("No such image: docker-sonic-telemetry:latest")'
Failed to get image 'docker-sonic-telemetry'. Error: '404 Client Error for http+docker://localhost/v1.43/images/docker-sonic-telemetry/json: Not Found ("No such image: docker-sonic-telemetry:latest")'
```

These logs are printed even though we have switched from telemetry to gnmi and the device states that the telemetry function is disabled.

There have been previous discussions about this error leaking in `monit status`: 

https://github.com/sonic-net/sonic-buildimage/issues/19352
https://github.com/sonic-net/sonic-buildimage/issues/20056

While this was fixed in monit status, system-health.service continues to report these errors.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
The `check_docker_image` helper function should not log a warning when an image is not present. This should be handled by the calling function.

https://github.com/arista-hpandya/sonic-buildimage/blob/bd0e6c34476377efecf61f18834a8a613da273c4/src/system-health/health_checker/service_checker.py#L28

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Verified by ensuring that the logs are no longer populated in the syslog.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202503

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202511

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Remove log_warning from check_docker_image function in `service_checker.py`

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
NA

#### A picture of a cute animal (not mandatory but encouraged)

<img width="1000" height="562" alt="image" src="https://github.com/user-attachments/assets/1687b639-7822-4f16-b235-275a951cc383" />
