### PR TITLE
Move the pending_config* files from `/tmp/` to `/etc/sonic/`

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -306,7 +306,7 @@ function postStartAction()
             fi
         fi
 
-        if [ -e /tmp/pending_config_migration ] || [ -e /tmp/pending_config_initialization ]; then
+        if [ -e /etc/sonic/pending_config_migration ] || [ -e /etc/sonic/pending_config_initialization ]; then
             # this is first boot to a new image, config-setup execution is pending.
             # for warmboot case, DB is loaded but migration is still pending
             # For firstbboot/fast/cold reboot case, DB contains nothing at this point

--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -309,7 +309,7 @@ do_config_initialization()
         rm -f ${TMP_ZTP_CONFIG_DB_JSON}
     fi
 
-    rm -f /tmp/pending_config_initialization
+    rm -f /etc/sonic/pending_config_initialization
     sonic-db-cli CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"
 }
 
@@ -405,7 +405,7 @@ do_config_migration()
     if [ x"${WARM_BOOT}" == x"true" ]; then
         echo "Warm reboot detected..."
         do_db_migration
-        rm -f /tmp/pending_config_migration
+        rm -f /etc/sonic/pending_config_migration
         exit 0
     elif check_all_config_db_present; then
         echo "Use config_db.json from old system..."
@@ -419,7 +419,7 @@ do_config_migration()
         echo "Didn't found neither config_db.json nor minigraph.xml ..."
     fi
 
-    rm -f /tmp/pending_config_migration
+    rm -f /etc/sonic/pending_config_migration
 }
 
 # Take a backup of current SONiC configuration
@@ -443,7 +443,7 @@ do_config_backup()
 boot_config()
 {
     check_system_warm_boot
-    if [ -e /tmp/pending_config_migration ] || [ -e  ${CONFIG_SETUP_POST_MIGRATION_FLAG} ]; then
+    if [ -e /etc/sonic/pending_config_migration ] || [ -e  ${CONFIG_SETUP_POST_MIGRATION_FLAG} ]; then
         do_config_migration
     fi
 
@@ -467,7 +467,7 @@ boot_config()
         return 0
     fi	
 
-    if [ -e /tmp/pending_config_initialization ] || [ -e  ${CONFIG_SETUP_INITIALIZATION_FLAG} ]; then
+    if [ -e /etc/sonic/pending_config_initialization ] || [ -e  ${CONFIG_SETUP_INITIALIZATION_FLAG} ]; then
         do_config_initialization
     fi
 

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -279,7 +279,7 @@ if [ -f $FIRST_BOOT_FILE ]; then
     if [ -d /host/old_config ]; then
         mv -f /host/old_config /etc/sonic/
         rm -rf /etc/sonic/old_config/old_config
-        touch /tmp/pending_config_migration
+        touch /etc/sonic/pending_config_migration
     elif [ -f /host/minigraph.xml ]; then
         mkdir -p /etc/sonic/old_config
         mv /host/minigraph.xml /etc/sonic/old_config/
@@ -287,7 +287,7 @@ if [ -f $FIRST_BOOT_FILE ]; then
         [ -f /host/port_config.json ] && mv /host/port_config.json /etc/sonic/old_config/
         [ -f /host/snmp.yml ] && mv /host/snmp.yml /etc/sonic/old_config/
         [ -f /host/golden_config_db.json ] && mv /host/golden_config_db.json /etc/sonic/old_config/
-        touch /tmp/pending_config_migration
+        touch /etc/sonic/pending_config_migration
     elif [ -n "$migration" ] && [ -f /host/migration/minigraph.xml ];  then
         mkdir -p /etc/sonic/old_config
         mv /host/migration/minigraph.xml /etc/sonic/old_config/
@@ -295,9 +295,9 @@ if [ -f $FIRST_BOOT_FILE ]; then
         [ -f /host/migration/port_config.json ] && mv /host/migration/port_config.json /etc/sonic/old_config/
         [ -f /host/migration/snmp.yml ] && mv /host/migration/snmp.yml /etc/sonic/old_config/
         [ -f /host/migration/golden_config_db.json ] && mv /host/migration/golden_config_db.json /etc/sonic/old_config/
-        touch /tmp/pending_config_migration
+        touch /etc/sonic/pending_config_migration
     else
-        touch /tmp/pending_config_initialization
+        touch /etc/sonic/pending_config_initialization
     fi
 
     # Notify firstboot to Platform, to use it for reboot-cause


### PR DESCRIPTION
This will solve the issue where a reboot occurs between the first run of `rc.local` and `config-setup` causing the pending_config* files to be lost.

Details can be found in: https://github.com/sonic-net/sonic-buildimage/issues/25202

#### How to verify it

You can reset the system to a 'firstboot' state with the following commands (image path will need to be adjusted):
```
mv /etc/sonic/minigraph.xml /host/
rm -rf /etc/sonic/old_config
rm /etc/sonic/config_db*
touch /host/image-branch.msft-202405-ars.f532d7ef-buildimage.origin.202405-nightly-dbg-2026.01.25.20.14/platform/firsttime
```
I also added a forced reboot after rc.local here:
```
169 firsttime_exit() {
170     rm -rf $FIRST_BOOT_FILE
+ 171     echo "First boot complete, rebooting to end up in stuck state"
+ 172     exec /sbin/reboot
173     exit 0
174 }
```
Then I reboot the LC and after the double reboot I still see config-setup do the db_migration steps:
```
root@cmp235-3:~# journalctl -u config-setup.service
Jan 27 00:59:26 sonic systemd[1]: Starting config-setup.service - Config initialization and migration service...
Jan 27 00:59:26 sonic config-setup[2371]: Copying SONiC configuration minigraph.xml ...
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [x] msft-202405
- [x] 202411
- [x] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

- [x] msft-202405


