### PR TITLE
[docker] Mount /etc/passwd and /etc/group to fix gNMI authentication

### DIFF
--- a/rules/docker-gnmi.mk
+++ b/rules/docker-gnmi.mk
@@ -40,6 +40,10 @@ $(DOCKER_GNMI)_RUN_OPT += -v /:/mnt/host:ro
 $(DOCKER_GNMI)_RUN_OPT += -v /tmp:/mnt/host/tmp:rw
 # For sonic binary image downloads to persistent file system.
 $(DOCKER_GNMI)_RUN_OPT += -v /var/tmp:/mnt/host/var/tmp:rw
+# Read-only mount of host machine /etc/passwd to container
+$(DOCKER_GNMI)_RUN_OPT += -v /etc/passwd:/etc/passwd:ro
+# Read-only mount of host /etc/group to container
+$(DOCKER_GNMI)_RUN_OPT += -v /etc/group:/etc/group:ro
 # For host command execution in gnoi.
 $(DOCKER_GNMI)_RUN_OPT += --pid=host
 # For host command execution in gnoi.


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

When using password authentication, executing the `gnmi_get` command fails for the `admin` user.
Closes https://github.com/sonic-net/sonic-buildimage/issues/25745

This occurs because the host's `/etc/passwd` and `/etc/group` files are not mounted into the gNMI docker container, preventing the container from resolving the host's users. To fix this, I updated `docker-gnmi.mk` to explicitly mount these files into the container, allowing gNMI to authenticate users properly.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added the following volume mounts in `docker-gnmi.mk` to map the host's user and group files:
```
RUN_OPT += -v /etc/passwd:/etc/passwd:ro
RUN_OPT += -v /etc/group:/etc/group:ro
```

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Verify that the `gnmi_get` command can successfully query information and authenticate the admin user:

```
gnmi_get -xpath_target SONiC-YANG -xpath /sonic-port:sonic-port/ -target_addr 127.0.0.1:8080 -username admin -password YourPaSsWoRd -insecure true
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202505
- [x] 202511
- [x] master

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

Built 202511 and master images.

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

Fix gNMI password authentication failure by mounting host user directories into the container.
