### PR TITLE
[build] Wire up SONIC_USE_DOCKER_BUILDKIT for parallel Docker layer builds

### DIFF
--- a/rules/config
+++ b/rules/config
@@ -42,6 +42,11 @@ DEFAULT_BUILD_LOG_TIMESTAMP = none
 # in the dockers/ and platform/ subdirs to use a variable reference instead of an explicit image name.
 # SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD = y
 
+# SONIC_USE_DOCKER_BUILDKIT - use Docker BuildKit for image builds.
+# BuildKit builds individual layers in parallel and provides better caching.
+# Requires Docker 18.09+ (available on all supported build hosts).
+# SONIC_USE_DOCKER_BUILDKIT = y
+
 # SONIC_CONFIG_ENABLE_COLORS - enable colored output in build system.
 # Comment next line to disable:
 # SONIC_CONFIG_ENABLE_COLORS = y

--- a/slave.mk
+++ b/slave.mk
@@ -426,6 +426,12 @@ $(info "SONIC_BUILD_JOBS"                : "$(SONIC_BUILD_JOBS)")
 $(info "SONIC_CONFIG_MAKE_JOBS"          : "$(SONIC_CONFIG_MAKE_JOBS)")
 $(info "USE_NATIVE_DOCKERD_FOR_BUILD"    : "$(SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD)")
 $(info "SONIC_USE_DOCKER_BUILDKIT"       : "$(SONIC_USE_DOCKER_BUILDKIT)")
+
+# Enable Docker BuildKit when configured
+ifeq ($(SONIC_USE_DOCKER_BUILDKIT),y)
+export DOCKER_BUILDKIT := 1
+endif
+
 $(info "USERNAME"                        : "$(USERNAME)")
 $(info "PASSWORD"                        : "$(PASSWORD)")
 $(info "CHANGE_DEFAULT_PASSWORD"         : "$(CHANGE_DEFAULT_PASSWORD)")


### PR DESCRIPTION
#### What I did
Wired up the existing `SONIC_USE_DOCKER_BUILDKIT` config variable to actually enable Docker BuildKit by exporting `DOCKER_BUILDKIT=1`.

#### Why I did it
`SONIC_USE_DOCKER_BUILDKIT` has existed as a config variable — it's passed to the slave container (`Makefile.work` line 572) and printed in the build config summary (`slave.mk` line 428) — but was never wired up to actually set `DOCKER_BUILDKIT=1`. The variable is a dead config knob.

Docker BuildKit provides:
- **Parallel layer builds** within each Docker image (independent `RUN`/`COPY` steps execute concurrently)
- Better cache management with inline cache metadata
- Improved build output with progress tracking
- Available on Docker 18.09+ (all supported build hosts)

#### How I did it
- Added the config knob documentation to `rules/config` (default: off/commented out)
- Added `export DOCKER_BUILDKIT := 1` in `slave.mk` when `SONIC_USE_DOCKER_BUILDKIT=y`

The change is minimal — just exporting an environment variable that Docker picks up automatically for all `docker build` commands.

#### How to verify it

```bash
# Enable in rules/config.user:
echo 'SONIC_USE_DOCKER_BUILDKIT = y' >> rules/config.user

# Build and observe BuildKit output format (shows parallel layer execution):
make configure PLATFORM=vs
make target/sonic-vs.img.gz 2>&1 | grep -i buildkit
```

When combined with Docker cache (`SONIC_CONFIG_USE_DOCKER_CACHE`), BuildKit enables inline cache metadata for efficient layer reuse across builds.
