### PR TITLE
[Mellanox] enable xcvrd thermal task and read temperature data from redis

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/pmon_daemon_control.json
@@ -3,6 +3,9 @@
     "skip_fancontrol": true,
     "delay_xcvrd": true,
     "skip_xcvrd_cmis_mgr": true,
-    "delay_non_critical_daemon": true
+    "delay_non_critical_daemon": true,
+    "xcvrd": {
+        "dom_temperature_poll_interval": 20
+    }
 }
 

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O32/pmon_daemon_control.json
@@ -1,6 +1,9 @@
 {
     "skip_ledd": true,
     "skip_fancontrol": true,
-    "skip_xcvrd_cmis_mgr": false
+    "skip_xcvrd_cmis_mgr": false,
+    "xcvrd": {
+        "dom_temperature_poll_interval": 20
+    }
 }
 

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8C48/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8C48/pmon_daemon_control.json
@@ -2,5 +2,8 @@
     "skip_ledd": true,
     "skip_fancontrol": true,
     "delay_xcvrd": false,
-    "skip_xcvrd_cmis_mgr": false
+    "skip_xcvrd_cmis_mgr": false,
+    "xcvrd": {
+        "dom_temperature_poll_interval": 20
+    }
 }

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8V48/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8V48/pmon_daemon_control.json
@@ -2,5 +2,8 @@
     "skip_ledd": true,
     "skip_fancontrol": true,
     "delay_xcvrd": false,
-    "skip_xcvrd_cmis_mgr": false
+    "skip_xcvrd_cmis_mgr": false,
+    "xcvrd": {
+        "dom_temperature_poll_interval": 20
+    }
 }

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/pmon_daemon_control.json
@@ -1,6 +1,9 @@
 {
     "skip_ledd": true,
     "skip_fancontrol": true,
-    "skip_xcvrd_cmis_mgr": false
+    "skip_xcvrd_cmis_mgr": false,
+    "xcvrd": {
+        "dom_temperature_poll_interval": 20
+    }
 }
 

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/pmon_daemon_control.json
@@ -1,6 +1,9 @@
 {
     "skip_ledd": true,
     "skip_fancontrol": true,
-    "skip_xcvrd_cmis_mgr": true
+    "skip_xcvrd_cmis_mgr": true,
+    "xcvrd": {
+        "dom_temperature_poll_interval": 20
+    }
 }
 

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C224O8/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C224O8/pmon_daemon_control.json
@@ -1,5 +1,8 @@
 {
     "skip_ledd": true,
     "skip_fancontrol": true,
-    "skip_xcvrd_cmis_mgr": false
+    "skip_xcvrd_cmis_mgr": false,
+    "xcvrd": {
+        "dom_temperature_poll_interval": 20
+    }
 }

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/pmon_daemon_control.json
@@ -1,5 +1,8 @@
 {
     "skip_ledd": true,
     "skip_fancontrol": true,
-    "skip_xcvrd_cmis_mgr": false
+    "skip_xcvrd_cmis_mgr": false,
+    "xcvrd": {
+        "dom_temperature_poll_interval": 20
+    }
 }

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-O128/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-O128/pmon_daemon_control.json
@@ -1,6 +1,9 @@
 {
     "skip_ledd": true,
     "skip_fancontrol": true,
-    "skip_xcvrd_cmis_mgr": false
+    "skip_xcvrd_cmis_mgr": false,
+    "xcvrd": {
+        "dom_temperature_poll_interval": 20
+    }
 }
 

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-V256/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-V256/pmon_daemon_control.json
@@ -1,6 +1,9 @@
 {
     "skip_ledd": true,
     "skip_fancontrol": true,
-    "skip_xcvrd_cmis_mgr": false
+    "skip_xcvrd_cmis_mgr": false,
+    "xcvrd": {
+        "dom_temperature_poll_interval": 20
+    }
 }
 

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/pmon_daemon_control.json
@@ -1,6 +1,9 @@
 {
     "skip_ledd": true,
     "skip_fancontrol": true,
-    "skip_xcvrd_cmis_mgr": true
+    "skip_xcvrd_cmis_mgr": true,
+    "xcvrd": {
+        "dom_temperature_poll_interval": 20
+    }
 }
 

--- a/device/mellanox/x86_64-nvidia_sn5610n-r0/Mellanox-SN5610N-C224O8/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-nvidia_sn5610n-r0/Mellanox-SN5610N-C224O8/pmon_daemon_control.json
@@ -1,6 +1,9 @@
 {
     "skip_ledd": true,
     "skip_fancontrol": true,
-    "skip_xcvrd_cmis_mgr": false
+    "skip_xcvrd_cmis_mgr": false,
+    "xcvrd": {
+        "dom_temperature_poll_interval": 20
+    }
 }
 

--- a/device/mellanox/x86_64-nvidia_sn5610n-r0/Mellanox-SN5610N-C256S2/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-nvidia_sn5610n-r0/Mellanox-SN5610N-C256S2/pmon_daemon_control.json
@@ -1,6 +1,9 @@
 {
     "skip_ledd": true,
     "skip_fancontrol": true,
-    "skip_xcvrd_cmis_mgr": false
+    "skip_xcvrd_cmis_mgr": false,
+    "xcvrd": {
+        "dom_temperature_poll_interval": 20
+    }
 }
 

--- a/device/mellanox/x86_64-nvidia_sn5610n-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-nvidia_sn5610n-r0/pmon_daemon_control.json
@@ -1,6 +1,9 @@
 {
     "skip_ledd": true,
     "skip_fancontrol": true,
-    "skip_xcvrd_cmis_mgr": true
+    "skip_xcvrd_cmis_mgr": true,
+    "xcvrd": {
+        "dom_temperature_poll_interval": 20
+    }
 }
 

--- a/device/mellanox/x86_64-nvidia_sn5640-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-nvidia_sn5640-r0/pmon_daemon_control.json
@@ -1,6 +1,9 @@
 {
     "skip_ledd": true,
     "skip_fancontrol": true,
-    "skip_xcvrd_cmis_mgr": true
+    "skip_xcvrd_cmis_mgr": true,
+    "xcvrd": {
+        "dom_temperature_poll_interval": 20
+    }
 }
 

--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/pmon_daemon_control.json
@@ -1,7 +1,10 @@
 {
-        "skip_ledd": true,
-        "thermalctld": {
-                "enable_liquid_cooling": true,
-                "liquid_cooling_update_interval": 0.5
-            }
+    "skip_ledd": true,
+    "thermalctld": {
+        "enable_liquid_cooling": true,
+        "liquid_cooling_update_interval": 0.5
+    },
+    "xcvrd": {
+        "dom_temperature_poll_interval": 20
+    }
 }

