### PR TITLE
[build] Disable debian helper auto install for cargo project.

### DIFF
--- a/dockers/docker-auditd-watchdog/watchdog/debian/rules
+++ b/dockers/docker-auditd-watchdog/watchdog/debian/rules
@@ -9,6 +9,10 @@
 override_dh_auto_build:
 	cargo build --release --all
 
+override_dh_auto_install:
+	# do nothing
+	:
+
 override_dh_auto_clean:
 	cargo clean --release
 

--- a/dockers/docker-bmp-watchdog/watchdog/debian/rules
+++ b/dockers/docker-bmp-watchdog/watchdog/debian/rules
@@ -9,6 +9,10 @@
 override_dh_auto_build:
 	cargo build --release --all
 
+override_dh_auto_install:
+	# do nothing
+	:
+
 override_dh_auto_clean:
 	cargo clean --release
 

--- a/dockers/docker-telemetry-watchdog/watchdog/debian/rules
+++ b/dockers/docker-telemetry-watchdog/watchdog/debian/rules
@@ -9,6 +9,10 @@
 override_dh_auto_build:
 	cargo build --release --all
 
+override_dh_auto_install:
+	# do nothing
+	:
+
 override_dh_auto_clean:
 	cargo clean --release
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Cargo install will download latest dependency version, which may break SONiC build.
Now supervisord depends on time. latest time package depends on rustc new version.
```
    time@0.3.46 requires rustc 1.88.0
```
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Remove dh_auto_install step, because we don't need to install these packages to slave docker.
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

