### PR TITLE
[Nexthop] Fix unit test failure: No module named 'sonic_py_common.logger'

### DIFF
--- a/platform/broadcom/sonic-platform-modules-nexthop/test/fixtures/mock_imports_unit_tests.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/test/fixtures/mock_imports_unit_tests.py
@@ -12,7 +12,7 @@ that are not available in test environments.
 
 import types
 
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 from fixtures.fake_swsscommon import fake_swsscommon_modules
 
 
@@ -59,6 +59,7 @@ def mock_syslog_modules():
 
     class MockSysLogger:
         # Methods as mocks so tests can assert calls
+        log_notice = Mock()
         log_info = Mock()
         log_error = Mock()
         log_warning = Mock()
@@ -68,15 +69,19 @@ def mock_syslog_modules():
         def __init__(self, *args, **kwargs):
             pass
 
-    syslogger = Mock()
+    syslogger = MagicMock()
     syslogger.SysLogger = MockSysLogger
+    
+    logger = MagicMock()
+    logger.Logger = MockSysLogger
 
-    syslog = Mock()
+    syslog = MagicMock()
     syslog.SYSLOG_IDENTIFIER_THERMAL = "nh_thermal"
     syslog.NhLoggerMixin = MockSysLogger
 
     return {
         "sonic_py_common.syslogger": syslogger,
+        "sonic_py_common.logger": logger,
         "sonic_platform.syslog": syslog,
     }
 

--- a/platform/broadcom/sonic-platform-modules-nexthop/test/integration/conftest.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/test/integration/conftest.py
@@ -15,6 +15,9 @@ import sys
 
 from unittest.mock import patch
 
+from fixtures.mock_imports_unit_tests import mock_syslog_modules
+from fixtures.fake_swsscommon import fake_swsscommon_modules
+
 
 @pytest.fixture(scope="module", autouse=True)
 def patch_dependencies():
@@ -23,14 +26,16 @@ def patch_dependencies():
     This fixture is automatically applied to all tests in the integration/ directory.
     It uses module scope, so it won't interfere with unit tests.
     """
-    TEST_DIR = os.path.dirname(os.path.realpath(__file__))
-    sonic_platform_common = os.path.join(
-        TEST_DIR, "../../../../../src/sonic-platform-common/"
-    )
-    pddf_base = os.path.join(
-        TEST_DIR, "../../../../../platform/pddf/platform-api-pddf-base"
-    )
+    modules = {}
+    modules.update(mock_syslog_modules())
+    modules.update(fake_swsscommon_modules())
 
-    with patch.object(sys, "path", [sonic_platform_common, pddf_base] + sys.path):
-        # Keep the patch active while integration tests are running
-        yield
+    TEST_DIR = os.path.dirname(os.path.realpath(__file__))
+    sonic_py_common = os.path.join(TEST_DIR, "../../../../../src/sonic-py-common/")
+    sonic_platform_common = os.path.join(TEST_DIR, "../../../../../src/sonic-platform-common/")
+    pddf_base = os.path.join(TEST_DIR, "../../../../../platform/pddf/platform-api-pddf-base")
+
+    with patch.dict(sys.modules, modules):
+        with patch.object(sys, "path", [sonic_py_common, sonic_platform_common, pddf_base] + sys.path):
+            # Keep the patch active while integration tests are running
+            yield

--- a/platform/broadcom/sonic-platform-modules-nexthop/test/integration/conftest.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/test/integration/conftest.py
@@ -31,9 +31,15 @@ def patch_dependencies():
     modules.update(fake_swsscommon_modules())
 
     TEST_DIR = os.path.dirname(os.path.realpath(__file__))
-    sonic_py_common = os.path.join(TEST_DIR, "../../../../../src/sonic-py-common/")
-    sonic_platform_common = os.path.join(TEST_DIR, "../../../../../src/sonic-platform-common/")
-    pddf_base = os.path.join(TEST_DIR, "../../../../../platform/pddf/platform-api-pddf-base")
+    sonic_py_common = os.path.join(
+        TEST_DIR, "../../../../../src/sonic-py-common/"
+    )
+    sonic_platform_common = os.path.join(
+        TEST_DIR, "../../../../../src/sonic-platform-common/"
+    )
+    pddf_base = os.path.join(
+        TEST_DIR, "../../../../../platform/pddf/platform-api-pddf-base"
+    )
 
     with patch.dict(sys.modules, modules):
         with patch.object(sys, "path", [sonic_py_common, sonic_platform_common, pddf_base] + sys.path):

--- a/platform/broadcom/sonic-platform-modules-nexthop/test/integration/nexthop/test_adm1266_chassis_integration.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/test/integration/nexthop/test_adm1266_chassis_integration.py
@@ -14,11 +14,8 @@ from unittest.mock import Mock, patch
 def mock_unimportant_modules():
     """Mock modules that aren't important for integration testing."""
     modules = {}
-    modules["sonic_py_common"] = Mock()
     modules["sonic_platform.dpm"] = Mock()
     modules["sonic_platform.dpm"].SystemDPMLogHistory = Mock()
-    modules.update(mock_syslog_modules())
-    modules.update(fake_swsscommon_modules())
 
     with patch.dict(sys.modules, modules):
         yield

--- a/platform/broadcom/sonic-platform-modules-nexthop/test/integration/sonic_platform/test_chassis_sfp_integration.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/test/integration/sonic_platform/test_chassis_sfp_integration.py
@@ -20,18 +20,7 @@ XCVR_REMOVED = "0"
 
 
 @pytest.fixture(scope="module")
-def mock_unimportant_modules():
-    """Mock modules that aren't important for integration testing."""
-    modules = {}
-    modules.update(mock_syslog_modules())
-    modules.update(fake_swsscommon_modules())
-
-    with patch.dict(sys.modules, modules):
-        yield
-
-
-@pytest.fixture(scope="module")
-def chassis_module(mock_unimportant_modules):
+def chassis_module():
     """Loads the module before all tests. This is to let conftest.py inject deps first."""
     from sonic_platform import chassis
 
@@ -39,7 +28,7 @@ def chassis_module(mock_unimportant_modules):
 
 
 @pytest.fixture(scope="module")
