### PR TITLE
[build-hooks] Fix wget cache skip for trafficmanager.net URLs

### DIFF
--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -34,7 +34,7 @@ PKG_CACHE_FILE_NAME=${PKG_CACHE_PATH}/cache.tgz
 . ${BUILDINFO_PATH}/scripts/utils.sh
 
 
-URL_PREFIX=$(echo "${PACKAGE_URL_PREFIX}" | sed -E "s#(//[^/]*/).*#\1#")
+URL_PREFIX="${PACKAGE_URL_PREFIX}"
 
 log_err()
 {


### PR DESCRIPTION
## Description
The wget hook's `download_packages()` function in `buildinfo_base.sh` computes `URL_PREFIX` by stripping the path from `PACKAGE_URL_PREFIX`, keeping only the scheme and hostname (e.g., `https://packages.trafficmanager.net/`). Any URL matching this prefix is skipped entirely via `continue`, bypassing both download and version tracking.

After commit 805e1288a5 changed download URLs from `sonicstorage.blob.core.windows.net` to `packages.trafficmanager.net`, the download URLs (under `/public/`) now share the same hostname as `PACKAGE_URL_PREFIX` (under `/packages/`). This triggers the skip condition — wget silently produces no output and files are never created, breaking slave image builds on the 202505 branch.

## Root Cause
```bash
# Before (broken): strips path, matches any URL on the same host
URL_PREFIX=$(echo "${PACKAGE_URL_PREFIX}" | sed -E "s#(//[^/]*/).*#\1#")
# Result: https://packages.trafficmanager.net/

# After (fixed): uses full prefix, only matches proxy redirect URLs
URL_PREFIX="${PACKAGE_URL_PREFIX}"
# Result: https://packages.trafficmanager.net/packages
```

## Fix
Use the full `PACKAGE_URL_PREFIX` as `URL_PREFIX` so only actual proxy redirect URLs (under `/packages/`) are skipped, while download URLs under other paths (e.g., `/public/`) proceed normally.

Fixes #23352