### PR TITLE
[rsyslog] Fix Trixie restart delay with conditional restart

### DIFF
--- a/files/image_config/rsyslog/rsyslog-config.sh
+++ b/files/image_config/rsyslog/rsyslog-config.sh
@@ -40,8 +40,34 @@ if [ -z "$syslog_counter" ]; then
     syslog_counter="false"
 fi
 
+# Generate config to a temp file so we can compare before restarting.
+# On Debian 13 (Trixie), rsyslog.service has systemd sandboxing directives
+# (PrivateTmp, ProtectSystem, etc.) that add ~4 seconds of overhead per
+# restart due to namespace setup/teardown.  Skipping the restart when the
+# config is unchanged avoids this delay on warm/fast reboot and config_reload
+# where nothing actually changed.
+#
+# When the config IS unchanged we still send SIGHUP so rsyslog re-opens its
+# log files (needed after log rotation or /var/log remounts).
+#
+# See: https://github.com/sonic-net/sonic-buildimage/issues/25382
+
+TMPFILE=$(mktemp /tmp/rsyslog.conf.XXXXXX)
+trap 'rm -f "$TMPFILE"' EXIT
+
 sonic-cfggen -d -t /usr/share/sonic/templates/rsyslog.conf.j2 \
     -a "{\"udp_server_ip\": \"$udp_server_ip\", \"hostname\": \"$hostname\", \"docker0_ip\": \"$docker0_ip\", \"forward_with_osversion\": \"$syslog_with_osversion\", \"os_version\": \"$os_version\", \"syslog_counter\": \"$syslog_counter\"}" \
-    > /etc/rsyslog.conf
+    > "$TMPFILE"
 
-systemctl restart rsyslog
+if [ ! -f /etc/rsyslog.conf ] || ! cmp -s "$TMPFILE" /etc/rsyslog.conf; then
+    # Config changed (or first boot) — install and restart
+    if cp "$TMPFILE" /etc/rsyslog.conf; then
+        systemctl restart rsyslog
+    else
+        echo "Failed to update /etc/rsyslog.conf; not restarting rsyslog" >&2
+        exit 1
+    fi
+else
+    # Config unchanged — just signal rsyslog to re-open log files
+    systemctl kill -s HUP rsyslog
+fi


### PR DESCRIPTION
#### Why I did it
On Debian 13 (Trixie), `rsyslog.service` includes systemd sandboxing directives (`PrivateTmp`, `ProtectSystem`, `ProtectKernelTunables`, etc.) that add ~4 seconds of overhead per restart due to namespace setup/teardown. This causes syslog-dependent tests to fail by missing log messages during the extended restart window.

Fixes #25382

#### How I did it
Instead of always restarting rsyslog after generating the config, we now:

1. Generate the config to a unique temp file (`mktemp`)
2. Compare with the existing `/etc/rsyslog.conf` using `cmp -s`
3. **Config changed** (or first boot): install the new config and restart rsyslog
4. **Config unchanged**: send `SIGHUP` to rsyslog to re-open log files without a full restart

The `SIGHUP` fallback is critical — it ensures rsyslog re-opens its file handles even when the config has not changed (needed after log rotation or `/var/log` remounts), while completely avoiding the 4-second namespace teardown/setup cycle. This preserves the upstream Trixie sandboxing directives.

Additional hardening:
- `mktemp` for unique temp files with `trap`-based cleanup on exit
- Explicit first-boot handling (missing `/etc/rsyslog.conf`)
- Error handling on `cp` failure (do not restart with stale config)

#### How to verify it
1. Build a VS image with this change
2. Boot and verify rsyslog is running: `systemctl status rsyslog`
3. Run `config reload` — rsyslog should NOT restart (config unchanged), only SIGHUP:
   ```
   journalctl -u rsyslog --since "1 min ago"
   # Should show rsyslog re-opening files, NOT a stop/start cycle
   ```
4. Change a syslog config (e.g., add a remote server), run `config reload` — rsyslog should do a full restart
5. Run `syslog/test_logrotate.py` — both test cases should pass (SIGHUP re-opens files after /var/log remount)