### PR TITLE
[yang-mgmt] Downgrade loadData error log from ERR to WARNING

### DIFF
--- a/src/sonic-yang-mgmt/sonic_yang_ext.py
+++ b/src/sonic-yang-mgmt/sonic_yang_ext.py
@@ -1224,6 +1224,8 @@ class SonicYangExtMixin(SonicYangPathMixin):
     load_data: load Config DB, crop, xlate and create data tree from it. (Public)
     input:    configdbJson - will NOT be modified
               debug Flag
+              error_log_level - syslog level for data loading failures
+                                (default: syslog.LOG_WARNING)
     returns:  True - success   False - failed
     """
     def loadData(self, configdbJson, debug=False, error_log_level=syslog.LOG_WARNING):


### PR DESCRIPTION
### Description
[agent]

`loadData()` in `sonic_yang_ext.py` logs to syslog at `LOG_ERR` when YANG data validation fails. However, callers like GCU's `validate_config_db_config()` treat validation failure as an **expected outcome** during patch sorting — the exception is caught and the sorter simply tries a different move ordering.

This causes spurious `ERR sonic_yang: Data Loading Failed:Invalid JSON data (unexpected value).` entries in syslog even when `config apply-patch` operations succeed.

### Root Cause

During GCU patch sorting, `FullConfigMoveValidator` calls `validate_config_db_config()` → `loadData()` for many intermediate configurations. Invalid intermediate states are expected — the sorter catches the `SonicYangException` and tries other orderings. But the `LOG_ERR` syslog entry is already written before the exception is raised.

### Fix

- Change the default error log level in `loadData()` from `LOG_ERR` to `LOG_WARNING`
- Add an `error_log_level` parameter so callers can override if needed
- The exception is always re-raised, so callers that need ERR-level logging can pass `error_log_level=syslog.LOG_ERR` explicitly

### Testing

Reproduced on SONiC VS (master branch):
1. Created ACL table: `sudo config acl add table EVERFLOW MIRROR --ports Ethernet0,Ethernet4`
2. Applied patch: `[{"op": "replace", "path": "/ACL_TABLE/EVERFLOW/ports", "value": [""]}]`
3. **Before fix:** `journalctl -p err` shows `ERR sonic_yang: Data Loading Failed:Invalid JSON data (unexpected value).`
4. **After fix:** No ERR entries in syslog. Message appears at WARNING level only. Patch still applies successfully.

Fixes #24295