### PR TITLE
grub2: fix cpio test with large uid

### DIFF
--- a/src/grub2/patch/large-uid-skip-cpio-ustar.patch
+++ b/src/grub2/patch/large-uid-skip-cpio-ustar.patch
@@ -1,0 +1,16 @@
+diff --git a/tests/cpio_test.in b/tests/cpio_test.in
+index 5742cf17b..add41ef22 100644
+--- a/tests/cpio_test.in
++++ b/tests/cpio_test.in
+@@ -11,6 +11,10 @@ fi
+ "@builddir@/grub-fs-tester" cpio_odc
+ "@builddir@/grub-fs-tester" cpio_newc
+ "@builddir@/grub-fs-tester" cpio_crc
+-"@builddir@/grub-fs-tester" cpio_ustar
++# If the UID of the user running tests is > 2097151 skip testing ustar as the format does
++# not support large uids.
++if [ `id -u` -le "2097151" ] ; then
++   "@builddir@/grub-fs-tester" cpio_ustar
++fi
+ "@builddir@/grub-fs-tester" cpio_hpbin
+ "@builddir@/grub-fs-tester" cpio_hpodc

--- a/src/grub2/patch/series
+++ b/src/grub2/patch/series
@@ -1,2 +1,3 @@
 # This series applies on GIT commit f954d68d5e8dc7eb0081ad7bc1ced9ff5ca687a7
 adjust-build-rules-for-debian.patch
+large-uid-skip-cpio-ustar.patch


### PR DESCRIPTION
#### Why I did it

The cpio ustar tests have a maximum UID capability of 2097151.  

This causes failures on systems with large UID like:
```
cpio: ./: value uid 1220800073 out of allowed range 0..2097151
cpio: hard: value uid 1220800073 out of allowed range 0..2097151
cpio: cAsE: value uid 1220800073 out of allowed range 0..2097151
cpio: qwertzuiopasdfghjklyxcvbnm1234567890qwertzuiopasdfghjklyxcvbnm1234567890oiewqfiewioqoiqoiurqruewqoi: value uid 1220800073 out of allowed range 0..2097151
cpio: .?*\!"#%@$%&'()+ ,-.:;<=>^{_}[]`|~.: value uid 1220800073 out of allowed range 0..2097151
cpio: éàèüöäëñкирилица莭莽茝Ελληνικά😁😜😒: value uid 1220800073 out of allowed range 0..2097151
...
```

#### How I did it

Skip these tests if we detect the user running the tests has a larger UID.

#### How to verify it

Create a user with a UID > 2097151 and build grub and run tests without this patch and observe failures.  Then apply this patch and observe it succeed.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202505
- [X] 202511

#### Tested branch (Please provide the tested image version)

master as of 2026-02-9

#### Description for the changelog

grub2: fix cpio test with large uid

#### Link to config_db schema for YANG module changes
N/A

#### A picture of a cute animal (not mandatory but encouraged)
Fixes #25401