### PR TITLE
[Mellanox] Add missing After=hw-management.service to config-setup service dependency

### DIFF
--- a/files/build_templates/config-setup.service.j2
+++ b/files/build_templates/config-setup.service.j2
@@ -7,6 +7,7 @@ Requires=config-topology.service
 Requires=database.service
 {% if sonic_asic_platform == 'mellanox' -%}
 Requires=hw-management.service
+After=hw-management.service
 {% endif -%}
 
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

On Mellanox platforms, `xcvrd` (transceiver daemon) inside the `pmon` container crashes during boot with:

```
ERR pmon#xcvrd: SFP OBJ INIT: Failed to get SFP object for port N due to
    ModuleNotFoundError("No module named 'hw_management_independent_mode_update'")
```

**Root cause**: `config-setup.service` has `Requires=hw-management.service` but is missing `After=hw-management.service`.

In systemd, `Requires=` and `After=` are **two independent concepts** ([systemd.unit(5)](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html)):

- **`Requires=`** — Declares a **dependency requirement**. If this unit is activated, the listed units will also be activated. If any required unit fails to start or is deactivated, this unit will also be deactivated. However, `Requires=` says nothing about **start order**. From the official documentation:

  > *"Note that requirement dependencies do not influence the order in which services are started or stopped. This has to be configured independently with the `After=` or `Before=` options."*

- **`After=`** — Declares **startup ordering**. If both units are being activated, the unit with `After=` will wait for the listed unit to **finish starting** before it begins. From the official documentation:

  > *"If unit `foo.service` contains a setting `After=bar.service` and both units are being started, `foo.service`'s start-up is delayed until `bar.service` has finished starting up."*

Without `After=`, even though `Requires=` ensures both services are activated, systemd starts them simultaneously in parallel. This is by design for maximum parallelism, but in our case it creates a race condition.

```
config-setup starts ──> config-setup finishes ──> pmon starts ──> xcvrd tries to import sfp.py
        ↓ (parallel, no ordering)
hw-management starts ───────────────────────────> hw-management creates /run/hw-management/bin/*.py
```

When `hw-management.service` takes longer than `config-setup.service`, `xcvrd` starts before `/run/hw-management/bin/hw_management_independent_mode_update.py` exists.

If syncd ever becomes faster (e.g., warm boot, faster SDK, new ASIC), or hw-management becomes slower (e.g., I2C delays, new platform with more hardware probing), it may hit the exact same race condition.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added `After=hw-management.service` to `config-setup.service.j2` inside the existing Mellanox platform conditional block, pairing it with the existing `Requires=hw-management.service`.

With both directives together, systemd now enforces:
1. `Requires=` — hw-management **must** be activated when config-setup starts (existing behavior)
2. `After=` — config-setup **waits** for hw-management to finish starting before beginning its own start (new behavior)

This fixes the boot sequence to:
```
hw-management starts ──> hw-management finishes (creates /run/hw-management/bin/*.py)
                                 ↓ (After= enforces ordering)
                         config-setup starts ──> config-setup finishes
                                                        ↓
                                                 pmon starts ──> xcvrd imports sfp.py ──> OK
```

#### How to verify it


1. Verify the systemd dependency is correct (on a Mellanox switch):
   ```bash
   # Check that After= now includes hw-management.service
   systemctl show config-setup.service --property=After | grep hw-management
   # Expected: hw-management.service appears in the After= list
   ```

2. Verify service ordering on boot:
   ```bash
   # Check timestamps after a reboot
   systemctl show hw-management.service --property=ActiveEnterTimestamp
   systemctl show config-setup.service --property=ActiveEnterTimestamp
   systemctl show pmon.service --property=ActiveEnterTimestamp
   # Expected: hw-management finishes BEFORE config-setup finishes BEFORE pmon starts
   ```

3. Verify xcvrd is healthy after reboot:
   ```bash
   sudo docker exec pmon supervisorctl status xcvrd
   # Expected: xcvrd RUNNING (not FATAL)

   # Check syslog for absence of the error
   grep "ModuleNotFoundError.*hw_management_independent_mode_update" /var/log/syslog
   # Expected: no matches
   ```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

