### PR TITLE
Upgrade pyangbind to avoid SyntaxWarning

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -207,6 +207,7 @@ install_pip_package {{sonic_yang_mgmt_py3_wheel_path}}
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install python3-lxml python3-regex
 
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install pyangbind==0.8.7
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 uninstall -y enum34
 
 # Install SONiC config engine Python 3 package
 install_pip_package {{config_engine_py3_wheel_path}}
@@ -1219,7 +1220,7 @@ sudo rm -rf $FILESYSTEM_ROOT/tmp/mask_disabled_services.py
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install python3-dbus
 
 {% if installer_python_debs.strip() -%}
-# Install FIPS python package will break apt-get purge command, so install after all purge command finish 
+# Install FIPS python package will break apt-get purge command, so install after all purge command finish
 if [ "$INCLUDE_FIPS" == y ]; then
     install_deb_package {{installer_python_debs}}
 fi

--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -76,6 +76,7 @@ RUN eatmydata apt-get install -y swig libssl-dev
 
 RUN PATH=/python_virtualenv/env3/bin/:$PATH python3 -m pip install pyang==2.4.0
 RUN PATH=/python_virtualenv/env3/bin/:$PATH python3 -m pip install pyangbind==0.8.7
+RUN PATH=/python_virtualenv/env3/bin/:$PATH python3 -m pip uninstall -y enum34
 RUN PATH=/python_virtualenv/env3/bin/:$PATH pip3 install --force-reinstall --no-cache-dir coverage
 {%- endif %}
 
@@ -587,6 +588,7 @@ RUN pip3 install \
 
 
 RUN pip3 install pyangbind==0.8.7
+RUN pip3 uninstall -y enum34
 
 # For sonic-platform-common testing
 RUN pip3 install redis


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
fixes https://github.com/sonic-net/sonic-buildimage/issues/24527 and https://github.com/sonic-net/sonic-buildimage/issues/24772
Python was upgraded to 3.13 on sonic, current `pyangbind` 0.8.2 version has `SyntaxWarning` issue with python3.13.

```
admin@bjw2-can-7260-11:~$ show acl rule
/usr/local/lib/python3.13/dist-packages/pyangbind/lib/yangtypes.py:185: SyntaxWarning: invalid escape sequence '\g'
  current_restricted_class_type = regex.sub("<(type|class) '(?P<class>.*)'>", "\g<class>", six.text_type(base_type))
/usr/local/lib/python3.13/dist-packages/pyangbind/lib/yangtypes.py:227: SyntaxWarning: invalid escape sequence '\-'
  range_regex = regex.compile("(?P<low>\-?[0-9\.]+|min)([ ]+)?\.\.([ ]+)?" + "(?P<high>(\-?[0-9\.]+|max))")
/usr/local/lib/python3.13/dist-packages/pyangbind/lib/yangtypes.py:227: SyntaxWarning: invalid escape sequence '\-'
  range_regex = regex.compile("(?P<low>\-?[0-9\.]+|min)([ ]+)?\.\.([ ]+)?" + "(?P<high>(\-?[0-9\.]+|max))")
/usr/local/lib/python3.13/dist-packages/pyangbind/lib/yangtypes.py:228: SyntaxWarning: invalid escape sequence '\-'
  range_single_value_regex = regex.compile("(?P<value>\-?[0-9\.]+)")
/usr/local/lib/python3.13/dist-packages/pyangbind/lib/yangtypes.py:241: SyntaxWarning: invalid escape sequence '\$'
  tmp_pattern = tmp_pattern.replace("$", "\$")
/usr/local/lib/python3.13/dist-packages/pyangbind/lib/yangtypes.py:255: SyntaxWarning: invalid escape sequence '\g'
  low, high = range_regex.sub("\g<low>,\g<high>", range_spec).split(",")
/usr/local/lib/python3.13/dist-packages/pyangbind/lib/yangtypes.py:264: SyntaxWarning: invalid escape sequence '\g'
  eqval = range_single_value_regex.sub("\g<value>", range_spec)
/usr/local/lib/python3.13/dist-packages/pyangbind/lib/yangtypes.py:1030: SyntaxWarning: invalid escape sequence '\g'
  _pybind_base_class = regex.sub("<(type|class) '(?P<class>.*)'>", "\g<class>", str(base_type))
/usr/local/lib/python3.13/dist-packages/pyangbind/lib/yangtypes.py:1296: SyntaxWarning: invalid escape sequence '\g'
  self._type = regex.sub("<(type|class) '(?P<class>.*)'>", "\g<class>", str(get_method()._base_type))
Table    Rule    Priority    Action    Match    Status
-------  ------  ----------  --------  -------  --------
admin@bjw2-can-7260-11:~$ show version

SONiC Software Version: SONiC.20251110.05
SONiC OS Version: 13
Distribution: Debian 13.3
Kernel: 6.12.41+deb13-sonic-amd64
Build commit: 9a47682d2a
Build date: Sat Jan 31 01:46:23 UTC 2026
Built by: azureuser@1fb3cba1c000003
admin@bjw2-can-7260-11:~$ pip3 list | grep pyang
pyang                      2.7.1
pyangbind                  0.8.2
```

