### PR TITLE
Re-order route-map commands in idf_isolate template

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/idf_isolate/idf_isolate.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/idf_isolate/idf_isolate.conf.j2
@@ -9,12 +9,15 @@ route-map CHECK_IDF_ISOLATION permit 3
     set community {{ constants.bgp.traffic_shift_community }}
 {# #}
 {%- if isolation_status == "isolated_withdraw_all" -%}
-    route-map CHECK_IDF_ISOLATION deny 4
-    route-map CHECK_IDF_ISOLATION permit 10
-        no set community no-export additive{# Added to clean up state, in case of transition from isolated_no_export (not expected) #}
+
+route-map CHECK_IDF_ISOLATION deny 4
+route-map CHECK_IDF_ISOLATION permit 10
+    no set community no-export additive
+
 {%- elif isolation_status == "isolated_no_export" -%}
-    no route-map CHECK_IDF_ISOLATION deny 4{# Added to clean up state, in case of transition from isolated_withdraw_all (not expected) #}
-    route-map CHECK_IDF_ISOLATION permit 10
-        set community no-export additive
+
+no route-map CHECK_IDF_ISOLATION deny 4
+route-map CHECK_IDF_ISOLATION permit 10
+    set community no-export additive
 {# #}
 {%- endif -%}

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_all_idf_isolated_no_export.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_all_idf_isolated_no_export.conf
@@ -29,6 +29,6 @@ route-map CHECK_IDF_ISOLATION permit 3
     match tag 1001
     set community 12345:12345
 no route-map CHECK_IDF_ISOLATION deny 4
-    route-map CHECK_IDF_ISOLATION permit 10
-        set community no-export additive
+route-map CHECK_IDF_ISOLATION permit 10
+    set community no-export additive
 

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_all_idf_isolated_withdraw_all.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_all_idf_isolated_withdraw_all.conf
@@ -29,5 +29,5 @@ route-map CHECK_IDF_ISOLATION permit 3
     match tag 1001
     set community 12345:12345
 route-map CHECK_IDF_ISOLATION deny 4
-    route-map CHECK_IDF_ISOLATION permit 10
-        no set community no-export additive
+route-map CHECK_IDF_ISOLATION permit 10
+    no set community no-export additive

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_idf_isolated.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_idf_isolated.conf
@@ -8,5 +8,5 @@ route-map CHECK_IDF_ISOLATION permit 3
     match tag 1001
     set community 12345:12345
 no route-map CHECK_IDF_ISOLATION deny 4
-    route-map CHECK_IDF_ISOLATION permit 10
-        set community no-export additive
+route-map CHECK_IDF_ISOLATION permit 10
+    set community no-export additive

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/idf_isolate/idf_isolated_no_export.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/idf_isolate/idf_isolated_no_export.conf
@@ -8,5 +8,5 @@ route-map CHECK_IDF_ISOLATION permit 3
     match tag 1002
     set community 12345:555
 no route-map CHECK_IDF_ISOLATION deny 4
-    route-map CHECK_IDF_ISOLATION permit 10
-        set community no-export additive
+route-map CHECK_IDF_ISOLATION permit 10
+    set community no-export additive

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/idf_isolate/idf_isolated_withdraw_all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/idf_isolate/idf_isolated_withdraw_all.conf
@@ -8,5 +8,5 @@ route-map CHECK_IDF_ISOLATION permit 3
     match tag 1002
     set community 12345:555
 route-map CHECK_IDF_ISOLATION deny 4
-    route-map CHECK_IDF_ISOLATION permit 10
-        no set community no-export additive
+route-map CHECK_IDF_ISOLATION permit 10
+    no set community no-export additive


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To ensure the template ends with the same frr configuration context (route-map context) for all isolation options. 

This is a workaround for https://github.com/sonic-net/sonic-buildimage/issues/23616 which is caused by an assumption about the configuration context after the template is rendered

More details here - https://github.com/sonic-net/sonic-buildimage/pull/24827#discussion_r2723255829

Fixes https://github.com/sonic-net/sonic-buildimage/issues/23616

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Re-ordered the route-map configuration within the template.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
On a supported T2 device, run idf_isolation isolated_no_export and check the correct configurations are applied. Issue in https://github.com/sonic-net/sonic-buildimage/issues/23616 should also no longer be seen

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

