### PR TITLE
Yang: COPP_TRAP_EXCLUDE_PORTS model

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -21,7 +21,7 @@
   * [Buffer port egress profile list](#buffer-port-egress-profile-list)
   * [Cable length](#cable-length)
   * [Chassis module](#chassis-module)
-  * [COPP_TABLE](#copp_table)
+  * [COPP](#copp)
   * [Console](#console)
   * [CRM](#crm)
   * [CRM DASH](#crm-dash)
@@ -816,7 +816,9 @@ It currently allows user to administratively bring down a line-card or fabric-ca
 
 ```
 
-### COPP_TABLE
+### COPP
+
+#### COPP_TABLE
 
 ```
 {
@@ -867,6 +869,23 @@ It currently allows user to administratively bring down a line-card or fabric-ca
 	 "trap_ids": "ip2me",
 	 "trap_priority": "1"
       }
+    }
+}
+```
+
+#### COPP_TRAP_EXCLUDE_PORTS
+
+Exclude ports from CoPP Traps.  In some cases, such as sonic-mgmt testbeds, LACP and LLDP packets may be trapped
+instead of being relayed to the desired endpoint.  This allows configuration to exclude ports from traps to allow
+these packets to flow all the way to the desired endpoint.  By default all ports on a switch will have the standard
+traps applied.
+
+```
+{
+    "COPP_TRAP_EXCLUDE_PORTS": {
+        "GLOBAL": {
+            "ports": [ "Ethernet0", "Ethernet4"]
+        }
     }
 }
 ```

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2032,7 +2032,11 @@
                 "trap_group": "queue1_group1"
             }
         },
-
+        "COPP_TRAP_EXCLUDE_PORTS": {
+            "GLOBAL": {
+                "ports": [ "Ethernet0", "Ethernet4" ]
+            }
+        },
         "AUTO_TECHSUPPORT": {
             "GLOBAL": {
                 "state" : "enabled",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/copp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/copp.json
@@ -25,5 +25,12 @@
     "COPP_GROUP_WHEN_SRTCM_WITH_PIR": {
     "desc": "Configure COPP_GROUP with srtcm and pir.",
     "eStrKey" : "When"
+    },
+    "COPP_TRAP_EXCLUDE_PORTS_ALL_VALID": {
+        "desc": "Configure CoPP trap exclusion list valid ports."
+    },
+    "COPP_TRAP_EXCLUDE_PORT_INVALID_PORT": {
+        "desc": "Reference invalid port",
+        "eStrKey": "LeafRef"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/copp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/copp.json
@@ -143,5 +143,45 @@
                 }]
             }
         }
+    },
+
+    "COPP_TRAP_EXCLUDE_PORTS_ALL_VALID": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "speed": 25000,
+                        "lanes": "65"
+                    }
+                ]
+            }
+        },
+        "sonic-copp:sonic-copp": {
+            "sonic-copp:COPP_TRAP_EXCLUDE_PORTS": {
+                "GLOBAL": {
+                    "ports": [
+                       "Ethernet0"
+                    ]
+                }
+            }
+        }
+    },
+
+    "COPP_TRAP_EXCLUDE_PORT_INVALID_PORT": {
+        "sonic-copp:sonic-copp": {
+            "sonic-copp:COPP_TRAP_EXCLUDE_PORTS": {
+                "GLOBAL": {
+                    "ports": [
+                       "Ethernet0"
+                    ]
+                }
+            }
+        }
     }
+
 }

--- a/src/sonic-yang-models/yang-models/sonic-copp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-copp.yang
@@ -9,11 +9,18 @@ module sonic-copp {
 		prefix stypes;
 	}
 
+	import sonic-port {
+		prefix port;
+	}
+
 	description "CoPP YANG Module for SONiC OS";
 
 	revision 2021-03-31 {
-		description
-			"First Revision";
+		description "First Revision";
+	}
+
+	revision 2026-01-09 {
+		description "Add COPP_TRAP_EXCLUDE_PORTS";
 	}
 
 	container sonic-copp {
@@ -168,6 +175,21 @@ module sonic-copp {
 			/* end of list COPP_TRAP_LIST */
 		}
 		/* end of container COPP_TRAP */
+
+		container COPP_TRAP_EXCLUDE_PORTS {
+			description "List of ports to exclude from CoPP traps";
+
+			container GLOBAL {
+				leaf-list ports {
+					type leafref {
+						path /port:sonic-port/port:PORT/port:PORT_LIST/port:name;
+					}
+					ordered-by user;
+				}
+			}
+			/* end of container GLOBAL */
+		}
+		/* end of container COPP_TRAP_EXCLUDE_PORTS */
 	}
 	/* end of top level container */
 


### PR DESCRIPTION
#### Why I did it

Exclude ports from CoPP Traps.  In some cases, such as sonic-mgmt testbeds, LACP and LLDP packets may be trapped
instead of being relayed to the desired endpoint.  This allows configuration to exclude ports from traps to allow
these packets to flow all the way to the desired endpoint.  By default all ports on a switch will have the standard
traps applied.

Implementation in https://github.com/sonic-net/sonic-swss/pull/4234

HLD update: https://github.com/sonic-net/SONiC/pull/2229

#### How I did it

This is just a basic Yang model and validation of the Yang model.  The real implementation is in sonic-swss.

#### How to verify it

Run tests included in this PR.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

master as of 2026-01-09

#### Description for the changelog
Yang model implementation and tests for CoPP trap exclude ports

#### Link to config_db schema for YANG module changes
https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#copp_trap_exclude_ports

#### A picture of a cute animal (not mandatory but encouraged)

Fixes #25570 