### PR TITLE
srv6: creating sr0 dummy interface for srv6

### DIFF
--- a/dockers/docker-fpm-frr/docker_init.sh
+++ b/dockers/docker-fpm-frr/docker_init.sh
@@ -100,16 +100,13 @@ fi
 chown -R frr:frr /etc/frr/
 
 # Create sr0 interface for SRv6 support
-SONIC_ASIC_TYPE=$(sed -n 's/^asic_type:[[:space:]]*//p' /etc/sonic/sonic_version.yml)
-if [ "$SONIC_ASIC_TYPE" == "vpp" ]; then
-    if ! ip link show sr0 > /dev/null 2>&1; then
-        echo "Interface sr0 does not exist. Creating sr0..."
-        ip link add sr0 type dummy || true
-    else
-        echo "Interface sr0 already exists."
-    fi
-    ip link set sr0 up || true
+if ! ip link show sr0 > /dev/null 2>&1; then
+    echo "Interface sr0 does not exist. Creating sr0..."
+    ip link add sr0 type dummy || true
+else
+    echo "Interface sr0 already exists."
 fi
+ip link set sr0 up || true
 
 chown root:root /usr/sbin/bgp-isolate
 chmod 0755 /usr/sbin/bgp-isolate


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
[notes] This PR is a replacement for PR #24084 which is corrupted when fixing DCO, please check PR #24084 for history.
 
#### Why I did it
double commit @BYGX-wcr PR https://github.com/Azure/sonic-buildimage-msft/pull/517 to master branch for SRv6 feature.
branch 202505 also need this fix.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)


