### PR TITLE
Use uniform mode for IPinIP packet dscp decap on cisco gr2

### DIFF
--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -15,7 +15,7 @@
 
 {# Check if the ASIC is Cisco GR2 #}
 {% set is_cisco_gr2 = false %}
-{%- set gr2_pid_list = ["x86_64-8122_64ehf_o-r0", "x86_64-8122_64eh_o-r0", "x86_64-8122_64ehf-r0", "x86_64-8122_64ehf_g-r0", "x86_64_8121-16ehf-bp_o-r0", "x86_64_hf-64eh-o-r0", "x86_64-hf6100-64ed-o-r0"] %}
+{%- set gr2_pid_list = ["x86_64-8122_64eh_o-r0", "x86_64-8122_64ehf_o-r0", "x86_64-8122_64ehf_g-r0", "x86_64-8121_16ehf_bp_o-r0", "x86_64-hf6100_64ed-r0"] %}
 {% if DEVICE_METADATA['localhost']['platform'] in gr2_pid_list %}
   {% set is_cisco_gr2 = true %}
 {% endif %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Cisco G200 (asic gr2) doesn't support dscp decap pipe mode.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Set dscp decap mode to uniform if it is cisco gr2 devices.

#### How to verify it
Verified on gr2 device.
```
admin@light-dut:~$ docker exec -it swss bash
root@light-dut:/# vi /usr/share/sonic/templates/ipinip.json.j2.new
root@light-dut:/# cd /etc/swss/config.d
root@light-dut:/etc/swss/config.d# sonic-cfggen -d -t /usr/share/sonic/templates/ipinip.json.j2.new > ipinip.json.new
root@light-dut:/etc/swss/config.d# diff ipinip.json ipinip.json.new
3a4
>   
10c11
<             "dscp_mode":"pipe",
---
>             "dscp_mode":"uniform",
170c171
<             "dscp_mode":"pipe",
---
>             "dscp_mode":"uniform",
327a329
> 
root@light-dut:/etc/swss/config.d# grep dscp ipinip.json.new 
            "dscp_mode":"uniform",
            "decap_dscp_to_tc_map":"AZURE",
            "dscp_mode":"uniform",
            "decap_dscp_to_tc_map":"AZURE",
root@light-dut:/etc/swss/config.d# 
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

