### PR TITLE
Update media settings for Nexthop 5010

### DIFF
--- a/device/nexthop/x86_64-nexthop_5010-r0/media_settings.json
+++ b/device/nexthop/x86_64-nexthop_5010-r0/media_settings.json
@@ -1,1284 +1,13572 @@
 {
-    "PORT_MEDIA_SETTINGS": {
-        "33": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xffffffea",
-                    "lane1": "0xffffffea",
-                    "lane2": "0xffffffea",
-                    "lane3": "0xffffffea"
-                },
-                "main": {
-                    "lane0": "0x68",
-                    "lane1": "0x68",
-                    "lane2": "0x68",
-                    "lane3": "0x68"
-                },
-                "post1": {
-                    "lane0": "0xffffffec",
-                    "lane1": "0xffffffec",
-                    "lane2": "0xffffffec",
-                    "lane3": "0xffffffec"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
+  "PORT_MEDIA_SETTINGS": {
+    "1": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
         },
-        "34": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x68",
-                    "lane1": "0x68",
-                    "lane2": "0x68",
-                    "lane3": "0x68"
-                },
-                "post1": {
-                    "lane0": "0xffffffec",
-                    "lane1": "0xffffffec",
-                    "lane2": "0xffffffec",
-                    "lane3": "0xffffffec"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
         },
-        "35": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x68",
-                    "lane1": "0x68",
-                    "lane2": "0x68",
-                    "lane3": "0x68"
-                },
-                "post1": {
-                    "lane0": "0xffffffec",
-                    "lane1": "0xffffffec",
-                    "lane2": "0xffffffec",
-                    "lane3": "0xffffffec"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
+        "gb_line_pre1": {
+          "lane0": "0xffffffec",
+          "lane1": "0xffffffec",
+          "lane2": "0xffffffec",
+          "lane3": "0xffffffec",
+          "lane4": "0xffffffec",
+          "lane5": "0xffffffec",
+          "lane6": "0xffffffec",
+          "lane7": "0xffffffec"
         },
-        "36": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x68",
-                    "lane1": "0x68",
-                    "lane2": "0x68",
-                    "lane3": "0x68"
-                },
-                "post1": {
-                    "lane0": "0xffffffec",
-                    "lane1": "0xffffffec",
-                    "lane2": "0xffffffec",
-                    "lane3": "0xffffffec"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
+        "gb_line_main": {
+          "lane0": "0x0000008c",
+          "lane1": "0x0000008c",
+          "lane2": "0x0000008c",
+          "lane3": "0x0000008c",
+          "lane4": "0x0000008c",
+          "lane5": "0x0000008c",
+          "lane6": "0x0000008c",
+          "lane7": "0x0000008c"
         },
-        "37": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xffffffea",
-                    "lane1": "0xffffffea",
-                    "lane2": "0xffffffea",
-                    "lane3": "0xffffffea"
-                },
-                "main": {
-                    "lane0": "0x68",
-                    "lane1": "0x68",
-                    "lane2": "0x68",
-                    "lane3": "0x68"
-                },
-                "post1": {
-                    "lane0": "0xffffffec",
-                    "lane1": "0xffffffec",
-                    "lane2": "0xffffffec",
-                    "lane3": "0xffffffec"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
         },
-        "38": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x62",
-                    "lane1": "0x62",
-                    "lane2": "0x62",
-                    "lane3": "0x62"
-                },
-                "post1": {
-                    "lane0": "0xffffffec",
-                    "lane1": "0xffffffec",
-                    "lane2": "0xffffffec",
-                    "lane3": "0xffffffec"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
         },
-        "39": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xffffffec",
-                    "lane1": "0xffffffec",
-                    "lane2": "0xffffffec",
-                    "lane3": "0xffffffec"
-                },
-                "main": {
-                    "lane0": "0x6e",
-                    "lane1": "0x6e",
-                    "lane2": "0x6e",
-                    "lane3": "0x6e"
-                },
-                "post1": {
-                    "lane0": "0xffffffec",
-                    "lane1": "0xffffffec",
-                    "lane2": "0xffffffec",
-                    "lane3": "0xffffffec"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
         },
-        "40": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x2"
-                },
-                "pre1": {
-                    "lane0": "0xffffffec",
-                    "lane1": "0xffffffec",
-                    "lane2": "0xffffffec",
-                    "lane3": "0xffffffec"
-                },
-                "main": {
-                    "lane0": "0x5a",
-                    "lane1": "0x5a",
-                    "lane2": "0x5a",
-                    "lane3": "0x5a"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff4",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffff4"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
         },
-        "41": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x5e",
-                    "lane1": "0x5e",
-                    "lane2": "0x5e",
-                    "lane3": "0x5e"
-                },
-                "post1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
         },
-        "42": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x6e",
-                    "lane1": "0x6e",
-                    "lane2": "0x6e",
-                    "lane3": "0x6e"
-                },
-                "post1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
         },
