### PR TITLE
Use supervisor-proc-exit-listener-rs as listener in 3 more docker images

### DIFF
--- a/dockers/docker-sonic-otel/supervisord.conf
+++ b/dockers/docker-sonic-otel/supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/local/bin/supervisor-proc-exit-listener --container-name otel
+command=/usr/bin/supervisor-proc-exit-listener-rs --container-name otel
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected

--- a/platform/clounix/docker-syncd-clounix/supervisord.conf
+++ b/platform/clounix/docker-syncd-clounix/supervisord.conf
@@ -13,10 +13,11 @@ events=PROCESS_STATE
 buffer_size=25
 
 [eventlistener:supervisor-proc-exit-listener]
-command=python3 /usr/bin/supervisor-proc-exit-listener --container-name syncd
+command=/usr/bin/supervisor-proc-exit-listener-rs --container-name syncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected
+buffer_size=1024
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n -iNONE

--- a/platform/components/docker-gbsyncd-agera2/supervisord.conf
+++ b/platform/components/docker-gbsyncd-agera2/supervisord.conf
@@ -12,7 +12,7 @@ exitcodes=0,3
 events=PROCESS_STATE
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/local/bin/supervisor-proc-exit-listener --container-name gbsyncd
+command=/usr/bin/supervisor-proc-exit-listener-rs --container-name gbsyncd
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING
 autostart=true
 autorestart=unexpected


### PR DESCRIPTION
#### Why I did it
Use supervisor-proc-exit-listener-rs as listener in 3 more docker images, in order to save RAM usage.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it
Build passing and PR checker passing.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

