### PR TITLE
[build] Drop --privileged in native dockerd mode, use specific capabilities

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -326,7 +326,18 @@ ifneq ($(SONIC_BUILD_MEMORY),none)
 endif
 endif
 
-DOCKER_RUN := docker run --rm=true --privileged --init \
+# When using native dockerd (DooD), we don't need --privileged for Docker-in-Docker.
+# Use specific capabilities instead for better security.
+# When using DinD (default), --privileged is required for the nested dockerd.
+ifeq ($(strip $(SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD)),y)
+DOCKER_PRIVMODE := --cap-add SYS_ADMIN --cap-add SYS_CHROOT --cap-add NET_ADMIN \
+    --cap-add MKNOD --cap-add DAC_OVERRIDE \
+    --security-opt apparmor=unconfined --security-opt seccomp=unconfined
+else
+DOCKER_PRIVMODE := --privileged
+endif
+
+DOCKER_RUN := docker run --rm=true $(DOCKER_PRIVMODE) --init \
     -v $(DOCKER_BUILDER_MOUNT) \
     -v "$(DOCKER_LOCKDIR):$(DOCKER_LOCKDIR)" \
     -w $(DOCKER_BUILDER_WORKDIR) \


### PR DESCRIPTION
## Problem

The build slave container always runs with `--privileged` (#5702), which grants full root capabilities to the container — a security concern for build hosts, especially shared CI/CD environments.

## Root Cause

The `--privileged` flag was originally needed for Docker-in-Docker (DinD), where `dockerd` runs inside the slave container. However, when using `SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD=y` (Docker-outside-of-Docker / DooD mode), the host's Docker socket is mounted instead — no nested `dockerd` is needed.

## Fix

Make the privilege mode conditional:

| Mode | Flag | Why |
|------|------|-----|
| **DinD** (default) | `--privileged` | Nested dockerd requires full privileges |
| **Native dockerd** (DooD) | Specific `--cap-add` | Only needs build-related capabilities |

Capabilities used in DooD mode:
- `SYS_ADMIN` — mount, debootstrap, overlayfs
- `SYS_CHROOT` — chroot for filesystem assembly  
- `NET_ADMIN` — network config in chroot
- `MKNOD` — device node creation
- `DAC_OVERRIDE` — file permission bypass for build ops

Plus `--security-opt apparmor=unconfined --security-opt seccomp=unconfined` to allow mount/chroot syscalls.

## Verification

```bash
# Native dockerd mode - uses specific capabilities
make -f Makefile.work SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD=y -p 2>/dev/null | grep DOCKER_PRIVMODE
# DOCKER_PRIVMODE := --cap-add SYS_ADMIN --cap-add SYS_CHROOT ...

# Default DinD mode - retains --privileged  
make -f Makefile.work -p 2>/dev/null | grep DOCKER_PRIVMODE
# DOCKER_PRIVMODE := --privileged
```

Follows the same pattern as #25089 (docker-gnmi container hardening) and the [SONiC Container Hardening HLD](https://github.com/sonic-net/SONiC/blob/master/doc/Container%20Hardening/SONiC_container_hardening_HLD.md).

Partially addresses #5702