### PR TITLE
[build] Add make clean-docker target for stale image cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ $(PLATFORM_PATH):
 configure : $(PLATFORM_PATH)
 	$(call make_work, $@)
 
-clean showtag docker-cleanup sonic-slave-build sonic-slave-bash :
+clean showtag docker-cleanup clean-docker sonic-slave-build sonic-slave-bash :
 	$(call make_work, $@)
 
 # Freeze the versions, see more detail options: scripts/versions_manager.py freeze -h


### PR DESCRIPTION
#### What I did
Added a `make clean-docker` target that safely cleans up Docker build artifacts.

#### Why I did it
On development machines with multiple builds, Docker images accumulate quickly:

```
$ docker system df
TYPE            TOTAL     ACTIVE    SIZE      RECLAIMABLE
Images          42        2         265.2GB   147.2GB (55%)
Build Cache     841       0         149.6GB   99.51GB
```

That's **265 GB in images + 150 GB build cache** — over 400 GB of Docker artifacts. The existing `docker-cleanup` target only cleans dangling images and user-tagged intermediates (and only in native dockerd mode).

#### How I did it
The new `clean-docker` target cleans:
1. **Old sonic-slave images** — keeps only the current build tag, removes all older versions
2. **Dangling images** — untagged layers left over from rebuilds
3. **Stopped build containers** — exited containers from previous builds
4. **Docker build cache** — `docker builder prune` to reclaim layer cache

Shows a summary via `docker system df` after cleanup.

#### How to verify it
```bash
# Before cleanup:
docker system df

# Run cleanup:
make clean-docker PLATFORM=vs

# After cleanup:
docker system df  # Should show significantly less usage
```

The target is safe — it only removes stale images and never touches the currently active build slave.