--- a/platform/mellanox/hw-management/0003-Disable-hw-management-thermal-updater.patch
+++ b/platform/mellanox/hw-management/0003-Disable-hw-management-thermal-updater.patch
@@ -1,0 +1,32 @@
+From 29a649691e9c52d21c4050ba43fc2cf951da74ed Mon Sep 17 00:00:00 2001
+From: Junchao-Mellanox <junchao@nvidia.com>
+Date: Mon, 26 Jan 2026 08:51:56 +0200
+Subject: [PATCH] Disable hw-management-thermal-updater
+
+---
+ debian/rules | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/debian/rules b/debian/rules
+index ddd057eb..e550d69d 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -67,7 +67,6 @@ override_dh_systemd_enable:
+ 	dh_systemd_enable --name=hw-management
+ 	dh_systemd_enable --name=hw-management-tc
+ 	dh_systemd_enable --name=hw-management-peripheral-updater
+-	dh_systemd_enable --name=hw-management-thermal-updater
+ 	dh_systemd_enable --name=hw-management-sysfs-monitor
+ 	dh_systemd_enable --name=hw-management-fast-sysfs-monitor
+ 	dh_systemd_enable --name=hw-management-blacklist-generator
+@@ -77,7 +76,6 @@ override_dh_systemd_start:
+ 	dh_systemd_start --name=hw-management
+ 	dh_systemd_start --name=hw-management-tc
+ 	dh_systemd_start --name=hw-management-peripheral-updater
+-	dh_systemd_start --name=hw-management-thermal-updater
+ 	dh_systemd_start --name=hw-management-sysfs-monitor
+ 	dh_systemd_start --name=hw-management-fast-sysfs-monitor
+ 	dh_systemd_start --name=hw-management-blacklist-generator
+-- 
+2.49.0
+

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/db_table_helper.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/db_table_helper.py
@@ -1,0 +1,80 @@
+#
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import threading
+from swsscommon.swsscommon import DBConnector, Table
+from sonic_py_common import multi_asic
+
+TRANSCEIVER_DOM_TEMPERATURE_TABLE = 'TRANSCEIVER_DOM_TEMPERATURE'
+TRANSCEIVER_DOM_THRESHOLD_TABLE = 'TRANSCEIVER_DOM_THRESHOLD'
+TRANSCEIVER_INFO_TABLE = 'TRANSCEIVER_INFO'
+STATE_DB = 'STATE_DB'
+APPL_DB = 'APPL_DB'
+
+
+class DbTableHelper:    
+    def __init__(self):
+        self.state_dbs = {}
+        self.appl_dbs = {}
+        self.module_temperature_table = None
+        self.module_threshold_table = None
+        self.module_info_table = None
+        self._initialized = False
+
+    def initialize(self):
+        if not self._initialized:
+            for namespace in multi_asic.get_front_end_namespaces():
+                self.state_dbs[namespace] = DBConnector(STATE_DB, 0, True, namespace)
+                self.appl_dbs[namespace] = DBConnector(APPL_DB, 0, True, namespace)
+
+            # Following tables are always in global namespace
+            default_namespace = multi_asic.DEFAULT_NAMESPACE
+            self.module_temperature_table = Table(self.state_dbs[default_namespace], TRANSCEIVER_DOM_TEMPERATURE_TABLE)
+            self.module_threshold_table = Table(self.state_dbs[default_namespace], TRANSCEIVER_DOM_THRESHOLD_TABLE)
+            self.module_info_table = Table(self.state_dbs[default_namespace], TRANSCEIVER_INFO_TABLE)
+            self._initialized = True
+
+    def get_module_temperature_table(self):
+        self.initialize()
+        return self.module_temperature_table
+
+    def get_module_threshold_table(self):
+        self.initialize()
+        return self.module_threshold_table
+
+    def get_module_info_table(self):
+        self.initialize()
+        return self.module_info_table
+
+    def get_appl_db(self, namespace):
+        self.initialize()
+        return self.appl_dbs[namespace]
+
+    def get_state_db(self, namespace):
+        self.initialize()
+        return self.state_dbs[namespace]
+
+
+# Global instance of DbTableHelper
+_thread_local = threading.local()
+
+
+def get_db_table_helper():
+    if not hasattr(_thread_local, 'helper'):
+        _thread_local.helper = DbTableHelper()
+    return _thread_local.helper

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
@@ -465,3 +465,9 @@ class DeviceDataManager:
     @utils.read_only_cache()
     def is_multi_asic_platform(cls):
         return cls.get_asic_count() > 1
+
+    @classmethod
+    @utils.read_only_cache()
+    def is_spc1(cls):
+        platform_name = cls.get_platform_name()
+        return platform_name in ('x86_64-mlnx_msn2700-r0', 'x86_64-mlnx_msn2700a1-r0')

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -26,13 +26,14 @@
 try:
     import ctypes
     import select
-    import subprocess
     import os
     import threading
     import time
     from sonic_py_common.logger import Logger
-    from sonic_py_common.general import check_output_pipe
+    from sonic_py_common import multi_asic
+    from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
     from . import utils
+    from .db_table_helper import get_db_table_helper
     from .device_data import DeviceDataManager
     from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
     from sonic_platform_base.sonic_xcvr.fields import consts
@@ -283,6 +284,10 @@ limited_eeprom = {
     }
 }
 
+# Redis constants
+CFG_PORT_TABLE = 'PORT'
+PORT_CONFIG_DONE = 'PORT_TABLE:PortConfigDone'
+
 # Global logger class instance
 logger = Logger()
 
@@ -328,6 +333,7 @@ class NvidiaSFPCommon(SfpOptoeBase):
         self.index = sfp_index + 1
         self.sdk_index = sfp_index
         self.asic_id = asic_id
+        self.asic_index = multi_asic.get_asic_index_from_namespace(asic_id)
 
     @classmethod
     def _get_module_info(self, sdk_index):
@@ -416,6 +422,9 @@ class SFP(NvidiaSFPCommon):
     # Class level action table which stores the mapping from action name to action function,
     # only applicable for module host management
     action_table = None
+    
+    # Class level port mapping dictionary, key is index, value is logical port
+    port_mapping = {}
 
     def __init__(self, sfp_index, sfp_type=None, slot_id=0, linecard_port_count=0, lc_name=None, asic_id='asic0'):
         super(SFP, self).__init__(sfp_index, asic_id=asic_id)
