### PR TITLE
Add additional temp sensors in arista 7280r4 SKUs

### DIFF
--- a/device/arista/x86_64-arista_7280r4_32qf_32df/platform.json
+++ b/device/arista/x86_64-arista_7280r4_32qf_32df/platform.json
@@ -145,6 +145,62 @@
             {
                 "name": "D1 Temp diode 1",
                 "controllable": false
+            },
+            {
+                "name": "POS0V75_VDDC_D0",
+                "controllable": false
+            },
+            {
+                "name": "POS3V3_OPTICS_A",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_HBM_D0",
+                "controllable": false
+            },
+            {
+                "name": "POS0V9_D0",
+                "controllable": false
+            },
+            {
+                "name": "POS0V75_D0",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_VAA_PHY",
+                "controllable": false
+            },
+            {
+                "name": "POS0V75_VDD_PHY1",
+                "controllable": false
+            },
+            {
+                "name": "POS0V75_VDD_PHY2",
+                "controllable": false
+            },
+            {
+                "name": "POS0V75_VDDC_D1",
+                "controllable": false
+            },
+            {
+                "name": "POS3V3_OPTICS_B",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_HBM_D1",
+                "controllable": false
+            },
+            {
+                "name": "POS0V9_D1",
+                "controllable": false
+            },
+            {
+                "name": "POS0V75_D1",
+                "controllable": false
+            },
+            {
+                "name": "POS0V8_PBVDD",
+                "controllable": false
             }
         ],
         "sfps": [

--- a/device/arista/x86_64-arista_7280r4k_32qf_32df/platform.json
+++ b/device/arista/x86_64-arista_7280r4k_32qf_32df/platform.json
@@ -145,6 +145,62 @@
             {
                 "name": "D1 Temp diode 1",
                 "controllable": false
+            },
+            {
+                "name": "POS0V75_VDDC_D0",
+                "controllable": false
+            },
+            {
+                "name": "POS3V3_OPTICS_A",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_HBM_D0",
+                "controllable": false
+            },
+            {
+                "name": "POS0V9_D0",
+                "controllable": false
+            },
+            {
+                "name": "POS0V75_D0",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_VAA_PHY",
+                "controllable": false
+            },
+            {
+                "name": "POS0V75_VDD_PHY1",
+                "controllable": false
+            },
+            {
+                "name": "POS0V75_VDD_PHY2",
+                "controllable": false
+            },
+            {
+                "name": "POS0V75_VDDC_D1",
+                "controllable": false
+            },
+            {
+                "name": "POS3V3_OPTICS_B",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_HBM_D1",
+                "controllable": false
+            },
+            {
+                "name": "POS0V9_D1",
+                "controllable": false
+            },
+            {
+                "name": "POS0V75_D1",
+                "controllable": false
+            },
+            {
+                "name": "POS0V8_PBVDD",
+                "controllable": false
             }
         ],
         "sfps": [


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
We need more temp sensors added to Arista 7280r4 SKUs

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added it to platform.json

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202511

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

<img width="686" height="386" alt="image" src="https://github.com/user-attachments/assets/921954ff-a6ed-4209-af0e-d3c46201d0be" />
