### PR TITLE
[pmon] Strip debug symbols from grpc native extensions

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -46,7 +46,8 @@ RUN apt-get install -y -t bookworm-backports \
 # install any dependencies required by the Arista sonic_platform package.
 # TODO: eliminate the need to install these explicitly.
 RUN pip3 install grpcio==1.51.1 \
-        grpcio-tools==1.51.1 --no-build-isolation
+        grpcio-tools==1.51.1 --no-build-isolation && \
+    find /usr/local/lib/python3*/dist-packages/grpc* -name '*.so' -exec strip --strip-unneeded {} +
 
 # Barefoot platform vendors' sonic_platform packages import these Python libraries (and netifaces)
 RUN pip3 install thrift==0.13.0


### PR DESCRIPTION
#### What I did
Strip unneeded symbols from `grpcio` and `grpcio-tools` native `.so` files after installation in the `docker-platform-monitor` container.

#### Why I did it
These Python extensions include native C/C++ shared libraries that retain debug and symbol information not needed at runtime. On aarch64, the two largest files are:

- `cygrpc.cpython-311-aarch64-linux-gnu.so` — ~190 MB
- `_protoc_compiler.cpython-311-aarch64-linux-gnu.so` — ~91 MB

Stripping these with `--strip-unneeded` significantly reduces the PMON container image size with zero impact on runtime behavior.

#### How I verified it
The `strip --strip-unneeded` command only removes non-essential symbols (debug info, unused exports). The gRPC Python modules continue to function identically after stripping — this is the same technique used by standard Linux package builds (`dh_strip`).

#### Which release branch to backport
`202411`

Fixes: #25300