### PR TITLE
Enable ZMQ in Orchagent.

### DIFF
--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -35,8 +35,11 @@ fi
 # Set zmq mode by default for smartswitch DPU and increase the max bulk limit
 # Otherwise, set synchronous mode if it is enabled in CONFIG_DB
 SYNC_MODE=$(echo $SWSS_VARS | jq -r '.synchronous_mode')
+ZMQ_MODE=$(echo $SWSS_VARS | jq -r '.zmq_mode')
 if [ "$LOCALHOST_SWITCHTYPE" == "dpu" ]; then
     ORCHAGENT_ARGS+="-z zmq_sync -k 65536 "
+elif [ "$ZMQ_MODE" == "enable" ]; then
+    ORCHAGENT_ARGS+="-z zmq_sync "
 elif [ "$SYNC_MODE" == "enable" ]; then
     ORCHAGENT_ARGS+="-s "
 fi
@@ -61,6 +64,9 @@ fi
 if [[ "$NAMESPACE_ID" ]]; then
     ORCHAGENT_ARGS+="-f swss.asic$NAMESPACE_ID.rec -j sairedis.asic$NAMESPACE_ID.rec "
 fi
+
+# Enable zmq
+ORCHAGENT_ARGS+="-q ipc:///zmq/zmq_swss_ep "
 
 # Add platform specific arguments if necessary
 if [ "$platform" == "broadcom" ]; then

--- a/files/build_templates/swss_vars.j2
+++ b/files/build_templates/swss_vars.j2
@@ -7,6 +7,7 @@
     "mac": "{{ DEVICE_METADATA.localhost.mac }}",
     "resource_type": "{{ DEVICE_METADATA.localhost.resource_type }}",
     "synchronous_mode": {% if DEVICE_METADATA.localhost.synchronous_mode == "disable" %}"disable"{% else %}"enable"{% endif %},
+    "zmq_mode": {% if DEVICE_METADATA.localhost.zmq_mode == "enable" %}"enable"{% else %}"disable"{% endif %},
     {%if DEVICE_METADATA.localhost.supporting_bulk_counter_groups is defined and DEVICE_METADATA.localhost.supporting_bulk_counter_groups != '' -%}
     "supporting_bulk_counter_groups": "{{ DEVICE_METADATA.localhost.supporting_bulk_counter_groups|join(',') }}",
     {% endif -%}

--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -168,6 +168,10 @@ COPY ["frr/zebra.conf", "/etc/frr/"]
 # Create /var/warmboot/teamd folder for teammgrd
 RUN mkdir -p /var/warmboot/teamd
 
+# Create /zmq folder for zmq sync mode.
+RUN mkdir -p /zmq
+COPY ["context_config.json", "/zmq/"]
+
 FROM $BASE
 
 {{ rsync_from_builder_stage() }}

--- a/platform/vs/docker-sonic-vs/context_config.json
+++ b/platform/vs/docker-sonic-vs/context_config.json
@@ -1,0 +1,21 @@
+{
+    "CONTEXTS": [
+        {
+            "guid" : 0,
+            "name" : "syncd",
+            "dbAsic" : "ASIC_DB",
+            "dbCounters" : "COUNTERS_DB",
+            "dbFlex": "FLEX_COUNTER_DB",
+            "dbState" : "STATE_DB",
+            "zmq_enable": true,
+            "zmq_endpoint": "ipc:///zmq/zmq_ep",
+            "zmq_ntf_endpoint": "ipc:///zmq/zmq_ntf_ep",
+            "switches": [
+                {
+                    "index" : 0,
+                    "hwinfo" : ""
+                }
+            ]
+        }
+    ]
+}

--- a/platform/vs/docker-sonic-vs/init_cfg.json.j2
+++ b/platform/vs/docker-sonic-vs/init_cfg.json.j2
@@ -3,7 +3,8 @@
         "localhost": {
             "mac": "{{ system_mac }}",
             "switch_type": "{{ switch_type }}",
-            "buffer_model": "traditional"
+            "buffer_model": "traditional",
+            "zmq_mode": "enable"
         }
     },
 {% if switch_type != "dpu" %}

--- a/platform/vs/docker-sonic-vs/orchagent.sh
+++ b/platform/vs/docker-sonic-vs/orchagent.sh
@@ -49,12 +49,17 @@ fi
 # Set zmq mode by default for DPU vs
 # Otherwise, set synchronous mode if it is enabled in CONFIG_DB
 SYNC_MODE=$(echo $SWSS_VARS | jq -r '.synchronous_mode')
+ZMQ_MODE=$(echo $SWSS_VARS | jq -r '.zmq_mode')
 
-if [ "$SWITCH_TYPE" == "dpu" ]; then
-    ORCHAGENT_ARGS+="-z zmq_sync -k 65536 "
+if [[ "$ZMQ_MODE" == "enable" || "$SWITCH_TYPE" == "dpu" ]]; then
+    ORCHAGENT_ARGS+="-z zmq_sync "
+    [[ "$SWITCH_TYPE" == "dpu" ]] && ORCHAGENT_ARGS+="-k 65536 "
 elif [ "$SYNC_MODE" == "enable" ]; then
     ORCHAGENT_ARGS+="-s "
 fi
+
+# Enable zmq
+ORCHAGENT_ARGS+="-q ipc:///zmq_swss/zmq_swss_ep "
 
 # Enable ring buffer
 ORCHDAEMON_RING_ENABLED=`sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "ring_thread_enabled"`


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

