### PR TITLE
[Arista] Improve Removal of __pycache__ Directories

### DIFF
--- a/src/sonic-build-hooks/scripts/post_run_cleanup
+++ b/src/sonic-build-hooks/scripts/post_run_cleanup
@@ -40,7 +40,7 @@ rm -f $VERSION_DEB_PREFERENCE
 rm -f /etc/apt/preferences.d/01-versions-deb
 
 # Remove all doc files
-find /usr/share/doc -depth \( -type f -o -type l \) ! -name copyright | xargs rm || true
+find /usr/share/doc -depth \( -type f -o -type l \) ! -name copyright -exec rm {} + 2>/dev/null || true
 
 # Clean doc directories that are empty or only contain empty directories
 while [ -n "$(find /usr/share/doc -depth -type d -empty -print -exec rmdir {} +)" ]; do :; done && \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The following trace of shell commands was spotted in a build of the Sonic master, in the middle of a sonic-buildimage build:
```
01:21:23  #82 5.951 + find / ```
01:21:23  #82 5.952 + grep -E __pycache__  
01:21:23  #82 5.952 + xargs rm -rf  
01:21:24  #82 6.902 find: '/proc/359/task/359/net': Invalid argument  
01:21:24  #82 6.902 find: '/proc/359/net': Invalid argument
```
There is a more efficient way to do this than listing all files and grepping; for example: `find / -type d -name "__pycache__" -exec rm -rf {}`

#### How I did it

replaced `find / | grep -E "__pycache__" | xargs rm -rf` with `find / -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true`. which improves efficiency by avoiding the overhead of piping into grep and ensuring the operation finishes silently even if permission errors occur.

#### How to verify it

We verified that `__pycache__` is successfully removed after the cleanup.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

