### PR TITLE
Update the Arista SKUs gearbox files for 7060DX5 and 7060PX5

### DIFF
--- a/device/arista/x86_64-arista_7060dx5_64s/Arista-7060DX5-64S/blackhawk.xml
+++ b/device/arista/x86_64-arista_7060dx5_64s/Arista-7060DX5-64S/blackhawk.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <root version="2">
-    <name>CSDK-BH</name>
+    <name>blackhawk</name>
     <mode>retimer</mode>
     <phy context_id="1">
         <phy_addr>0</phy_addr>

--- a/device/arista/x86_64-arista_7060px5_64s/Arista-7060PX5-64S/blackhawk.xml
+++ b/device/arista/x86_64-arista_7060px5_64s/Arista-7060PX5-64S/blackhawk.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <root>
-  <name>CSDK-BH</name>
+  <name>blackhawk</name>
   <phy_addr>0</phy_addr>
   <mode>retimer</mode>
   <topology>1</topology>

--- a/device/arista/x86_64-arista_7060px5_64s/Arista-7060PX5-64S/psai.profile
+++ b/device/arista/x86_64-arista_7060px5_64s/Arista-7060PX5-64S/psai.profile
@@ -1,1 +1,1 @@
-SAI_KEY_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/blackhawk.xml
+SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/blackhawk.xml


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Need to update platform files to be compatible with new versions of gearbox SAI.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Updated the psai.profile keys and updated the chip names.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202511

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
<img width="494" height="640" alt="image" src="https://github.com/user-attachments/assets/3dda0e4b-2a50-40b3-83a6-fd9dede71b8b" />

