### PR TITLE
Add SONIC_CONFIG_USE_DOCKER_CACHE to allow Docker layer caching

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -456,8 +456,13 @@ SPLIT_LOG = 2>&1 | tee
 DOCKER_BASE_LOG = $(SLAVE_DIR)/$(SLAVE_BASE_IMAGE)_$(SLAVE_BASE_TAG).log
 DOCKER_LOG = $(SLAVE_DIR)/$(SLAVE_IMAGE)_$(SLAVE_TAG).log
 
+# When SONIC_CONFIG_USE_DOCKER_CACHE is enabled, allow Docker layer caching
+# by omitting --no-cache. This speeds up incremental builds significantly.
+ifneq ($(strip $(SONIC_CONFIG_USE_DOCKER_CACHE)),y)
+DOCKER_NO_CACHE_FLAG = --no-cache
+endif
 
-DOCKER_SLAVE_BASE_BUILD = docker build --no-cache \
+DOCKER_SLAVE_BASE_BUILD = docker build $(DOCKER_NO_CACHE_FLAG) \
 		    -t $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) \
 		    --build-arg http_proxy=$(http_proxy) \
 		    --build-arg https_proxy=$(https_proxy) \
@@ -470,7 +475,7 @@ DOCKER_SLAVE_BASE_BUILD = docker build --no-cache \
 DOCKER_BASE_PULL = docker pull \
 			$(REGISTRY_SERVER):$(REGISTRY_PORT)$(REGISTRY_SERVER_PATH)/$(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG)
 
-DOCKER_USER_BUILD = docker build --no-cache \
+DOCKER_USER_BUILD = docker build $(DOCKER_NO_CACHE_FLAG) \
 	       --build-arg user=$(USER) \
 	       --build-arg uid=$(shell id -u) \
 	       --build-arg guid=$(shell id -g) \
@@ -587,6 +592,7 @@ SONIC_BUILD_INSTRUCTION :=  $(MAKE) \
                            DOCKER_LOCKDIR=$(DOCKER_LOCKDIR) \
                            DOCKER_LOCKFILE_SAVE=$(DOCKER_LOCKFILE_SAVE) \
                            SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD=$(SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD) \
+                           SONIC_CONFIG_USE_DOCKER_CACHE=$(SONIC_CONFIG_USE_DOCKER_CACHE) \
                            SONIC_INCLUDE_SYSTEM_TELEMETRY=$(INCLUDE_SYSTEM_TELEMETRY) \
                            SONIC_INCLUDE_SYSTEM_GNMI=$(INCLUDE_SYSTEM_GNMI) \
                            SONIC_INCLUDE_SYSTEM_BMP=$(INCLUDE_SYSTEM_BMP) \

--- a/rules/config
+++ b/rules/config
@@ -390,3 +390,9 @@ BUILD_PROCESS_TIMEOUT ?= 0
 
 # BUILD_SKIP_TEST - skip all tests when building to reduce build time
 BUILD_SKIP_TEST ?= n
+# SONIC_CONFIG_USE_DOCKER_CACHE - use Docker layer cache for image builds.
+# Removes --no-cache from docker build commands, allowing unchanged layers
+# to be reused. Significantly speeds up incremental builds (~20+ min savings)
+# but may use stale layers if base images changed without version bumps.
+# Recommended for local development; CI should leave this disabled.
+# SONIC_CONFIG_USE_DOCKER_CACHE = y

--- a/slave.mk
+++ b/slave.mk
@@ -342,6 +342,11 @@ endif
 MAKEFLAGS += -j $(SONIC_BUILD_JOBS)
 export SONIC_CONFIG_MAKE_JOBS
 
+# When SONIC_CONFIG_USE_DOCKER_CACHE is enabled, allow Docker layer caching
+ifneq ($(strip $(SONIC_CONFIG_USE_DOCKER_CACHE)),y)
+DOCKER_NO_CACHE_FLAG = --no-cache
+endif
+
 ifeq ($(CONFIGURED_PLATFORM),vs)
 export BUILD_MULTIASIC_KVM
 endif
