### PR TITLE
[frr] Fix return-mismatch in SONiC patch for GCC 14 (trixie)

### DIFF
--- a/src/sonic-frr/patch/0014-SONiC-ONLY-Adding-changes-to-write-ip-nht-resolve-via-default-c.patch
+++ b/src/sonic-frr/patch/0014-SONiC-ONLY-Adding-changes-to-write-ip-nht-resolve-via-default-c.patch
@@ -49,7 +49,7 @@ index 3231b03b8..3beb552c6 100644
 +		else
 +			vty_out(vty, "!\n");
 +	}
-+	return 0;
++	return;
 +
 +}
 +


### PR DESCRIPTION
#### What I did
Fix `return 0;` in a `void` function in SONiC FRR patch 0014 (`zebra_vrf_config_write`).

#### Why I did it
GCC 14 (Debian trixie) promotes `-Wreturn-mismatch` to an error, breaking the FRR build when `BLDENV=trixie`. GCC 12 (bookworm) only warns, so this hasn't been caught until now.

#### How I verified it
Built FRR 10.4.1 under trixie slave container (`BLDENV=trixie`) — build succeeds with this fix, fails without it.

#### Description for the changelog
Fixed FRR build failure under Debian trixie (GCC 14) caused by `return 0;` in void function `zebra_vrf_config_write()` in SONiC patch 0014.