### PR TITLE
Fix lldpmgrd crash on DEVICE_METADATA events for non-localhost keys

### DIFF
--- a/dockers/docker-lldp/lldpmgrd
+++ b/dockers/docker-lldp/lldpmgrd
@@ -81,6 +81,9 @@ class LldpManager(daemon_base.DaemonBase):
         self.port_init_done = False
 
     def update_hostname(self, hostname):
+        if not hostname:
+            self.log_warning("Ignoring invalid hostname: '{}'".format(hostname))
+            return
         cmd = ["lldpcli", "configure", "system", "hostname", hostname]
         self.log_debug("Running command: '{}'".format(cmd))
 
@@ -244,12 +247,11 @@ class LldpManager(daemon_base.DaemonBase):
     def lldp_process_device_table_event(self, op, device_dict, key):
         if not op in ["SET", "DEL"]:
             return
+        if key != "localhost":
+            return
         self.log_info("Device Config Opcode: {} Dict {} Key {}".format(op, device_dict, key))
-        try:
-            hostname = device_dict["chassis_hostname"]
-        except:
-            hostname = device_dict.get("hostname")
-        if not self.hostname == hostname:
+        hostname = device_dict.get("chassis_hostname") or device_dict.get("hostname")
+        if hostname and not self.hostname == hostname:
             self.log_info("Hostname changed old {0}, new {1}".format(self.hostname, hostname))
             self.update_hostname(hostname)
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

After a power-cycle reboot, `lldpmgrd` crashes with an unhandled `TypeError` when processing `DEVICE_METADATA` table events for non-`localhost` keys (e.g., `bmc`). These keys do not contain `hostname` or `chassis_hostname` fields, so the hostname resolves to `None`, which is then passed to `subprocess.Popen` causing:

```
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

Since `lldpmgrd` is configured with `autorestart=false` in supervisord, the process stays dead after crashing, which fails the critical process health check and causes test failures (e.g., `test_power_off_reboot`).

The crash sequence is:
1. On boot, `lldpmgrd` subscribes to `DEVICE_METADATA` table changes and receives SET events for all keys (including `localhost` and `bmc`).
2. The `localhost` event sets `self.hostname` to a valid value (e.g., `"ch5s-164"`).
3. The `bmc` event has no hostname field, so hostname resolves to `None`.
4. Since `self.hostname ("ch5s-164") != None`, `update_hostname(None)` is called.
5. `subprocess.Popen(["lldpcli", "configure", "system", "hostname", None])` raises `TypeError`.
6. The unhandled exception kills the `lldpmgrd` process.

This affects any platform with non-`localhost` entries in `DEVICE_METADATA` (e.g., BMC-enabled platforms like SN5810).


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Three changes in `dockers/docker-lldp/lldpmgrd`:

1. **`lldp_process_device_table_event`**: Added `if key != "localhost": return` to skip events for non-`localhost` keys (e.g., `bmc`, `chassis`, `linecard`). Only the `localhost` key carries hostname information.

2. **`lldp_process_device_table_event`**: Simplified hostname extraction from `try/except` to `device_dict.get("chassis_hostname") or device_dict.get("hostname")`, and added a `hostname` truthiness check before calling `update_hostname`. This eliminates the bare `except:` clause and guards against `None` at the call site.

3. **`update_hostname`**: Added `if not hostname:` validation at the top to reject `None` or empty hostnames with a warning log, and wrapped the `subprocess.Popen` call in a `try/except Exception` block as defense-in-depth.


#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

1. **Functional test on switch** — Create a `DEVICE_METADATA|bmc` entry and verify `lldpmgrd` survives:
   ```bash
   # Record PID before
   docker exec lldp supervisorctl pid lldpmgrd

   # Trigger the event that previously caused the crash
   sudo redis-cli -n 4 hset "DEVICE_METADATA|bmc" "bmc_addr" "169.254.0.1" "bmc_net_mask" "255.255.255.252"
   sleep 5

   # Verify lldpmgrd is still running with same PID
   docker exec lldp supervisorctl status lldpmgrd

   # Cleanup
   sudo redis-cli -n 4 DEL "DEVICE_METADATA|bmc"
   ```

2. **Hostname update still works** — Verify normal hostname changes propagate to lldpd:
   ```bash
   sudo redis-cli -n 4 hset "DEVICE_METADATA|localhost" "hostname" "test-hostname"
   sleep 5
   docker exec lldp lldpcli show chassis | grep SysName
   # Should show: SysName: test-hostname

   # Restore
   sudo redis-cli -n 4 hset "DEVICE_METADATA|localhost" "hostname" "<original>"
   ```



#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

