### PR TITLE
Fix: Skip git commands in container to avoid spurious errors

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -51,6 +51,15 @@ docker_try_rmi() {
 }
 
 sonic_get_version() {
+    # Detect if running in container (no .git in current dir)
+    # Skip git commands inside docker to avoid spurious "fatal: not a git repository" errors
+    if [ ! -d ".git" ]; then
+        # Container fallback: use BUILD_NUMBER as version
+        BUILD_NUMBER=${BUILD_NUMBER:-0}
+        echo "sonic.${BUILD_NUMBER}-container"
+        return 0
+    fi
+
     local describe=$(git describe --tags 2>/dev/null)
     local latest_tag=$(git describe --tags --abbrev=0 2>/dev/null)
     local branch_name=$(git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
Fixes #25529

When sonic_get_version() runs inside the docker slave container, the current directory is /sonic/ which is a bind-mounted directory without a .git folder. This causes spurious 'fatal: not a git repository' errors that clutter build logs and confuse users, even though the build succeeds.

This fix detects if we're running in a container (no .git present) and uses a simple fallback version string instead of running git commands.