### PR TITLE
[build] Add SONIC_BUILD_MEMORY config to limit container memory

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -304,10 +304,24 @@ endif
 
 # Consider removing the --ulimit flag once nothing older
 # than Bullseye is being used as a slave container.
+# Build container memory limit (set SONIC_BUILD_MEMORY=none to disable).
+# Constrains OOM kills to the container instead of the kernel silently
+# killing unrelated host processes.
+SONIC_BUILD_MEMORY_FLAGS =
+ifneq ($(SONIC_BUILD_MEMORY),)
+ifneq ($(SONIC_BUILD_MEMORY),none)
+    SONIC_BUILD_MEMORY_FLAGS += --memory=$(SONIC_BUILD_MEMORY)
+    ifneq ($(SONIC_BUILD_MEMORY_SWAP),)
+        SONIC_BUILD_MEMORY_FLAGS += --memory-swap=$(SONIC_BUILD_MEMORY_SWAP)
+    endif
+endif
+endif
+
 DOCKER_RUN := docker run --rm=true --privileged --init \
     -v $(DOCKER_BUILDER_MOUNT) \
     -v "$(DOCKER_LOCKDIR):$(DOCKER_LOCKDIR)" \
     -w $(DOCKER_BUILDER_WORKDIR) \
+    $(SONIC_BUILD_MEMORY_FLAGS) \
     -e "http_proxy=$(http_proxy)" \
     -e "https_proxy=$(https_proxy)" \
     -e "no_proxy=$(no_proxy)" \

--- a/rules/config
+++ b/rules/config
@@ -16,6 +16,21 @@ SONIC_CONFIG_BUILD_JOBS = 1
 # Corresponding -j argument will be passed to make/dpkg commands that build separate packages
 SONIC_CONFIG_MAKE_JOBS = $(shell nproc)
 
+# SONIC_BUILD_MEMORY - set memory limit for the build container.
+# When set, passes --memory and --memory-swap flags to docker run.
+# This prevents the kernel OOM killer from silently killing build processes
+# (or unrelated host processes) when parallel builds exhaust system RAM.
+# The OOM will instead be contained within the build container.
+# Example: SONIC_BUILD_MEMORY = 24g
+# Set to "none" to explicitly disable.
+# SONIC_BUILD_MEMORY =
+
+# SONIC_BUILD_MEMORY_SWAP - set memory+swap limit for the build container.
+# Only takes effect when SONIC_BUILD_MEMORY is set. Defaults to double
+# the value of SONIC_BUILD_MEMORY if not specified (Docker default behavior).
+# Set to -1 for unlimited swap. Set equal to SONIC_BUILD_MEMORY to disable swap.
+# SONIC_BUILD_MEMORY_SWAP =
+
 # DEFAULT_BUILD_LOG_TIMESTAMP - add timestamp in build log
 # Supported format: simple, none
 DEFAULT_BUILD_LOG_TIMESTAMP = none


### PR DESCRIPTION
#### What I did

Added `SONIC_BUILD_MEMORY` and `SONIC_BUILD_MEMORY_SWAP` configuration knobs to control the memory limit of the build container.

#### Why I did it

When building with `SONIC_BUILD_JOBS > 1`, parallel C++ compilation (especially packages like sonic-swss, p4lang-p4c) can exhaust system RAM. The kernel OOM killer then silently terminates build processes — or worse, unrelated applications like browsers and IDEs — with no error message or diagnostics. The build just stops, and the developer has no idea why.

By setting a Docker `--memory` limit on the build container, OOM behavior becomes **predictable and contained**: the container gets killed with a clear error instead of the kernel randomly shooting processes across the entire system.

#### How I did it

- Added `SONIC_BUILD_MEMORY` in `rules/config` (commented out by default — no behavior change)
- Added `SONIC_BUILD_MEMORY_SWAP` for optional swap limit control
- Wired both into `DOCKER_RUN` in `Makefile.work` via `--memory` and `--memory-swap` flags

#### How to verify it

1. Set `SONIC_BUILD_MEMORY = 24g` in `rules/config.user`
2. Run a build with `SONIC_BUILD_JOBS=4`
3. Verify with `docker inspect <container>` that MemoryLimit is set
4. If memory is exceeded, the container exits with OOM error (instead of silent kernel kills)

#### Usage

```makefile
# In rules/config.user:
SONIC_BUILD_MEMORY = 24g
SONIC_BUILD_MEMORY_SWAP = 32g
```

Recommended: leave 4-6 GB free for the host OS.

Signed-off-by: Rustiqly <rustiqly@users.noreply.github.com>