@@ -444,12 +453,10 @@ class SFP(NvidiaSFPCommon):
             self.state = STATE_FCP_DOWN
         self.processing_insert_event = False
         self.sn = None
-        self.temp_high_threshold = None
-        self.temp_critical_threshold = None
-        self.retry_read_threshold = 5
-        self.retry_read_vendor = 5
-        self.manufacturer = None
-        self.part_number = None
+        if DeviceDataManager.is_multi_asic_platform():
+            self.namespace = asic_id
+        else:
+            self.namespace = multi_asic.DEFAULT_NAMESPACE
 
     def __str__(self):
         return f'SFP {self.sdk_index}'
@@ -908,18 +915,7 @@ class SFP(NvidiaSFPCommon):
         sn = self._get_serial()
         if sn != self.sn:
             self.reinit()
-            # Clear cached vendor info so a new module will be re-read
-            self.manufacturer = None
-            self.part_number = None
-            self.temp_high_threshold = None
-            self.temp_critical_threshold = None
             self.sn = self._get_serial()
-            if self.sn is not None:
-                self.retry_read_threshold = 5
-                self.retry_read_vendor = 5
-            else:
-                self.retry_read_threshold = 0
-                self.retry_read_vendor = 0
             return True
         return False
 
@@ -1062,40 +1058,6 @@ class SFP(NvidiaSFPCommon):
 
         self.reinit_if_sn_changed()
         return super().get_temperature()
-
-    def get_temperature_warning_threshold(self):
-        """Get temperature warning threshold
-
-        Returns:
-            None if there is an error (module EEPROM not readable)
-            0.0 if warning threshold is not supported or module is under initialization
-            other float value if warning threshold is available
-        """
-        try:
-            sw_control = self.is_sw_control()
-        except:
-            return 0.0
-        
-        self.reinit_if_sn_changed()
-        self._update_temperature_threshold(sw_control)
-        return self.temp_high_threshold
-
-    def get_temperature_critical_threshold(self):
-        """Get temperature critical threshold
-
-        Returns:
-            None if there is an error (module EEPROM not readable)
-            0.0 if critical threshold is not supported or module is under initialization
-            other float value if critical threshold is available
-        """
-        try:
-            sw_control = self.is_sw_control()
-        except:
-            return 0.0
-
-        self.reinit_if_sn_changed()
-        self._update_temperature_threshold(sw_control)
-        return self.temp_critical_threshold
 
     def get_xcvr_api(self):
         """
@@ -1680,7 +1642,96 @@ class SFP(NvidiaSFPCommon):
             logger.log_notice(f'SFP {index} is in state {s.state} after module initialization')
 
         cls.wait_sfp_eeprom_ready(sfp_list, 2)
-        
+
+    @classmethod
+    def get_port_config_done(cls, namespace):
+        app_db = get_db_table_helper().get_appl_db(namespace)
+        return app_db.exists(PORT_CONFIG_DONE)
+
+    @classmethod
+    def build_port_mapping(cls, namespace):
+        from natsort import natsorted
+        db = ConfigDBConnector(use_unix_socket_path=True, namespace=namespace)
+        db.db_connect(db.CONFIG_DB)
+        port_table = db.get_table(CFG_PORT_TABLE)
+        for logical_port, value in natsorted(port_table.items()):
+            index = int(value.get('index'))
+            if index not in cls.port_mapping:
+                cls.port_mapping[index] = logical_port
+
+    def get_logical_port(self):
+        logical_port = self.port_mapping.get(self.index)
+        if not logical_port:
+            port_config_done = self.get_port_config_done(self.namespace)
+            if not port_config_done:
+                return None
+            self.build_port_mapping(self.namespace)
+            logical_port = self.port_mapping.get(self.index)
+        return logical_port
+
+    def get_temperature_from_db(self):
+        """Get temperature from DB
+
+        Returns:
+            float: return 0 if module does not support temperature or not present, return -1 if read failed,
+                   return other float value if module supports temperature
+        """
+        present, value = self._get_data_from_db(get_db_table_helper().get_module_temperature_table,
+                                                'temperature')
+        if not present:
+            return 0
+
+        if value == 'None':
+            return -1
+
+        return float(value)
+
+    def get_warning_threshold_from_db(self):
+        present, value = self._get_data_from_db(get_db_table_helper().get_module_threshold_table,
+                                                'temphighwarning')
+        # xcvrd returns N/A if threshold is not supported
+        # xcvrd cannot tell read failure or not supported,
+        # so we return 0 in both cases
+        if not present or value == 'N/A':
+            return 0
+
+        return float(value)
+
+    def get_critical_threshold_from_db(self):
+        present, value = self._get_data_from_db(get_db_table_helper().get_module_threshold_table,
+                                                'temphighalarm')
+        # xcvrd returns N/A if threshold is not supported
+        # xcvrd cannot tell read failure or not supported,
+        # so we return 0 in both cases
+        if not present or value == 'N/A':
+            return 0
+
+        return float(value)
+    
+    def get_vendor_name_from_db(self):
+        present, value = self._get_data_from_db(get_db_table_helper().get_module_info_table,
+                                                'manufacturer')
+        if not present:
+            return ''
+        return value.strip()
+
+    def get_part_number_from_db(self):
+        present, value = self._get_data_from_db(get_db_table_helper().get_module_info_table,
+                                                'model')
+        if not present:
+            return ''
+        return value.strip()
+
+    def _get_data_from_db(self, table_cb, key):
+        logical_port = self.get_logical_port()
+        if not logical_port:
+            return False, None
+        return table_cb().hget(logical_port, key)
+
+    def get_asic_index(self):
+        return self.asic_index
+
+
 class RJ45Port(NvidiaSFPCommon):
     """class derived from SFP, representing RJ45 ports"""
 
@@ -1964,5 +2015,3 @@ class CpoPort(SFP):
         :return:
         """
         return
-
-

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/smartswitch_thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/smartswitch_thermal_updater.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,11 +58,10 @@ logger = logger.Logger('smart-switch-thermal-updater')
 
 
 class SmartswitchThermalUpdater(ThermalUpdater):
-    def __init__(self, sfp_list, dpu_list, is_host_mgmt_mode=True):
+    def __init__(self, sfp_list, dpu_list):
         super().__init__(sfp_list=sfp_list)
         self._dpu_list = dpu_list
         self._dpu_status = {}
-        self.host_mgmt_mode = is_host_mgmt_mode
 
     def load_tc_config_dpu(self):
         dpu_poll_interval = 3
