### PR TITLE
[202511][ssw] clean up DPU_APPL_DB and DPU_STATE_DB for DPU swss restart or DPU reboot

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -408,14 +408,19 @@ start() {
         $SONIC_DB_CLI RESTAPI_DB FLUSHDB
         clean_up_tables STATE_DB "'PORT_TABLE*', 'MGMT_PORT_TABLE*', 'VLAN_TABLE*', 'VLAN_MEMBER_TABLE*', 'LAG_TABLE*', 'LAG_MEMBER_TABLE*', 'INTERFACE_TABLE*', 'MIRROR_SESSION*', 'VRF_TABLE*', 'FDB_TABLE*', 'FG_ROUTE_TABLE*', 'BUFFER_POOL*', 'BUFFER_PROFILE*', 'MUX_CABLE_TABLE*', 'ADVERTISE_NETWORK_TABLE*', 'VXLAN_TUNNEL_TABLE*', 'VNET_ROUTE*', 'MACSEC_PORT_TABLE*', 'MACSEC_INGRESS_SA_TABLE*', 'MACSEC_EGRESS_SA_TABLE*', 'MACSEC_INGRESS_SC_TABLE*', 'MACSEC_EGRESS_SC_TABLE*', 'VRF_OBJECT_TABLE*', 'VNET_MONITOR_TABLE*', 'BFD_SESSION_TABLE*', 'SYSTEM_NEIGH_TABLE*', 'FABRIC_PORT_TABLE*', 'TUNNEL_DECAP_TABLE*', 'TUNNEL_DECAP_TERM_TABLE*'"
         $SONIC_DB_CLI APPL_STATE_DB FLUSHDB
-        # Flush DPU remote databases on NPU
-        # Check if DPU_APPL_DB remote database is reachable (indicates this is a DPU with an accessible DB)
-        if $SONIC_DB_CLI DPU_APPL_DB PING >/dev/null 2>&1; then
-            debug "Flushing DPU remote databases (DPU_APPL_DB, DPU_STATE_DB, DPU_APPL_STATE_DB, DPU_COUNTERS_DB) ..."
-            $SONIC_DB_CLI DPU_APPL_DB FLUSHDB
-            $SONIC_DB_CLI DPU_STATE_DB FLUSHDB
-            $SONIC_DB_CLI DPU_APPL_STATE_DB FLUSHDB
-            $SONIC_DB_CLI DPU_COUNTERS_DB FLUSHDB
+        # Flush DPU remote databases (DPU device only)
+        # Only run if this is a DPU device (type=SmartSwitchDPU or switch_type=dpu)
+        DEVICE_TYPE=`$SONIC_DB_CLI CONFIG_DB hget "DEVICE_METADATA|localhost" type`
+        SWITCH_TYPE=`$SONIC_DB_CLI CONFIG_DB hget "DEVICE_METADATA|localhost" switch_type`
+        if [[ x"${DEVICE_TYPE}" == x"SmartSwitchDPU" || x"${SWITCH_TYPE}" == x"dpu" ]]; then
+            # Check if DPU_APPL_DB remote database is reachable
+            if $SONIC_DB_CLI DPU_APPL_DB PING >/dev/null 2>&1; then
+                debug "Flushing DPU remote databases (DPU_APPL_DB, DPU_STATE_DB, DPU_APPL_STATE_DB, DPU_COUNTERS_DB) ..."
+                $SONIC_DB_CLI DPU_APPL_DB FLUSHDB
+                $SONIC_DB_CLI DPU_STATE_DB FLUSHDB
+                $SONIC_DB_CLI DPU_APPL_STATE_DB FLUSHDB
+                $SONIC_DB_CLI DPU_COUNTERS_DB FLUSHDB
+            fi
         fi
         clean_up_chassis_db_tables
         rm -rf /tmp/cache


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
For https://github.com/sonic-net/SONiC/pull/2175

sign-off: Jing Zhang zhangjing@microsoft.com 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
1. Check if DPU_APPL_DB is pingable 
2. If yes, flush all DB entries when swss starts. 

#### How to verify it
Tested on ssw testbed. 
- Entries got removed. 
```
$ redis-cli -p 6381 -n 15 
127.0.0.1:6381[15]> keys *
1) "BFD_SESSION_TABLE:default:default:10.1.0.32"
2) "BFD_SESSION_TABLE:default:default:10.1.2.32"
3) "BFD_SESSION_TABLE:default:default:10.1.1.32"
127.0.0.1:6381[15]> keys *
(empty array)
```

```
$ redis-cli  -p 6381 MONITOR
OK

... ...
1769395816.952661 [18 169.254.200.1:34286] "PING"
1769395816.952718 [16 169.254.200.1:34280] "PING"
1769395816.954712 [17 169.254.200.1:34296] "SELECT" "17"
1769395816.954877 [17 169.254.200.1:34296] "PING"
1769395817.183169 [15 169.254.200.1:34310] "SELECT" "15"
1769395817.183386 [15 169.254.200.1:34310] "PING"
1769395817.210425 [15 169.254.200.1:34320] "SELECT" "15"
1769395817.210602 [15 169.254.200.1:34320] "FLUSHDB"
1769395817.229074 [17 169.254.200.1:34322] "SELECT" "17"
1769395817.229309 [17 169.254.200.1:34322] "FLUSHDB"
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

