### PR TITLE
[build] Fix grpcio 1.15.1 install failure in arm64 env. (#25393)

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -47,7 +47,7 @@ RUN apt-get install -y -t bookworm-backports \
 # install any dependencies required by the Arista sonic_platform package.
 # TODO: eliminate the need to install these explicitly.
 RUN pip3 install grpcio==1.51.1 \
-        grpcio-tools==1.51.1
+        grpcio-tools==1.51.1 --no-build-isolation
 
 # Barefoot platform vendors' sonic_platform packages import these Python libraries (and netifaces)
 RUN pip3 install thrift==0.13.0

--- a/sonic-slave-bookworm/Dockerfile.j2
+++ b/sonic-slave-bookworm/Dockerfile.j2
@@ -566,7 +566,7 @@ RUN pip3 install pyyaml-include
 
 # For building sonic_ycabled
 # Note: Match version in bookworm
-RUN pip3 install grpcio==1.51.1 grpcio-tools==1.51.1
+RUN pip3 install grpcio==1.51.1 grpcio-tools==1.51.1 --no-build-isolation
 
 # For running Python unit tests
 RUN pip3 install pytest-runner==5.2


### PR DESCRIPTION
Why I did it
arm64 builds start to fail since 2026/02/09.
Root Cause is pypi package setuptools released new version v82.0.0. LINK pkg_resources is removed from setuptools.

pip3 uses tem env to build packages and uses latest dependency version. grpcio 1.51.1 didn't include pkg_resources in its dependencies. Build will fail.

Why amd64 and armhf build succeed? Because they have manylinux wheel. They don't need to build from source.

Open question:
How can we avoid this kind of build break?
Disable tem env for 'pip install'?

Work item tracking
Microsoft ADO (number only):
How I did it
Use host env instead of tem env when pip install grpcio.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