-        "43": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x2"
-                },
-                "pre1": {
-                    "lane0": "0xffffffea",
-                    "lane1": "0xffffffea",
-                    "lane2": "0xffffffea",
-                    "lane3": "0xffffffea"
-                },
-                "main": {
-                    "lane0": "0x6a",
-                    "lane1": "0x6a",
-                    "lane2": "0x6a",
-                    "lane3": "0x6a"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff4",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffff4"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
         },
-        "44": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x2"
-                },
-                "pre1": {
-                    "lane0": "0xffffffec",
-                    "lane1": "0xffffffec",
-                    "lane2": "0xffffffec",
-                    "lane3": "0xffffffec"
-                },
-                "main": {
-                    "lane0": "0x72",
-                    "lane1": "0x72",
-                    "lane2": "0x72",
-                    "lane3": "0x72"
-                },
-                "post1": {
-                    "lane0": "0xfffffff2",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
-        },
-        "45": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x2"
-                },
-                "pre1": {
-                    "lane0": "0xffffffec",
-                    "lane1": "0xffffffec",
-                    "lane2": "0xffffffec",
-                    "lane3": "0xffffffec"
-                },
-                "main": {
-                    "lane0": "0x72",
-                    "lane1": "0x72",
-                    "lane2": "0x72",
-                    "lane3": "0x72"
-                },
-                "post1": {
-                    "lane0": "0xfffffff2",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
-        },
-        "46": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x6a",
-                    "lane1": "0x6a",
-                    "lane2": "0x6a",
-                    "lane3": "0x6a"
-                },
-                "post1": {
-                    "lane0": "0xffffffec",
-                    "lane1": "0xffffffec",
-                    "lane2": "0xffffffec",
-                    "lane3": "0xffffffec"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
-        },
-        "47": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x6a",
-                    "lane1": "0x6a",
-                    "lane2": "0x6a",
-                    "lane3": "0x6a"
-                },
-                "post1": {
-                    "lane0": "0xffffffec",
-                    "lane1": "0xffffffec",
-                    "lane2": "0xffffffec",
-                    "lane3": "0xffffffec"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
-        },
-        "48": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x6e",
-                    "lane1": "0x6e",
-                    "lane2": "0x6e",
-                    "lane3": "0x6e"
-                },
-                "post1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
-        },
-        "49": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x5a",
-                    "lane1": "0x5a",
-                    "lane2": "0x5a",
-                    "lane3": "0x5a"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff4",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffff4"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
-        },
-        "50": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x2"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x5c",
-                    "lane1": "0x5c",
-                    "lane2": "0x5c",
-                    "lane3": "0x5c"
-                },
-                "post1": {
-                    "lane0": "0xfffffff2",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
-        },
-        "51": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x2"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x5c",
-                    "lane1": "0x5c",
-                    "lane2": "0x5c",
-                    "lane3": "0x5c"
-                },
-                "post1": {
-                    "lane0": "0xfffffff2",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
-        },
-        "52": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x5a",
-                    "lane1": "0x5a",
-                    "lane2": "0x5a",
-                    "lane3": "0x5a"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff4",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffff4"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
-        },
-        "53": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x5a",
-                    "lane1": "0x5a",
-                    "lane2": "0x5a",
-                    "lane3": "0x5a"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff4",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffff4"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
-        },
-        "54": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x2"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x5c",
-                    "lane1": "0x5c",
-                    "lane2": "0x5c",
-                    "lane3": "0x5c"
-                },
-                "post1": {
-                    "lane0": "0xfffffff2",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
-        },
-        "55": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x2"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x5c",
-                    "lane1": "0x5c",
-                    "lane2": "0x5c",
-                    "lane3": "0x5c"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff4",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffff4"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
-        },
-        "56": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x2"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x5c",
-                    "lane1": "0x5c",
-                    "lane2": "0x5c",
-                    "lane3": "0x5c"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff4",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffff4"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
-        },
-        "57": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x2"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x5c",
-                    "lane1": "0x5c",
-                    "lane2": "0x5c",
-                    "lane3": "0x5c"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff4",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffff4"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
-        },
-        "58": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x2"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x5c",
-                    "lane1": "0x5c",
-                    "lane2": "0x5c",
-                    "lane3": "0x5c"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff4",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffff4"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
-        },
-        "59": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x2"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x5a",
-                    "lane1": "0x5a",
-                    "lane2": "0x5a",
-                    "lane3": "0x5a"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff4",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffff4"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
-        },
-        "60": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x2"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x5a",
-                    "lane1": "0x5a",
-                    "lane2": "0x5a",
-                    "lane3": "0x5a"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff4",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffff4"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
-        },
-        "61": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x2"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x5a",
-                    "lane1": "0x5a",
-                    "lane2": "0x5a",
-                    "lane3": "0x5a"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff4",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffff4"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
-        },
-        "62": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x2"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x5a",
-                    "lane1": "0x5a",
-                    "lane2": "0x5a",
-                    "lane3": "0x5a"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff4",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffff4"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
-        },
-        "63": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x2"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x5a",
-                    "lane1": "0x5a",
-                    "lane2": "0x5a",
-                    "lane3": "0x5a"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff4",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffff4"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
-        },
-        "64": {
-            "OPTICAL100": {
-                "pre3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x2"
-                },
-                "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
-                    "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe8"
-                },
-                "main": {
-                    "lane0": "0x5a",
-                    "lane1": "0x5a",
-                    "lane2": "0x5a",
-                    "lane3": "0x5a"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff4",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffff4"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0"
-                }
-            }
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
         }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffec",
