### PR TITLE
[SmartSwitch] Make bfb installer install first bfb-intermediate file found inside archive

### DIFF
--- a/platform/mellanox/sonic-bfb-installer.sh
+++ b/platform/mellanox/sonic-bfb-installer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
#### Why I did it
The existing sonic-bfb-installer.sh script does not install bfb-intermediate files if they do not match the name of the bfb package. This PR removes the check that the bfb-intermediate file has the same name as the bfb package and instead matches to the first bfb-intermediate file found so that the installation script is more robust and can support bfb tar archives that have custom names.

#### How I did it
Removed  grep "$(basename "$bfb_file")" 

#### How to verify it

Test by giving the tar archive a different name than the bfb-intermediate file inside it:

root@npu:/home/admin# mv sonic-nvidia-bluefield.bfb 202511_RC_sonic-nvidia-bluefield.bfb
root@npu:/home/admin# sonic-bfb-installer.sh -b 202511_RC_sonic-nvidia-bluefield.bfb -r all
Detected tar archive extracting BFB and SHA256 hash...
Extracted BFB file: /tmp/tmp.xZ6fYNmZPk/sonic-nvidia-bluefield.bfb-intermediate
Found SHA256 hash file: /tmp/tmp.xZ6fYNmZPk/sonic-nvidia-bluefield.bfb-intermediate.sha256
Verifying SHA256 checksum...
SHA256 checksum verification successful

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202511


#### Description for the changelog
Make bfb installer install first bfb-intermediate file found inside archive.

