### PR TITLE
This script sets up console utilities on the bmc to access switch console

### DIFF
--- a/scripts/sonic-console-setup.sh
+++ b/scripts/sonic-console-setup.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# sonic-udev-setup.sh
+# Enables console mode and symlinks the platform udev rules file.
+# Assumes 99-sonic-tty.rules and udevprefix.conf already exist in the platform directory.
+# Must be run as root on a Debian-based system.
+#
+
+set -euo pipefail
+
+PLATFORM_NAME=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
+PLATFORM_DIR="/usr/share/sonic/device/${PLATFORM_NAME}"
+RULES_SRC="${PLATFORM_DIR}/99-sonic-tty.rules"
+RULES_DEST="/etc/udev/rules.d/99-sonic-tty.rules"
+
+# --- Ensure we are running as root ---
+if [[ "$(id -u)" -ne 0 ]]; then
+    echo "Error: this script must be run as root." >&2
+    exit 1
+fi
+
+# --- Enable console ---
+echo "Enabling console ..."
+sudo config console enable
+
+# --- Symlink udev rules ---
+echo "Creating symlink ${RULES_DEST} -> ${RULES_SRC} ..."
+ln -sf "${RULES_SRC}" "${RULES_DEST}"
+
+# --- Reload udev rules ---
+echo "Reloading udev rules ..."
+udevadm control --reload-rules
+udevadm trigger
+
+echo "sonic udev setup complete."
+echo "  Rules symlinked: ${RULES_DEST} -> ${RULES_SRC}"


### PR DESCRIPTION
This script assumes the presense of the following files in the following formats available at the platfomr directory for any particular vendor.

#### Platform directory location for configuration file
```
PLATFORM_NAME=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
PLATFORM_DIR="/usr/share/sonic/device/${PLATFORM_NAME}"
```

#### Udev rules to alias out the console devices to a uniform alias
```
# Mapping console ports to ttysonic aliases
# "console" --> vendor specific console device name under /dev/ for the host cpu console
KERNEL=="console", SUBSYSTEM=="tty", ATTR{line}=="0", SYMLINK+="ttysonic0", MODE="0666"
```

#### Contents of Udevprefixconf for consutil cli
```
/ttysonic
```
This helps the consutil cli in enumerating the console device 

These two files could be put in the platform directory for each vendor with the following file names :- 
1. 99-sonic-tty.rules
2. udevprefix.conf

And the script in the PR would be packaged as a systemd platform-independent service, which would initialise the console upon the device boot.
 