### PR TITLE
Fix 'show version' crash in docker-sonic-vs: add missing version fields

### DIFF
--- a/platform/vs/sonic-version/build_sonic_version.sh
+++ b/platform/vs/sonic-version/build_sonic_version.sh
@@ -1,8 +1,11 @@
 export build_version="${sonic_version}"
+export debian_version="$(cat /etc/debian_version 2>/dev/null || echo 'N/A')"
+export kernel_version="$(uname -r)"
 export asic_type="${sonic_asic_platform}"
 export commit_id="$(git rev-parse --short HEAD)"
 export branch="$(git rev-parse --abbrev-ref HEAD)"
 export build_date="$(date -u)"
 export build_number="${BUILD_NUMBER:-0}"
 export built_by="$USER@$BUILD_HOSTNAME"
+export sonic_os_version="${debian_version%%.*}"
 j2 sonic_version.yml.j2 > $1


### PR DESCRIPTION
## Description
`show version` crashes with `KeyError: 'debian_version'` inside docker-sonic-vs containers because `sonic_version.yml` is missing `debian_version` and `kernel_version` fields.

### Root Cause
`sonic_version.yml.j2` conditionally includes these fields only when the variables are defined:

```jinja2
{% if debian_version is defined -%}
debian_version: '{{ debian_version }}'
{% endif -%}
```

The full image build (`build_debian.sh`) exports them from the filesystem root, but the VS platform `build_sonic_version.sh` never exports these variables, so the j2 template omits them.

`show/main.py` then accesses them unconditionally:
```python
click.echo("Distribution: Debian {}".format(version_info['debian_version']))
click.echo("Kernel: {}".format(version_info['kernel_version']))
```

### Fix
Export `debian_version` and `kernel_version` from the build host in `platform/vs/sonic-version/build_sonic_version.sh`.

### Reproduction
```bash
docker exec <docker-sonic-vs-container> show version
# KeyError: 'debian_version'
```

### Testing
- Built docker-sonic-vs with the fix
- `show version` completes without errors
- `sonic_version.yml` now includes all expected fields

Fixes #25765

Signed-off-by: securely1g <securely1g@users.noreply.github.com>