-def mock_sfps(mock_unimportant_modules):
+def mock_sfps():
     """
     Fixture providing autospec'ed mock SFP objects for testing.
     Creates a list of mock SFPs and attaches them to the chassis.

--- a/platform/broadcom/sonic-platform-modules-nexthop/test/unit/nexthop/test_pddf_config_parser.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/test/unit/nexthop/test_pddf_config_parser.py
@@ -7,11 +7,9 @@
 Unit tests for the pddf_config_parser module.
 """
 
-import sys
 import os
 import json
 import pytest
-from unittest.mock import MagicMock
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -21,12 +19,6 @@ def pddf_config_parser_module():
 
     yield pddf_config_parser
 
-# Mock sonic_py_common if not available
-try:
-    import sonic_py_common
-except ImportError:
-    sys.modules["sonic_py_common"] = MagicMock()
-    sys.modules["sonic_py_common.logger"] = MagicMock()
 
 CWD = os.path.dirname(os.path.realpath(__file__))
 BASE_PLATFORM_PDDF_PATH = "../../../../../../device/nexthop/{}/pddf"


### PR DESCRIPTION
#### Why I did it

To fix the test failure like below:
```
    try:
        from sonic_platform_pddf_base.pddf_platform import PddfPlatform
    except ImportError as e:
>       raise ImportError(str(e) + "- required module not found")
E       ImportError: No module named 'sonic_py_common.logger'; 'sonic_py_common' is not a package- required module not found- required module not found- required module not found

common/sonic_platform/platform.py:18: ImportError
=========================== short test summary info ============================
ERROR test/integration/nexthop/test_adm1266_chassis_integration.py::TestAdm1266ChassisIntegration::test_chassis_get_reboot_cause - ImportError: No module named 'sonic_py_common.logger'; 'sonic_py_common' is not a package- required module not found- required module not found- required module not found
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

There are two problems here:
1. `sonic_py_common` was mocked at the fixture of `test_adm1266_chassis_integration.py`. So, it was not a package, and `sonic_py_common.logger` couldn't be loaded by [`sonic_platform_base.bmc_base`](https://github.com/sonic-net/sonic-platform-common/blob/95666c6f99883bd9cc8b1b420845f1b1eaf54e6b/sonic_platform_base/bmc_base.py#L18).
2. The patch `mock_syslog_modules()` only mocked `sonic_py_common.syslogger`, but we also needed to mock `sonic_py_common.logger`.
3. The unit test `test_pddf_config_parser.py` mutated `sys.modules["sonic_py_common"]` and `sys.modules["sonic_py_common.logger"]` to be `MagicMock()`. However, this could stay the entire pytest session and affect the tests under `platform/broadcom/sonic-platform-modules-nexthop/test/integration/**`. It pollutes other tests and makes the test result non-deterministic, especially if it gets run first, or if the subsequent pytests use the zombie process.

To fix this:
1. Add a (magic) mock of `sonic_py_common.logger` to `mock_syslog_modules()`.
2. Use the real `sonic_py_common` module.
3. Move all the necessary patching to `platform/broadcom/sonic-platform-modules-nexthop/test/integration/conftest.py`, to avoid similar problems in the future.

#### How to verify it

```
ouis@32dd771989dc:/sonic/platform/broadcom/sonic-platform-modules-nexthop$ python3 -m pytest
========================================================================== test session starts ===========================================================================
platform linux -- Python 3.13.5, pytest-8.3.5, pluggy-1.5.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /sonic/platform/broadcom/sonic-platform-modules-nexthop
configfile: pytest.ini
testpaths: test
plugins: pyfakefs-6.1.1, cov-5.0.0, typeguard-4.4.2
collected 287 items                                                                                                                                                      

test/integration/nexthop/test_adm1266_chassis_integration.py::TestAdm1266ChassisIntegration::test_chassis_get_reboot_cause PASSED                                  [  0%]
test/integration/nexthop/test_eeprom_utils_integration.py::TestEepromUtilsIntegration::test_program_and_decode PASSED                                              [  0%]
test/integration/nexthop/test_eeprom_utils_integration.py::TestEepromUtilsIntegration::test_decode_known_buggy_custom_serial_number PASSED                         [  1%]
test/integration/nexthop/test_eeprom_utils_integration.py::TestEepromUtilsIntegration::test_decode_buggy_regulatory_model_number PASSED                            [  1%]
test/integration/nexthop/test_eeprom_utils_integration.py::TestEepromUtilsIntegration::test_program_replace_nh_custom_fields PASSED                                [  1%]
test/integration/nexthop/test_eeprom_utils_integration.py::TestEepromUtilsIntegration::test_clear PASSED                                                           [  2%]
test/integration/sonic_platform/test_chassis_sfp_integration.py::TestChassisSfpIntegration::test_get_change_event_initial_state PASSED                             [  2%]
test/integration/sonic_platform/test_chassis_sfp_integration.py::TestChassisSfpIntegration::test_get_change_event_no_change_short_timeout PASSED                   [  2%]
test/integration/sonic_platform/test_chassis_sfp_integration.py::TestChassisSfpIntegration::test_get_change_event_no_change_long_timeout PASSED                    [  3%]
test/integration/sonic_platform/test_chassis_sfp_integration.py::TestChassisSfpIntegration::test_get_change_event_partial_change PASSED                            [  3%]
test/integration/sonic_platform/test_chassis_sfp_integration.py::TestChassisSfpIntegration::test_get_change_event_all_inserted PASSED                              [  3%]
test/integration/sonic_platform/test_chassis_sfp_integration.py::TestChassisSfpIntegration::test_get_change_event_all_removed PASSED                               [  4%]
test/unit/nexthop/test_eeprom_utils_unit.py::TestEepromUtils::test_get_find_at24_eeprom_paths PASSED                                                               [  4%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[0:0-0x0-0000:e3:00.0] PASSED                                                                            [  4%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[0:0-0x0-0000:00:02.0] PASSED                                                                            [  5%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[0:0-0x4-0000:e3:00.0] PASSED                                                                            [  5%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[0:0-0x4-0000:00:02.0] PASSED                                                                            [  5%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[0:0-0xab0bac08-0000:e3:00.0] PASSED                                                                     [  6%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[0:0-0xab0bac08-0000:00:02.0] PASSED                                                                     [  6%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[0:0-0xac-0000:e3:00.0] PASSED                                                                           [  6%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[0:0-0xac-0000:00:02.0] PASSED                                                                           [  7%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[0:0-0xa0-0000:e3:00.0] PASSED                                                                           [  7%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[0:0-0xa0-0000:00:02.0] PASSED                                                                           [  8%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[3:7-0x0-0000:e3:00.0] PASSED                                                                            [  8%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[3:7-0x0-0000:00:02.0] PASSED                                                                            [  8%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[3:7-0x4-0000:e3:00.0] PASSED                                                                            [  9%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[3:7-0x4-0000:00:02.0] PASSED                                                                            [  9%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[3:7-0xab0bac08-0000:e3:00.0] PASSED                                                                     [  9%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[3:7-0xab0bac08-0000:00:02.0] PASSED                                                                     [ 10%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[3:7-0xac-0000:e3:00.0] PASSED                                                                           [ 10%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[3:7-0xac-0000:00:02.0] PASSED                                                                           [ 10%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[3:7-0xa0-0000:e3:00.0] PASSED                                                                           [ 11%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[3:7-0xa0-0000:00:02.0] PASSED                                                                           [ 11%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[15:21-0x0-0000:e3:00.0] PASSED                                                                          [ 11%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[15:21-0x0-0000:00:02.0] PASSED                                                                          [ 12%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[15:21-0x4-0000:e3:00.0] PASSED                                                                          [ 12%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[15:21-0x4-0000:00:02.0] PASSED                                                                          [ 12%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[15:21-0xab0bac08-0000:e3:00.0] PASSED                                                                   [ 13%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[15:21-0xab0bac08-0000:00:02.0] PASSED                                                                   [ 13%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[15:21-0xac-0000:e3:00.0] PASSED                                                                         [ 13%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[15:21-0xac-0000:00:02.0] PASSED                                                                         [ 14%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[15:21-0xa0-0000:e3:00.0] PASSED                                                                         [ 14%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[15:21-0xa0-0000:00:02.0] PASSED                                                                         [ 14%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[0:31-0x0-0000:e3:00.0] PASSED                                                                           [ 15%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[0:31-0x0-0000:00:02.0] PASSED                                                                           [ 15%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[0:31-0x4-0000:e3:00.0] PASSED                                                                           [ 16%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[0:31-0x4-0000:00:02.0] PASSED                                                                           [ 16%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[0:31-0xab0bac08-0000:e3:00.0] PASSED                                                                    [ 16%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[0:31-0xab0bac08-0000:00:02.0] PASSED                                                                    [ 17%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[0:31-0xac-0000:e3:00.0] PASSED                                                                          [ 17%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[0:31-0xac-0000:00:02.0] PASSED                                                                          [ 17%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[0:31-0xa0-0000:e3:00.0] PASSED                                                                          [ 18%]
test/unit/nexthop/test_fpga_cli.py::test_read32_valid_args[0:31-0xa0-0000:00:02.0] PASSED                                                                          [ 18%]
test/unit/nexthop/test_fpga_cli.py::test_read32_unaligned_offset[0x1] PASSED                                                                                       [ 18%]
test/unit/nexthop/test_fpga_cli.py::test_read32_unaligned_offset[0x2] PASSED                                                                                       [ 19%]
test/unit/nexthop/test_fpga_cli.py::test_read32_unaligned_offset[0x3] PASSED                                                                                       [ 19%]
test/unit/nexthop/test_fpga_cli.py::test_read32_unaligned_offset[0xbeef] PASSED                                                                                    [ 19%]
test/unit/nexthop/test_fpga_cli.py::test_read32_bad_hex_offset[0xg] PASSED                                                                                         [ 20%]
test/unit/nexthop/test_fpga_cli.py::test_read32_bad_hex_offset[0x] PASSED                                                                                          [ 20%]
test/unit/nexthop/test_fpga_cli.py::test_read32_bad_hex_offset[0xcoffee] PASSED                                                                                    [ 20%]
test/unit/nexthop/test_fpga_cli.py::test_read32_malformed_bits[-1:31] PASSED                                                                                       [ 21%]
test/unit/nexthop/test_fpga_cli.py::test_read32_malformed_bits[0:] PASSED                                                                                          [ 21%]
test/unit/nexthop/test_fpga_cli.py::test_read32_malformed_bits[:0] PASSED                                                                                          [ 21%]
test/unit/nexthop/test_fpga_cli.py::test_read32_malformed_bits[0:15:31] PASSED                                                                                     [ 22%]
test/unit/nexthop/test_fpga_cli.py::test_read32_malformed_bits[a:b] PASSED                                                                                         [ 22%]
test/unit/nexthop/test_fpga_cli.py::test_read32_out_of_range_bits PASSED                                                                                           [ 22%]
test/unit/nexthop/test_fpga_cli.py::test_read32_invalid_start_bits PASSED                                                                                          [ 23%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[0:0-0x0-0000:e3:00.0] PASSED                                                                           [ 23%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[0:0-0x0-0000:00:02.0] PASSED                                                                           [ 24%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[0:0-0x4-0000:e3:00.0] PASSED                                                                           [ 24%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[0:0-0x4-0000:00:02.0] PASSED                                                                           [ 24%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[0:0-0xab0bac08-0000:e3:00.0] PASSED                                                                    [ 25%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[0:0-0xab0bac08-0000:00:02.0] PASSED                                                                    [ 25%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[0:0-0xac-0000:e3:00.0] PASSED                                                                          [ 25%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[0:0-0xac-0000:00:02.0] PASSED                                                                          [ 26%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[0:0-0xa0-0000:e3:00.0] PASSED                                                                          [ 26%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[0:0-0xa0-0000:00:02.0] PASSED                                                                          [ 26%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[3:7-0x0-0000:e3:00.0] PASSED                                                                           [ 27%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[3:7-0x0-0000:00:02.0] PASSED                                                                           [ 27%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[3:7-0x4-0000:e3:00.0] PASSED                                                                           [ 27%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[3:7-0x4-0000:00:02.0] PASSED                                                                           [ 28%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[3:7-0xab0bac08-0000:e3:00.0] PASSED                                                                    [ 28%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[3:7-0xab0bac08-0000:00:02.0] PASSED                                                                    [ 28%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[3:7-0xac-0000:e3:00.0] PASSED                                                                          [ 29%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[3:7-0xac-0000:00:02.0] PASSED                                                                          [ 29%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[3:7-0xa0-0000:e3:00.0] PASSED                                                                          [ 29%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[3:7-0xa0-0000:00:02.0] PASSED                                                                          [ 30%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[15:21-0x0-0000:e3:00.0] PASSED                                                                         [ 30%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[15:21-0x0-0000:00:02.0] PASSED                                                                         [ 31%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[15:21-0x4-0000:e3:00.0] PASSED                                                                         [ 31%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[15:21-0x4-0000:00:02.0] PASSED                                                                         [ 31%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[15:21-0xab0bac08-0000:e3:00.0] PASSED                                                                  [ 32%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[15:21-0xab0bac08-0000:00:02.0] PASSED                                                                  [ 32%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[15:21-0xac-0000:e3:00.0] PASSED                                                                        [ 32%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[15:21-0xac-0000:00:02.0] PASSED                                                                        [ 33%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[15:21-0xa0-0000:e3:00.0] PASSED                                                                        [ 33%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[15:21-0xa0-0000:00:02.0] PASSED                                                                        [ 33%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[0:31-0x0-0000:e3:00.0] PASSED                                                                          [ 34%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[0:31-0x0-0000:00:02.0] PASSED                                                                          [ 34%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[0:31-0x4-0000:e3:00.0] PASSED                                                                          [ 34%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[0:31-0x4-0000:00:02.0] PASSED                                                                          [ 35%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[0:31-0xab0bac08-0000:e3:00.0] PASSED                                                                   [ 35%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[0:31-0xab0bac08-0000:00:02.0] PASSED                                                                   [ 35%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[0:31-0xac-0000:e3:00.0] PASSED                                                                         [ 36%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[0:31-0xac-0000:00:02.0] PASSED                                                                         [ 36%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[0:31-0xa0-0000:e3:00.0] PASSED                                                                         [ 36%]
test/unit/nexthop/test_fpga_cli.py::test_write32_valid_args[0:31-0xa0-0000:00:02.0] PASSED                                                                         [ 37%]
test/unit/nexthop/test_fpga_cli.py::test_write32_unaligned_offset[0x1] PASSED                                                                                      [ 37%]
test/unit/nexthop/test_fpga_cli.py::test_write32_unaligned_offset[0x2] PASSED                                                                                      [ 37%]
test/unit/nexthop/test_fpga_cli.py::test_write32_unaligned_offset[0x3] PASSED                                                                                      [ 38%]
test/unit/nexthop/test_fpga_cli.py::test_write32_unaligned_offset[0xbeef] PASSED                                                                                   [ 38%]
test/unit/nexthop/test_fpga_cli.py::test_write32_bad_hex_offset[0xg] PASSED                                                                                        [ 39%]
test/unit/nexthop/test_fpga_cli.py::test_write32_bad_hex_offset[0x] PASSED                                                                                         [ 39%]
test/unit/nexthop/test_fpga_cli.py::test_write32_bad_hex_offset[0xcoffee] PASSED                                                                                   [ 39%]
test/unit/nexthop/test_fpga_cli.py::test_write32_malformed_bits[-1:31] PASSED                                                                                      [ 40%]
test/unit/nexthop/test_fpga_cli.py::test_write32_malformed_bits[0:] PASSED                                                                                         [ 40%]
test/unit/nexthop/test_fpga_cli.py::test_write32_malformed_bits[:0] PASSED                                                                                         [ 40%]
test/unit/nexthop/test_fpga_cli.py::test_write32_malformed_bits[0:15:31] PASSED                                                                                    [ 41%]
test/unit/nexthop/test_fpga_cli.py::test_write32_malformed_bits[a:b] PASSED                                                                                        [ 41%]
test/unit/nexthop/test_fpga_cli.py::test_write32_out_of_range_bits PASSED                                                                                          [ 41%]
test/unit/nexthop/test_fpga_cli.py::test_write32_invalid_start_bits PASSED                                                                                         [ 42%]
test/unit/nexthop/test_fpga_cli.py::test_write32_value_exceeds_bits PASSED                                                                                         [ 42%]
test/unit/nexthop/test_fpga_cli.py::test_read32_with_fpga_name PASSED                                                                                              [ 42%]
test/unit/nexthop/test_fpga_cli.py::test_write32_with_fpga_name PASSED                                                                                             [ 43%]
test/unit/nexthop/test_fpga_cli.py::test_invalid_fpga_name_error_message PASSED                                                                                    [ 43%]
test/unit/nexthop/test_fpga_cli.py::test_echo_available_fpgas PASSED                                                                                               [ 43%]
test/unit/nexthop/test_fpga_lib.py::test_find_pci_devices[4369-8738-pci_devices0-expected0] PASSED                                                                 [ 44%]
test/unit/nexthop/test_fpga_lib.py::test_find_pci_devices[4369-None-pci_devices1-expected1] PASSED                                                                 [ 44%]
test/unit/nexthop/test_fpga_lib.py::test_find_xilinx_fpgas[pci_devices0-expected0] PASSED                                                                          [ 44%]
test/unit/nexthop/test_fpga_lib.py::test_find_xilinx_fpgas[pci_devices1-expected1] PASSED                                                                          [ 45%]
test/unit/nexthop/test_fpga_lib.py::test_find_xilinx_fpgas[pci_devices2-expected2] PASSED                                                                          [ 45%]
test/unit/nexthop/test_fpga_lib.py::test_read_write PASSED                                                                                                         [ 45%]
test/unit/nexthop/test_fpga_lib.py::test_compute_bitmask PASSED                                                                                                    [ 46%]
test/unit/nexthop/test_fpga_lib.py::test_get_field PASSED                                                                                                          [ 46%]
test/unit/nexthop/test_fpga_lib.py::test_overwrite_field PASSED                                                                                                    [ 47%]
test/unit/nexthop/test_fpga_lib.py::test_overwrite_field_raises_when_value_exceed_bit_range PASSED                                                                 [ 47%]
test/unit/nexthop/test_gen_cli.py::test_generate_pddf_device_json_success PASSED                                                                                   [ 47%]
test/unit/nexthop/test_gen_cli.py::test_generate_pcie_yaml_success PASSED                                                                                          [ 48%]
test/unit/nexthop/test_gen_cli.py::test_generate_pddf_device_json_skipped_when_default_paths_not_found PASSED                                                      [ 48%]
test/unit/nexthop/test_gen_cli.py::test_generate_pcie_yaml_skipped_when_default_files_not_found PASSED                                                             [ 48%]
test/unit/nexthop/test_gen_cli.py::test_generate_pddf_device_json_raises_when_user_input_template_not_found PASSED                                                 [ 49%]
test/unit/nexthop/test_gen_cli.py::test_generate_pddf_device_json_raises_when_user_input_vars_not_found PASSED                                                     [ 49%]
test/unit/nexthop/test_gen_cli.py::test_generate_pddf_device_json_raises_when_user_input_platform_json_not_found PASSED                                            [ 49%]
test/unit/nexthop/test_gen_cli.py::test_generate_pcie_yaml_raises_when_user_input_template_not_found PASSED                                                        [ 50%]
test/unit/nexthop/test_gen_cli.py::test_generate_pcie_yaml_raises_when_user_input_vars_not_found PASSED                                                            [ 50%]
test/unit/nexthop/test_led_control.py::TestLedControl::test_led_control[Ethernet0-1-port_status_map0-True-PORT_LED_1-green] PASSED                                 [ 50%]
test/unit/nexthop/test_led_control.py::TestLedControl::test_led_control[Ethernet13-2-port_status_map1-True-PORT_LED_2-off] PASSED                                  [ 51%]
test/unit/nexthop/test_led_control.py::TestLedControl::test_led_control[Ethernet0-1-port_status_map2-False-PORT_LED_1-off] PASSED                                  [ 51%]
test/unit/nexthop/test_led_control.py::TestLedControl::test_led_control[Ethernet27-4-port_status_map3-True-PORT_LED_4-yellow] PASSED                               [ 51%]
test/unit/nexthop/test_led_control.py::TestLedControl::test_led_control[Ethernet0-1-port_status_map4-False-PORT_LED_1-yellow] PASSED                               [ 52%]
test/unit/nexthop/test_led_control.py::TestLedControl::test_led_control[Ethernet0-1-port_status_map5-True-PORT_LED_1-yellow] PASSED                                [ 52%]
test/unit/nexthop/test_led_control.py::TestLedControl::test_led_control[Ethernet0-1-port_status_map6-True-PORT_LED_1-green] PASSED                                 [ 52%]
test/unit/nexthop/test_led_control.py::TestLedControl::test_led_control[Ethernet0-1-port_status_map7-True-PORT_LED_1-off] PASSED                                   [ 53%]
test/unit/nexthop/test_led_control.py::TestLedControl::test_led_control[Ethernet0-1-port_status_map8-True-PORT_LED_1-yellow] PASSED                                [ 53%]
test/unit/nexthop/test_led_control.py::TestLedControl::test_led_control[Ethernet0-1-port_status_map9-True-PORT_LED_1-off] PASSED                                   [ 54%]
test/unit/nexthop/test_led_control.py::TestLedControl::test_led_control[Ethernet0-1-port_status_map10-True-PORT_LED_1-yellow] PASSED                               [ 54%]
test/unit/nexthop/test_led_control.py::TestLedControl::test_get_xcvr_presence[1-xcvr_info_map0-True] PASSED                                                        [ 54%]
test/unit/nexthop/test_led_control.py::TestLedControl::test_get_xcvr_presence[2-xcvr_info_map1-False] PASSED                                                       [ 55%]
test/unit/nexthop/test_led_control.py::TestLedControl::test_get_xcvr_presence[2-xcvr_info_map2-True] PASSED                                                        [ 55%]
test/unit/nexthop/test_led_control.py::TestLedControl::test_get_xcvr_presence[65-xcvr_info_map3-False] PASSED                                                      [ 55%]
test/unit/nexthop/test_led_control.py::TestLedControl::test_get_xcvr_presence[66-xcvr_info_map4-True] PASSED                                                       [ 56%]
test/unit/nexthop/test_led_control.py::TestLedControl::test_get_port_mappings[ports_dict0-expected_logical_to_physical0-expected_physical_to_logical0] PASSED      [ 56%]
test/unit/nexthop/test_led_control.py::TestLedControl::test_get_port_mappings[ports_dict1-expected_logical_to_physical1-expected_physical_to_logical1] PASSED      [ 56%]
test/unit/nexthop/test_led_control.py::TestLedControl::test_get_port_mappings[ports_dict2-expected_logical_to_physical2-expected_physical_to_logical2] PASSED      [ 57%]
test/unit/nexthop/test_pddf_config_parser.py::TestExtractXcvrList::test_extract_xcvr_list PASSED                                                                   [ 57%]
test/unit/nexthop/test_pddf_config_parser.py::TestExtractXcvrList::test_extract_xcvr_list_missing_required_attrs PASSED                                            [ 57%]
test/unit/nexthop/test_pddf_config_parser.py::TestExtractXcvrList::test_extract_xcvr_list_non_port_ctrl_devices PASSED                                             [ 58%]
test/unit/nexthop/test_pddf_config_parser.py::TestExtractXcvrList::test_extract_xcvr_list_missing_i2c_section PASSED                                               [ 58%]
test/unit/nexthop/test_pddf_config_parser.py::TestExtractXcvrList::test_extract_xcvr_list_empty_config PASSED                                                      [ 58%]
test/unit/nexthop/test_pddf_config_parser.py::TestExtractXcvrList::test_extract_xcvr_list_real_40x0_config[x86_64-nexthop_4010-r0] PASSED                          [ 59%]
test/unit/nexthop/test_pddf_config_parser.py::TestExtractXcvrList::test_extract_xcvr_list_real_40x0_config[x86_64-nexthop_4010-r1] PASSED                          [ 59%]
test/unit/nexthop/test_pddf_config_parser.py::TestExtractXcvrList::test_extract_xcvr_list_real_4220_config PASSED                                                  [ 59%]
test/unit/nexthop/test_pddf_config_parser.py::TestExtractXcvrList::test_extract_xcvr_list_real_5010_config PASSED                                                  [ 60%]
test/unit/nexthop/test_pddf_config_parser.py::TestExtractFpgaDevAttrs::test_extract_fpga_attrs_malformed_config PASSED                                             [ 60%]
test/unit/nexthop/test_pddf_config_parser.py::TestExtractFpgaDevAttrs::test_extract_fpga_attrs[x86_64-nexthop_4010-r0] PASSED                                      [ 60%]
test/unit/nexthop/test_pddf_config_parser.py::TestExtractFpgaDevAttrs::test_extract_fpga_attrs[x86_64-nexthop_4010-r1] PASSED                                      [ 61%]
test/unit/nexthop/test_pddf_config_parser.py::TestExtractFpgaDevAttrs::test_extract_fpga_attrs[x86_64-nexthop_5010-r0] PASSED                                      [ 61%]
test/unit/sonic_platform/test_adm1266.py::TestAdm1266Basic::test_read_blackbox PASSED                                                                              [ 62%]
test/unit/sonic_platform/test_adm1266.py::TestAdm1266Basic::test_parse_blackbox PASSED                                                                             [ 62%]
test/unit/sonic_platform/test_adm1266.py::TestAdm1266Basic::test_get_blackbox_records PASSED                                                                       [ 62%]
test/unit/sonic_platform/test_adm1266.py::TestAdm1266Basic::test_get_reboot_causes PASSED                                                                          [ 63%]
test/unit/sonic_platform/test_adm1266.py::TestAdm1266Basic::test_get_name PASSED                                                                                   [ 63%]
test/unit/sonic_platform/test_adm1266.py::TestAdm1266Basic::test_clear_blackbox PASSED                                                                             [ 63%]
test/unit/sonic_platform/test_adm1266.py::TestAdm1266Basic::test_get_all_faults PASSED                                                                             [ 64%]
test/unit/sonic_platform/test_adm1266.py::TestAdm1266Basic::test_module_get_reboot_cause PASSED                                                                    [ 64%]
test/unit/sonic_platform/test_adm1266.py::TestAdm1266Basic::test_get_reboot_cause_type PASSED                                                                      [ 64%]
test/unit/sonic_platform/test_adm1266.py::TestAdm1266Basic::test_time_since PASSED                                                                                 [ 65%]
test/unit/sonic_platform/test_adm1266.py::TestAdm1266Basic::test_channel_names PASSED                                                                              [ 65%]
test/unit/sonic_platform/test_adm1266.py::TestAdm1266Basic::test_decode_power_fault_cause_no_match PASSED                                                          [ 65%]
test/unit/sonic_platform/test_adm1266.py::TestAdm1266Basic::test_decode_power_fault_cause_single_match PASSED                                                      [ 66%]
test/unit/sonic_platform/test_adm1266.py::TestAdm1266Basic::test_decode_power_fault_cause_multiple_match PASSED                                                    [ 66%]
test/unit/sonic_platform/test_adm1266.py::TestAdm1266Basic::test_reboot_cause_str_to_type[REBOOT_CAUSE_POWER_LOSS] PASSED                                          [ 66%]
test/unit/sonic_platform/test_adm1266.py::TestAdm1266Basic::test_reboot_cause_str_to_type[REBOOT_CAUSE_POWER_LOSS,REBOOT_CAUSE_WATCHDOG] PASSED                    [ 67%]
test/unit/sonic_platform/test_adm1266.py::TestAdm1266Basic::test_reboot_cause_str_to_type[REBOOT_CAUSE_THERMAL_OVERLOAD_ASIC, REBOOT_CAUSE_HARDWARE_OTHER] PASSED  [ 67%]
test/unit/sonic_platform/test_adm1266.py::TestAdm1266Basic::test_reboot_cause_str_to_type[INVALID_CAUSE] PASSED                                                    [ 67%]
test/unit/sonic_platform/test_chassis.py::TestChassis::test_chassis_basic_functionality PASSED                                                                     [ 68%]
test/unit/sonic_platform/test_chassis.py::TestChassis::test_chassis_get_watchdog PASSED                                                                            [ 68%]
test/unit/sonic_platform/test_chassis.py::TestChassis::test_chassis_get_watchdog_pddf_data_is_empty PASSED                                                         [ 68%]
test/unit/sonic_platform/test_chassis.py::TestChassis::test_chassis_get_watchdog_no_watchdog_presence_in_pddf_data PASSED                                          [ 69%]
test/unit/sonic_platform/test_chassis.py::TestChassis::test_chassis_get_reboot_cause_sw_reboot PASSED                                                              [ 69%]
test/unit/sonic_platform/test_chassis.py::TestChassis::test_chassis_get_reboot_cause_sw_kernel_panic PASSED                                                        [ 70%]
test/unit/sonic_platform/test_chassis.py::TestChassis::test_chassis_get_reboot_cause_hw PASSED                                                                     [ 70%]
test/unit/sonic_platform/test_chassis.py::TestChassis::test_chassis_get_reboot_cause_unknown PASSED                                                                [ 70%]
test/unit/sonic_platform/test_fan.py::TestFan::test_get_presence PASSED                                                                                            [ 71%]
test/unit/sonic_platform/test_fan.py::TestFan::test_get_model_for_present_non_psu_fan PASSED                                                                       [ 71%]
test/unit/sonic_platform/test_fan.py::TestFan::test_get_model_for_non_present_fan PASSED                                                                           [ 71%]
test/unit/sonic_platform/test_fan.py::TestFan::test_fan_init_ok_when_db_conn_fails PASSED                                                                          [ 72%]
test/unit/sonic_platform/test_fan.py::TestFan::test_get_max_speed_default PASSED                                                                                   [ 72%]
test/unit/sonic_platform/test_fan.py::TestFan::test_set_max_speed PASSED                                                                                           [ 72%]
test/unit/sonic_platform/test_fan.py::TestFan::test_set_and_get_max_speed PASSED                                                                                   [ 73%]
test/unit/sonic_platform/test_fan.py::TestFan::test_set_speed_is_clamped_by_max_speed PASSED                                                                       [ 73%]
test/unit/sonic_platform/test_fan.py::TestFan::test_set_and_get_max_speed_when_db_conn_fails PASSED                                                                [ 73%]
test/unit/sonic_platform/test_fan.py::TestFan::test_set_and_get_max_speed_when_db_conn_resumes PASSED                                                              [ 74%]
test/unit/sonic_platform/test_thermal.py::TestPIDController::test_pid_controller_initialization PASSED                                                             [ 74%]
test/unit/sonic_platform/test_thermal.py::TestPIDController::test_pid_controller_custom_parameters[2.0-1.0-0.5-20.0-90.0] PASSED                                   [ 74%]
test/unit/sonic_platform/test_thermal.py::TestPIDController::test_pid_controller_custom_parameters[0.5-0.1-0.05-40.0-100.0] PASSED                                 [ 75%]
test/unit/sonic_platform/test_thermal.py::TestPIDController::test_pid_controller_custom_parameters[1.5-2.0-1.0-30.0-80.0] PASSED                                   [ 75%]
test/unit/sonic_platform/test_thermal.py::TestPIDController::test_pid_controller_compute_first_run PASSED                                                          [ 75%]
test/unit/sonic_platform/test_thermal.py::TestPIDController::test_pid_controller_compute_subsequent_runs PASSED                                                    [ 76%]
test/unit/sonic_platform/test_thermal.py::TestPIDController::test_pid_controller_output_saturation PASSED                                                          [ 76%]
test/unit/sonic_platform/test_thermal.py::TestPIDController::test_pid_controller_integral_anti_windup PASSED                                                       [ 77%]
test/unit/sonic_platform/test_thermal.py::TestPIDController::test_pid_controller_zero_error_steady_state PASSED                                                    [ 77%]
test/unit/sonic_platform/test_thermal.py::TestPIDController::test_pid_controller_oscillating_error PASSED                                                          [ 77%]
test/unit/sonic_platform/test_thermal.py::TestPIDController::test_pid_controller_step_response PASSED                                                              [ 78%]
test/unit/sonic_platform/test_thermal.py::TestPIDController::test_pid_controller_zero_gains PASSED                                                                 [ 78%]
test/unit/sonic_platform/test_thermal.py::TestPIDController::test_pid_controller_very_small_interval PASSED                                                        [ 78%]
test/unit/sonic_platform/test_thermal.py::TestPIDController::test_pid_controller_large_interval PASSED                                                             [ 79%]
test/unit/sonic_platform/test_thermal.py::TestPIDController::test_pid_controller_extreme_output_limits PASSED                                                      [ 79%]
test/unit/sonic_platform/test_thermal.py::TestPIDController::test_pid_controller_floating_point_arithmetic PASSED                                                  [ 79%]
test/unit/sonic_platform/test_thermal.py::TestFanSetSpeedAction::test_fan_set_speed_action_initialization PASSED                                                   [ 80%]
test/unit/sonic_platform/test_thermal.py::TestFanSetSpeedAction::test_fan_set_speed_action_load_from_json_valid PASSED                                             [ 80%]
test/unit/sonic_platform/test_thermal.py::TestFanSetSpeedAction::test_fan_set_speed_action_load_from_json_invalid PASSED                                           [ 80%]
test/unit/sonic_platform/test_thermal.py::TestFanSetSpeedAction::test_fan_set_speed_action_execute PASSED                                                          [ 81%]
test/unit/sonic_platform/test_thermal.py::TestFanSetMaxSpeedAction::test_fan_set_max_speed_action_initialization PASSED                                            [ 81%]
test/unit/sonic_platform/test_thermal.py::TestFanSetMaxSpeedAction::test_fan_set_max_speed_action_load_from_json_valid PASSED                                      [ 81%]
test/unit/sonic_platform/test_thermal.py::TestFanSetMaxSpeedAction::test_fan_set_max_speed_action_load_from_json_invalid PASSED                                    [ 82%]
test/unit/sonic_platform/test_thermal.py::TestFanSetMaxSpeedAction::test_fan_set_max_speed_action_load_from_json_range_validation PASSED                           [ 82%]
test/unit/sonic_platform/test_thermal.py::TestFanSetMaxSpeedAction::test_fan_set_max_speed_action_execute PASSED                                                   [ 82%]
test/unit/sonic_platform/test_thermal.py::TestThermalControlAlgorithmAction::test_thermal_control_action_initialization PASSED                                     [ 83%]
test/unit/sonic_platform/test_thermal.py::TestThermalControlAlgorithmAction::test_thermal_control_action_load_from_json_valid PASSED                               [ 83%]
test/unit/sonic_platform/test_thermal.py::TestThermalControlAlgorithmAction::test_thermal_control_action_load_from_json_missing_fields PASSED                      [ 83%]
test/unit/sonic_platform/test_thermal.py::TestThermalControlAlgorithmAction::test_thermal_control_action_pid_controller_creation PASSED                            [ 84%]
test/unit/sonic_platform/test_thermal.py::TestThermalControlAlgorithmAction::test_thermal_control_action_interval_mismatch PASSED                                  [ 84%]
test/unit/sonic_platform/test_thermal.py::TestThermalControlAlgorithmAction::test_thermal_control_action_convert_pid_output_to_speed PASSED                        [ 85%]
test/unit/sonic_platform/test_thermal.py::TestThermalControlAlgorithmAction::test_thermal_control_action_multiple_domains PASSED                                   [ 85%]
test/unit/sonic_platform/test_thermal.py::TestThermalControlAlgorithmAction::test_thermal_control_action_fan_limits_validation PASSED                              [ 85%]
test/unit/sonic_platform/test_thermal.py::TestThermalControlAlgorithmAction::test_thermal_control_action_missing_interval PASSED                                   [ 86%]
test/unit/sonic_platform/test_thermal.py::TestSetAllFanSpeedsErrorCases::test_set_all_fan_speeds_no_fans_available PASSED                                          [ 86%]
test/unit/sonic_platform/test_thermal.py::TestSetAllFanSpeedsErrorCases::test_set_all_fan_speeds_fan_set_speed_returns_false PASSED                                [ 86%]
test/unit/sonic_platform/test_thermal.py::TestSetAllFanSpeedsErrorCases::test_set_all_fan_speeds_fan_set_speed_raises_exception PASSED                             [ 87%]
test/unit/sonic_platform/test_thermal.py::TestSetAllFanSpeedsErrorCases::test_set_all_fan_speeds_mixed_success_and_failure PASSED                                  [ 87%]
test/unit/sonic_platform/test_thermal.py::TestSetAllFanSpeedsErrorCases::test_set_all_fan_speeds_none_fans_list PASSED                                             [ 87%]
test/unit/sonic_platform/test_thermal.py::TestSfpThermalGetPidSetpoint::test_sfp_thermal_get_pid_setpoint_valid_setpoint PASSED                                    [ 88%]
test/unit/sonic_platform/test_thermal.py::TestSfpThermalGetPidSetpoint::test_sfp_thermal_get_pid_setpoint_none_setpoint PASSED                                     [ 88%]
test/unit/sonic_platform/test_thermal.py::TestSfpThermalGetPidSetpoint::test_sfp_thermal_get_pid_setpoint_invalid_setpoint_below_minimum PASSED                    [ 88%]
test/unit/sonic_platform/test_thermal.py::TestSfpThermalGetPidSetpoint::test_sfp_thermal_get_pid_setpoint_invalid_setpoint_zero PASSED                             [ 89%]
test/unit/sonic_platform/test_thermal.py::TestSfpThermalGetPidSetpoint::test_sfp_thermal_get_pid_setpoint_invalid_setpoint_negative PASSED                         [ 89%]
test/unit/sonic_platform/test_thermal.py::TestSfpThermalGetPidSetpoint::test_sfp_thermal_get_pid_setpoint_warning_logged_only_once PASSED                          [ 89%]
test/unit/sonic_platform/test_thermal.py::TestSfpThermalGetPidSetpoint::test_sfp_thermal_get_pid_setpoint_boundary_conditions PASSED                               [ 90%]
test/unit/sonic_platform/test_thermal.py::TestPortIndexMapper::test_get_interface_name_picks_lowest_and_ignores_invalid PASSED                                     [ 90%]
test/unit/sonic_platform/test_thermal.py::TestSfpThermal::test_default_setpoint_when_thresholds_unavailable PASSED                                                 [ 90%]
test/unit/sonic_platform/test_thermal.py::TestSfpThermal::test_invalid_computed_setpoint_logs_once_and_uses_default PASSED                                         [ 91%]
test/unit/sonic_platform/test_thermal.py::TestSfpThermal::test_thresholds_parsing_and_cache PASSED                                                                 [ 91%]
test/unit/sonic_platform/test_watchdog.py::TestWatchdogHelpers::test_pause_watchdog_punching PASSED                                                                [ 91%]
test/unit/sonic_platform/test_watchdog.py::TestWatchdogAPI::test_read_watchdog_counter_register PASSED                                                             [ 92%]
test/unit/sonic_platform/test_watchdog.py::TestWatchdogAPI::test_read_watchdog_counter_enable PASSED                                                               [ 92%]
test/unit/sonic_platform/test_watchdog.py::TestWatchdogAPI::test_update_watchdog_countdown_value PASSED                                                            [ 93%]
test/unit/sonic_platform/test_watchdog.py::TestWatchdogAPI::test_toggle_watchdog_counter_enable[True-1] PASSED                                                     [ 93%]
test/unit/sonic_platform/test_watchdog.py::TestWatchdogAPI::test_toggle_watchdog_counter_enable[False-0] PASSED                                                    [ 93%]
test/unit/sonic_platform/test_watchdog.py::TestWatchdogAPI::test_toggle_watchdog_reboot[True-1] PASSED                                                             [ 94%]
test/unit/sonic_platform/test_watchdog.py::TestWatchdogAPI::test_toggle_watchdog_reboot[False-0] PASSED                                                            [ 94%]
test/unit/sonic_platform/test_watchdog.py::TestWatchdogAPI::test_arm_seconds_out_of_bound_error[-1] PASSED                                                         [ 94%]
test/unit/sonic_platform/test_watchdog.py::TestWatchdogAPI::test_arm_seconds_out_of_bound_error[0] PASSED                                                          [ 95%]
test/unit/sonic_platform/test_watchdog.py::TestWatchdogAPI::test_arm_seconds_out_of_bound_error[16777.216] PASSED                                                  [ 95%]
test/unit/sonic_platform/test_watchdog.py::TestWatchdogAPI::test_arm_should_update_counter PASSED                                                                  [ 95%]
test/unit/sonic_platform/test_watchdog.py::TestWatchdogAPI::test_arm_should_enable_counter_reboot PASSED                                                           [ 96%]
test/unit/sonic_platform/test_watchdog.py::TestWatchdogAPI::test_arm_should_pause_punching PASSED                                                                  [ 96%]
test/unit/sonic_platform/test_watchdog.py::TestWatchdogAPI::test_arm_should_unpause_punching_on_error PASSED                                                       [ 96%]
test/unit/sonic_platform/test_watchdog.py::TestWatchdogAPI::test_disarm_stops_counter PASSED                                                                       [ 97%]
test/unit/sonic_platform/test_watchdog.py::TestWatchdogAPI::test_disarm_unpause_punching PASSED                                                                    [ 97%]
test/unit/sonic_platform/test_watchdog.py::TestWatchdogAPI::test_disarm_fails_do_not_resume_punching PASSED                                                        [ 97%]
test/unit/sonic_platform/test_watchdog.py::TestWatchdogAPI::test_get_remaining_time_when_not_armed PASSED                                                          [ 98%]
test/unit/sonic_platform/test_watchdog.py::TestWatchdogAPI::test_get_remaining_time_when_armed PASSED                                                              [ 98%]
test/unit/utils/test_nh_reboot_cause.py::test_show_current PASSED                                                                                                  [ 98%]
test/unit/utils/test_nh_reboot_cause.py::test_show_history PASSED                                                                                                  [ 99%]
test/unit/utils/test_nh_reboot_cause.py::test_cli_help PASSED                                                                                                      [ 99%]
test/unit/utils/test_nh_reboot_cause.py::test_unsupported_dpm_type PASSED                                                                                          [100%]

========================================================================== 287 passed in 5.05s ===========================================================================
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

