### PR TITLE
[Mellanox] [BMC] Reset root password UT alignment

### DIFF
--- a/platform/mellanox/mlnx-platform-api/tests/test_bmc.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_bmc.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -80,14 +81,21 @@ class TestBMC:
     @mock.patch('sonic_py_common.device_info.get_bmc_data', \
                 mock.MagicMock(return_value={'bmc_addr': '169.254.0.1'}))
     @mock.patch('sonic_platform.bmc.BMC._get_tpm_password', mock.MagicMock(return_value=''))
+    @mock.patch('sonic_platform_base.redfish_client.RedfishClient.redfish_api_set_min_password_length')
     @mock.patch('sonic_platform_base.redfish_client.RedfishClient.redfish_api_change_login_password')
-    def test_bmc_reset_password(self, mock_change_password):
+    @mock.patch('sonic_platform_base.redfish_client.RedfishClient.redfish_api_get_min_password_length')
+    def test_bmc_reset_password(self, mock_get_min_length, mock_change_password, mock_set_min_length):
         """Test reset_password method with successful password reset"""
-        mock_change_password.return_value = (RedfishClient.ERR_CODE_OK, 'Password changed successfully')
+        mock_get_min_length.return_value = (RedfishClient.ERR_CODE_OK, 12)
+        mock_set_min_length.return_value = (RedfishClient.ERR_CODE_OK, '')
+        mock_change_password.return_value = (RedfishClient.ERR_CODE_OK, '')
         bmc = BMC.get_instance()
         ret, msg = bmc.reset_root_password()
         assert ret == RedfishClient.ERR_CODE_OK
-        assert msg == 'Password changed successfully'
+        assert msg == ''
+        mock_get_min_length.assert_called_once()
+        mock_set_min_length.assert_any_call(8)
+        mock_set_min_length.assert_any_call(12)
         mock_change_password.assert_called_once_with('testpass', BMCBase.ROOT_ACCOUNT)
 
     @mock.patch('sonic_py_common.device_info.get_bmc_build_config', \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

This PR must be merged after: https://github.com/sonic-net/sonic-platform-common/pull/622

#### Why I did it
Align/Fix the UT for the new functionality of the reset-root-password BMC method.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added the required Mocks.

#### How to verify it
UT execution.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

