### PR TITLE
remove spaces before processing dhcp relays info in minigraph

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1064,13 +1064,13 @@ def parse_dpg(dpg, hname):
             # containing a list of DHCP server IPs
             vintf_node = vintf.find(str(QName(ns, "DhcpRelays")))
             if vintf_node is not None and vintf_node.text is not None:
-                vintfdhcpservers = vintf_node.text
+                vintfdhcpservers = vintf_node.text.strip()
                 vdhcpserver_list = vintfdhcpservers.split(';')
                 vlan_attributes['dhcp_servers'] = vdhcpserver_list
 
             vintf_node = vintf.find(str(QName(ns, "Dhcpv6Relays")))
             if vintf_node is not None and vintf_node.text is not None:
-                vintfdhcpservers = vintf_node.text
+                vintfdhcpservers = vintf_node.text.strip()
                 vdhcpserver_list = vintfdhcpservers.split(';')
                 vlan_attributes['dhcpv6_servers'] = vdhcpserver_list
                 dhcp_attributes['dhcpv6_servers'] = vdhcpserver_list


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

dhcp_relay container crashes if the server list has '\n' in minigraph.  This PR is to enhance it with more robustness. 

Example minigraph:
```
                    <DhcpRelays>
                        10.10.10.1;10.10.10.31;10.10.10.41</DhcpRelays>
```

After load_minigraph, the above config will be converted to the following:
```
            "dhcp_servers": [
                "\n                        10.10.10.1",     >>>>> extra "\n" in config db causing dhcp_relay agent crash.
......
            ],
```

and cause crash:

ERR dhcp_relay#dhcprelayd: Running processes is not as expected! Runnning: [['/usr/sbin/dhcrelay', '-d', '-m', 'discard', '-a', '%h:%p', '%P', '--name-alias-map-file', '/tmp/port-name-alias-map.txt', '-id', 'Vlan7', '-iu', 'PortChannel1', '-iu', 'PortChannel2', '-iu', 'PortChannel3', '-iu', 'PortChannel4', '10.10.10.1', '10.10.10.31', '10.10.10.41']]. Expected: [['/usr/sbin/dhcrelay', '-d', '-m', 'discard', '-a', '%h:%p', '%P', '--name-alias-map-file', '/tmp/port-name-alias-map.txt', '-id', 'Vlan7', '-iu', 'PortChannel1', '-iu', 'PortChannel2', '-iu', 'PortChannel3', '-iu', 'PortChannel4', '']]




##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
remove white spaces before processing it.

#### How to verify it
verified in local testbed.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

