### PR TITLE
[initramfs-tools] Replace git clone with pinned tarball + SHA256

### DIFF
--- a/src/initramfs-tools/Makefile
+++ b/src/initramfs-tools/Makefile
@@ -5,16 +5,23 @@ SHELL = /bin/bash
 MAIN_TARGET = initramfs-tools_$(INITRAMFS_TOOLS_VERSION)_all.deb
 DERIVED_TARGETS = initramfs-tools-core_$(INITRAMFS_TOOLS_VERSION)_all.deb
 
-INITRAMFS_TOOLS_REVISION = v$(INITRAMFS_TOOLS_VERSION)
+# Use a pinned tarball instead of git clone for reliability and speed.
+# Tarball works here because quilt (used for patches) doesn't need git history.
+# SHA256 ensures integrity and reproducibility.
+INITRAMFS_TOOLS_TARBALL_URL = https://salsa.debian.org/kernel-team/initramfs-tools/-/archive/v$(INITRAMFS_TOOLS_VERSION)/initramfs-tools-v$(INITRAMFS_TOOLS_VERSION).tar.gz
+INITRAMFS_TOOLS_TARBALL_SHA256 = 27a78cc25acc3ca3d9c78deca165bf001b09b260ce25a3f3756e47a0e7bc0554
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
-	# Obtaining the initramfs-tools
+	# Obtaining the initramfs-tools from pinned tarball
 	rm -rf ./initramfs-tools
-	git clone https://salsa.debian.org/kernel-team/initramfs-tools.git ./initramfs-tools
+	wget -q -O initramfs-tools.tar.gz "$(INITRAMFS_TOOLS_TARBALL_URL)"
+	echo "$(INITRAMFS_TOOLS_TARBALL_SHA256)  initramfs-tools.tar.gz" | sha256sum -c -
+	tar xzf initramfs-tools.tar.gz
+	mv initramfs-tools-v$(INITRAMFS_TOOLS_VERSION) initramfs-tools
+	rm -f initramfs-tools.tar.gz
 
 	# Patch
 	pushd ./initramfs-tools
-	git checkout $(INITRAMFS_TOOLS_REVISION)
 	QUILT_PATCHES=.. quilt push -a
 
 	# Build the package


### PR DESCRIPTION
#### What I did
Replace the `git clone` from `salsa.debian.org` with a pinned tarball download and SHA256 checksum verification.

#### Why I did it
The initramfs-tools build fetches source via `git clone` from Debian's GitLab instance (salsa.debian.org) during the build. This is fragile:
- salsa.debian.org returning HTTP 502 causes the entire build to fail late in the process (after 400+ packages have already built successfully)
- The git clone is slower than a tarball download
- No integrity verification on the downloaded source

This happened in practice — a transient salsa.debian.org 502 killed a 30-minute build that was almost done.

#### How I did it
- Download the release tarball from salsa.debian.org's archive URL instead of git clone
- Verify SHA256 checksum (`27a78cc25a...`) to ensure integrity
- Extract and rename to match the expected directory structure
- Remove the `git checkout` step (tarball is already at the pinned version)
- Quilt patches still apply normally

#### How to verify it
```bash
make target/debs/trixie/initramfs-tools_0.142_all.deb
```
The package should build identically to the git-clone version.