### PR TITLE
[cfggen] Guard get_path_to_platform_dir calls in asic_sensors and smartswitch configs

### DIFF
--- a/src/sonic-config-engine/asic_sensors_config.py
+++ b/src/sonic-config-engine/asic_sensors_config.py
@@ -23,9 +23,12 @@ def get_asic_sensors_config():
     if os.environ.get("CFGGEN_UNIT_TESTING") == "2":
         json_file =  os.path.join(tests_path, "data",  "asic_sensors", "platform.json")
     else:
-        platform_path = device_info.get_path_to_platform_dir()
+        try:
+            platform_path = device_info.get_path_to_platform_dir()
+        except OSError:
+            return config
         json_file = os.path.join(platform_path, device_info.PLATFORM_JSON_FILE)
-        
+
     if not os.path.exists(json_file):
         return config
     

--- a/src/sonic-config-engine/smartswitch_config.py
+++ b/src/sonic-config-engine/smartswitch_config.py
@@ -27,8 +27,13 @@ def get_smartswitch_config(hwsku=None):
             json_file =  os.path.join(tests_path, "data", "smartswitch", "sample_switch_platform.json")
         elif hwsku == 'SS-DPU-1x400Gb':
             json_file =  os.path.join(tests_path, "data", "smartswitch", "sample_dpu_platform.json")
+        else:
+            return config
     else:
-        platform_path = device_info.get_path_to_platform_dir()
+        try:
+            platform_path = device_info.get_path_to_platform_dir()
+        except OSError:
+            return config
         json_file = os.path.join(platform_path, device_info.PLATFORM_JSON_FILE)
 
     platform_json = portconfig.readJson(json_file)


### PR DESCRIPTION
#### Why I did it

Fixes #20614.

`asic_sensors_config.py` and `smartswitch_config.py` call `device_info.get_path_to_platform_dir()` without handling the `OSError` raised when no platform directory exists. This causes `test_minigraph_packet_chassis_acl_local_host` (and several related tests) to fail during the `sonic_config_engine` wheel build, breaking the entire image build.

Multiple users have reported this across different platforms (Marvell AMD64, VS ARM64, VS x86_64) — see #20614.

#### Root Cause Analysis

The failure chain:

1. `test_minigraph_packet_chassis_acl_local_host` sets `CFGGEN_UNIT_TESTING = ""` (clearing it to avoid stale mock port data from previous tests that would break yang validation)
2. `run_script()` → `YangWrapper.validate()` spawns a **subprocess**: `sonic-cfggen -m <graph> --print-data`
3. The subprocess inherits `CFGGEN_UNIT_TESTING=""`. Since it is not `"2"`, `mock_tables.dbconnector` is **not** loaded
4. `sonic-cfggen` → `main()` → calls `get_asic_sensors_config()`
5. `get_asic_sensors_config()` checks `CFGGEN_UNIT_TESTING == "2"` → false, takes the `else` branch
6. Calls `device_info.get_path_to_platform_dir()` **directly with no guard**
7. Inside the build container: no `PLATFORM` env var, no `/host/machine.conf`, no `/usr/share/sonic/platform` directory → **`OSError("Failed to locate platform directory")`**

```
Traceback:
  sonic-cfggen:404  main()        → parse_xml(minigraph, platform, ...)
  minigraph.py:2064 parse_xml()   → get_port_config(hwsku=hwsku, ...)
  portconfig.py:193               → device_info.get_path_to_port_config_file(hwsku, asic_id)
  device_info.py:443              → get_path_to_platform_dir()
  device_info.py:264              → raise OSError("Failed to locate platform directory")
```

The same pattern exists in `smartswitch_config.py`. Additionally, `smartswitch_config.py` has a secondary bug: when `CFGGEN_UNIT_TESTING == "2"` but the hwsku does not match either known test value (`SSwitch-32x1000Gb` or `SS-DPU-1x400Gb`), `json_file` is never assigned, causing an `UnboundLocalError`.

#### How I did it

- **`asic_sensors_config.py`**: Wrap the `get_path_to_platform_dir()` call in a `try/except OSError` block. When no platform directory exists, return an empty config dict (no ASIC sensor data is available, which is the correct behavior for non-device environments).

- **`smartswitch_config.py`**: Same `try/except OSError` guard, plus add an `else` clause for unrecognized hwsku values during unit testing to return empty config instead of hitting `UnboundLocalError`.

This is consistent with the existing pattern in `device_info.get_path_to_port_config_file()`, which safely checks `get_platform()` before attempting to locate the platform directory:

```python
platform = get_platform()
if not platform:
    return None
```

#### How to verify it

**Reproduce the failure (before fix):**

```bash
make init
make configure PLATFORM=vs
make target/python-wheels/bookworm/sonic_config_engine-1.0-py3-none-any.whl
```

Look for:
```
FAILED tests/test_cfggen.py::TestCfgGen::test_minigraph_packet_chassis_acl_local_host
  OSError: Failed to locate platform directory
```

**After fix:** The above build step should pass with 0 test failures.

The fix is also safe on real devices: when a platform directory exists, `get_path_to_platform_dir()` succeeds and behavior is unchanged. The `try/except` only catches the `OSError` for environments where no platform is configured.

#### Which release branch to backport (provide reason below if selected)

- [x] 202411
- [x] 202405
- [x] 202311

Reason: This bug affects all builds in non-device environments (CI, developer workstations). Multiple users have reported it across platforms and architectures.

#### Description for the changelog

Guard `get_path_to_platform_dir()` calls in `asic_sensors_config.py` and `smartswitch_config.py` to handle missing platform directories gracefully, fixing build failures in non-device environments.

#### A picture of a cute animal (not mandatory but encouraged)

🦔