### PR TITLE
[monit] Pin git clone to specific commit hash for reproducibility

### DIFF
--- a/src/monit/Makefile
+++ b/src/monit/Makefile
@@ -5,19 +5,23 @@ SHELL = /bin/bash
 MAIN_TARGET = monit_$(MONIT_VERSION)_$(CONFIGURED_ARCH).deb
 DERIVED_TARGETS = monit-dbgsym_$(MONIT_VERSION)_$(CONFIGURED_ARCH).deb
 
+# Pinned commit hash for debian/1%5.34.3-1 tag.
+# We use a commit hash instead of a tarball because monit patches are applied
+# via stg (stacked git), which requires a git repository with history.
+MONIT_COMMIT = 0a01ce607eb8
+
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Remove any stale files
 	rm -rf ./monit
 
-	# Clone monit repo
+	# Clone monit repo (pinned to specific commit for reproducibility)
 	git clone https://salsa.debian.org/debian/monit.git
 	pushd ./monit
 
-	# Reset HEAD to the commit of the proper tag
+	# Reset HEAD to the pinned commit
 	# NOTE: Using "git checkout <tag_name>" here detaches our HEAD,
 	# which stg doesn't like, so we use this method instead
-	# NOTE: For some reason, tags in the Debian monit repo are prefixed with "1%"
-	git reset --hard debian/1\%$(MONIT_VERSION)
+	git reset --hard $(MONIT_COMMIT)
 
 	# Apply patches
 	stg init


### PR DESCRIPTION
#### What I did
Pin the monit `git clone` to a specific commit hash (`0a01ce607eb8`, `debian/1%5.34.3-1` tag).

#### Why I did it
The monit Makefile clones from `salsa.debian.org` and does `git reset --hard debian/1%$(MONIT_VERSION)` — this relies on the tag existing and pointing to the same commit. Two problems:

1. **salsa.debian.org fragility** — HTTP 502 errors have been observed, causing late build failures
2. **Reproducibility** — pinning to a commit hash is more robust than a tag reference

This is part of a series to pin all external git dependencies in the build for reproducibility and reliability.

#### How I did it
- Added `MONIT_COMMIT` variable with the commit hash
- Changed `git reset --hard debian/1\%$(MONIT_VERSION)` to `git reset --hard $(MONIT_COMMIT)`

#### How to verify it
```bash
make target/debs/trixie/monit_5.34.3-1_amd64.deb
```