### PR TITLE
[YANG] Support controlled_device attribute in CONSOLE_SWITCH

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2899,6 +2899,9 @@
         "CONSOLE_SWITCH": {
             "console_mgmt": {
                 "enabled": "yes"
+            },
+            "controlled_device": {
+                "enabled": "yes"
             }
         },
 	"STATIC_ROUTE": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/console.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/console.json
@@ -11,6 +11,22 @@
             "value": "no"
         }
     },
+    "CONSOLE_DEFAULT_CONTROLLED_DEVICE": {
+        "desc": "CONSOLE_SWITCH default value for controlled_device enabled field.",
+        "eStrKey": "Verify",
+        "verify": {
+            "xpath": "/sonic-console:sonic-console/CONSOLE_SWITCH/controlled_device/enabled",
+            "key": "sonic-console:enabled",
+            "value": "no"
+        }
+    },
+    "CONSOLE_VALID_CONTROLLED_DEVICE": {
+        "desc": "Verifying CONSOLE_SWITCH controlled_device configuration."
+    },
+    "CONSOLE_CONTROLLED_DEVICE_INCORRECT_PATTERN": {
+        "desc": "CONSOLE_SWITCH controlled_device configuration pattern failure.",
+        "eStrKey": "Pattern"
+    },
     "CONSOLE_DISABLED_INCORRECT_PATTERN": {
         "desc": "CONSOLE_SWITCH configuration pattern failure.",
         "eStrKey": "Pattern"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/console.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/console.json
@@ -16,6 +16,32 @@
             }
         }
     },
+    "CONSOLE_DEFAULT_CONTROLLED_DEVICE": {
+        "sonic-console:sonic-console": {
+            "sonic-console:CONSOLE_SWITCH": {
+                "sonic-console:controlled_device": {
+                }
+            }
+        }
+    },
+    "CONSOLE_VALID_CONTROLLED_DEVICE": {
+        "sonic-console:sonic-console": {
+            "sonic-console:CONSOLE_SWITCH": {
+                "sonic-console:controlled_device": {
+                    "enabled": "yes"
+                }
+            }
+        }
+    },
+    "CONSOLE_CONTROLLED_DEVICE_INCORRECT_PATTERN": {
+        "sonic-console:sonic-console": {
+            "sonic-console:CONSOLE_SWITCH": {
+                "sonic-console:controlled_device": {
+                    "enabled": "true"
+                }
+            }
+        }
+    },
     "CONSOLE_DISABLED_INCORRECT_PATTERN": {
         "sonic-console:sonic-console": {
             "sonic-console:CONSOLE_SWITCH": {

--- a/src/sonic-yang-models/yang-models/sonic-console.yang
+++ b/src/sonic-yang-models/yang-models/sonic-console.yang
@@ -69,6 +69,14 @@ module sonic-console {
                 }
             }
 
+            container controlled_device {
+                leaf enabled {
+                    description "This configuration indicate if enable controlled device feature on SONiC";
+                    type console-mgmt-enabled;
+                    default "no";
+                }
+            }
+
         } /* end of container CONSOLE_SWITCH */
 
     } /* end of top level container */


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To support controlled_device attribute in CONSOLE_SWITCH table to enable/disable the controlled device feature (heartbeat sending) on SONiC console switch.

Relate to [HLD](https://github.com/sonic-net/SONiC/pull/2178)

Sample config:

    "CONSOLE_SWITCH": {
        "console_mgmt": {
            "enabled": "yes"
        },
        "controlled_device": {
            "enabled": "yes"
        }
    }

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Update Yang model for sonic-console and add corresponding unit tests:
- Added controlled_device container in CONSOLE_SWITCH
- Added test cases for default value verification
- Added test cases for valid configuration
- Added test cases for invalid pattern detection

#### How to verify it

Verified by unit test.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

![Cat](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ2XBkqYzXuss6OBTfnyFwNX196batPDfa8Jg&s)
