### PR TITLE
Update port_config.ini header to correctly display 2024-2026

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn4280_simx-r0/ACS-SN4280/port_config.ini
+++ b/device/mellanox/x86_64-nvidia_sn4280_simx-r0/ACS-SN4280/port_config.ini
@@ -1,4 +1,5 @@
 ##
+## SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
 ## Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES.
 ## Apache-2.0
 ##


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
port_config.ini header has become outdated due to the new year and needs to be updated to 2026.