@@ -425,6 +430,7 @@ $(info "SONIC_CONFIG_PRINT_DEPENDENCIES" : "$(SONIC_CONFIG_PRINT_DEPENDENCIES)")
 $(info "SONIC_BUILD_JOBS"                : "$(SONIC_BUILD_JOBS)")
 $(info "SONIC_CONFIG_MAKE_JOBS"          : "$(SONIC_CONFIG_MAKE_JOBS)")
 $(info "USE_NATIVE_DOCKERD_FOR_BUILD"    : "$(SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD)")
+$(info "USE_DOCKER_CACHE"               : "$(SONIC_CONFIG_USE_DOCKER_CACHE)")
 $(info "USERNAME"                        : "$(USERNAME)")
 $(info "PASSWORD"                        : "$(PASSWORD)")
 $(info "CHANGE_DEFAULT_PASSWORD"         : "$(CHANGE_DEFAULT_PASSWORD)")
@@ -1084,7 +1090,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_SIMPLE_DOCKER_IMAGES)) : $(TARGET_PATH)/%.g
 	DBGOPT='$(DBGOPT)' \
 	scripts/prepare_docker_buildinfo.sh $* $($*.gz_PATH)/Dockerfile $(CONFIGURED_ARCH) $(TARGET_DOCKERFILE)/Dockerfile.buildinfo $(LOG)
 	docker info $(LOG)
-	docker build --no-cache \
+	docker build $(DOCKER_NO_CACHE_FLAG) \
 		--build-arg http_proxy=$(HTTP_PROXY) \
 		--build-arg https_proxy=$(HTTPS_PROXY) \
 		--build-arg no_proxy=$(NO_PROXY) \
@@ -1253,7 +1259,7 @@ $(addprefix $(TARGET_PATH)/, $(DOCKER_IMAGES)) : $(TARGET_PATH)/%.gz : .platform
 		DBGOPT='$(DBGOPT)' \
 		scripts/prepare_docker_buildinfo.sh $* $($*.gz_PATH)/Dockerfile $(CONFIGURED_ARCH) $(LOG)
 		docker info $(LOG)
-		docker build --no-cache \
+		docker build $(DOCKER_NO_CACHE_FLAG) \
 			--build-arg http_proxy=$(HTTP_PROXY) \
 			--build-arg https_proxy=$(HTTPS_PROXY) \
 			--build-arg no_proxy=$(NO_PROXY) \
@@ -1324,7 +1330,7 @@ $(addprefix $(TARGET_PATH)/, $(DOCKER_DBG_IMAGES)) : $(TARGET_PATH)/%-$(DBG_IMAG
 		scripts/prepare_docker_buildinfo.sh $*-dbg $($*.gz_PATH)/Dockerfile-dbg $(CONFIGURED_ARCH) $(LOG)
 		docker info $(LOG)
 		docker build \
-			--no-cache \
+			$(DOCKER_NO_CACHE_FLAG) \
 			--build-arg http_proxy=$(HTTP_PROXY) \
 			--build-arg https_proxy=$(HTTPS_PROXY) \
 			--build-arg no_proxy=$(NO_PROXY) \


### PR DESCRIPTION
## Description

Add a build config knob (`SONIC_CONFIG_USE_DOCKER_CACHE`) to control Docker's `--no-cache` flag across all docker build invocations.

Currently, **all** docker builds in the SONiC build system use `--no-cache`, forcing every layer to rebuild from scratch. This includes:
- 2 sonic-slave builds (base + user layers) in `Makefile.work`
- 3 runtime container image builds (standard, multi-arch, debug) in `slave.mk`

With 57 runtime docker images, this adds significant time to incremental builds even when nothing has changed.

## Changes

- Added `SONIC_CONFIG_USE_DOCKER_CACHE` config knob to `rules/config` (default: disabled)
- Replaced hardcoded `--no-cache` with conditional `$(DOCKER_NO_CACHE_FLAG)` in both `Makefile.work` and `slave.mk`
- Passes the config variable from `Makefile.work` into the slave container build

## Usage

```bash
# Enable Docker layer caching (in rules/config):
SONIC_CONFIG_USE_DOCKER_CACHE = y
```

## Impact

- **Default behavior unchanged** — `--no-cache` is used when the knob is unset (same as before)
- **When enabled** — Docker layer caching saves ~20+ minutes on incremental builds
- **CI should leave this disabled** to ensure reproducible builds
- **Local developers** can enable this for faster iteration

## Related

This addresses item 1.1 from the build improvements tracker — one of the highest-impact changes for developer productivity.