@@ -80,16 +79,7 @@ class SmartswitchThermalUpdater(ThermalUpdater):
     def start(self):
         self.clean_thermal_data_dpu()
         self.load_tc_config_dpu()
-        if self.host_mgmt_mode:
-            super().start()
-        else:
-            self._timer.start()
-
-    def stop(self):
-        if self.host_mgmt_mode:
-            super().stop()
-        else:
-            self._timer.stop()
+        super().start()
 
     def clean_thermal_data_dpu(self):
         for dpu in self._dpu_list:

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
@@ -492,10 +492,8 @@ class ModuleThermal(ThermalBase):
             A float number of current temperature in Celsius up to nearest thousandth
             of one degree Celsius, e.g. 30.125
         """
-        if not self.sfp.get_presence():
-            return None
-        value = self.sfp.get_temperature()
-        return value if (value != 0.0 and value is not None) else None
+        value = self.sfp.get_temperature_from_db()
+        return value if value and value > 0 else None
 
     def get_high_threshold(self):
         """
@@ -505,9 +503,7 @@ class ModuleThermal(ThermalBase):
             A float number, the high threshold temperature of thermal in Celsius
             up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
-        if not self.sfp.get_presence():
-            return None
-        value = self.sfp.get_temperature_warning_threshold()
+        value = self.sfp.get_warning_threshold_from_db()
         return value if (value != 0.0 and value is not None) else None
 
     def get_high_critical_threshold(self):
@@ -518,9 +514,7 @@ class ModuleThermal(ThermalBase):
             A float number, the high critical threshold temperature of thermal in Celsius
             up to nearest thousandth of one degree Celsius, e.g. 30.125
         """
-        if not self.sfp.get_presence():
-            return None
-        value = self.sfp.get_temperature_critical_threshold()
+        value = self.sfp.get_critical_threshold_from_db()
         return value if (value != 0.0 and value is not None) else None
 
     def get_position_in_parent(self):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_manager.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_manager.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,19 +36,16 @@ class ThermalManager(ThermalManagerBase):
         :return:
         """
         dpus_present = DeviceDataManager.get_platform_dpus_data()
-        host_mgmt_mode = DeviceDataManager.is_module_host_management_mode()
-        if not dpus_present and host_mgmt_mode:
+        if not dpus_present:
             # Non smart switch behaviour has highest priority
             from .chassis import Chassis
-            cls.thermal_updater_task = thermal_updater.ThermalUpdater(sfp_list=Chassis.chassis_instance.get_all_sfps(), update_asic=False)
-        elif dpus_present:
+            cls.thermal_updater_task = thermal_updater.ThermalUpdater(sfp_list=Chassis.chassis_instance.get_all_sfps())
+        else:
             from .chassis import Chassis
             dpus = Chassis.chassis_instance.get_all_modules()
             cls.thermal_updater_task = smartswitch_thermal_updater.SmartswitchThermalUpdater(sfp_list=Chassis.chassis_instance.get_all_sfps(),
-                                                                                             dpu_list=dpus,
-                                                                                             is_host_mgmt_mode=host_mgmt_mode)
-        if cls.thermal_updater_task:
-            cls.thermal_updater_task.start()
+                                                                                             dpu_list=dpus)
+        cls.thermal_updater_task.start()
 
     @classmethod
     def deinitialize(cls):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
@@ -24,7 +24,7 @@ import atexit
 import functools
 import re
 import sys
-import time
+import glob
 import os
 
 sys.path.append('/run/hw-management/bin')
@@ -57,15 +57,15 @@ logger = logger.Logger('thermal-updater')
 
 # Register a clean-up routine that will run when the process exits
 def clean_thermal_data(sfp_list):
+    asic_count = DeviceDataManager.get_asic_count()
+    for asic_index in range(asic_count):
+        hw_management_independent_mode_update.thermal_data_clean_asic(asic_index)
+
     if not sfp_list:
         return
     hw_management_independent_mode_update.module_data_set_module_counter(len(sfp_list))
     for sfp in sfp_list:
         try:
