### PR TITLE
Issue 25728: Add vrf ordering dependency to chrony config

### DIFF
--- a/files/image_config/chrony/override.conf
+++ b/files/image_config/chrony/override.conf
@@ -1,6 +1,7 @@
 [Unit]
 Requires=config-setup.service
 After=config-setup.service
+After=interfaces-config.service
 BindsTo=sonic.target
 After=sonic.target
 


### PR DESCRIPTION
When chrony is configured to start in the mgmt vrf, it needs to be ordered after interfaces-config.service, since that's the service that sets up the mgmt vrf.

Closes #25728

Why I did it
NTP/chrony service is not coming up correctly after reboot/reload when configured to start in the mgmt vrf.

How I did it
When being run in the mgmt vrf, chrony needs to wait to start up until the mgmt vrf is created, so add an After dependency in the chrony config override file that waits for the appropriate service to finish (interfaces-config.service).

How to verify it
Manually verified. Configure the device to enable the mgmt vrf and to have ntp configured to use the mgmt vrf. Then issue a reboot or 'config reload'. Without these changes, chrony will come up incorrectly and require a restart to function (this is a race condition, so the exact failure can be different, and it can even work occasionally, but fails pretty consistently). With these changes, reboot/reload work as expected.
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

