### PR TITLE
[build] Auto-detect SONIC_CONFIG_BUILD_JOBS from CPU and RAM

### DIFF
--- a/rules/config
+++ b/rules/config
@@ -10,7 +10,29 @@
 # SONIC_CONFIG_BUILD_JOBS - set number of jobs for parallel build.
 # Corresponding -j argument will be passed to make command inside docker
 # container.
-SONIC_CONFIG_BUILD_JOBS = 1
+# Default: auto-detect based on available CPU cores and RAM.
+# When SONIC_BUILD_MEMORY is set, uses that as the RAM limit instead of host RAM.
+# Formula: min(nproc/4, effective_ram_gb/8), clamped to [1, 8].
+# This balances parallelism with memory safety — each concurrent package
+# build can use up to ~8GB RAM (dpkg-buildpackage with nproc make jobs).
+# Override with a fixed number if needed, e.g. SONIC_CONFIG_BUILD_JOBS = 1
+# for sequential builds or higher values on machines with more RAM.
+SONIC_CONFIG_BUILD_JOBS = $(shell \
+	cores=$$(nproc 2>/dev/null || echo 4); \
+	host_ram=$$(awk '/^MemTotal/ {printf "%d", $$2/1048576}' /proc/meminfo 2>/dev/null || echo 8); \
+	ram_gb=$$host_ram; \
+	if [ -n "$(SONIC_BUILD_MEMORY)" ] && [ "$(SONIC_BUILD_MEMORY)" != "none" ]; then \
+		mem_val=$$(echo "$(SONIC_BUILD_MEMORY)" | sed 's/[gG]$$//'); \
+		if [ "$$mem_val" -gt 0 ] 2>/dev/null; then \
+			ram_gb=$$(( mem_val < host_ram ? mem_val : host_ram )); \
+		fi; \
+	fi; \
+	by_cores=$$(( cores / 4 )); \
+	by_ram=$$(( ram_gb / 8 )); \
+	jobs=$$(( by_cores < by_ram ? by_cores : by_ram )); \
+	[ $$jobs -lt 1 ] && jobs=1; \
+	[ $$jobs -gt 8 ] && jobs=8; \
+	echo $$jobs)
 
 # SONIC_CONFIG_MAKE_JOBS - set number of parallel make jobs per package.
 # Corresponding -j argument will be passed to make/dpkg commands that build separate packages


### PR DESCRIPTION
## What I did
Change the default `SONIC_CONFIG_BUILD_JOBS` from `1` (sequential) to an auto-detected value based on available CPU cores and RAM.

**Formula:** `min(nproc/4, total_ram_gb/8)`, clamped to `[1, 8]`

## Why I did it
The current default of `SONIC_CONFIG_BUILD_JOBS=1` means only one package builds at a time, resulting in 3+ hour builds on multi-core machines with ~95% idle CPU. Most developers and CI systems have enough resources for safe parallel builds.

**Build timing analysis** (from instrumentation scripts in #25643) shows:
- With JOBS=1: ~2h wall time, max concurrency 1
- With JOBS=4: ~53m wall time, max concurrency 5
- CPU utilization at JOBS=1: ~4% on a 24-core machine

The formula is conservative:
- Divides cores by 4 because each package build already uses `-j$(nproc)` internally
- Divides RAM by 8GB per concurrent build (empirical: heavy packages like swss use 4-6GB)
- Caps at 8 to prevent disk I/O contention and dpkg lock conflicts
- Falls back to 1 on systems with <8GB RAM (unchanged behavior)

## Examples
| Machine | Cores | RAM | Auto JOBS |
|---------|-------|-----|-----------|
| Small VM | 4 | 8GB | 1 |
| Dev laptop | 8 | 16GB | 1 |
| Workstation | 8 | 32GB | 2 |
| Build server | 24 | 30GB | 3 |
| CI agent | 32 | 64GB | 8 |
| Large CI | 96 | 256GB | 8 (capped) |

## How to override
Users can still set a fixed value:
```
# In rules/config.user:
SONIC_CONFIG_BUILD_JOBS = 1

# Or on the command line:
make SONIC_BUILD_JOBS=4 target/sonic-vs.img.gz
```

## How I verified it
1. Tested formula evaluation via Make on a 24-core/30GB machine → correctly auto-detects 3
2. Verified override still works (`SONIC_BUILD_JOBS=1` on command line → uses 1)
3. Build timing report from nightly VS builds confirms JOBS=4 is safe on 30GB RAM (JOBS=8 causes OOM)
4. The formula would return 1 on small VMs (4 cores, 8GB), preserving existing behavior
