### PR TITLE
grub2: grub_cmd_sleep increase tolerance to 14sec

### DIFF
--- a/src/grub2/patch/grub_cmd_sleep-increase-tolerance-to-14-sec.patch
+++ b/src/grub2/patch/grub_cmd_sleep-increase-tolerance-to-14-sec.patch
@@ -1,0 +1,29 @@
+From 6c83ac29ab6f095214914bee379b78d0c86387b3 Mon Sep 17 00:00:00 2001
+From: Yan Markman <ymarkman@marvell.com>
+Date: Tue, 24 Feb 2026 21:44:01 +0200
+Subject: [PATCH 1/1] grub_cmd_sleep: increase tolerance to 14 sec
+
+The sleep(10) wall-clock timing is flake under several parallel build-jobs.
+Do not SKIP it but increase fail threshold tolerance from 11 sec to 14 sec.
+
+Signed-off-by: Yan Markman <ymarkman@marvell.com>
+---
+ tests/grub_cmd_sleep.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/grub_cmd_sleep.in b/tests/grub_cmd_sleep.in
+index 8797f6632..11d1b2775 100644
+--- a/tests/grub_cmd_sleep.in
++++ b/tests/grub_cmd_sleep.in
+@@ -19,7 +19,7 @@ if [ "${grub_modinfo_target_cpu}" = arm ] && [ $((dt2 - dt1)) -ge 15 ] && [ $((d
+   exit 0;
+ fi
+ 
+-if [ $((dt2 - dt1)) -gt 11 ] || [ $((dt2 - dt1)) -lt 9 ]; then
++if [ $((dt2 - dt1)) -gt 14 ] || [ $((dt2 - dt1)) -lt 9 ]; then
+   echo "Interval not in range $dt2-$dt1 != 10"
+   exit 1
+ fi
+-- 
+2.34.1
+

--- a/src/grub2/patch/series
+++ b/src/grub2/patch/series
@@ -1,3 +1,4 @@
+grub_cmd_sleep-increase-tolerance-to-14-sec.patch
 # This series applies on GIT commit f954d68d5e8dc7eb0081ad7bc1ced9ff5ca687a7
 adjust-build-rules-for-debian.patch
 large-uid-skip-cpio-ustar.patch


### PR DESCRIPTION
#### Why I did it
Under BUILD with SONIC_BUILD_JOBS>1 the wall-clock sleep
checked by the 'grub_cmd_sleep' test may be blocked/delayed for some seconds
(e.g., sleep(10) measuring 13 seconds).
This failure is not due to GRUB logic and test should be decided OK.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Do not SLKIP this flake test, do not use SONIC_BUILD_JOBS=1,
but
Increase the fail-decision tolerance from 11sec to 14sec if SONIC_BUILD_JOBS>1
This change is done over grub2/patches/series: grub_cmd_sleep-increase-tolerance-to-14-sec.patch
NOTE:
The "series" file in <master> branch has an extra patch on the bottom vs <202511> branch.
To unify this PR for both branches and eliminate merge-conflict add the increase-tolerance patch on top of "series".

#### How to verify it
Build SONiC AMD64 with SONIC_BUILD_JOBS=8 and check it is passed successfully

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

#### Tested branch (Please provide the tested image version)
The 
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
#### Link to config_db schema for YANG module changes
#### A picture of a cute animal (not mandatory but encouraged)

