### PR TITLE
[grub2] Pin git clone to specific commit hash for reproducibility

### DIFF
--- a/src/grub2/Makefile
+++ b/src/grub2/Makefile
@@ -18,14 +18,18 @@ endif
 SUFFIX := $(shell date +%Y%m%d\.%H%M%S)
 STG_BRANCH := stg_temp.$(SUFFIX)
 
+# Pinned commit hash for debian/2.06-13+deb13u1 tag.
+# We use a commit hash instead of a tarball because grub2 patches are applied
+# via stg (stacked git), which requires a git repository with history.
+GRUB2_COMMIT = f954d68d5e8dc7eb0081ad7bc1ced9ff5ca687a7
+
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
-	# Get grub2 debian packaging
+	# Get grub2 debian packaging (pinned to specific commit for reproducibility)
 	export
 	rm -rf ./grub2
 	git clone https://salsa.debian.org/grub-team/grub.git ./grub2
-
 	pushd ./grub2
-	git checkout debian/$(GRUB2_VERSION)
+	git checkout $(GRUB2_COMMIT)
 	git checkout -b $(STG_BRANCH)
 	stg init
 	stg import -s ../patch/series


### PR DESCRIPTION
#### What I did
Pin the grub2 `git clone` to a specific commit hash (`f954d68d`) instead of the `debian/2.06-13+deb13u1` tag name.

#### Why I did it
The grub2 build clones from `salsa.debian.org` using a tag name. This has two problems:
1. **Fragility** — salsa.debian.org has been observed returning HTTP 502 errors, causing late build failures (after 400+ packages have already built)
2. **Reproducibility** — tag names can theoretically be moved; commit hashes cannot

grub2 uses `stg` (stacked git) for patch management, which requires a git repository. A tarball approach is not practical here, so we pin to the commit hash instead.

#### How I did it
- Added `GRUB2_COMMIT` variable with the commit hash of the `debian/2.06-13+deb13u1` tag
- Changed `git checkout debian/$(GRUB2_VERSION)` to `git checkout $(GRUB2_COMMIT)`
- No changes to patch application or build logic

#### How to verify it
```bash
make target/debs/trixie/grub2-common_2.06-13+deb13u1_amd64.deb
```