-            sw_control = sfp.is_sw_control()
-            if not sw_control:
-                continue
-
             hw_management_independent_mode_update.thermal_data_clean_module(
                 0,
                 sfp.sdk_index + 1
@@ -74,41 +74,11 @@ def clean_thermal_data(sfp_list):
             logger.log_warning(f'Cleanup skipped for module {sfp.sdk_index + 1}: {e}')
 
 class ThermalUpdater:
-    def __init__(self, sfp_list, update_asic=True):
+    def __init__(self, sfp_list):
         self._sfp_list = sfp_list
         self._sfp_status = {}
         self._timer = utils.Timer()
-        self._update_asic = update_asic
-
         atexit.register(functools.partial(clean_thermal_data, self._sfp_list))
-
-    def wait_for_sysfs_nodes(self):
-        """
-        Wait for temperature sysfs nodes to be present before proceeding.
-        Returns:
-            bool: True if wait success else timeout
-        """
-        start_time = time.time()
-        logger.log_notice('Waiting for temperature sysfs nodes to be present...')
-        conditions = []
-
-        # ASIC temperature sysfs node
-        asic_count = DeviceDataManager.get_asic_count()
-        for asic_index in range(asic_count):
-            conditions.append(lambda idx=asic_index: os.path.exists(f'/sys/module/sx_core/asic{idx}/temperature/input'))
-
-        # Module temperature sysfs nodes
-        sfp_count = len(self._sfp_list) if self._sfp_list else 0
-        result = DeviceDataManager.wait_sysfs_ready(sfp_count)
-        end_time = time.time()
-        elapsed_time = end_time - start_time
-
-        if result:
-            logger.log_notice(f'Temperature sysfs nodes are ready. Wait time: {elapsed_time:.4f} seconds')
-        else:
-            logger.log_error(f'Timeout waiting for temperature sysfs nodes. Wait time: {elapsed_time:.4f} seconds')
-
-        return result
 
     def _find_matching_key(self, dev_parameters, pattern):
         """
@@ -155,22 +125,15 @@ class ThermalUpdater:
                 else:
                     logger.log_error(f'Module parameter not found (pattern: module\\d+), using default interval: {sfp_poll_interval}')
 
-        if self._update_asic:
-            logger.log_notice(f'ASIC polling interval: {asic_poll_interval}')
-            self._timer.schedule(asic_poll_interval, self.update_asic)
+        logger.log_notice(f'ASIC polling interval: {asic_poll_interval}')
+        self._timer.schedule(asic_poll_interval, self.update_asic)
         logger.log_notice(f'Module polling interval: {sfp_poll_interval}')
         self._timer.schedule(sfp_poll_interval, self.update_module)
 
     def start(self):
         self.control_tc(False)
         self.load_tc_config()
-
-        # Wait for temperature sysfs nodes to be ready before starting the timer
-        if not self.wait_for_sysfs_nodes():
-            logger.log_error('Failed to start thermal updater: temperature sysfs nodes not available')
-            self.control_tc(True)  # Suspend TC to protect the system
-            return False
-
+        self.unlink_hw_mgmt_thermal_files()
         self._timer.start()
 
     def stop(self):
@@ -198,33 +161,56 @@ class ThermalUpdater:
             presence = sfp.get_presence()
             pre_presence = self._sfp_status.get(sfp.sdk_index)
             if presence:
-                sw_control, temperature, warning_thresh, critical_thresh = sfp.get_temperature_info()
-                if not sw_control:
-                    return
-                fault = ERROR_READ_THERMAL_DATA if (temperature is None or warning_thresh is None or critical_thresh is None) else 0
-                temperature = 0 if temperature is None else temperature * SFP_TEMPERATURE_SCALE
-                warning_thresh = 0 if warning_thresh is None else warning_thresh * SFP_TEMPERATURE_SCALE
-                critical_thresh = 0 if critical_thresh is None else critical_thresh * SFP_TEMPERATURE_SCALE
+                fault = 0
+                temperature = sfp.get_temperature_from_db()
+                if temperature > 0:
+                    warning_thresh = sfp.get_warning_threshold_from_db()
+                    critical_thresh = sfp.get_critical_threshold_from_db()
+                    if warning_thresh > critical_thresh:
+                        fault = ERROR_READ_THERMAL_DATA
+                else:
+                    if temperature == -1: # read failed
+                        fault = ERROR_READ_THERMAL_DATA
+                    temperature = 0
+                    warning_thresh = 0
+                    critical_thresh = 0
 
+                vendor_name = sfp.get_vendor_name_from_db()
+                part_number = sfp.get_part_number_from_db()
+
+                vendor_info = {
+                    'manufacturer': vendor_name,
+                    'part_number': part_number
+                }
                 hw_management_independent_mode_update.thermal_data_set_module(
-                    0, # ASIC index always 0 for now
+                    sfp.get_asic_index(),
                     sfp.sdk_index + 1,
-                    int(temperature),
-                    int(critical_thresh),
-                    int(warning_thresh),
+                    int(temperature * SFP_TEMPERATURE_SCALE),
+                    int(critical_thresh * SFP_TEMPERATURE_SCALE),
+                    int(warning_thresh * SFP_TEMPERATURE_SCALE),
                     fault
+                )
+                hw_management_independent_mode_update.vendor_data_set_module(
+                    sfp.get_asic_index(),
+                    sfp.sdk_index + 1,
+                    vendor_info
                 )
             else:
                 if pre_presence != presence:
                     # thermal control service requires to
                     # set value 0 to all temperature files when module is not present
                     hw_management_independent_mode_update.thermal_data_set_module(
-                        0,  # ASIC index always 0 for now
+                        sfp.get_asic_index(),
                         sfp.sdk_index + 1,
                         0,
                         0,
                         0,
                         0
+                    )
+                    hw_management_independent_mode_update.vendor_data_set_module(
+                        sfp.get_asic_index(),
+                        sfp.sdk_index + 1,
+                        {'manufacturer': '', 'part_number': ''}
                     )
 
             if pre_presence != presence:
@@ -232,7 +218,7 @@ class ThermalUpdater:
         except Exception as e:
             logger.log_error(f'Failed to update module {sfp.sdk_index} thermal data - {e}')
             hw_management_independent_mode_update.thermal_data_set_module(
-                0, # ASIC index always 0 for now
+                sfp.get_asic_index(),
                 sfp.sdk_index + 1,
                 0,
                 0,
@@ -272,3 +258,29 @@ class ThermalUpdater:
                 0,
                 ERROR_READ_THERMAL_DATA
             )
+
+    def unlink_hw_mgmt_thermal_files(self):
+        if not DeviceDataManager.is_spc1():
+            return
+
+        conditions = [lambda: os.path.islink('/run/hw-management/thermal/asic')]
+        sfp_count = DeviceDataManager.get_sfp_count()
+        for sfp_index in range(sfp_count):
+            index = sfp_index + 1
+            conditions.append(lambda idx=index: os.path.islink(f'/run/hw-management/thermal/module{idx}_temp_input'))
+            conditions.append(lambda idx=index: os.path.islink(f'/run/hw-management/thermal/module{idx}_temp_fault'))
+            conditions.append(lambda idx=index: os.path.islink(f'/run/hw-management/thermal/module{idx}_temp_crit'))
+            conditions.append(lambda idx=index: os.path.islink(f'/run/hw-management/thermal/module{idx}_temp_emergency'))
+
+        logger.log_notice(f'Waiting for ASIC and modules thermal files to be created')
+        if not utils.wait_until_conditions(conditions, 300, 1):
+            logger.log_error('Failed to wait for thermal files to be created')
+            return
+        logger.log_notice(f'All ASIC and modules thermal files are created')
+
+        for f in glob.iglob('/run/hw-management/thermal/asic*'):
+            if os.path.islink(f):
+                os.unlink(f)
+        for f in glob.iglob('/run/hw-management/thermal/module*_temp_*'):
+            if os.path.islink(f):
+                os.unlink(f)

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -362,72 +362,6 @@ class TestSfp:
         assert sfp.get_temperature() == 56.0
 
     @mock.patch('sonic_platform.utils.read_int_from_file')
-    def test_get_temperature_threshold(self, mock_read_int):
-        sfp = SFP(0)
-        sfp.is_sw_control = mock.MagicMock(return_value=True)
-        mock_serial = 'some serial'
-        mock_api = mock.MagicMock()
-        mock_api.xcvr_eeprom = mock.MagicMock()
-        from sonic_platform_base.sonic_xcvr.fields import consts
-        def mock_read(field):
-            if field == consts.TEMP_HIGH_ALARM_FIELD:
-                return 85.0
-            elif field == consts.TEMP_HIGH_WARNING_FIELD:
-                return 75.0
-            elif field == consts.VENDOR_SERIAL_NO_FIELD:
-                return mock_serial
-        mock_api.xcvr_eeprom.read = mock.MagicMock(side_effect=mock_read)
-
-        # No api object, means no access to EEPROM, expect None and retry_read_threshold - 1
-        sfp.get_xcvr_api = mock.MagicMock(return_value=None)
-        retry = sfp.retry_read_threshold
-        assert sfp.get_temperature_warning_threshold() == None
-        assert sfp.retry_read_threshold == retry - 1
-        retry = sfp.retry_read_threshold
-        assert sfp.get_temperature_critical_threshold() == None
-        assert sfp.retry_read_threshold == retry - 1
-
-        # No threshold support, expect None
-        mock_serial = 'some other serial' 
-        mock_api.get_transceiver_thresholds_support = mock.MagicMock(return_value=False)
-        sfp.get_xcvr_api.return_value = mock_api
-        assert sfp.get_temperature_warning_threshold() == None  
-        assert sfp.get_temperature_critical_threshold() == None
-
-        # Threshold support, expect threshold values
-        mock_api.get_transceiver_thresholds_support.return_value = True
-        
-        assert sfp.get_temperature_warning_threshold() == 75.0
-        assert sfp.get_temperature_critical_threshold() == 85.0
-        assert sfp.retry_read_threshold == 0
-
-        # No serial number, expect None and retry_read_threshold = 0
-        mock_serial = None
-        assert sfp.get_temperature_warning_threshold() == None
-        assert sfp.get_temperature_critical_threshold() == None
-        assert sfp.retry_read_threshold == 0
-        
-        # Firmware control, expect threshold values from sysfs
-        sfp.is_sw_control.return_value = False
-        mock_serial = "some serial"
-        def mock_read_int_side_effect(file_path, *args, **kwargs):
-            if 'threshold_hi' in file_path:
-                return 448  # 56.0 * 8.0
-            elif 'threshold_critical_hi' in file_path:
-                return 480  # 60.0 * 8.0
-            return None
-
-        mock_read_int.side_effect = mock_read_int_side_effect
-        assert sfp.get_temperature_warning_threshold() == 56.0
-        assert sfp.get_temperature_critical_threshold() == 60.0
-        assert sfp.retry_read_threshold == 0
-
-        # Exception in is_sw_control, expect 0.0
-        sfp.is_sw_control.side_effect = Exception('')
-        assert sfp.get_temperature_warning_threshold() == 0.0
-        assert sfp.get_temperature_critical_threshold() == 0.0
-
-    @mock.patch('sonic_platform.utils.read_int_from_file')
     @mock.patch('sonic_platform.device_data.DeviceDataManager.is_module_host_management_mode')
     def test_is_sw_control(self, mock_mode, mock_read):
         sfp = SFP(0)
@@ -605,45 +539,6 @@ class TestSfp:
         assert sfp.set_lpmode(True)
         mock_write.assert_called_with('/sys/module/sx_core/asic0/module0/power_mode_policy', '3')
 
-    @mock.patch('sonic_platform.sfp.SfpOptoeBase.get_temperature')
-    def test_get_temperature_info(self, mock_super_get_temperature):
-        sfp = SFP(0)
-
-        sfp.is_sw_control = mock.MagicMock(return_value=False)
-        assert sfp.get_temperature_info() == (False, None, None, None)
-
-        sfp.is_sw_control.return_value = True
-        sfp._update_temperature_threshold = mock.MagicMock()
-        sfp.temp_high_threshold = 75.0
-        sfp.temp_critical_threshold = 85.0
-        mock_super_get_temperature.return_value = 58.0
-        assert sfp.get_temperature_info() == (True, 58.0, 75.0, 85.0)
-        
-        mock_super_get_temperature.return_value = None
-        assert sfp.get_temperature_info() == (True, None, None, None)
-        
-        mock_super_get_temperature.return_value = 0.0
-        assert sfp.get_temperature_info() == (True, 0.0, 0.0, 0.0)
-
-    @mock.patch('time.sleep', mock.MagicMock())
-    def test_get_temperature_info_vendor_retry_loop(self):
-        sfp = SFP(0)
-        sfp.reinit_if_sn_changed = mock.MagicMock(side_effect=[True, False, False])
-        sfp.is_sw_control = mock.MagicMock(return_value=False)
-        sfp.retry_read_vendor = 5
-        # First two attempts fail, third succeeds
-        sfp.get_vendor_info = mock.MagicMock(side_effect=[(None, None), (None, None), ('Mellanox', 'PN-9999')])
-
-        # Attempt 1: reinit sets retry counter, first vendor read fails (counter -> 4)
-        sfp.get_temperature_info()
-        # Attempt 2: retry counter >0, second vendor read fails (counter -> 3)
-        sfp.get_temperature_info()
-        # Attempt 3: retry counter >0, vendor read succeeds, counter cleared
-        sfp.get_temperature_info()
-
-        assert sfp.get_vendor_info.call_count == 3
-        assert sfp.retry_read_vendor == 0
-
     def test_reinit_if_sn_changed(self):
         sfp = SFP(0)
         sfp.get_xcvr_api = mock.MagicMock(return_value=None)
@@ -652,107 +547,102 @@ class TestSfp:
         sfp.get_xcvr_api.return_value = mock.MagicMock()
         sfp.get_xcvr_api.return_value.xcvr_eeprom.read = mock.MagicMock(return_value='1234567890')
         assert sfp.reinit_if_sn_changed()
-        assert sfp.retry_read_vendor == 5
 
         sfp.get_xcvr_api.return_value.xcvr_eeprom.read.return_value = '1234567891'
         assert sfp.reinit_if_sn_changed()
-        assert sfp.retry_read_vendor == 5
 
-        # Vendor cache should reset on reinit to allow new modules to be read
-        sfp.sn = 'old_sn'
-        sfp.manufacturer = 'OldVendor'
-        sfp.part_number = 'OldPart'
-        sfp._get_serial = mock.MagicMock(return_value='new_sn')
-        assert sfp.reinit_if_sn_changed()
-        assert sfp.manufacturer is None
-        assert sfp.part_number is None
-        assert sfp.retry_read_vendor == 5
-
-    @mock.patch('time.sleep', mock.MagicMock())
-    def test_get_vendor_info_success_and_cache(self):
+    @pytest.mark.parametrize("data_from_db, expected", [
+        ((False, None), 0),
+        ((True, 'None'), -1),
+        ((True, '25.5'), 25.5),
+        ((True, '0.0'), 0.0),
+        ((True, '-10.5'), -10.5),
+    ])
+    def test_get_temperature_from_db(self, data_from_db, expected):
         sfp = SFP(0)
-        mock_api = mock.MagicMock()
-        mock_eeprom = mock.MagicMock()
-        mock_api.xcvr_eeprom = mock_eeprom
-        sfp.get_xcvr_api = mock.MagicMock(return_value=mock_api)
+        
+        sfp._get_data_from_db = mock.MagicMock(return_value=data_from_db)
+        assert sfp.get_temperature_from_db() == expected
 
-        from sonic_platform_base.sonic_xcvr.fields import consts
-        def mock_read(field):
-            if field == consts.VENDOR_NAME_FIELD:
-                return 'Mellanox'
-            if field == consts.VENDOR_PART_NO_FIELD:
-                return 'PN-1234'
-            return None
-        mock_eeprom.read.side_effect = mock_read
-
-        # First call reads from eeprom
-        manufacturer, part_number = sfp.get_vendor_info()
-        assert manufacturer == 'Mellanox'
-        assert part_number == 'PN-1234'
-        assert mock_eeprom.read.call_count == 2
-
-        # Second call should return cached values without additional reads
-        manufacturer, part_number = sfp.get_vendor_info()
-        assert manufacturer == 'Mellanox'
-        assert part_number == 'PN-1234'
-        assert mock_eeprom.read.call_count == 2
-
-    @mock.patch('time.sleep', mock.MagicMock())
-    def test_get_vendor_info_retry_then_success(self):
+    @pytest.mark.parametrize("data_from_db, expected", [
+        ((False, None), 0),
+        ((True, 'N/A'), 0),
+        ((False, '10.5'), 0),
+        ((True, '25.5'), 25.5),
+        ((True, '0.0'), 0.0),
+        ((True, '-10.5'), -10.5),
+    ])
+    def test_get_warning_threshold_from_db(self, data_from_db, expected):
         sfp = SFP(0)
-        mock_api = mock.MagicMock()
-        mock_eeprom = mock.MagicMock()
-        mock_api.xcvr_eeprom = mock_eeprom
-        sfp.get_xcvr_api = mock.MagicMock(return_value=mock_api)
+        
+        sfp._get_data_from_db = mock.MagicMock(return_value=data_from_db)
+        assert sfp.get_warning_threshold_from_db() == expected
 
-        from sonic_platform_base.sonic_xcvr.fields import consts
-        state = {'fail_reads': 2}
-        def flaky_read(field):
-            if state['fail_reads'] > 0:
-                state['fail_reads'] -= 1
-                raise Exception('EEPROM not ready')
-            if field == consts.VENDOR_NAME_FIELD:
-                return 'Mellanox'
-            if field == consts.VENDOR_PART_NO_FIELD:
-                return 'PN-5678'
-            return None
-        mock_eeprom.read.side_effect = flaky_read
-
-        # First call fails (counter decremented)
-        manufacturer, part_number = sfp.get_vendor_info()
-        assert (manufacturer, part_number) == (None, None)
-        # Second call fails (counter decremented)
-        manufacturer, part_number = sfp.get_vendor_info()
-        assert (manufacturer, part_number) == (None, None)
-        # Third call succeeds (reads both fields)
-        manufacturer, part_number = sfp.get_vendor_info()
-        assert (manufacturer, part_number) == ('Mellanox', 'PN-5678')
-        # Total read invocations: first two calls each raise on first field (2),
-        # third call reads both fields (2) → 4 total
-        assert mock_eeprom.read.call_count == 4
-
-    @mock.patch('time.sleep', mock.MagicMock())
-    def test_get_vendor_info_all_fail(self):
+    @pytest.mark.parametrize("data_from_db, expected", [
+        ((False, None), 0),
+        ((True, 'N/A'), 0),
+        ((False, '10.5'), 0),
+        ((True, '25.5'), 25.5),
+        ((True, '0.0'), 0.0),
+        ((True, '-10.5'), -10.5),
+    ])
+    def test_get_critical_threshold_from_db(self, data_from_db, expected):
         sfp = SFP(0)
-        mock_api = mock.MagicMock()
-        mock_eeprom = mock.MagicMock()
-        mock_api.xcvr_eeprom = mock_eeprom
-        sfp.get_xcvr_api = mock.MagicMock(return_value=mock_api)
-        mock_eeprom.read.side_effect = Exception('EEPROM error')
+        
+        sfp._get_data_from_db = mock.MagicMock(return_value=data_from_db)
+        assert sfp.get_critical_threshold_from_db() == expected
 
-        manufacturer, part_number = sfp.get_vendor_info()
-        assert manufacturer is None
-        assert part_number is None
-
-    def test_get_vendor_info_no_api_or_missing_attr(self):
+    @pytest.mark.parametrize("data_from_db, expected", [
+        ((False, None), ''),
+        ((True, 'Mellanox'), 'Mellanox'),
+        ((True, ''), ''),
+    ])
+    def test_get_vendor_name_from_db(self, data_from_db, expected):
         sfp = SFP(0)
-        # No API
-        sfp.get_xcvr_api = mock.MagicMock(return_value=None)
-        assert sfp.get_vendor_info() == (None, None)
+        sfp._get_data_from_db = mock.MagicMock(return_value=data_from_db)
+        assert sfp.get_vendor_name_from_db() == expected
+        
+    @pytest.mark.parametrize("data_from_db, expected", [
+        ((False, None), ''),
+        ((True, 'Mellanox'), 'Mellanox'),
+        ((True, ''), ''),
+    ])
+    def test_get_part_number_from_db(self, data_from_db, expected):
+        sfp = SFP(0)
+        sfp._get_data_from_db = mock.MagicMock(return_value=data_from_db)
+        assert sfp.get_part_number_from_db() == expected
 
-        # API without xcvr_eeprom attribute
-        class DummyApi(object):
-            pass
-        sfp.get_xcvr_api.return_value = DummyApi()
-        assert sfp.get_vendor_info() == (None, None)
+    def test_get_data_from_db(self):
+        sfp = SFP(0)
+        sfp.get_logical_port = mock.MagicMock(return_value=None)
+        assert sfp._get_data_from_db(None, None) == (False, None)
 
+        sfp.get_logical_port.return_value = 'Ethernet0'
+        mock_table = mock.MagicMock()
+        def mock_get_table():
+            return mock_table
+        mock_table.hget = mock.MagicMock(return_value=(True, '25.5'))
+        assert sfp._get_data_from_db(mock_get_table, 'temperature') == (True, '25.5')
+
+    def test_get_logical_port(self):
+        sfp = SFP(0)
+        sfp.get_port_config_done = mock.MagicMock(return_value=False)
+        assert sfp.get_logical_port() is None
+
+        sfp.get_port_config_done.return_value = True
+        sfp.build_port_mapping = mock.MagicMock()
+        assert sfp.get_logical_port() is None
+
+        sfp.port_mapping = {1: 'Ethernet0'}
+        assert sfp.get_logical_port() == 'Ethernet0'
+
+    @mock.patch('sonic_platform.sfp.get_db_table_helper')
+    def test_get_port_config_done(self, mock_db_table_helper):
+        sfp = SFP(0)
+        app_db = mock.MagicMock()
+        app_db.exists = mock.MagicMock(return_value=False)
+        mock_db_table_helper.return_value.get_appl_db = mock.MagicMock(return_value=app_db)
+        assert not sfp.get_port_config_done('')
+        
+        app_db.exists.return_value = True
+        assert sfp.get_port_config_done('')

--- a/platform/mellanox/mlnx-platform-api/tests/test_thermal.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_thermal.py
@@ -166,26 +166,20 @@ class TestThermal:
         assert thermal.get_name() == rule['name'].format(start_index)
         assert thermal.get_position_in_parent() == 1
         assert thermal.is_replaceable() == False
-        sfp.get_presence = mock.MagicMock(return_value=True)
-        sfp.get_temperature = mock.MagicMock(return_value=35.4)
-        sfp.get_temperature_warning_threshold = mock.MagicMock(return_value=70)
-        sfp.get_temperature_critical_threshold = mock.MagicMock(return_value=80)
+        sfp.get_temperature_from_db = mock.MagicMock(return_value=35.4)
         assert thermal.get_temperature() == 35.4
+        sfp.get_temperature_from_db.return_value = 0.0
+        assert thermal.get_temperature() is None
+        sfp.get_temperature_from_db.return_value = -1
+        assert thermal.get_temperature() is None
+        
+        sfp.get_warning_threshold_from_db = mock.MagicMock(return_value=70)
         assert thermal.get_high_threshold() == 70
+        sfp.get_warning_threshold_from_db.return_value = 0
+        assert thermal.get_high_threshold() is None
+        sfp.get_critical_threshold_from_db = mock.MagicMock(return_value=80)
         assert thermal.get_high_critical_threshold() == 80
-        sfp.get_presence = mock.MagicMock(return_value=False)
-        sfp.get_temperature = mock.MagicMock(return_value=35.4)
-        sfp.get_temperature_warning_threshold = mock.MagicMock(return_value=70)
-        sfp.get_temperature_critical_threshold = mock.MagicMock(return_value=80)
-        assert thermal.get_temperature() is None
-        assert thermal.get_high_threshold() is None
-        assert thermal.get_high_critical_threshold() is None
-        sfp.get_presence = mock.MagicMock(return_value=True)
-        sfp.get_temperature = mock.MagicMock(return_value=0)
-        sfp.get_temperature_warning_threshold = mock.MagicMock(return_value=0)
-        sfp.get_temperature_critical_threshold = mock.MagicMock(return_value=None)
-        assert thermal.get_temperature() is None
-        assert thermal.get_high_threshold() is None
+        sfp.get_critical_threshold_from_db.return_value = 0
         assert thermal.get_high_critical_threshold() is None
 
     @mock.patch('sonic_platform.utils.read_float_from_file')

--- a/platform/mellanox/mlnx-platform-api/tests/test_thermal_manager.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_thermal_manager.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,11 +23,9 @@ from sonic_platform.thermal_manager import ThermalManager
 class TestThermalManager:
 
     @mock.patch('sonic_platform.chassis.Chassis.chassis_instance', new_callable=mock.MagicMock)
-    @mock.patch('sonic_platform.device_data.DeviceDataManager.is_module_host_management_mode')
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_platform_dpus_data')
-    def test_updater_init(self, mock_dpus_data, mock_management_mode, mock_chassis_instance):
+    def test_updater_init(self, mock_dpus_data, mock_chassis_instance):
         mock_dpus_data.return_value = {}
-        mock_management_mode.return_value = True
         sfp_mock = mock.MagicMock()
         mod_mock = mock.MagicMock()
         mock_chassis_instance.get_all_sfps = sfp_mock
@@ -40,28 +38,14 @@ class TestThermalManager:
             # Host mgmt mode, no DPUs are used for init
             mgr = ThermalManager()
             mgr.initialize()
-            mock_thermal.assert_called_once_with(sfp_list=['sfp1', 'sfp2'], update_asic=False)
+            mock_thermal.assert_called_once_with(sfp_list=['sfp1', 'sfp2'])
             mgr.deinitialize()
             mgr.thermal_updater_task.stop.assert_called_once()
-            # Not initialized if no DPUs and not in host mgmt mode
-            mock_management_mode.return_value = False
-            mock_thermal.reset_mock()
-            mgr.initialize()
-            mock_thermal.assert_not_called()
-            mgr.deinitialize()
-            mgr.thermal_updater_task.stop.assert_called_once()
+
             # Initialized with DPUs if DPUs are present
             mock_dpus_data.return_value = {'DPUS': 'dpu1'}
             mock_thermal.reset_mock()
             mgr.initialize()
-            mock_sm_thermal.assert_called_once_with(sfp_list=['sfp1', 'sfp2'], dpu_list=['dpu1', 'dpu2'], is_host_mgmt_mode=False)
-            mgr.deinitialize()
-            mgr.thermal_updater_task.stop.assert_called_once()
-            # Host mgmt mode, with DPUS
-            mock_thermal.reset_mock()
-            mock_sm_thermal.reset_mock()
-            mock_management_mode.return_value = True
-            mgr.initialize()
-            mock_sm_thermal.assert_called_once_with(sfp_list=['sfp1', 'sfp2'], dpu_list=['dpu1', 'dpu2'], is_host_mgmt_mode=True)
+            mock_sm_thermal.assert_called_once_with(sfp_list=['sfp1', 'sfp2'], dpu_list=['dpu1', 'dpu2'])
             mgr.deinitialize()
             mgr.thermal_updater_task.stop.assert_called_once()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The PR is to optimize I2C access on Nvidia platforms. Currently, there are more than 1 tasks to read module EEPROM directly via I2C. The idea is to ensure that only one task read module EEPROM from I2C and cache to redis, other tasks should read from redis instead of I2C.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

After this commit, Nvidia thermal/module data path is effectively:

1. enable Nvidia platform polling module temperature data via DomThermalInfoUpdateTask by adding `dom_temperature_poll_interval` to `pmon_daemon_control.json`
2. thermal updater thread reads module temperature from Redis instead of SDK sysfs.
3. legacy hw-management thermal updater service is disabled to prevent overlap.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
sonic-mgmt regression passed on Nvidia platforms
new unit test cases passed

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