+          "lane1": "0xffffffec",
+          "lane2": "0xffffffec",
+          "lane3": "0xffffffec",
+          "lane4": "0xffffffec",
+          "lane5": "0xffffffec",
+          "lane6": "0xffffffec",
+          "lane7": "0xffffffec"
+        },
+        "gb_line_main": {
+          "lane0": "0x0000008c",
+          "lane1": "0x0000008c",
+          "lane2": "0x0000008c",
+          "lane3": "0x0000008c",
+          "lane4": "0x0000008c",
+          "lane5": "0x0000008c",
+          "lane6": "0x0000008c",
+          "lane7": "0x0000008c"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "2": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "3": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff0",
+          "lane1": "0xfffffff0",
+          "lane2": "0xfffffff0",
+          "lane3": "0xfffffff0",
+          "lane4": "0xfffffff0",
+          "lane5": "0xfffffff0",
+          "lane6": "0xfffffff0",
+          "lane7": "0xfffffff0"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080",
+          "lane4": "0x00000080",
+          "lane5": "0x00000080",
+          "lane6": "0x00000080",
+          "lane7": "0x00000080"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6",
+          "lane4": "0xfffffff6",
+          "lane5": "0xfffffff6",
+          "lane6": "0xfffffff6",
+          "lane7": "0xfffffff6"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff0",
+          "lane1": "0xfffffff0",
+          "lane2": "0xfffffff0",
+          "lane3": "0xfffffff0",
+          "lane4": "0xfffffff0",
+          "lane5": "0xfffffff0",
+          "lane6": "0xfffffff0",
+          "lane7": "0xfffffff0"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080",
+          "lane4": "0x00000080",
+          "lane5": "0x00000080",
+          "lane6": "0x00000080",
+          "lane7": "0x00000080"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6",
+          "lane4": "0xfffffff6",
+          "lane5": "0xfffffff6",
+          "lane6": "0xfffffff6",
+          "lane7": "0xfffffff6"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "4": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "5": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "6": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "7": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "8": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "9": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "10": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "11": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "12": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "13": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "14": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "15": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000064",
+          "lane1": "0x00000064",
+          "lane2": "0x00000064",
+          "lane3": "0x00000064",
+          "lane4": "0x00000064",
+          "lane5": "0x00000064",
+          "lane6": "0x00000064",
+          "lane7": "0x00000064"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe",
+          "lane4": "0xfffffffe",
+          "lane5": "0xfffffffe",
+          "lane6": "0xfffffffe",
+          "lane7": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000064",
+          "lane1": "0x00000064",
+          "lane2": "0x00000064",
+          "lane3": "0x00000064",
+          "lane4": "0x00000064",
+          "lane5": "0x00000064",
+          "lane6": "0x00000064",
+          "lane7": "0x00000064"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe",
+          "lane4": "0xfffffffe",
+          "lane5": "0xfffffffe",
+          "lane6": "0xfffffffe",
+          "lane7": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "16": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "17": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "18": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "19": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff0",
+          "lane1": "0xfffffff0",
+          "lane2": "0xfffffff0",
+          "lane3": "0xfffffff0",
+          "lane4": "0xfffffff0",
+          "lane5": "0xfffffff0",
+          "lane6": "0xfffffff0",
+          "lane7": "0xfffffff0"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff0",
+          "lane1": "0xfffffff0",
+          "lane2": "0xfffffff0",
+          "lane3": "0xfffffff0",
+          "lane4": "0xfffffff0",
+          "lane5": "0xfffffff0",
+          "lane6": "0xfffffff0",
+          "lane7": "0xfffffff0"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "20": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "21": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "22": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "23": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff0",
+          "lane1": "0xfffffff0",
+          "lane2": "0xfffffff0",
+          "lane3": "0xfffffff0",
+          "lane4": "0xfffffff0",
+          "lane5": "0xfffffff0",
+          "lane6": "0xfffffff0",
+          "lane7": "0xfffffff0"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000074",
+          "lane1": "0x00000074",
+          "lane2": "0x00000074",
+          "lane3": "0x00000074",
+          "lane4": "0x00000074",
+          "lane5": "0x00000074",
+          "lane6": "0x00000074",
+          "lane7": "0x00000074"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffc",
+          "lane1": "0xfffffffc",
+          "lane2": "0xfffffffc",
+          "lane3": "0xfffffffc",
+          "lane4": "0xfffffffc",
+          "lane5": "0xfffffffc",
+          "lane6": "0xfffffffc",
+          "lane7": "0xfffffffc"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff0",
+          "lane1": "0xfffffff0",
+          "lane2": "0xfffffff0",
+          "lane3": "0xfffffff0",
+          "lane4": "0xfffffff0",
+          "lane5": "0xfffffff0",
+          "lane6": "0xfffffff0",
+          "lane7": "0xfffffff0"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000074",
+          "lane1": "0x00000074",
+          "lane2": "0x00000074",
+          "lane3": "0x00000074",
+          "lane4": "0x00000074",
+          "lane5": "0x00000074",
+          "lane6": "0x00000074",
+          "lane7": "0x00000074"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffc",
+          "lane1": "0xfffffffc",
+          "lane2": "0xfffffffc",
+          "lane3": "0xfffffffc",
+          "lane4": "0xfffffffc",
+          "lane5": "0xfffffffc",
+          "lane6": "0xfffffffc",
+          "lane7": "0xfffffffc"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "24": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "25": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000064",
+          "lane1": "0x00000064",
+          "lane2": "0x00000064",
+          "lane3": "0x00000064",
+          "lane4": "0x00000064",
+          "lane5": "0x00000064",
+          "lane6": "0x00000064",
+          "lane7": "0x00000064"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffff0",
+          "lane1": "0xfffffff0",
+          "lane2": "0xfffffff0",
+          "lane3": "0xfffffff0",
+          "lane4": "0xfffffff0",
+          "lane5": "0xfffffff0",
+          "lane6": "0xfffffff0",
+          "lane7": "0xfffffff0"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000064",
+          "lane1": "0x00000064",
+          "lane2": "0x00000064",
+          "lane3": "0x00000064",
+          "lane4": "0x00000064",
+          "lane5": "0x00000064",
+          "lane6": "0x00000064",
+          "lane7": "0x00000064"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffff0",
+          "lane1": "0xfffffff0",
+          "lane2": "0xfffffff0",
+          "lane3": "0xfffffff0",
+          "lane4": "0xfffffff0",
+          "lane5": "0xfffffff0",
+          "lane6": "0xfffffff0",
+          "lane7": "0xfffffff0"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "26": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff0",
+          "lane1": "0xfffffff0",
+          "lane2": "0xfffffff0",
+          "lane3": "0xfffffff0",
+          "lane4": "0xfffffff0",
+          "lane5": "0xfffffff0",
+          "lane6": "0xfffffff0",
+          "lane7": "0xfffffff0"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000068",
+          "lane1": "0x00000068",
+          "lane2": "0x00000068",
+          "lane3": "0x00000068",
+          "lane4": "0x00000068",
+          "lane5": "0x00000068",
+          "lane6": "0x00000068",
+          "lane7": "0x00000068"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffc",
+          "lane1": "0xfffffffc",
+          "lane2": "0xfffffffc",
+          "lane3": "0xfffffffc",
+          "lane4": "0xfffffffc",
+          "lane5": "0xfffffffc",
+          "lane6": "0xfffffffc",
+          "lane7": "0xfffffffc"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff0",
+          "lane1": "0xfffffff0",
+          "lane2": "0xfffffff0",
+          "lane3": "0xfffffff0",
+          "lane4": "0xfffffff0",
+          "lane5": "0xfffffff0",
+          "lane6": "0xfffffff0",
+          "lane7": "0xfffffff0"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000068",
+          "lane1": "0x00000068",
+          "lane2": "0x00000068",
+          "lane3": "0x00000068",
+          "lane4": "0x00000068",
+          "lane5": "0x00000068",
+          "lane6": "0x00000068",
+          "lane7": "0x00000068"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffc",
+          "lane1": "0xfffffffc",
+          "lane2": "0xfffffffc",
+          "lane3": "0xfffffffc",
+          "lane4": "0xfffffffc",
+          "lane5": "0xfffffffc",
+          "lane6": "0xfffffffc",
+          "lane7": "0xfffffffc"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "27": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "28": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff0",
+          "lane1": "0xfffffff0",
+          "lane2": "0xfffffff0",
+          "lane3": "0xfffffff0",
+          "lane4": "0xfffffff0",
+          "lane5": "0xfffffff0",
+          "lane6": "0xfffffff0",
+          "lane7": "0xfffffff0"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000078",
+          "lane1": "0x00000078",
+          "lane2": "0x00000078",
+          "lane3": "0x00000078",
+          "lane4": "0x00000078",
+          "lane5": "0x00000078",
+          "lane6": "0x00000078",
+          "lane7": "0x00000078"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff0",
+          "lane1": "0xfffffff0",
+          "lane2": "0xfffffff0",
+          "lane3": "0xfffffff0",
+          "lane4": "0xfffffff0",
+          "lane5": "0xfffffff0",
+          "lane6": "0xfffffff0",
+          "lane7": "0xfffffff0"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000078",
+          "lane1": "0x00000078",
+          "lane2": "0x00000078",
+          "lane3": "0x00000078",
+          "lane4": "0x00000078",
+          "lane5": "0x00000078",
+          "lane6": "0x00000078",
+          "lane7": "0x00000078"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "29": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "30": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "31": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff0",
+          "lane1": "0xfffffff0",
+          "lane2": "0xfffffff0",
+          "lane3": "0xfffffff0",
+          "lane4": "0xfffffff0",
+          "lane5": "0xfffffff0",
+          "lane6": "0xfffffff0",
+          "lane7": "0xfffffff0"
+        },
+        "gb_line_main": {
+          "lane0": "0x0000007c",
+          "lane1": "0x0000007c",
+          "lane2": "0x0000007c",
+          "lane3": "0x0000007c",
+          "lane4": "0x0000007c",
+          "lane5": "0x0000007c",
+          "lane6": "0x0000007c",
+          "lane7": "0x0000007c"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff0",
+          "lane1": "0xfffffff0",
+          "lane2": "0xfffffff0",
+          "lane3": "0xfffffff0",
+          "lane4": "0xfffffff0",
+          "lane5": "0xfffffff0",
+          "lane6": "0xfffffff0",
+          "lane7": "0xfffffff0"
+        },
+        "gb_line_main": {
+          "lane0": "0x0000007c",
+          "lane1": "0x0000007c",
+          "lane2": "0x0000007c",
+          "lane3": "0x0000007c",
+          "lane4": "0x0000007c",
+          "lane5": "0x0000007c",
+          "lane6": "0x0000007c",
+          "lane7": "0x0000007c"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "32": {
+      "COPPER50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL50": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xffffffee",
+          "lane1": "0xffffffee",
+          "lane2": "0xffffffee",
+          "lane3": "0xffffffee",
+          "lane4": "0xffffffee",
+          "lane5": "0xffffffee",
+          "lane6": "0xffffffee",
+          "lane7": "0xffffffee"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070",
+          "lane4": "0x00000070",
+          "lane5": "0x00000070",
+          "lane6": "0x00000070",
+          "lane7": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000",
+          "lane4": "0x00000000",
+          "lane5": "0x00000000",
+          "lane6": "0x00000000",
+          "lane7": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "COPPER25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "OPTICAL25": {
+        "gb_line_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_line_pre1": {
+          "lane0": "0xfffffff6",
+          "lane1": "0xfffffff6",
+          "lane2": "0xfffffff6",
+          "lane3": "0xfffffff6"
+        },
+        "gb_line_main": {
+          "lane0": "0x00000070",
+          "lane1": "0x00000070",
+          "lane2": "0x00000070",
+          "lane3": "0x00000070"
+        },
+        "gb_line_post1": {
+          "lane0": "0xfffffffe",
+          "lane1": "0xfffffffe",
+          "lane2": "0xfffffffe",
+          "lane3": "0xfffffffe"
+        },
+        "gb_line_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      },
+      "Default": {
+        "gb_system_pre3": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_pre1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_main": {
+          "lane0": "0x00000080",
+          "lane1": "0x00000080",
+          "lane2": "0x00000080",
+          "lane3": "0x00000080"
+        },
+        "gb_system_post1": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        },
+        "gb_system_post2": {
+          "lane0": "0x00000000",
+          "lane1": "0x00000000",
+          "lane2": "0x00000000",
+          "lane3": "0x00000000"
+        }
+      }
+    },
+    "33": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre1": {
+          "lane0": "0xffffffea",
+          "lane1": "0xffffffea",
+          "lane2": "0xffffffea",
+          "lane3": "0xffffffea"
+        },
+        "main": {
+          "lane0": "0x68",
+          "lane1": "0x68",
+          "lane2": "0x68",
+          "lane3": "0x68"
+        },
+        "post1": {
+          "lane0": "0xffffffec",
+          "lane1": "0xffffffec",
+          "lane2": "0xffffffec",
+          "lane3": "0xffffffec"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "34": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x68",
+          "lane1": "0x68",
+          "lane2": "0x68",
+          "lane3": "0x68"
+        },
+        "post1": {
+          "lane0": "0xffffffec",
+          "lane1": "0xffffffec",
+          "lane2": "0xffffffec",
+          "lane3": "0xffffffec"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "35": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x68",
+          "lane1": "0x68",
+          "lane2": "0x68",
+          "lane3": "0x68"
+        },
+        "post1": {
+          "lane0": "0xffffffec",
+          "lane1": "0xffffffec",
+          "lane2": "0xffffffec",
+          "lane3": "0xffffffec"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "36": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x68",
+          "lane1": "0x68",
+          "lane2": "0x68",
+          "lane3": "0x68"
+        },
+        "post1": {
+          "lane0": "0xffffffec",
+          "lane1": "0xffffffec",
+          "lane2": "0xffffffec",
+          "lane3": "0xffffffec"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "37": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre1": {
+          "lane0": "0xffffffea",
+          "lane1": "0xffffffea",
+          "lane2": "0xffffffea",
+          "lane3": "0xffffffea"
+        },
+        "main": {
+          "lane0": "0x68",
+          "lane1": "0x68",
+          "lane2": "0x68",
+          "lane3": "0x68"
+        },
+        "post1": {
+          "lane0": "0xffffffec",
+          "lane1": "0xffffffec",
+          "lane2": "0xffffffec",
+          "lane3": "0xffffffec"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "38": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x62",
+          "lane1": "0x62",
+          "lane2": "0x62",
+          "lane3": "0x62"
+        },
+        "post1": {
+          "lane0": "0xffffffec",
+          "lane1": "0xffffffec",
+          "lane2": "0xffffffec",
+          "lane3": "0xffffffec"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "39": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre1": {
+          "lane0": "0xffffffec",
+          "lane1": "0xffffffec",
+          "lane2": "0xffffffec",
+          "lane3": "0xffffffec"
+        },
+        "main": {
+          "lane0": "0x6e",
+          "lane1": "0x6e",
+          "lane2": "0x6e",
+          "lane3": "0x6e"
+        },
+        "post1": {
+          "lane0": "0xffffffec",
+          "lane1": "0xffffffec",
+          "lane2": "0xffffffec",
+          "lane3": "0xffffffec"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "40": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x2",
+          "lane1": "0x2",
+          "lane2": "0x2",
+          "lane3": "0x2"
+        },
+        "pre1": {
+          "lane0": "0xffffffec",
+          "lane1": "0xffffffec",
+          "lane2": "0xffffffec",
+          "lane3": "0xffffffec"
+        },
+        "main": {
+          "lane0": "0x5a",
+          "lane1": "0x5a",
+          "lane2": "0x5a",
+          "lane3": "0x5a"
+        },
+        "post1": {
+          "lane0": "0xfffffff4",
+          "lane1": "0xfffffff4",
+          "lane2": "0xfffffff4",
+          "lane3": "0xfffffff4"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "41": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x5e",
+          "lane1": "0x5e",
+          "lane2": "0x5e",
+          "lane3": "0x5e"
+        },
+        "post1": {
+          "lane0": "0xfffffff0",
+          "lane1": "0xfffffff0",
+          "lane2": "0xfffffff0",
+          "lane3": "0xfffffff0"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "42": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x6e",
+          "lane1": "0x6e",
+          "lane2": "0x6e",
+          "lane3": "0x6e"
+        },
+        "post1": {
+          "lane0": "0xfffffff0",
+          "lane1": "0xfffffff0",
+          "lane2": "0xfffffff0",
+          "lane3": "0xfffffff0"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "43": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x2",
+          "lane1": "0x2",
+          "lane2": "0x2",
+          "lane3": "0x2"
+        },
+        "pre1": {
+          "lane0": "0xffffffea",
+          "lane1": "0xffffffea",
+          "lane2": "0xffffffea",
+          "lane3": "0xffffffea"
+        },
+        "main": {
+          "lane0": "0x6a",
+          "lane1": "0x6a",
+          "lane2": "0x6a",
+          "lane3": "0x6a"
+        },
+        "post1": {
+          "lane0": "0xfffffff4",
+          "lane1": "0xfffffff4",
+          "lane2": "0xfffffff4",
+          "lane3": "0xfffffff4"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "44": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x2",
+          "lane1": "0x2",
+          "lane2": "0x2",
+          "lane3": "0x2"
+        },
+        "pre1": {
+          "lane0": "0xffffffec",
+          "lane1": "0xffffffec",
+          "lane2": "0xffffffec",
+          "lane3": "0xffffffec"
+        },
+        "main": {
+          "lane0": "0x72",
+          "lane1": "0x72",
+          "lane2": "0x72",
+          "lane3": "0x72"
+        },
+        "post1": {
+          "lane0": "0xfffffff2",
+          "lane1": "0xfffffff2",
+          "lane2": "0xfffffff2",
+          "lane3": "0xfffffff2"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "45": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x2",
+          "lane1": "0x2",
+          "lane2": "0x2",
+          "lane3": "0x2"
+        },
+        "pre1": {
+          "lane0": "0xffffffec",
+          "lane1": "0xffffffec",
+          "lane2": "0xffffffec",
+          "lane3": "0xffffffec"
+        },
+        "main": {
+          "lane0": "0x72",
+          "lane1": "0x72",
+          "lane2": "0x72",
+          "lane3": "0x72"
+        },
+        "post1": {
+          "lane0": "0xfffffff2",
+          "lane1": "0xfffffff2",
+          "lane2": "0xfffffff2",
+          "lane3": "0xfffffff2"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "46": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x6a",
+          "lane1": "0x6a",
+          "lane2": "0x6a",
+          "lane3": "0x6a"
+        },
+        "post1": {
+          "lane0": "0xffffffec",
+          "lane1": "0xffffffec",
+          "lane2": "0xffffffec",
+          "lane3": "0xffffffec"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "47": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x6a",
+          "lane1": "0x6a",
+          "lane2": "0x6a",
+          "lane3": "0x6a"
+        },
+        "post1": {
+          "lane0": "0xffffffec",
+          "lane1": "0xffffffec",
+          "lane2": "0xffffffec",
+          "lane3": "0xffffffec"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "48": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x6e",
+          "lane1": "0x6e",
+          "lane2": "0x6e",
+          "lane3": "0x6e"
+        },
+        "post1": {
+          "lane0": "0xfffffff0",
+          "lane1": "0xfffffff0",
+          "lane2": "0xfffffff0",
+          "lane3": "0xfffffff0"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "49": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x5a",
+          "lane1": "0x5a",
+          "lane2": "0x5a",
+          "lane3": "0x5a"
+        },
+        "post1": {
+          "lane0": "0xfffffff4",
+          "lane1": "0xfffffff4",
+          "lane2": "0xfffffff4",
+          "lane3": "0xfffffff4"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "50": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x2",
+          "lane1": "0x2",
+          "lane2": "0x2",
+          "lane3": "0x2"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x5c",
+          "lane1": "0x5c",
+          "lane2": "0x5c",
+          "lane3": "0x5c"
+        },
+        "post1": {
+          "lane0": "0xfffffff2",
+          "lane1": "0xfffffff2",
+          "lane2": "0xfffffff2",
+          "lane3": "0xfffffff2"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "51": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x2",
+          "lane1": "0x2",
+          "lane2": "0x2",
+          "lane3": "0x2"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x5c",
+          "lane1": "0x5c",
+          "lane2": "0x5c",
+          "lane3": "0x5c"
+        },
+        "post1": {
+          "lane0": "0xfffffff2",
+          "lane1": "0xfffffff2",
+          "lane2": "0xfffffff2",
+          "lane3": "0xfffffff2"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "52": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x5a",
+          "lane1": "0x5a",
+          "lane2": "0x5a",
+          "lane3": "0x5a"
+        },
+        "post1": {
+          "lane0": "0xfffffff4",
+          "lane1": "0xfffffff4",
+          "lane2": "0xfffffff4",
+          "lane3": "0xfffffff4"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "53": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x5a",
+          "lane1": "0x5a",
+          "lane2": "0x5a",
+          "lane3": "0x5a"
+        },
+        "post1": {
+          "lane0": "0xfffffff4",
+          "lane1": "0xfffffff4",
+          "lane2": "0xfffffff4",
+          "lane3": "0xfffffff4"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "54": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x2",
+          "lane1": "0x2",
+          "lane2": "0x2",
+          "lane3": "0x2"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x5c",
+          "lane1": "0x5c",
+          "lane2": "0x5c",
+          "lane3": "0x5c"
+        },
+        "post1": {
+          "lane0": "0xfffffff2",
+          "lane1": "0xfffffff2",
+          "lane2": "0xfffffff2",
+          "lane3": "0xfffffff2"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "55": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x2",
+          "lane1": "0x2",
+          "lane2": "0x2",
+          "lane3": "0x2"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x5c",
+          "lane1": "0x5c",
+          "lane2": "0x5c",
+          "lane3": "0x5c"
+        },
+        "post1": {
+          "lane0": "0xfffffff4",
+          "lane1": "0xfffffff4",
+          "lane2": "0xfffffff4",
+          "lane3": "0xfffffff4"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "56": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x2",
+          "lane1": "0x2",
+          "lane2": "0x2",
+          "lane3": "0x2"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x5c",
+          "lane1": "0x5c",
+          "lane2": "0x5c",
+          "lane3": "0x5c"
+        },
+        "post1": {
+          "lane0": "0xfffffff4",
+          "lane1": "0xfffffff4",
+          "lane2": "0xfffffff4",
+          "lane3": "0xfffffff4"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "57": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x2",
+          "lane1": "0x2",
+          "lane2": "0x2",
+          "lane3": "0x2"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x5c",
+          "lane1": "0x5c",
+          "lane2": "0x5c",
+          "lane3": "0x5c"
+        },
+        "post1": {
+          "lane0": "0xfffffff4",
+          "lane1": "0xfffffff4",
+          "lane2": "0xfffffff4",
+          "lane3": "0xfffffff4"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "58": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x2",
+          "lane1": "0x2",
+          "lane2": "0x2",
+          "lane3": "0x2"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x5c",
+          "lane1": "0x5c",
+          "lane2": "0x5c",
+          "lane3": "0x5c"
+        },
+        "post1": {
+          "lane0": "0xfffffff4",
+          "lane1": "0xfffffff4",
+          "lane2": "0xfffffff4",
+          "lane3": "0xfffffff4"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "59": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x2",
+          "lane1": "0x2",
+          "lane2": "0x2",
+          "lane3": "0x2"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x5a",
+          "lane1": "0x5a",
+          "lane2": "0x5a",
+          "lane3": "0x5a"
+        },
+        "post1": {
+          "lane0": "0xfffffff4",
+          "lane1": "0xfffffff4",
+          "lane2": "0xfffffff4",
+          "lane3": "0xfffffff4"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "60": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x2",
+          "lane1": "0x2",
+          "lane2": "0x2",
+          "lane3": "0x2"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x5a",
+          "lane1": "0x5a",
+          "lane2": "0x5a",
+          "lane3": "0x5a"
+        },
+        "post1": {
+          "lane0": "0xfffffff4",
+          "lane1": "0xfffffff4",
+          "lane2": "0xfffffff4",
+          "lane3": "0xfffffff4"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "61": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x2",
+          "lane1": "0x2",
+          "lane2": "0x2",
+          "lane3": "0x2"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x5a",
+          "lane1": "0x5a",
+          "lane2": "0x5a",
+          "lane3": "0x5a"
+        },
+        "post1": {
+          "lane0": "0xfffffff4",
+          "lane1": "0xfffffff4",
+          "lane2": "0xfffffff4",
+          "lane3": "0xfffffff4"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "62": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x2",
+          "lane1": "0x2",
+          "lane2": "0x2",
+          "lane3": "0x2"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x5a",
+          "lane1": "0x5a",
+          "lane2": "0x5a",
+          "lane3": "0x5a"
+        },
+        "post1": {
+          "lane0": "0xfffffff4",
+          "lane1": "0xfffffff4",
+          "lane2": "0xfffffff4",
+          "lane3": "0xfffffff4"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "63": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x2",
+          "lane1": "0x2",
+          "lane2": "0x2",
+          "lane3": "0x2"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x5a",
+          "lane1": "0x5a",
+          "lane2": "0x5a",
+          "lane3": "0x5a"
+        },
+        "post1": {
+          "lane0": "0xfffffff4",
+          "lane1": "0xfffffff4",
+          "lane2": "0xfffffff4",
+          "lane3": "0xfffffff4"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
+    },
+    "64": {
+      "OPTICAL100": {
+        "pre3": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        },
+        "pre2": {
+          "lane0": "0x2",
+          "lane1": "0x2",
+          "lane2": "0x2",
+          "lane3": "0x2"
+        },
+        "pre1": {
+          "lane0": "0xffffffe8",
+          "lane1": "0xffffffe8",
+          "lane2": "0xffffffe8",
+          "lane3": "0xffffffe8"
+        },
+        "main": {
+          "lane0": "0x5a",
+          "lane1": "0x5a",
+          "lane2": "0x5a",
+          "lane3": "0x5a"
+        },
+        "post1": {
+          "lane0": "0xfffffff4",
+          "lane1": "0xfffffff4",
+          "lane2": "0xfffffff4",
+          "lane3": "0xfffffff4"
+        },
+        "post2": {
+          "lane0": "0x0",
+          "lane1": "0x0",
+          "lane2": "0x0",
+          "lane3": "0x0"
+        }
+      }
     }
