### PR TITLE
Make sonic-bfb-installer reset dpus synchronously.

### DIFF
--- a/platform/mellanox/sonic-bfb-installer.sh
+++ b/platform/mellanox/sonic-bfb-installer.sh
@@ -356,11 +356,10 @@ bfb_install_call() {
         cat "$result_file"
     fi
 
-    # Stop rshim application and reset DPU
+    # Stop rshim application.
     stop_rshim_daemon "$rid"
-    log_info "$rid: Resetting DPU $dpu"
 
-    reset_dpu "$dpu" "$verbose"
+    # The dpu will be reset in a later step.
 }
 
 file_cleanup(){
@@ -605,7 +604,7 @@ main() {
         validate_config_files "${sorted_devs[@]}" "${arr[@]}"
     fi
 
-    # Install BFB on each device
+    # Install BFB on each device (in parallel)
     trap 'kill_ch_procs' SIGINT SIGTERM SIGHUP
     
     for i in "${!sorted_devs[@]}"; do
@@ -614,6 +613,17 @@ main() {
         bfb_install_call "$rshim_name" "$dpu_name" "$EXTRACTED_BFB_PATH" "${arr[$i]}" &
     done
     wait
+
+    # Reset DPUs.
+    # Done one-by-one to avoid PCI race conditions.
+    for i in "${!sorted_devs[@]}"; do
+        rshim_name=${sorted_devs[$i]}
+        rid=${rshim_name#rshim}
+        dpu_name=${rshim2dpu[$rshim_name]}
+        log_info "$rid: Resetting DPU $dpu_name"
+        reset_dpu "$dpu_name" "$verbose"
+    done
+    log_info "Done resetting DPUs"
 }
 
 # Helper function to parse command line arguments


### PR DESCRIPTION
This is just an experimental draft right now.



<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