##### Work item tracking
- Microsoft ADO **36625666**:

#### How I did it
After the upgrade of pyangbind, it works, the SyntaxWarning is gone.
And the issue https://github.com/robshakir/pyangbind/issues/232 was fixed, we don't have to remove enum34.

Latest versions of pyangbind are able to work with enum34 and Python >= 3.7

$ pip show enum34
Name: enum34
Version: 1.1.10
Summary: Python 3.4 Enum backported to 3.3, 3.2, 3.1, 2.7, 2.6, 2.5, and 2.4
Home-page: https://bitbucket.org/stoneleaf/enum34
Author: Ethan Furman
Author-email: [ethan@stoneleaf.us](mailto:ethan@stoneleaf.us)
License: BSD License
Required-by: pyangbin


```
admin@bjw2-can-7260-11:~$ pip3 install --upgrade pyangbind
Defaulting to user installation because normal site-packages is not writeable
Requirement already satisfied: pyangbind in /usr/local/lib/python3.13/dist-packages (0.8.2)
Collecting pyangbind
  Downloading pyangbind-0.8.7-py3-none-any.whl.metadata (4.2 kB)
Requirement already satisfied: pyang in /usr/local/lib/python3.13/dist-packages (from pyangbind) (2.7.1)
Requirement already satisfied: lxml in /usr/lib/python3/dist-packages (from pyangbind) (5.4.0)
Requirement already satisfied: regex in /usr/lib/python3/dist-packages (from pyangbind) (2024.11.6)
Collecting enum34 (from pyangbind)
  Downloading enum34-1.1.10-py3-none-any.whl.metadata (1.6 kB)
Downloading pyangbind-0.8.7-py3-none-any.whl (52 kB)
Downloading enum34-1.1.10-py3-none-any.whl (11 kB)
Installing collected packages: enum34, pyangbind
Successfully installed enum34-1.1.10 pyangbind-0.8.7
admin@bjw2-can-7260-11:~$ show acl rule
Table    Rule    Priority    Action    Match    Status
-------  ------  ----------  --------  -------  --------
```



#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
```
admin@bjw2-can-7260-11:~$ pip3 install pyangbind==0.8.7
Defaulting to user installation because normal site-packages is not writeable
Collecting pyangbind==0.8.7
  Using cached pyangbind-0.8.7-py3-none-any.whl.metadata (4.2 kB)
Requirement already satisfied: pyang in /usr/local/lib/python3.13/dist-packages (from pyangbind==0.8.7) (2.7.1)
Requirement already satisfied: lxml in /usr/lib/python3/dist-packages (from pyangbind==0.8.7) (5.4.0)
Requirement already satisfied: regex in /usr/lib/python3/dist-packages (from pyangbind==0.8.7) (2024.11.6)
Collecting enum34 (from pyangbind==0.8.7)
  Using cached enum34-1.1.10-py3-none-any.whl.metadata (1.6 kB)
Using cached pyangbind-0.8.7-py3-none-any.whl (52 kB)
Using cached enum34-1.1.10-py3-none-any.whl (11 kB)
Installing collected packages: enum34, pyangbind
Successfully installed enum34-1.1.10 pyangbind-0.8.7
admin@bjw2-can-7260-11:~$ pip3 list | grep enum
enum34                     1.1.10
admin@bjw2-can-7260-11:~$ pip3 list | grep pyangbind
pyangbind                  0.8.7
admin@bjw2-can-7260-11:~$ show acl rule
Table    Rule    Priority    Action    Match    Status
-------  ------  ----------  --------  -------  --------
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

