### PR TITLE
Add `preserve_fqdn` to `SYSLOG_CONFIG` and toggle long/short hostname

### DIFF
--- a/files/image_config/rsyslog/rsyslog-config.sh
+++ b/files/image_config/rsyslog/rsyslog-config.sh
@@ -23,7 +23,12 @@ if [ $contain_dhcp_server ]; then
     docker0_ip=$(ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1)
 fi
 
-hostname=$(hostname)
+syslog_preserve_fqdn=$(sonic-db-cli CONFIG_DB hget "SYSLOG_CONFIG|GLOBAL" "preserve_fqdn")
+if [[ "$syslog_preserve_fqdn" == "true" ]]; then
+    hostname=$(hostname -f)
+else
+    hostname=$(hostname -s)
+fi
 
 syslog_with_osversion=$(sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "syslog_with_osversion")
 if [ -z "$syslog_with_osversion" ]; then

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -2373,7 +2373,8 @@ the system generates logs.
             "rate_limit_burst": "100",
             "format": "welf",
             "welf_firewall_name": "bla",
-            "severity": "info"
+            "severity": "info",
+            "preserve_fqdn": "false"
         }
     }
 }
@@ -2384,6 +2385,7 @@ the system generates logs.
 * `format` - syslog log format: `{standard, welf}`
 * `welf_firewall_name` - WELF format firewall name: `string`
 * `severity` - global log severity: `{emerg, alert, crit, error, warning, notice, info, debug}`
+* `preserve_fqdn` - preserve Fully Qualified Domain Name in remote syslog messages: `boolean`
 
 ***Syslog Rate Limit***
 

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/syslog.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/syslog.json
@@ -117,5 +117,8 @@
     "SYSLOG_CONFIG_SEVERITY_INVALID": {
         "desc": "Global invalid syslog severity",
         "eStrKey": "InvalidValue"
+    },
+    "SYSLOG_CONFIG_PRESERVE_FQDN_ENABLED": {
+        "desc": "Global syslog preserve FQDN flag"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/syslog.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/syslog.json
@@ -439,5 +439,14 @@
                 }
             }
         }
+    },
+    "SYSLOG_CONFIG_PRESERVE_FQDN_ENABLED": {
+        "sonic-syslog:sonic-syslog": {
+            "sonic-syslog:SYSLOG_CONFIG": {
+                "GLOBAL": {
+                    "preserve_fqdn": true
+                }
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-syslog.yang
+++ b/src/sonic-yang-models/yang-models/sonic-syslog.yang
@@ -187,6 +187,12 @@ module sonic-syslog {
                     description "Minimum severity level for local syslog messages.";
                 }
 
+                leaf preserve_fqdn {
+                    type boolean;
+                    description "Enable syslog to preserve FQDN in remote messages.";
+                    default "false";
+                }
+
             }
             /* end of list SYSLOG_CONFIG_LIST */
         }


### PR DESCRIPTION
Add `preserve_fqdn` to `SYSLOG_CONFIG` and update `hostname` in `rsyslog-config.sh` such that the remote syslog messages have the long/short hostname accordingly.
Fixes https://github.com/sonic-net/sonic-buildimage/issues/23863
[CLOSED] Original PR was https://github.com/sonic-net/sonic-buildimage/pull/23864.
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The original PR was https://github.com/sonic-net/sonic-buildimage/pull/23864.
This was closed since the changes for hardcoding the `hostname` got committed as part of https://github.com/sonic-net/sonic-buildimage/pull/24394

Currently, in SONiC, syslog messages are only sent with the shortened hostname, not the FQDN. It would be good to conditionally be able to toggle the hostname to the long (FQDN) or short form in remote syslog messages.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Added a new leaf - `preseve_fqdn` - to `SYSLOG_CONFIG` in `sonic-syslog.yang`
- Since any change inside `SYSLOG_CONFIG|GLOBAL` automatically triggers an `rsyslog-config` restart, I just added a check for `preserve_fqdn` in `rsyslog-config.sh` such that it sets the `hostname` to the long/short form correctly.
- Note that, adding `PreserveFQDN on|off` in the syslog config would have been an alternate solution, but that approach requires an update and restart of rsyslog in the host AS WELL AS all the containers separately since each run their own syslog daemon. This was a more disruptive solution and we chose to not go down that path.

#### How to verify it
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
Enabling `preserve_fqdn` and doing a tcpdump for the syslog messages shows the correct FQDN.
```
host$ show syslog
SERVER IP    SOURCE IP    PORT    VRF
-----------  -----------  ------  -----
10.11.0.5    N/A          N/A     N/A
10.11.0.6    N/A          N/A     N/A

host$ sonic-db-cli CONFIG_DB HSET "SYSLOG_CONFIG|GLOBAL" "preserve_fqdn" "true"
1

(snmp)root@host:/# logger --priority CRIT "Test syslog message from snmp container MSG1"

23:50:54.629484 lo    In  IP localhost.38482 > localhost.syslog: SYSLOG user.critical, length: 104
E.....@.@..H.........R...p..<10>2025-07-31T23:50:54.629330+00:00 <host_FQDN> snmp#root: Test syslog message from snmp container MSG1
23:50:54.629610 eth0  Out IP 10.250.15.2.36470 > 10.11.0.5.syslog: SYSLOG user.critical, length: 130
E....!@.@.M"
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Adding `preserve_fqdn` to `SYSLOG_CONFIG` to conditionally toggle the full/short hostname sent in syslog messages.
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
https://github.com/spandan-nexthop/sonic-buildimage/blob/spandan-nexthop.add-fqdn-syslog/src/sonic-yang-models/yang-models/sonic-syslog.yang#L184

#### A picture of a cute animal (not mandatory but encouraged)

