### PR TITLE
Add kubernetes Python library to sonic-mgmt container

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -127,6 +127,7 @@ RUN pip install --no-cache-dir \
     tabulate \
     textfsm \
     thrift \
+    kubernetes \
     && wget https://github.com/nanomsg/nanomsg/archive/refs/tags/1.2.1.tar.gz \
     && tar xvfz 1.2.1.tar.gz \
     && cd nanomsg-1.2.1      \


### PR DESCRIPTION
Add kubernetes Python package to docker-sonic-mgmt for kubesonic test automation support.

The Python library provides K8s API access for tests that verify SONiC's Kubernetes integration (kubesonic).

Note: kubectl binary is not needed - tests use:
- Python kubernetes library for API operations
- minikube kubectl on vmhost for cluster management

#### Why I did it

Enable kubesonic integration tests in sonic-mgmt. The tests use Python kubernetes client to interact with the K8s cluster API.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added `kubernetes` to the pip install list in docker-sonic-mgmt Dockerfile.

#### How to verify it

Build sonic-mgmt container and verify kubernetes package is installed:
```bash
python -c "import kubernetes; print(kubernetes.__version__)"
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] 
- [ ] 

#### Description for the changelog

Add kubernetes Python library to sonic-mgmt container for kubesonic test support.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

