### PR TITLE
[Nexthop] Fix tight loop in poll_wait in pddf_custom_fpga_algo (i2c driver)

### DIFF
--- a/platform/broadcom/sonic-platform-modules-nexthop/common/modules/pddf_custom_fpga_algo.c
+++ b/platform/broadcom/sonic-platform-modules-nexthop/common/modules/pddf_custom_fpga_algo.c
@@ -109,7 +109,15 @@ enum {
 /* timeout waiting for the controller to respond */
 #define XIIC_I2C_TIMEOUT	(msecs_to_jiffies(1000))
 
+/* Adjustable parameters for the polling loop */
+#define XIIC_POLL_RETRIES_MIN	1
+#define XIIC_POLL_RETRIES_MAX	6
+#define XIIC_POLL_SLEEP_MIN	200	/* us */
+#define XIIC_POLL_SLEEP_MAX	2000	/* us */
+#define XIIC_POLL_SLEEP_INC	50	/* us */
+
 struct fpgalogic_i2c {
+    struct i2c_adapter *adap;
     void __iomem *base;
     u32 reg_shift;
     u32 reg_io_width;
@@ -124,6 +132,7 @@ struct fpgalogic_i2c {
     u8 (*reg_get)(struct fpgalogic_i2c *i2c, int reg);
     u32 timeout;
     struct mutex lock;
+    unsigned long poll_wait_before_retry;
 };
 
 static struct fpgalogic_i2c fpgalogic_i2c[I2C_PCI_MAX_BUS];
@@ -203,6 +212,7 @@ static int poll_wait(struct fpgalogic_i2c *i2c,
 		       const unsigned long timeout)
 {
 	unsigned long j;
+	unsigned int retries = 0;
 	u8 status = 0;
 
 	j = jiffies + timeout;
@@ -212,11 +222,26 @@ static int poll_wait(struct fpgalogic_i2c *i2c,
 		mutex_unlock(&i2c->lock);
 		if ((status & mask) == val)
 			break;
+		else
+			retries++;
 		if (time_after(jiffies, j))
 			return -ETIMEDOUT;
-                cpu_relax();
-                cond_resched();		
+		usleep_range(i2c->poll_wait_before_retry,
+			     i2c->poll_wait_before_retry + XIIC_POLL_SLEEP_INC);
 	}
+
+	mutex_lock(&i2c->lock);
+	if (retries > XIIC_POLL_RETRIES_MAX && i2c->poll_wait_before_retry < XIIC_POLL_SLEEP_MAX) {
+		i2c->poll_wait_before_retry += XIIC_POLL_SLEEP_INC;
+		dev_dbg(&i2c->adap->dev, "too many (%u > %u) retries, adjusted wait time up to %luusec\n",
+			retries, XIIC_POLL_RETRIES_MAX, i2c->poll_wait_before_retry);
+	} else if (retries < XIIC_POLL_RETRIES_MIN && i2c->poll_wait_before_retry > XIIC_POLL_SLEEP_MIN) {
+		i2c->poll_wait_before_retry -= XIIC_POLL_SLEEP_INC;
+		dev_dbg(&i2c->adap->dev, "too few (%u < %u) retries, adjusted wait time down to %luusec\n",
+			retries, XIIC_POLL_RETRIES_MIN, i2c->poll_wait_before_retry);
+	}
+	mutex_unlock(&i2c->lock);
+
 	return 0;
 }
 
@@ -513,6 +538,7 @@ static int xiic_reinit(struct fpgalogic_i2c *i2c)
 	if (ret)
 		return ret;
 
+	i2c->poll_wait_before_retry = XIIC_POLL_SLEEP_MIN;
 	return 0;
 }
 
@@ -570,6 +596,7 @@ static int adap_data_init(struct i2c_adapter *adap, int index)
     fpgalogic_i2c[i2c_ch_index].base = i2c_data.ch_base_addr +
                           index * i2c_data.ch_size;
     mutex_init(&fpgalogic_i2c[i2c_ch_index].lock);
+    fpgalogic_i2c[i2c_ch_index].adap = adap;
     fpgai2c_init(&fpgalogic_i2c[i2c_ch_index]);
 
     adap->algo_data = &fpgalogic_i2c[i2c_ch_index];


### PR DESCRIPTION
#### Why I did it
This PR improves the efficiency in the `poll_wait` function of NH's pddf_custom_fpga_algo module. This results in reduced CPU usage by xcvrd.

The current implementation uses cond_resched() during retry cycles. In scenarios where no other higher-priority tasks are pending, this can lead to a "tight loop" where the process yields and is immediately rescheduled, resulting in higher than necessary CPU utilization.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
This PR introduces a dynamic scaling algorithm for sleep timeouts between retries, replacing the previous yielding behavior with a more efficient backoff.

We start out with a 200 usecs and try to keep the number of retries between 1 and 6. We increase the timeout by 50 usec when the number of retries goes above the high threshold and decrease by 50 usec when it falls below the low threshold.

#### How to verify it
The chosen constants provide a balance between rapid system initialization and CPU efficiency. Testing on an NH platform shows that this approach significantly reduces the CPU overhead of the xcvrd process while maintaining fast convergence on the optimal timeout, preventing unnecessary scheduler churn.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Additional improvements to the NH pddf_custom_fpga_algo