### PR TITLE
[build] Fix rsync failure in otel Docker builds when SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD is enabled

### DIFF
--- a/dockers/docker-sonic-otel/Dockerfile.j2
+++ b/dockers/docker-sonic-otel/Dockerfile.j2
@@ -1,4 +1,4 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, rsync_from_builder_stage %}
 ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 FROM $BASE AS base
@@ -62,7 +62,7 @@ COPY ["critical_processes", "/etc/supervisor"]
 
 FROM $BASE
 
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=/proc --exclude=/dev --exclude=resolv.conf /changes-to-image/ /
+{{ rsync_from_builder_stage() }}
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
This is the same fix as in #24604 to the new otel docker

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When building SONiC with `SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD=y`, Docker multi-stage builds fail during rsync operations with the following error:

```
rsync: [generator] failed to set times on "/changes-to-image": Read-only file system (30)
rsync error: some files/attrs were not transferred (see previous errors) (code 23)
```

This issue occurs specifically when:
- Using Docker Engine 20.10.x with BuildKit
- Running builds inside containers (Docker-in-Docker scenario)
- Accessing the host Docker daemon via socket mount
- Using `--mount=type=bind` in multi-stage Dockerfiles

The root cause is that Docker BuildKit creates read-only bind mounts, and rsync with the `-a` flag (which includes `-t` for preserving times) attempts to set timestamps on the mounted directory itself, failing on the read-only mount point.

This blocks builds in environments using native dockerd for build acceleration.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Use the defined in dockerfile-macros.j2 on the otel docker

#### How to verify it
Build SONiC using SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD=y
Verify Docker images build successfully

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

