### PR TITLE
[prerequisites] Fix j2 install for Python 3.12+ hosts

### DIFF
--- a/scripts/prerequisites.sh
+++ b/scripts/prerequisites.sh
@@ -36,11 +36,12 @@ run_step "Installing prerequisites (python3-pip, git)" \
     sudo apt install -y python3-pip git
 
 run_step "Installing jinjanator (j2)" \
-    bash -c 'pip3 install --user jinjanator || sudo apt install j2cli'
+    bash -c 'pip3 install --user jinjanator || sudo apt-get install -y j2cli'
 
 echo "==> Testing j2 availability..."
 if ! command -v j2 >/dev/null 2>&1; then
     echo "[ERROR] j2 is not runnable."
+    echo "If installed via pip, ensure ~/.local/bin is in your PATH."
     echo "Please logout and login, then run the script again."
     exit 1
 else


### PR DESCRIPTION
#### Why I did it

On hosts with Python >= 3.12, pip-installed j2cli fails with `ModuleNotFoundError: No module named 'imp'` (see #20353). The prerequisites script already prefers `jinjanator` (which works on Python 3.12+) with `j2cli` as fallback, but has two minor issues.

#### How I did it

- Use `apt-get install -y` instead of `apt install` for the j2cli fallback to ensure non-interactive operation.
- Add a PATH hint when `j2` is not found after install, since `pip3 install --user` puts binaries in `~/.local/bin` which may not be on PATH.

Note: Dockerfile changes for bookworm/bullseye base images are intentionally not included — those containers use Python 3.11/3.9 respectively and are unaffected by the `imp` module removal. The trixie slave container already uses apt-packaged `j2cli`.

#### How to verify it

Run `scripts/prerequisites.sh` on a host with Python >= 3.12 — jinjanator should install successfully via pip. On systems where pip fails, the fallback to `apt-get install -y j2cli` runs non-interactively.

#### Which release branch to backport

- [ ] 202311
- [ ] 202405
- [ ] 202411

#### Description for the changelog

Fix prerequisites.sh j2cli fallback to use non-interactive apt-get -y and add PATH hint for pip user installs.

#### A picture of a cute animal (not mandatory but encouraged)

🦔