### PR TITLE
[healthd] Fix crash on systemd unit names with multiple dots

### DIFF
--- a/src/system-health/health_checker/sysmonitor.py
+++ b/src/system-health/health_checker/sysmonitor.py
@@ -311,7 +311,7 @@ class Sysmonitor(ProcessTaskBase):
         try:
             service_status = "Down"
             service_up_status = "Down"
-            service_name,last_name = event.split('.')
+            service_name,last_name = event.rsplit('.', 1)
 
             sysctl_show = self.run_systemctl_show(event)
 
@@ -454,7 +454,7 @@ class Sysmonitor(ProcessTaskBase):
                 astate = "DOWN"
             self.publish_system_status(astate)
 
-            srv_name,last = event.split('.')
+            srv_name,last = event.rsplit('.', 1)
             # stop on service maybe propagated to timers and in that case,
             # the state_db entry for the service should not be deleted
             if last == "service":

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -1016,3 +1016,22 @@ def test_healthd_check_interval(mock_log_warning, mock_log_notice, mock_time):
 
     daemon.stop_event.wait.return_value = True
     assert not daemon._run_checker(manager, chassis)
+
+
+@patch('health_checker.sysmonitor.Sysmonitor.get_all_service_list', MagicMock(return_value=['mock_snmp.service']))
+@patch('health_checker.sysmonitor.Sysmonitor.publish_system_status', MagicMock())
+def test_check_unit_status_multi_dot_unit_name():
+    """Test that check_unit_status does not crash on unit names with multiple dots.
+
+    Systemd device/mount units can have names like 'sys-devices-pci0000:00.device'
+    which contain multiple dots. Using str.split('.') would raise ValueError
+    (too many values to unpack). Using rsplit('.', 1) correctly handles this.
+    Regression test for issue #25291.
+    """
+    sysmon = Sysmonitor()
+    # These should not raise ValueError
+    sysmon.check_unit_status('sys-devices-pci0000:00-0000:00:1f.0.device')
+    sysmon.check_unit_status('dev-disk-by\\x2did-wwn\\x2d0x5001.mount')
+    sysmon.check_unit_status('run-user-1000.mount')
+    # Normal service name should still work
+    sysmon.check_unit_status('mock_snmp.timer')


### PR DESCRIPTION
## Description

Fixes healthd/sysmonitor crashing with `ValueError: too many values to unpack (expected 2)` when receiving dbus events for systemd units whose names contain multiple dots.

**Root cause:** `event.split(".")` in both `get_unit_status()` and `check_unit_status()` assumes unit names contain exactly one dot. Systemd device and mount unit names can legally contain multiple dots (e.g., `sys-devices-pci0000:00-0000:00:1f.0.device`), causing the unpacking to fail.

**Fix:** Replace `split(".")` with `rsplit(".", 1)` which splits from the right at most once, correctly extracting the suffix (`.service`, `.device`, `.timer`, etc.) regardless of how many dots appear in the unit name.

**Verification:**
```python
# Old behavior (crashes):
>>> "sys-devices-pci0000:00-0000:00:1f.0.device".split(".")
["sys-devices-pci0000:00-0000:00:1f", "0", "device"]  # ValueError on unpack

# New behavior (works):
>>> "sys-devices-pci0000:00-0000:00:1f.0.device".rsplit(".", 1)
["sys-devices-pci0000:00-0000:00:1f.0", "device"]  # Correct
```

Normal service names (single dot) are unaffected:
```python
>>> "mock_bgp.service".rsplit(".", 1)
["mock_bgp", "service"]  # Same as before
```

## Test added
- `test_check_unit_status_multi_dot_unit_name`: verifies that `check_unit_status()` handles multi-dot unit names without crashing.

Fixes: #25291