### PR TITLE
[sonic-slave] Pin bazelisk to v1.28.1 with SHA256 verification

### DIFF
--- a/sonic-slave-bookworm/Dockerfile.j2
+++ b/sonic-slave-bookworm/Dockerfile.j2
@@ -768,9 +768,17 @@ RUN eatmydata apt install -y python-is-python3
 
 # Install Bazel build system (amd64 and arm64 architectures are supported using this method)
 # TODO(PINS): Remove once pre-build Bazel binaries are available for armhf (armv7l)
+{%- if CONFIGURED_ARCH == "amd64" %}
+ARG bazelisk_url=https://github.com/bazelbuild/bazelisk/releases/download/v1.28.1/bazelisk-linux-amd64
+ARG bazelisk_sha256=22e7d3a188699982f661cf4687137ee52d1f24fec1ec893d91a6c4d791a75de8
+{%- elif CONFIGURED_ARCH == "arm64" %}
+ARG bazelisk_url=https://github.com/bazelbuild/bazelisk/releases/download/v1.28.1/bazelisk-linux-arm64
+ARG bazelisk_sha256=8ded44b58a0d9425a4178af26cf17693feac3b87bdcfef0a2a0898fcd1afc9f2
+{%- endif %}
 {%- if CONFIGURED_ARCH == "amd64" or CONFIGURED_ARCH == "arm64" %}
-ARG bazelisk_url=https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-{{ CONFIGURED_ARCH }}
-RUN curl -fsSL -o /usr/local/bin/bazel ${bazelisk_url} && chmod 755 /usr/local/bin/bazel
+RUN curl -fsSL -o /usr/local/bin/bazel ${bazelisk_url} \
+ && echo "${bazelisk_sha256}  /usr/local/bin/bazel" | sha256sum -c - \
+ && chmod 755 /usr/local/bin/bazel
 {% endif -%}
 
 # Install Rust


### PR DESCRIPTION
#### What I did
Pinned bazelisk to v1.28.1 (from `/latest/`) and added SHA256 checksum verification for both amd64 and arm64.

#### Why I did it
The bazelisk download used a `/latest/` URL:
```
https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-{{ CONFIGURED_ARCH }}
```
This means every sonic-slave rebuild could pull a **different binary**, making builds non-reproducible. This was already flagged in #25128 when an upstream release caused hash mismatches in CI.

#### How I did it
- Pinned URL to `v1.28.1` release
- Added per-architecture SHA256 checksums via Jinja2 conditionals
- `sha256sum -c` verification before setting executable bit

#### How to verify it
```bash
# amd64:
curl -fsSL -o bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.28.1/bazelisk-linux-amd64
echo '22e7d3a188699982f661cf4687137ee52d1f24fec1ec893d91a6c4d791a75de8  bazelisk' | sha256sum -c -

# arm64:
curl -fsSL -o bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.28.1/bazelisk-linux-arm64
echo '8ded44b58a0d9425a4178af26cf17693feac3b87bdcfef0a2a0898fcd1afc9f2  bazelisk' | sha256sum -c -
```

Part of a series to add SHA256 verification to all external downloads.