+  }
 }

--- a/src/sonic-device-data/tests/media_checker
+++ b/src/sonic-device-data/tests/media_checker
@@ -7,12 +7,42 @@ import sys
 
 level1_keys = ["GLOBAL_MEDIA_SETTINGS","PORT_MEDIA_SETTINGS"]
 
-si_param_list = ["preemphasis", "idriver", "ipredriver", \
-                 "main", "pre1", "pre2", "pre3", \
-                 "post1", "post2", "post3", "attn", \
-                 "ob_m2lp", "ob_alev_out", "obplev", "obnlev", \
-                 "regn_bfm1p", "regn_bfm1n", "unreliable_los", \
-                 "rxpolarity", "interface_type"]
+si_param_list = [
+    "preemphasis",
+    "idriver",
+    "ipredriver",
+    "main",
+    "pre1",
+    "pre2",
+    "pre3",
+    "post1",
+    "post2",
+    "post3",
+    "gb_line_pre1",
+    "gb_line_pre2",
+    "gb_line_pre3",
+    "gb_line_main",
+    "gb_line_post1",
+    "gb_line_post2",
+    "gb_line_post3",
+    "gb_system_pre1",
+    "gb_system_pre2",
+    "gb_system_pre3",
+    "gb_system_main",
+    "gb_system_post1",
+    "gb_system_post2",
+    "gb_system_post3",
+    "attn",
+    "ob_m2lp",
+    "ob_alev_out",
+    "obplev", 
+    "obnlev",
+    "regn_bfm1p",
+    "regn_bfm1n",
+    "unreliable_los",
+    "rxpolarity",
+    "interface_type"
+]
 lane_speed_key_prefix = 'speed:'
 lane_prefix = "lane"
 comma_separator = ","


### PR DESCRIPTION
#### Why I did it

Update media settings for Nexthop 5010 to use the new gearbox media settings format introduced in https://github.com/sonic-net/sonic-platform-daemons/pull/728.

#### How to verify it

- Installed media_settings.json on a nexthop device. Links came up and the expected SI values were programmed into hardware.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511


#### Description for the changelog
Update media settings for Nexthop 5010