### PR TITLE
Modify the Arista SKUs gearbox files to transition to v1.2.4-rc1 CredoSAI

### DIFF
--- a/device/arista/x86_64-arista_7280cr3mk_32p4/Arista-7280CR3-C40/gearbox_100G_PAM4.xml
+++ b/device/arista/x86_64-arista_7280cr3mk_32p4/Arista-7280CR3-C40/gearbox_100G_PAM4.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <root>
-    <name>CSDK-B52</name>
+    <name>owl400</name>
     <phy_addr>0</phy_addr>
     <mode>gearbox</mode>
     <topology>2</topology>

--- a/device/arista/x86_64-arista_7280cr3mk_32p4/Arista-7280CR3-C40/psai.profile
+++ b/device/arista/x86_64-arista_7280cr3mk_32p4/Arista-7280CR3-C40/psai.profile
@@ -1,1 +1,1 @@
-SAI_KEY_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/gearbox_100G_PAM4.xml
+SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/gearbox_100G_PAM4.xml

--- a/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/gearbox_100G_PAM4.xml
+++ b/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/gearbox_100G_PAM4.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <root>
-    <name>CSDK-B52</name>
+    <name>owl400</name>
     <phy_addr>0</phy_addr>
     <mode>gearbox</mode>
     <topology>2</topology>

--- a/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/psai.profile
+++ b/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/psai.profile
@@ -1,1 +1,1 @@
-SAI_KEY_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/gearbox_100G_PAM4.xml
+SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/gearbox_100G_PAM4.xml


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The new versions of CredoSAI use a different naming convention

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Modified the hardware SKU files for the platforms

#### How to verify it
Verified by loading sonic on these devices. Gearboxes initialize as expected.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master
- [x] 202511

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
<img width="1180" height="842" alt="image" src="https://github.com/user-attachments/assets/b9b1f8ff-d5c9-419b-8724-f399c818fdca" />
