### PR TITLE
Include generated services in Sysmonitor

### DIFF
--- a/src/system-health/health_checker/sysmonitor.py
+++ b/src/system-health/health_checker/sysmonitor.py
@@ -327,7 +327,7 @@ class Sysmonitor(ProcessTaskBase):
                 #Raise syslog for service state change
                 logger.log_info("{} service state changed to [{}/{}]".format(event, active_state, sub_state))
 
-                if status == "enabled" or status == "enabled-runtime" or status == "static":
+                if status in ("enabled", "enabled-runtime", "static", "generated"):
                     if fail_reason == "success":
                         fail_reason = "-"
                     if (active_state == "active" and sub_state == "exited"):

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -789,7 +789,9 @@ def test_get_app_ready_status(mock_config_db, mock_run, mock_docker_client):
 
 mock_srv_props={
 'mock_radv.service':{'Type': 'simple', 'Result': 'success', 'Id': 'mock_radv.service', 'LoadState': 'loaded', 'ActiveState': 'active', 'SubState': 'running', 'UnitFileState': 'enabled'},
-'mock_bgp.service':{'Type': 'simple', 'Result': 'success', 'Id': 'mock_bgp.service', 'LoadState': 'loaded', 'ActiveState': 'inactive', 'SubState': 'dead', 'UnitFileState': 'enabled'}
+'mock_bgp.service':{'Type': 'simple', 'Result': 'success', 'Id': 'mock_bgp.service', 'LoadState': 'loaded', 'ActiveState': 'inactive', 'SubState': 'dead', 'UnitFileState': 'enabled'},
+'mock_swss_generated.service':{'Type': 'simple', 'Result': 'success', 'Id': 'mock_swss_generated.service', 'LoadState': 'loaded', 'ActiveState': 'active', 'SubState': 'running', 'UnitFileState': 'generated'},
+'mock_syncd_generated.service':{'Type': 'simple', 'Result': 'success', 'Id': 'mock_syncd_generated.service', 'LoadState': 'loaded', 'ActiveState': 'inactive', 'SubState': 'dead', 'UnitFileState': 'generated'}
 }
 
 @patch('health_checker.sysmonitor.Sysmonitor.get_all_service_list', MagicMock(return_value=['mock_snmp.service', 'mock_bgp.service', 'mock_ns.service']))
@@ -855,6 +857,28 @@ def test_get_unit_status_not_ok():
     sysmon = Sysmonitor()
     result = sysmon.get_unit_status('mock_bgp.service')
     print("get_unit_status:{}".format(result))
+    assert result == 'NOT OK'
+
+
+@patch('health_checker.sysmonitor.Sysmonitor.run_systemctl_show', MagicMock(return_value=mock_srv_props['mock_swss_generated.service']))
+@patch('health_checker.sysmonitor.Sysmonitor.get_app_ready_status', MagicMock(return_value=('Up','-','-')))
+@patch('health_checker.sysmonitor.Sysmonitor.post_unit_status', MagicMock())
+def test_get_unit_status_generated_running_ok():
+    """Test that active/running services with UnitFileState=generated are reported as OK."""
+    sysmon = Sysmonitor()
+    result = sysmon.get_unit_status('mock_swss_generated.service')
+    print("get_unit_status for generated running service:{}".format(result))
+    assert result == 'OK'
+
+
+@patch('health_checker.sysmonitor.Sysmonitor.run_systemctl_show', MagicMock(return_value=mock_srv_props['mock_syncd_generated.service']))
+@patch('health_checker.sysmonitor.Sysmonitor.get_app_ready_status', MagicMock(return_value=('Up','-','-')))
+@patch('health_checker.sysmonitor.Sysmonitor.post_unit_status', MagicMock())
+def test_get_unit_status_generated_inactive_not_ok():
+    """Test that inactive services with UnitFileState=generated are reported as NOT OK."""
+    sysmon = Sysmonitor()
+    result = sysmon.get_unit_status('mock_syncd_generated.service')
+    print("get_unit_status for generated inactive service:{}".format(result))
     assert result == 'NOT OK'
 
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Starting from the systemd version used in Debian Trixie (systemd 257), `systemd-sonic-generator` creates service unit files in `/run/systemd/generator/` to handle multi-instance dependency expansion on DPU and multi-ASIC platforms. systemd marks these units as `UnitFileState=generated` instead of `enabled` or `static`.

`sysmonitor` did not recognize `"generated"` as a valid state, causing these services to be silently skipped during health checks — they were missing from `show system-health sysready-status` and `STATE_DB ALL_SERVICE_STATUS`.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Adds `"generated"` to the accepted `UnitFileState` values in `sysmonitor.py`, so that services with `UnitFileState=generated` are correctly reported in `show system-health sysready-status`.

This 1-line change adds `"generated"` to the accepted states so that all services are properly monitored regardless of where their unit file resides.

#### Tests

Added two unit tests to verify that the `generated` state is handled correctly:

- `test_get_unit_status_generated_running_ok` — a service with `UnitFileState=generated` and `ActiveState=active` is reported as OK
- `test_get_unit_status_generated_inactive_not_ok` — a service with `UnitFileState=generated` and `ActiveState=inactive` is reported as NOT OK

#### How to verify it

`show system-health sysready-status`

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

