### PR TITLE
[build] Enforce Cargo.lock in Makefile to fix build failure

### DIFF
--- a/src/sonic-supervisord-utilities-rs/Makefile
+++ b/src/sonic-supervisord-utilities-rs/Makefile
@@ -24,7 +24,7 @@ clean:
 
 # Install the binary
 install: build
-	cargo install --path .
+	cargo install --locked --path .
 
 # Run linting
 lint:


### PR DESCRIPTION
#### Why I did it

The build failed because the `time` crate was updated to version `0.3.45`, which introduces a dependency requirement for `rustc 1.88.0` (incompatible with the current build environment). 
See issue: https://github.com/sonic-net/sonic-buildimage/issues/25186

Although sonic-supervisord-utilities-rs includes a `Cargo.lock` file, the install step in the `Makefile` was not strictly enforcing it. This caused cargo to ignore the lockfile and pull in the latest incompatible dependencies.

##### Work item tracking

- Microsoft ADO **(number only)**:

#### How I did it

Updated the `Makefile` to enforce the use of `Cargo.lock` during the install step (by adding the `--locked`).

#### How to verify it

Successfully built images for both the `202511` branch and the `master` branch.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202505
- [x] 202511
- [x] master

#### Tested branch (Please provide the tested image version)

Built 202511 and master images.

#### Description for the changelog
Fix build failure by enforcing Cargo.lock in the sonic-supervisord-utilities-rs `Makefile`.

