### PR TITLE
Fix dhcp_dos_logger.py to wait for PortInitDone before starting

### DIFF
--- a/files/image_config/dhcp_dos_logger/dhcp_dos_logger.py
+++ b/files/image_config/dhcp_dos_logger/dhcp_dos_logger.py
@@ -56,8 +56,9 @@ def wait_for_port_init_done():
     Wait for PortInitDone event from APP_DB.
 
     Returns:
-        None (blocks until PortInitDone is received)
+        None (blocks until PortInitDone is received or timeout occurs)
     """
+    MAX_WAIT_SECONDS = 300
     appl_db = daemon_base.db_connect("APPL_DB")
 
     sel = swsscommon.Select()
@@ -65,8 +66,14 @@ def wait_for_port_init_done():
     sel.addSelectable(sst)
 
     logger.log_info("Waiting for PortInitDone...")
+    start_time = time.time()
     while True:
         (state, _) = sel.select(1000)
+        elapsed = time.time() - start_time
+
+        if elapsed >= MAX_WAIT_SECONDS:
+            logger.log_warning("Timed out waiting for PortInitDone, proceeding anyway")
+            return
 
         if state == swsscommon.Select.TIMEOUT:
             continue
@@ -75,7 +82,7 @@ def wait_for_port_init_done():
             continue
 
         while True:
-            (key, op, fvp) = sst.pop()
+            (key, _, _) = sst.pop()
             if not key:
                 break
 


### PR DESCRIPTION
Fix dhcp_dos_logger.py to wait for PortInitDone before running tc commands on any interfaces.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Addressing the flaky issue mentioned in [Issue](https://github.com/sonic-net/sonic-buildimage/issues/25556)

When config reload happens, dhcp_dos_logger service is restarted and it keeps executing tc command for various interfaces.
During this time, the ports are being removed and reinitialized which causes a the tc commands to fail sometimes when the ports are not in usable states.
The expectation is that dhcp_dos_logger should wait for portInitDone and only then execute tc commands.

#### How I did it
Introduced a wait function in dhcp_dos_logger.py to wait for PortInitDone notification.

#### How to verify it
Can be verified by multiple rounds of config reload and we must not see the following error - 
`ERR dhcp_dos_logger.py: TC command failed for Ethernet\d*: Cannot find device \\"Ethernet\d*\\"`

#### Testing
Manual - ran reload config in repetition to find out no error was seen from dhcp logger.

fix testing - 
Tested this in these two scenarios -
1) When port init phase is happening -
Steps -> do config reload, and see the wait time for the PortInitDone
notification in dhcp dos logger logs.
(Here wait time was found to be around 40 seconds)
logs-
```
Feb 17 03:46:55 ld595 dhcp_dos_logger.py[39636]: Waiting for PortInitDone...
Feb 17 03:47:37 ld595 dhcp_dos_logger.py[39636]: PortInitDone received
```

2) When port init is already done -
Steps -> when system is stable just restart dhcp_dos_logger service, and
see the wait time for the PortInitDone notification in dhcp dos logger logs.
(Here wait time was found to be around 0.1 seconds)
logs-
```
Feb 17 03:48:33 ld595 dhcp_dos_logger.py[46357]: Waiting for PortInitDone...
Feb 17 03:48:33 ld595 dhcp_dos_logger.py[46357]: PortInitDone received
```

#### Which release branch to backport (provide reason below if selected)



- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511