### PR TITLE
[Arista] Fix the missing speed column in port_config.ini

### DIFF
--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/port_config.ini
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/port_config.ini
@@ -1,33 +1,33 @@
-# name          lanes             alias         index
-Ethernet0       33,34,35,36       Ethernet1/1   1
-Ethernet4       37,38,39,40       Ethernet2/1   2
-Ethernet8       41,42,43,44       Ethernet3/1   3
-Ethernet12      45,46,47,48       Ethernet4/1   4
-Ethernet16      49,50,51,52       Ethernet5/1   5
-Ethernet20      53,54,55,56       Ethernet6/1   6
-Ethernet24      57,58,59,60       Ethernet7/1   7
-Ethernet28      61,62,63,64       Ethernet8/1   8
-Ethernet32      65,66,67,68       Ethernet9/1   9
-Ethernet36      69,70,71,72       Ethernet10/1  10
-Ethernet40      73,74,75,76       Ethernet11/1  11
-Ethernet44      77,78,79,80       Ethernet12/1  12
-Ethernet48      81,82,83,84       Ethernet13/1  13
-Ethernet52      85,86,87,88       Ethernet14/1  14
-Ethernet56      89,90,91,92       Ethernet15/1  15
-Ethernet60      93,94,95,96       Ethernet16/1  16
-Ethernet64      97,98,99,100      Ethernet17/1  17
-Ethernet68      101,102,103,104   Ethernet18/1  18
-Ethernet72      105,106,107,108   Ethernet19/1  19
-Ethernet76      109,110,111,112   Ethernet20/1  20
-Ethernet80      113,114,115,116   Ethernet21/1  21
-Ethernet84      117,118,119,120   Ethernet22/1  22
-Ethernet88      121,122,123,124   Ethernet23/1  23
-Ethernet92      125,126,127,128   Ethernet24/1  24
-Ethernet96      1,2,3,4           Ethernet25/1  25
-Ethernet100     5,6,7,8           Ethernet26/1  26
-Ethernet104     9,10,11,12        Ethernet27/1  27
-Ethernet108     13,14,15,16       Ethernet28/1  28
-Ethernet112     17,18,19,20       Ethernet29/1  29
-Ethernet116     21,22,23,24       Ethernet30/1  30
-Ethernet120     25,26,27,28       Ethernet31/1  31
-Ethernet124     29,30,31,32       Ethernet32/1  32
+# name          lanes             alias         index   speed
+Ethernet0       33,34,35,36       Ethernet1/1   1       100000
+Ethernet4       37,38,39,40       Ethernet2/1   2       100000
+Ethernet8       41,42,43,44       Ethernet3/1   3       100000
+Ethernet12      45,46,47,48       Ethernet4/1   4       100000
+Ethernet16      49,50,51,52       Ethernet5/1   5       100000
+Ethernet20      53,54,55,56       Ethernet6/1   6       100000
+Ethernet24      57,58,59,60       Ethernet7/1   7       100000
+Ethernet28      61,62,63,64       Ethernet8/1   8       100000
+Ethernet32      65,66,67,68       Ethernet9/1   9       100000
+Ethernet36      69,70,71,72       Ethernet10/1  10      100000
+Ethernet40      73,74,75,76       Ethernet11/1  11      100000
+Ethernet44      77,78,79,80       Ethernet12/1  12      100000
+Ethernet48      81,82,83,84       Ethernet13/1  13      100000
+Ethernet52      85,86,87,88       Ethernet14/1  14      100000
+Ethernet56      89,90,91,92       Ethernet15/1  15      100000
+Ethernet60      93,94,95,96       Ethernet16/1  16      100000
+Ethernet64      97,98,99,100      Ethernet17/1  17      100000
+Ethernet68      101,102,103,104   Ethernet18/1  18      100000
+Ethernet72      105,106,107,108   Ethernet19/1  19      100000
+Ethernet76      109,110,111,112   Ethernet20/1  20      100000
+Ethernet80      113,114,115,116   Ethernet21/1  21      100000
+Ethernet84      117,118,119,120   Ethernet22/1  22      100000
+Ethernet88      121,122,123,124   Ethernet23/1  23      100000
+Ethernet92      125,126,127,128   Ethernet24/1  24      100000
+Ethernet96      1,2,3,4           Ethernet25/1  25      100000
+Ethernet100     5,6,7,8           Ethernet26/1  26      100000
+Ethernet104     9,10,11,12        Ethernet27/1  27      100000
+Ethernet108     13,14,15,16       Ethernet28/1  28      100000
+Ethernet112     17,18,19,20       Ethernet29/1  29      100000
+Ethernet116     21,22,23,24       Ethernet30/1  30      100000
+Ethernet120     25,26,27,28       Ethernet31/1  31      100000
+Ethernet124     29,30,31,32       Ethernet32/1  32      100000

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/port_config.ini
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/port_config.ini
@@ -1,33 +1,33 @@
-# name          lanes             alias         index
-Ethernet0       33,34,35,36       Ethernet1/1   1
-Ethernet4       37,38,39,40       Ethernet2/1   2
-Ethernet8       41,42,43,44       Ethernet3/1   3
-Ethernet12      45,46,47,48       Ethernet4/1   4
-Ethernet16      49,50,51,52       Ethernet5/1   5
-Ethernet20      53,54,55,56       Ethernet6/1   6
-Ethernet24      57,58,59,60       Ethernet7/1   7
-Ethernet28      61,62,63,64       Ethernet8/1   8
-Ethernet32      65,66,67,68       Ethernet9/1   9
-Ethernet36      69,70,71,72       Ethernet10/1  10
-Ethernet40      73,74,75,76       Ethernet11/1  11
-Ethernet44      77,78,79,80       Ethernet12/1  12
-Ethernet48      81,82,83,84       Ethernet13/1  13
-Ethernet52      85,86,87,88       Ethernet14/1  14
-Ethernet56      89,90,91,92       Ethernet15/1  15
-Ethernet60      93,94,95,96       Ethernet16/1  16
-Ethernet64      97,98,99,100      Ethernet17/1  17
-Ethernet68      101,102,103,104   Ethernet18/1  18
-Ethernet72      105,106,107,108   Ethernet19/1  19
-Ethernet76      109,110,111,112   Ethernet20/1  20
-Ethernet80      113,114,115,116   Ethernet21/1  21
-Ethernet84      117,118,119,120   Ethernet22/1  22
-Ethernet88      121,122,123,124   Ethernet23/1  23
-Ethernet92      125,126,127,128   Ethernet24/1  24
-Ethernet96      1,2,3,4           Ethernet25/1  25
-Ethernet100     5,6,7,8           Ethernet26/1  26
-Ethernet104     9,10,11,12        Ethernet27/1  27
-Ethernet108     13,14,15,16       Ethernet28/1  28
-Ethernet112     17,18,19,20       Ethernet29/1  29
-Ethernet116     21,22,23,24       Ethernet30/1  30
-Ethernet120     25,26,27,28       Ethernet31/1  31
-Ethernet124     29,30,31,32       Ethernet32/1  32
+# name          lanes             alias         index   speed
+Ethernet0       33,34,35,36       Ethernet1/1   1       40000
+Ethernet4       37,38,39,40       Ethernet2/1   2       40000
+Ethernet8       41,42,43,44       Ethernet3/1   3       40000
+Ethernet12      45,46,47,48       Ethernet4/1   4       40000
+Ethernet16      49,50,51,52       Ethernet5/1   5       40000
+Ethernet20      53,54,55,56       Ethernet6/1   6       40000
+Ethernet24      57,58,59,60       Ethernet7/1   7       40000
+Ethernet28      61,62,63,64       Ethernet8/1   8       40000
+Ethernet32      65,66,67,68       Ethernet9/1   9       40000
+Ethernet36      69,70,71,72       Ethernet10/1  10      40000
+Ethernet40      73,74,75,76       Ethernet11/1  11      40000
+Ethernet44      77,78,79,80       Ethernet12/1  12      40000
+Ethernet48      81,82,83,84       Ethernet13/1  13      40000
+Ethernet52      85,86,87,88       Ethernet14/1  14      40000
+Ethernet56      89,90,91,92       Ethernet15/1  15      40000
+Ethernet60      93,94,95,96       Ethernet16/1  16      40000
+Ethernet64      97,98,99,100      Ethernet17/1  17      40000
+Ethernet68      101,102,103,104   Ethernet18/1  18      40000
+Ethernet72      105,106,107,108   Ethernet19/1  19      40000
+Ethernet76      109,110,111,112   Ethernet20/1  20      40000
+Ethernet80      113,114,115,116   Ethernet21/1  21      40000
+Ethernet84      117,118,119,120   Ethernet22/1  22      40000
+Ethernet88      121,122,123,124   Ethernet23/1  23      40000
+Ethernet92      125,126,127,128   Ethernet24/1  24      40000
+Ethernet96      1,2,3,4           Ethernet25/1  25      40000
+Ethernet100     5,6,7,8           Ethernet26/1  26      40000
+Ethernet104     9,10,11,12        Ethernet27/1  27      40000
+Ethernet108     13,14,15,16       Ethernet28/1  28      40000
+Ethernet112     17,18,19,20       Ethernet29/1  29      40000
+Ethernet116     21,22,23,24       Ethernet30/1  30      40000
+Ethernet120     25,26,27,28       Ethernet31/1  31      40000
+Ethernet124     29,30,31,32       Ethernet32/1  32      40000

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S/port_config.ini
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S/port_config.ini
@@ -1,35 +1,35 @@
-# name          lanes             alias         index
-Ethernet0       33,34,35,36       Ethernet1/1   1
-Ethernet4       37,38,39,40       Ethernet2/1   2
-Ethernet8       41,42,43,44       Ethernet3/1   3
-Ethernet12      45,46,47,48       Ethernet4/1   4
-Ethernet16      49,50,51,52       Ethernet5/1   5
-Ethernet20      53,54,55,56       Ethernet6/1   6
-Ethernet24      57,58,59,60       Ethernet7/1   7
-Ethernet28      61,62,63,64       Ethernet8/1   8
-Ethernet32      65,66,67,68       Ethernet9/1   9
-Ethernet36      69,70,71,72       Ethernet10/1  10
-Ethernet40      73,74,75,76       Ethernet11/1  11
-Ethernet44      77,78,79,80       Ethernet12/1  12
-Ethernet48      81,82,83,84       Ethernet13/1  13
-Ethernet52      85,86,87,88       Ethernet14/1  14
-Ethernet56      89,90,91,92       Ethernet15/1  15
-Ethernet60      93,94,95,96       Ethernet16/1  16
-Ethernet64      97,98,99,100      Ethernet17/1  17
-Ethernet68      101,102,103,104   Ethernet18/1  18
-Ethernet72      105,106,107,108   Ethernet19/1  19
-Ethernet76      109,110,111,112   Ethernet20/1  20
-Ethernet80      113,114,115,116   Ethernet21/1  21
-Ethernet84      117,118,119,120   Ethernet22/1  22
-Ethernet88      121,122,123,124   Ethernet23/1  23
-Ethernet92      125,126,127,128   Ethernet24/1  24
-Ethernet96      1,2,3,4           Ethernet25/1  25
-Ethernet100     5,6,7,8           Ethernet26/1  26
-Ethernet104     9,10,11,12        Ethernet27/1  27
-Ethernet108     13,14,15,16       Ethernet28/1  28
-Ethernet112     17,18,19,20       Ethernet29/1  29
-Ethernet116     21,22,23,24       Ethernet30/1  30
-Ethernet120     25,26,27,28       Ethernet31/1  31
-Ethernet124     29,30,31,32       Ethernet32/1  32
-Ethernet128     129               Ethernet33    33
-Ethernet129     131               Ethernet34    34
+# name          lanes             alias         index   speed
+Ethernet0       33,34,35,36       Ethernet1/1   1       100000
+Ethernet4       37,38,39,40       Ethernet2/1   2       100000
+Ethernet8       41,42,43,44       Ethernet3/1   3       100000
+Ethernet12      45,46,47,48       Ethernet4/1   4       100000
+Ethernet16      49,50,51,52       Ethernet5/1   5       100000
+Ethernet20      53,54,55,56       Ethernet6/1   6       100000
+Ethernet24      57,58,59,60       Ethernet7/1   7       100000
+Ethernet28      61,62,63,64       Ethernet8/1   8       100000
+Ethernet32      65,66,67,68       Ethernet9/1   9       100000
+Ethernet36      69,70,71,72       Ethernet10/1  10      100000
+Ethernet40      73,74,75,76       Ethernet11/1  11      100000
+Ethernet44      77,78,79,80       Ethernet12/1  12      100000
+Ethernet48      81,82,83,84       Ethernet13/1  13      100000
+Ethernet52      85,86,87,88       Ethernet14/1  14      100000
+Ethernet56      89,90,91,92       Ethernet15/1  15      100000
+Ethernet60      93,94,95,96       Ethernet16/1  16      100000
+Ethernet64      97,98,99,100      Ethernet17/1  17      100000
+Ethernet68      101,102,103,104   Ethernet18/1  18      100000
+Ethernet72      105,106,107,108   Ethernet19/1  19      100000
+Ethernet76      109,110,111,112   Ethernet20/1  20      100000
+Ethernet80      113,114,115,116   Ethernet21/1  21      100000
+Ethernet84      117,118,119,120   Ethernet22/1  22      100000
+Ethernet88      121,122,123,124   Ethernet23/1  23      100000
+Ethernet92      125,126,127,128   Ethernet24/1  24      100000
+Ethernet96      1,2,3,4           Ethernet25/1  25      100000
+Ethernet100     5,6,7,8           Ethernet26/1  26      100000
+Ethernet104     9,10,11,12        Ethernet27/1  27      100000
+Ethernet108     13,14,15,16       Ethernet28/1  28      100000
+Ethernet112     17,18,19,20       Ethernet29/1  29      100000
+Ethernet116     21,22,23,24       Ethernet30/1  30      100000
+Ethernet120     25,26,27,28       Ethernet31/1  31      100000
+Ethernet124     29,30,31,32       Ethernet32/1  32      100000
+Ethernet128     129               Ethernet33    33      10000
+Ethernet129     131               Ethernet34    34      10000


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This is to pass the sonic-mgmt test l2/test_l2_configure.py::test_no_hardcoded_tables

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

