### PR TITLE
eventd: zmq: Use custom ports for test cases to prevent conflicts with other tests

### DIFF
--- a/src/sonic-eventd/tests/main.cpp
+++ b/src/sonic-eventd/tests/main.cpp
@@ -1,5 +1,8 @@
 #include "gtest/gtest.h"
 #include <swss/dbconnector.h>
+#include <swss/events_common.h>
+#include <cstdio>
+#include <fstream>
 #include <iostream>
 #include <stdexcept>
 
@@ -20,6 +23,24 @@ class SwsscommonEnvironment : public ::testing::Environment {
 public:
     // Override this to define how to set up the environment
     void SetUp() override {
+        // Set up ZMQ custom ports so other tests don't interfere
+        cout << "Setting custom ZMQ ports" << endl;
+        std::string configfilename = std::tmpnam(nullptr);
+        EXPECT_FALSE(configfilename.empty());
+        ofstream configfile(configfilename);
+        EXPECT_TRUE(configfile.is_open());
+        configfile <<
+            "{\n"
+            "  \"events\" : {\n"
+            "     \"xsub_path\": \"tcp://127.0.0.1:25570\",\n"
+            "     \"xpub_path\": \"tcp://127.0.0.1:25571\",\n"
+            "     \"capture_path\": \"tcp://127.0.0.1:25573\"\n"
+            "  }\n"
+            "}\n";
+        configfile.close();
+        read_init_config(configfilename.c_str());
+        remove(configfilename.c_str());
+
         // by default , init should be false
         cout << "Default : isInit = " << SonicDBConfig::isInit() << endl;
         EXPECT_FALSE(SonicDBConfig::isInit());


### PR DESCRIPTION
#### Why I did it

By default ZMQ ports are opened up on the standard ports SONiC uses.  When other tests run they may inject data into these ports, it can cause tests to fail due to unexpected data.  One instance identified was when sonic-supervisord-utilities-rs test were run at the same time. sonic-supervisord-ubilities-rs has logic to ignore errors in sending events as it doesn't expect the ports to be online.

#### How I did it

This patch creates a temporary configuration file and injects it early into the initialization to listen on non-standard ZMQ ports.

This can fix errors during tests such as:
```
{ ("d", "{\"sonic-events-host:process-exited-unexpectedly\":{\"ctr_name\":\"swss\",\"process_name\":\"orchagent\",\"timestamp\":\"2026-02-17T17:06:20.744756Z\"}}"), ("r", "29e93237-697d-4969-9a85-e332b9eb9681"), ("s", "1"), ("t", "1771347980745085222") }, { ("d", "CONTROL_DEINIT"), ("r", "29e93237-697d-4969-9a85-e332b9eb9681"), ("s", "2"), ("t", "1771347980746220186") }
```

#### How to verify it

Run sonic-eventd and sonic-supervisord-ubilities-rs tests simultaneously.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

Master as of 2026-02-18

#### Description for the changelog

ZMQ: Use custom ports for test cases to prevent conflicts with other tests

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

Fixes #25543