### PR TITLE
marvell-prestera: SMDEP ignore symlink

### DIFF
--- a/platform/marvell-prestera/mrvl-prestera.dep
+++ b/platform/marvell-prestera/mrvl-prestera.dep
@@ -2,6 +2,10 @@ MPATH       := $($(MRVL_PRESTERA_DEB)_SRC_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) $(PLATFORM_PATH)/mrvl-prestera.mk $(PLATFORM_PATH)/mrvl-prestera.dep
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 SMDEP_FILES := $(addprefix $(MPATH)/,$(shell cd $(MPATH) && git ls-files))
+# Filter out the run-time symlink that is not in build-source tree
+SLINKS := $(shell find $(MPATH)/platform/*/common/etc/systemd -type l -exec echo {} \; | grep -Ev ' ')
+SLINKS += $(shell find $(MPATH)/platform/common/etc/systemd -type l -exec echo {} \; | grep -Ev ' ')
+SMDEP_FILES := $(filter-out $(SLINKS),$(SMDEP_FILES))
 
 $(MRVL_PRESTERA_DEB)_CACHE_MODE  := GIT_CONTENT_SHA
 $(MRVL_PRESTERA_DEB)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)


### PR DESCRIPTION
#### Why I did it
Marvell's SUBMODULE platform/marvell-prestera/mrvl-prestera
requires to ignore SYMLINK in the file platform/marvell-prestera/mrvl-prestera.dep
(just like some other vendor/platform do)

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it
BUILD marvell-prestera

#### Which release branch to backport (provide reason below if selected)
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

#### Description for the changelog

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

