### PR TITLE
Adding yang model changes to allow VNET neighbors in BGP yang

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
@@ -146,7 +146,7 @@ module sonic-bgp-neighbor {
 
                 leaf vnet_name {
                     type leafref {
-                        path "svnet:sonic-vnet/svnet:VNET/svnet:VNET_LIST/svnet:name";
+                        path "/svnet:sonic-vnet/svnet:VNET/svnet:VNET_LIST/svnet:name";
                     }
 
                     description "VNET name (from sonic-vnet)";


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

In current SONiC releases, BGP configuration is VRF-scoped and rendered by the FRR management framework from CONFIG_DB tables such as BGP_NEIGHBOR and BGP_NEIGHBOR_AF, which are keyed by VRF (e.g., 'Vrf-Blue|10.0.0.1'). The VNET feature, however, does not expose a Linux VRF context that FRR can bind to. As a result, attempting to model 'BGP neighbors per VNET' does not bring up sessions, since FRR expects VRF-aware neighbors.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

MAde changes to the bgp-neighbor yang model to include VNET neighbors as well

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

