### PR TITLE
gnxi commands on PTF fails when we have "-" in key [Blocking Openconfig sonic-mgmt tests]

### DIFF
--- a/dockers/docker-ptf/gnxi-patches/0010-Fix-regex-to-allow-hyphen-character-in-key-name.patch
+++ b/dockers/docker-ptf/gnxi-patches/0010-Fix-regex-to-allow-hyphen-character-in-key-name.patch
@@ -1,0 +1,13 @@
+diff --git a/gnmi_cli_py/py_gnmicli.py b/gnmi_cli_py/py_gnmicli.py
+index 150239a..1d43eb6 100644
+--- a/gnmi_cli_py/py_gnmicli.py
++++ b/gnmi_cli_py/py_gnmicli.py
+@@ -56,7 +56,7 @@ __version__ = '0.5'
+ _RE_PATH_COMPONENT = re.compile(r'''
+ ^
+ (?P<pname>[^[]+)  # gNMI path name
+-(\[(?P<key>\w+)   # gNMI path key
++(\[(?P<key>\w\D+)   # gNMI path key
+ =
+ (?P<value>.*)    # gNMI path value
+ \])?$

--- a/dockers/docker-ptf/gnxi-patches/series
+++ b/dockers/docker-ptf/gnxi-patches/series
@@ -7,3 +7,4 @@
 0007-Fix-py_gnmicli.py-POLL-mode.patch
 0008-Fix-ipv6-addr-port-format-for-grpc.patch
 0009-chore-remove-deprecated-use_aliases-field-and-fix-syntax.patch
+0010-Fix-regex-to-allow-hyphen-character-in-key-name.patch


### PR DESCRIPTION
#### Why I did it
1. When we do get request from pygnmi for the xpaths where keyname has "-" character, pygnmi returns error

2. Exception seen 
```
     raise Exception("GNMI Error:" + output['stderr'])
E           Exception: GNMI Error:/root/gnxi/gnmi_cli_py/py_gnmicli.py:537: SyntaxWarning: "is not" with a literal. Did you mean "!="?
E             if filter_event_regex is not "":
E           /root/gnxi/gnmi_cli_py/py_gnmicli.py:539: SyntaxWarning: "is not" with a literal. Did you mean "!="?
E             if len(match) is not 0:
```
##### Work item tracking


#### How I did it
1. Ported patch from gnxi upstream to sonic-buildimage
https://github.com/google/gnxi/pull/240

2. Fix the python syntax issues 

```
root@docker-ptf:~# python /root/gnxi/gnmi_cli_py/py_gnmicli.py --timeout 30 -t  192.168.122.54 -p 8080 -xt oc-yang -m get --xpath  "/openconfig-network-instance:network-instances/network-instance[name=Vrf4]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=192.168.20.1]/" 
Traceback (most recent call last):  
 File "/root/gnxi/gnmi_cli_py/py_gnmicli.py", line 652, in   
<module>  
 main()  
 File "/root/gnxi/gnmi_cli_py/py_gnmicli.py", line 573, in   
main  
 paths.append(_parse_path(_path_names(xpath)))  
 File "/root/gnxi/gnmi_cli_py/py_gnmicli.py", line 258, in   
_parse_path  
 raise XpathError('xpath component parse error: %s' %   
word)  
__main__.XpathError: xpath component parse error:   
neighbor[neighbor-address=192.168.20.1]  
```

#### How to verify it
1. Test patch application
2. Run pygnmi command with key-name with "-"
3. Run sonic-mgmt gnmi tests

```
root@b260562538a8:~# python /root/gnxi/gnmi_cli_py/py_gnmicli.py --timeout 30 -t 10.89.171.137  -p 11865 -xt oc-yang -m get --xpath "/openconfig-network-instance:network-instances/network-instance[name=Vrf4]/protocols/protocol[identifier=BGP][name =bgp]/bgp/neighbors/neighbor[neighbor-address=192.168.20.1]/" -n
/root/gnxi/gnmi_cli_py/py_gnmicli.py:537: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if filter_event_regex is not "":
/root/gnxi/gnmi_cli_py/py_gnmicli.py:539: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if len(match) is not 0:
Traceback (most recent call last):
  File "/root/gnxi/gnmi_cli_py/py_gnmicli.py", line 678, in <module>
    main()
  File "/root/gnxi/gnmi_cli_py/py_gnmicli.py", line 599, in main
    paths.append(_parse_path(_path_names(xpath)))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/gnxi/gnmi_cli_py/py_gnmicli.py", line 269, in _parse_path
    raise XpathError('xpath component parse error: %s' % word)
XpathError: xpath component parse error: neighbor[neighbor-address=192.168.20.1]
root@b260562538a8:~#
root@b260562538a8:~#
root@b260562538a8:~# cd /root/gnxi/
root@b260562538a8:~/gnxi#
root@b260562538a8:~/gnxi# patch -p1 < 0009-Fix-regex-to-allow-hyphen-character-in-key-name.patch
patching file gnmi_cli_py/py_gnmicli.py
Hunk #1 succeeded at 56 (offset 4 lines).
root@b260562538a8:~/gnxi#
root@b260562538a8:~/gnxi# python /root/gnxi/gnmi_cli_py/py_gnmicli.py --timeout 30 -t 10.89.171.137  -p 11865 -xt oc-yang -m get --xpath "/openconfig-network-instance:network-instances/network-instance[name=Vrf4]/protocols/protocol[identifier=BGP][name =bgp]/bgp/neighbors/neighbor[neighbor-address=192.168.20.1]/" -n
/root/gnxi/gnmi_cli_py/py_gnmicli.py:537: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if filter_event_regex is not "":
/root/gnxi/gnmi_cli_py/py_gnmicli.py:539: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if len(match) is not 0:
Performing GetRequest, encoding=JSON_IETF to 10.89.171.137  with the following gNMI Path
 -------------------------
 [elem {
  name: "openconfig-network-instance:network-instances"
}
elem {
  name: "network-instance"
  key {
    key: "name"
    value: "Vrf4"
  }
}
elem {
  name: "protocols"
}
elem {
  name: "protocol"
  key {
    key: "identifier"
    value: "BGP"
  }
  ```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

