### PR TITLE
[device-data] Fix empty lines in port_config.ini creating bogus lanemap entries

### DIFF
--- a/src/sonic-device-data/Makefile
+++ b/src/sonic-device-data/Makefile
@@ -56,7 +56,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 				i=$$(($$i+1)); \
 			fi; \
 			while IFS= read -r line || [ -n "$$line" ]; do \
-				if ! grep -q "^#" <<< "$$line"; then \
+				if [ -n "$$line" ] && ! grep -q "^#" <<< "$$line"; then \
 					i=$$(($$i+1)); \
 					lanes=$$(echo "$$line" | awk '{print $$2}'); \
 					echo "eth$$i:$$lanes" >> device/x86_64-kvm_x86_64-r0/$$(basename $$d)/lanemap.ini; \
@@ -98,7 +98,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 					last_line=$$(tail -n 1 device/x86_64-kvm_x86_64-r0/$$(basename $$d)/$$(basename $$subdir)/port_config.ini); \
 					num_columns=$$(echo $$last_line | awk '{print NF}'); \
 					while IFS= read -r line || [ -n "$$line" ]; do \
-						if ! grep -q "^#" <<< "$$line"; then \
+						if [ -n "$$line" ] && ! grep -q "^#" <<< "$$line"; then \
 							i=$$(($$i+1)); \
 							lanes=$$(echo "$$line" | awk '{print $$2}'); \
 							echo "eth$$i:$$lanes" >> device/x86_64-kvm_x86_64-r0/$$(basename $$d)/$$(basename $$subdir)/lanemap.ini; \


### PR DESCRIPTION
#### What I did
Added an empty-line check to the HwSKU lanemap.ini generator loop in `src/sonic-device-data/Makefile`.

#### Why I did it
The loop skips comment lines (`grep -q "^#"`) but does not skip empty lines. Many `port_config.ini` files have empty lines between a license header and the data rows. These empty lines are processed as port entries, creating lanemap entries like `eth1:` with empty lanes.

This affects **30 HwSKUs** and causes an off-by-one in eth numbering for all subsequent ports in those HwSKUs.

**Example — ACS-SN2201 (before fix):**
```
eth1:          ← bogus entry from empty line
eth2:0
eth3:4
...
eth53:204,201,202,203
```

**After fix:**
```
eth1:0
eth2:4
...
eth52:204,201,202,203
```

#### How I did it
Added `[ -n "$$line" ]` check before the `grep` check, in both the main HwSKU loop and the multi-ASIC subdirectory loop.

#### How to verify it
```bash
cd src/sonic-device-data/src
rm -rf device && mkdir device && cp -r -L ../../../device/*/* device/
# Run the Makefile's HwSKU generation logic, then check:
head -3 device/x86_64-kvm_x86_64-r0/ACS-SN2201/lanemap.ini
# Should show 'eth1:0' (not 'eth1:')
```