### PR TITLE
[rasdaemon] Pin git clone to specific commit hash for reproducibility

### DIFF
--- a/src/rasdaemon/Makefile
+++ b/src/rasdaemon/Makefile
@@ -5,13 +5,19 @@ SHELL = /bin/bash
 MAIN_TARGET = rasdaemon_$(RASDAEMON_VERSION)_$(CONFIGURED_ARCH).deb
 DERIVED_TARGETS = rasdaemon-dbgsym_$(RASDAEMON_VERSION)_$(CONFIGURED_ARCH).deb
 
+# Pinned commit hash for debian/0.6.8-1 tag.
+# We use a commit hash instead of a tarball because the patch is applied
+# via git apply, which requires a git repository.
+RASDAEMON_COMMIT = 51a7f485f8b2e2ae43e613f19c5a387595174132
+
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf rasdaemon/
 
-	# Checkout Repository
-	git clone https://salsa.debian.org/tai271828/rasdaemon.git -b debian/$(RASDAEMON_VERSION)
-
+	# Checkout Repository (pinned to specific commit for reproducibility)
+	git clone https://salsa.debian.org/tai271828/rasdaemon.git
 	pushd ./rasdaemon
+	git checkout $(RASDAEMON_COMMIT)
+
 	# Patch
 	git apply ../0001-Check-CPUs-online-not-configured.patch
 ifeq ($(CROSS_BUILD_ENVIRON), y)


### PR DESCRIPTION
#### What I did
Pin the rasdaemon `git clone` to a specific commit hash (`51a7f485f8b2`, `debian/0.6.8-1` tag).

#### Why I did it
Part of a series to pin all external git dependencies in the build system for reproducibility and reliability. The rasdaemon build clones from `salsa.debian.org`, which has been observed returning HTTP 502 errors causing late build failures.

Pinning to a commit hash (vs branch name `-b debian/0.6.8-1`) ensures:
- Exact same source on every build
- Explicit failure if the commit disappears
- No surprise from tag/branch mutation

Related PRs: #25664 (initramfs-tools), #25666 (grub2), #25667 (monit)

#### How I did it
- Added `RASDAEMON_COMMIT` variable
- Clone without `-b`, then `git checkout $(RASDAEMON_COMMIT)`

#### How to verify it
```bash
make target/debs/trixie/rasdaemon_0.6.8-1_amd64.deb
```