### PR TITLE
fixes #23757 : Added multi-asic support for dhcp_dos_logger service

### DIFF
--- a/files/image_config/dhcp_dos_logger/dhcp_dos_logger.py
+++ b/files/image_config/dhcp_dos_logger/dhcp_dos_logger.py
@@ -19,7 +19,6 @@ is_multi_asic = multi_asic.is_multi_asic()
 if is_multi_asic:
     SonicDBConfig.initializeGlobalConfig()
     ports_table = multi_asic.get_table('PORT')
-
 else:
     config_db = ConfigDBConnector()
     config_db.connect()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To stop the dumping of the WARNING messages getting logged in syslog file every 10 secs for all interfaces in the chassis. These WARNING messages should not be logged

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

The dhcp_dos_logger was missing multi-asic support. Previously, we used to check the interface in global namespace and since the interfaces are in asic namespace for multi-asic platforms, the interface was not found. Now, we fetch the ports for all asics, identify the namespace they belong to, and check if the interface exists in that namespace. 

Single asic scenario is still supported as before.   

#### How to verify it

We restart the dhcp_dos_service and take a look at the /var/log/syslog. The WARNING messages are no longer present.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] <!-- image version 1 -->master
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added multi-asic support for dhcp_dos_logger service
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

