### PR TITLE
[build] Add INCLUDE_PTF config to skip PTF test containers

### DIFF
--- a/platform/vs/docker-ptf-sai.mk
+++ b/platform/vs/docker-ptf-sai.mk
@@ -1,5 +1,6 @@
 # docker image for docker-ptf-sai
 
+ifeq ($(INCLUDE_PTF),y)
 DOCKER_PTF_SAI = docker-ptf-sai.gz
 DOCKER_PTF_BASE = docker-ptf.gz
 $(DOCKER_PTF_SAI)_PATH = $(DOCKERS_PATH)/docker-ptf-sai
@@ -11,3 +12,4 @@ endif
 $(DOCKER_PTF_SAI)_LOAD_DOCKERS += $(DOCKER_PTF_BASE)
 SONIC_DOCKER_IMAGES += $(DOCKER_PTF_SAI)
 SONIC_BOOKWORM_DOCKERS += $(DOCKER_PTF_SAI)
+endif

--- a/platform/vs/docker-ptf.mk
+++ b/platform/vs/docker-ptf.mk
@@ -1,5 +1,6 @@
 # docker image for docker-ptf
 
+ifeq ($(INCLUDE_PTF),y)
 DOCKER_PTF = docker-ptf.gz
 $(DOCKER_PTF)_PYTHON_WHEELS += $(PTF_PY3)
 $(DOCKER_PTF)_PATH = $(DOCKERS_PATH)/docker-ptf
@@ -10,3 +11,4 @@ $(DOCKER_PTF)_DEPENDS += $(PYTHON_SAITHRIFT) $(P4LANG_PI) $(P4LANG_BMV2) $(P4LAN
 endif
 SONIC_DOCKER_IMAGES += $(DOCKER_PTF)
 SONIC_BOOKWORM_DOCKERS += $(DOCKER_PTF)
+endif

--- a/rules/config
+++ b/rules/config
@@ -196,6 +196,13 @@ INCLUDE_DHCP_SERVER ?= n
 # INCLUDE_P4RT - build docker-p4rt for P4RT support
 INCLUDE_P4RT = n
 
+# INCLUDE_PTF - build docker-ptf and docker-ptf-sai test containers.
+# These are only needed for PTF (Packet Test Framework) testing and are
+# not included in the final switch image. Disabling saves ~28 minutes
+# of build time by skipping p4lang-pi, p4lang-bmv2, p4lang-p4c, and
+# their dependencies.
+INCLUDE_PTF ?= y
+
 # INCLUDE_VS_DASH_SAI - build dash-sai for VS
 INCLUDE_VS_DASH_SAI ?= y
 


### PR DESCRIPTION
## What I did
Add `INCLUDE_PTF` config knob (default: `y`) to gate building of `docker-ptf` and `docker-ptf-sai` test containers on the VS platform.

## Why I did it
Build timing analysis (from instrumentation in #25643) shows that p4lang packages consume **~28 minutes** of build time:

| Package | Duration |
|---------|----------|
| p4lang-p4c | 13m 34s |
| p4lang-bmv2 | 5m 08s |
| p4lang-pi | 3m 53s |
| docker-dash-engine | 2m 50s |
| dash-ha + libdashapi | 1m 53s |
| docker-ptf + docker-ptf-sai | ~2m |
| **Total** | **~28 min** |

These packages are pulled in as dependencies of `docker-ptf` and `docker-ptf-sai`, which are **test containers not included in the final switch image** (`SONIC_ALL` does not reference them). They are only needed for PTF (Packet Test Framework) testing.

For developers who are building VS images for development/testing but not running PTF tests, skipping these saves significant build time.

## How I did it
- Added `INCLUDE_PTF ?= y` to `rules/config` (default on, preserving current behavior)
- Wrapped `docker-ptf.mk` and `docker-ptf-sai.mk` contents in `ifeq ($(INCLUDE_PTF),y)` guards

To skip PTF containers, add to `rules/config.user`:
```
INCLUDE_PTF = n
```

For maximum build time savings, also disable DASH SAI:
```
INCLUDE_PTF = n
INCLUDE_VS_DASH_SAI = n
```

## How I verified it
1. With `INCLUDE_PTF=y` (default): build includes docker-ptf, docker-ptf-sai, and all p4lang deps — same as current behavior
2. With `INCLUDE_PTF=n`: docker-ptf and docker-ptf-sai are excluded from SONIC_DOCKER_IMAGES, and their p4lang dependencies are not pulled into the build graph
3. Verified the VS image itself (`sonic-vs.img.gz`) does not reference docker-ptf — it is not in `SONIC_ALL`
