### PR TITLE
Add installer.conf for x86_64-arista_7280r4[k]_32qf_32df

### DIFF
--- a/device/arista/x86_64-arista_7280r4_32qf_32df/installer.conf
+++ b/device/arista/x86_64-arista_7280r4_32qf_32df/installer.conf
@@ -1,0 +1,2 @@
+ARISTA_SID="*CitrineDd"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="modprobe.blacklist=snd_hda_intel,hdaudio,amd_sfh"

--- a/device/arista/x86_64-arista_7280r4k_32qf_32df/installer.conf
+++ b/device/arista/x86_64-arista_7280r4k_32qf_32df/installer.conf
@@ -1,0 +1,2 @@
+ARISTA_SID="*CitrineDdBk"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="modprobe.blacklist=snd_hda_intel,hdaudio,amd_sfh"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This is needed to support UEFI on this SKU.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added the file to platform specific directory of x86_64-arista_7280r4[k]_32qf_32df

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202511

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add installer.conf to x86_64-arista_7280r4[k]_32qf_32df

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/cbfbcf91-aaeb-47f2-90c3-b603c352ce51" />
