### PR TITLE
Build: Fix restapi-sidecar docker Makefile

### DIFF
--- a/rules/docker-restapi-sidecar.mk
+++ b/rules/docker-restapi-sidecar.mk
@@ -42,10 +42,3 @@ $(DOCKER_RESTAPI_SIDECAR)_FILES += $(CONTAINER_CHECKER)
 $(DOCKER_RESTAPI_SIDECAR)_FILES += $(RESTAPI_SYSTEMD)
 $(DOCKER_RESTAPI_SIDECAR)_FILES += $(K8S_POD_CONTROL)
 
-.PHONY: docker-restapi-sidecar-ut
-docker-restapi-sidecar-ut: $(PYTHON_WHEELS_PATH)/sonic_py_common-1.0-py3-none-any.whl-install
-	@echo "Running unit tests for systemd_stub.py..."
-	@PYTHONPATH=dockers/docker-restapi-sidecar \
-		python3 -m pytest -q dockers/docker-restapi-sidecar/cli-plugin-tests
-
-target/docker-restapi-sidecar.gz: docker-restapi-sidecar-ut


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Having this PHONY target results in unconditional builds. We should use the docker UT Schema to run the tests instead of doing it from the Makefile.

Note this was done for the telemetry sidecar here: https://github.com/sonic-net/sonic-buildimage/pull/25122

Tests are run from here:
https://github.com/sonic-net/sonic-buildimage/blob/0364048fe1b9aeee71b8f1d556954c4aa79cd479/slave.mk#L1195

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

Test still runs when docker-restapi-sidecar is built:

```
Build start time: Tue Feb 10 19:15:36 UTC 2026
[ REASON ] :      target/docker-restapi-sidecar.gz does not exist   NON-EXISTENT PREREQUISITES: docker-start target/docker-config-engine-bookworm.gz-load target/python-wheels/bookworm/sonic_py_common-1.0-py3-none-any.whl-install target/debs/bookworm/libswsscommon_1.0.0_amd64.deb-install target/debs/bookworm/python3-swsscommon_1.0.0_amd64.deb-install target/debs/bookworm/python3-yang_1.0.73_amd64.deb-install
[ FLAGS  FILE    ] : []
[ FLAGS  DEPENDS ] : []
[ FLAGS  DIFF    ] : []
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-7.2.1, pluggy-1.0.0+repack -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /sonic, configfile: pytest.ini
plugins: pyfakefs-5.10.2, cov-4.0.0
collecting ... collected 38 items

test_systemd_stub.py::test_sync_no_change_fast_path PASSED               [  2%]
test_systemd_stub.py::test_sync_updates_and_post_actions PASSED          [  5%]
test_systemd_stub.py::test_sync_missing_src_returns_false PASSED         [  7%]
test_systemd_stub.py::test_main_once_exits_zero_and_disables_post_actions PASSED [ 10%]
test_systemd_stub.py::test_env_controls_restapi_src_false PASSED         [ 13%]
<snip>
test_systemd_stub.py::test_per_branch_files_with_v1_flag[202311-True] PASSED [ 89%]
test_systemd_stub.py::test_per_branch_files_with_v1_flag[202405-True] PASSED [ 92%]
test_systemd_stub.py::test_per_branch_files_with_v1_flag[202411-True] PASSED [ 94%]
test_systemd_stub.py::test_per_branch_files_with_v1_flag[202505-True] PASSED [ 97%]
test_systemd_stub.py::test_per_branch_files_with_v1_flag[202511-True] PASSED [100%]

============================== 38 passed in 0.05s ==============================
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

