### PR TITLE
[sonic-slave] Add SHA256 verification for CMake download

### DIFF
--- a/sonic-slave-bookworm/Dockerfile.j2
+++ b/sonic-slave-bookworm/Dockerfile.j2
@@ -504,9 +504,11 @@ RUN eatmydata apt-get install -y \
 
 {%- if CONFIGURED_ARCH == "amd64" %}
 # Upgrade CMAKE version
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.27.6/cmake-3.27.6-linux-x86_64.sh
-RUN chmod +x cmake-3.27.6-linux-x86_64.sh
-RUN sudo ./cmake-3.27.6-linux-x86_64.sh --skip-license --prefix=/usr
+RUN wget -O cmake-3.27.6-linux-x86_64.sh https://github.com/Kitware/CMake/releases/download/v3.27.6/cmake-3.27.6-linux-x86_64.sh \
+ && echo "8c449dabb2b2563ec4e6d5e0fb0ae09e729680efab71527b59015131cea4a042  cmake-3.27.6-linux-x86_64.sh" | sha256sum -c - \
+ && chmod +x cmake-3.27.6-linux-x86_64.sh \
+ && sudo ./cmake-3.27.6-linux-x86_64.sh --skip-license --prefix=/usr \
+ && rm cmake-3.27.6-linux-x86_64.sh
 RUN sudo apt-get update -y
 {%- endif %}
 


### PR DESCRIPTION
#### What I did
Added SHA256 checksum verification for the CMake 3.27.6 installer in the bookworm sonic-slave Dockerfile.

#### Why I did it
The CMake installer is downloaded from GitHub without integrity verification. Also consolidated 3 separate `RUN` commands into one (fewer Docker layers) and added cleanup of the installer script.

#### How I did it
- Added `sha256sum -c` verification after download
- Combined wget + chmod + install into a single `RUN` layer
- Added `rm` to clean up the installer

#### How to verify it
```bash
wget -O cmake.sh https://github.com/Kitware/CMake/releases/download/v3.27.6/cmake-3.27.6-linux-x86_64.sh
echo '8c449dabb2b2563ec4e6d5e0fb0ae09e729680efab71527b59015131cea4a042  cmake.sh' | sha256sum -c -
```

Part of a series to add SHA256 verification to all external downloads.