### PR TITLE
Add GNMI bypass validation config file

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -578,6 +578,9 @@ if [[ ! -f './asic_config_checksum' ]]; then
 fi
 sudo cp ./asic_config_checksum $FILESYSTEM_ROOT/etc/sonic/asic_config_checksum
 
+# Copy GNMI bypass validation configuration
+sudo cp files/image_config/gnmi_bypass/gnmi_bypass.yml $FILESYSTEM_ROOT/etc/sonic/
+
 ## Check if not a last stage of RFS build
 fi
 

--- a/files/image_config/gnmi_bypass/gnmi_bypass.yml
+++ b/files/image_config/gnmi_bypass/gnmi_bypass.yml
@@ -1,0 +1,19 @@
+# GNMI Bypass Validation Configuration
+# This file configures which tables and SKUs can use the bypass fast path
+# for gNMI Set operations (direct ConfigDB writes, skipping DBUS/GCU validation)
+
+bypass:
+  # Tables that are allowed to use bypass validation (exact match)
+  allowed_tables:
+    - VNET
+    - VNET_ROUTE_TUNNEL
+    - VLAN_SUB_INTERFACE
+    - ACL_RULE
+    - BGP_PEER_RANGE
+
+  # SKU prefixes that are allowed to use bypass validation
+  # Device hwsku must start with one of these prefixes
+  allowed_sku_prefixes:
+    - Cisco-8102
+    - Cisco-8101
+    - Cisco-8223


### PR DESCRIPTION
## Summary

Add `/etc/sonic/gnmi_bypass.yml` configuration file to allow runtime configuration of the gNMI bypass validation feature. This file is read by sonic-gnmi to determine which tables and SKUs can use the fast-path direct ConfigDB writes.

**Related PR:** https://github.com/sonic-net/sonic-gnmi/pull/568

## Config File

```yaml
# /etc/sonic/gnmi_bypass.yml
bypass:
  allowed_tables:
    - VNET
    - VNET_ROUTE_TUNNEL
    - VLAN_SUB_INTERFACE
    - ACL_RULE
    - BGP_PEER_RANGE
  allowed_sku_prefixes:
    - Cisco-8102
    - Cisco-8101
    - Cisco-8223
```

## Changes

- Add `files/image_config/gnmi_bypass/gnmi_bypass.yml` with default bypass configuration
- Update `build_debian.sh` to copy config file to `/etc/sonic/` during image build

#### Why I did it

The gNMI bypass validation feature allows direct ConfigDB writes for specific tables/SKUs, reducing Set operation latency from ~5s to ~70ms. Making the allowed tables and SKU prefixes configurable allows operators to adjust the bypass behavior without code changes.

#### How I did it

Added a YAML config file following the pattern of other SONiC config files (e.g., `constants.yml`). The file is copied to `/etc/sonic/` during the root filesystem build phase in `build_debian.sh`.

#### How to verify it

1. Build a SONiC image with this change
2. Verify `/etc/sonic/gnmi_bypass.yml` exists on the device
3. Modify the file and restart telemetry to apply new configuration

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Description for the changelog

Add GNMI bypass validation config file (/etc/sonic/gnmi_bypass.yml) for configuring fast-path gNMI Set operations