### PR TITLE
Issue 25726: chrony.conf intf bind is invalid when run in mgmt vrf

### DIFF
--- a/files/image_config/chrony/chrony.conf.j2
+++ b/files/image_config/chrony/chrony.conf.j2
@@ -103,10 +103,8 @@ vrf (default is not to listen on anything) -#}
     {%- endif %}
 {% endif %}
 
-{% if ns.source_intf_ip == 'true' -%}
+{% if not ((NTP) and NTP['global']['vrf'] == 'mgmt') and ns.source_intf_ip == 'true' -%}
 bindacqdevice {{ns.source_intf}}
-{% elif (NTP) and NTP['global']['vrf'] == 'mgmt' -%}
-bindacqdevice eth0
 {% endif %}
 
 # Use time sources from DHCP.


### PR DESCRIPTION
There's a [wrapper script](https://github.com/nexthop-ai/private-sonic-buildimage/blob/1559e32eab1745329ecea01f1cc79c99b5e505dd/files/image_config/chrony/chronyd-starter.sh#L11) sonic-buildimage/files/image-config/chrony/chronyd-starter.sh that will start the `chronyd` service in the mgmt vrf if configured to do so, using `ip vrf exec mgmt /usr/sbin/chronyd $DAEMON_OPTS`.

There's a [wrapper script](https://github.com/nexthop-ai/private-sonic-buildimage/blob/1559e32eab1745329ecea01f1cc79c99b5e505dd/files/image_config/chrony/chronyd-starter.sh#L11) sonic-buildimage/files/image-config/chrony/chronyd-starter.sh that will start the chronyd service in the mgmt vrf if configured to do so, using ip vrf exec mgmt  /usr/sbin/chronyd $DAEMON_OPTS.

Since the VRF routing logic already already handles getting the chrony sync packets to the right interface, there is no need for chrony config to bind to the source interface itself. In fact, doing the bind manually will break the linux network namespace isolation that the VRF uses, and will cause the created socket to be invalid and not usable, making chronyd unable to sync when running in as part of the mgmt VRF.

Closes #25726 

Why I did it
NTP service (using chronyd under the hood) was not working when configured under the mgmt VRF. It would come up, but not actually sync time correctly.

How I did it
The generated configuration file was binding to the given interface, rather than going through the VRF routing mechanism

How to verify it
Without this change, show ntp shows no time sync occurring when bound to the mgmt VRF. With this change, time sync is detected as normal.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

