### PR TITLE
Add lldpd to docker-sonic-vs for LLDP neighbor discovery

### DIFF
--- a/platform/vs/docker-sonic-vs.mk
+++ b/platform/vs/docker-sonic-vs.mk
@@ -12,14 +12,16 @@ $(DOCKER_SONIC_VS)_DEPENDS += $(SYNCD_VS) \
                               $(LIBYANG_PY3) \
                               $(SONIC_UTILITIES_DATA) \
                               $(SONIC_HOST_SERVICES_DATA) \
-                              $(SYSMGR)
+                              $(SYSMGR) \
+                              $(LLDPD)
 
 $(DOCKER_SONIC_VS)_PYTHON_WHEELS += $(SONIC_PY_COMMON_PY3) \
                                     $(SONIC_PLATFORM_COMMON_PY3) \
                                     $(SONIC_YANG_MODELS_PY3) \
                                     $(SONIC_YANG_MGMT_PY3) \
                                     $(SONIC_UTILITIES_PY3) \
-                                    $(SONIC_HOST_SERVICES_PY3)
+                                    $(SONIC_HOST_SERVICES_PY3) \
+                                    $(DBSYNCD_PY3)
 
 ifeq ($(INSTALL_DEBUG_TOOLS), y)
 $(DOCKER_SONIC_VS)_DEPENDS += $(LIBSWSSCOMMON_DBG) \
@@ -52,3 +54,13 @@ $(DOCKER_SONIC_VS)_LOAD_DOCKERS += $(DOCKER_SWSS_LAYER_BOOKWORM)
 SONIC_DOCKER_IMAGES += $(DOCKER_SONIC_VS)
 
 SONIC_BOOKWORM_DOCKERS += $(DOCKER_SONIC_VS)
+
+# Copy LLDP files into build context
+DOCKER_SONIC_VS_LLDP_FILES = $(PLATFORM_PATH)/docker-sonic-vs/.lldp-files-stamp
+$(DOCKER_SONIC_VS_LLDP_FILES):
+	cp -f dockers/docker-lldp/lldpmgrd $(PLATFORM_PATH)/docker-sonic-vs/
+	cp -f dockers/docker-lldp/lldpd.conf.j2 $(PLATFORM_PATH)/docker-sonic-vs/
+	cp -f dockers/docker-lldp/lldpdSysDescr.conf.j2 $(PLATFORM_PATH)/docker-sonic-vs/
+	cp -f dockers/docker-lldp/waitfor_lldp_ready.sh $(PLATFORM_PATH)/docker-sonic-vs/
+	touch $@
+$(DOCKER_SONIC_VS)_DEPENDS += $(DOCKER_SONIC_VS_LLDP_FILES)

--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -165,6 +165,13 @@ RUN rm /etc/frr/frr.conf
 
 COPY ["frr/zebra.conf", "/etc/frr/"]
 
+# Copy LLDP configuration files
+COPY ["lldpmgrd", "/usr/bin/lldpmgrd"]
+COPY ["lldpd.conf.j2", "/usr/share/sonic/templates/lldpd.conf.j2"]
+COPY ["lldpdSysDescr.conf.j2", "/usr/share/sonic/templates/lldpdSysDescr.conf.j2"]
+COPY ["waitfor_lldp_ready.sh", "/usr/bin/waitfor_lldp_ready.sh"]
+RUN chmod +x /usr/bin/lldpmgrd /usr/bin/waitfor_lldp_ready.sh
+
 # Create /var/warmboot/teamd folder for teammgrd
 RUN mkdir -p /var/warmboot/teamd
 

--- a/platform/vs/docker-sonic-vs/start.sh
+++ b/platform/vs/docker-sonic-vs/start.sh
@@ -180,6 +180,21 @@ supervisorctl start tunnelmgrd
 
 supervisorctl start fabricmgrd
 
+# Generate LLDP configuration
+sonic-cfggen -d -y /etc/sonic/sonic_version.yml \
+    -t /usr/share/sonic/templates/lldpd.conf.j2 \
+    -t /usr/share/sonic/templates/lldpdSysDescr.conf.j2 > /etc/lldpd.conf
+mkdir -p /var/sonic
+rm -f /var/run/lldpd.socket
+# Configure lldpd to advertise interface name (not MAC) as port ID
+mkdir -p /etc/lldpd.d
+echo 'configure lldp portidsubtype ifname' > /etc/lldpd.d/port_id.conf
+
+supervisorctl start lldpd
+supervisorctl start waitfor_lldp_ready
+supervisorctl start lldp-syncd
+supervisorctl start lldpmgrd
+
 supervisorctl start rebootbackend
 
 # Start arp_update when VLAN exists

--- a/platform/vs/docker-sonic-vs/supervisord.conf.j2
+++ b/platform/vs/docker-sonic-vs/supervisord.conf.j2
@@ -405,3 +405,44 @@ stderr_syslog=true
 {% if ENABLE_ASAN == "y" %}
 environment=ASAN_OPTIONS="log_path=/var/log/asan/fabricmgrd-asan.log{{ asan_extra_options }}"
 {% endif %}
+
+[program:lldpd]
+command=/usr/sbin/lldpd -d -I Ethernet[0-9]*,eth0 -C eth0
+priority=28
+autostart=false
+autorestart=false
+stdout_logfile=NONE
+stdout_syslog=true
+stderr_logfile=NONE
+stderr_syslog=true
+
+[program:waitfor_lldp_ready]
+command=/usr/bin/waitfor_lldp_ready.sh
+priority=29
+autostart=false
+autorestart=false
+startsecs=0
+stdout_logfile=NONE
+stdout_syslog=true
+stderr_logfile=NONE
+stderr_syslog=true
+
+[program:lldp-syncd]
+command=/usr/bin/env python3 -m lldp_syncd
+priority=30
+autostart=false
+autorestart=false
+stdout_logfile=NONE
+stdout_syslog=true
+stderr_logfile=NONE
+stderr_syslog=true
+
+[program:lldpmgrd]
+command=/usr/bin/lldpmgrd
+priority=31
+autostart=false
+autorestart=false
+stdout_logfile=NONE
+stdout_syslog=true
+stderr_logfile=NONE
+stderr_syslog=true


### PR DESCRIPTION
## Description
Add lldpd, lldp-syncd, lldpmgrd, and waitfor_lldp_ready to the docker-sonic-vs container so that virtual switch instances can participate in LLDP neighbor discovery.

Currently docker-sonic-vs has no LLDP support at all — lldpd is not in the Dockerfile, .mk, or supervisord config. This means sonic-mgmt LLDP tests fail on cSONiC (docker-sonic-vs) testbeds.

## Changes
- **docker-sonic-vs.mk**: Add `$(LLDPD)` deb and `$(DBSYNCD_PY3)` (lldp-syncd) wheel as dependencies; add stamp target to copy lldpmgrd, lldpd.conf.j2, lldpdSysDescr.conf.j2, and waitfor_lldp_ready.sh from `dockers/docker-lldp/` into the build context
- **Dockerfile.j2**: COPY lldpmgrd and LLDP config templates into the image
- **supervisord.conf.j2**: Add program entries for lldpd, waitfor_lldp_ready, lldp-syncd, and lldpmgrd
- **start.sh**: Generate `/etc/lldpd.conf` from CONFIG_DB + `sonic_version.yml`, configure portidsubtype as ifname, and start all LLDP services

## Test Results
Tested on cSONiC KVM testbed (4 docker-sonic-vs neighbors, T0 topology):
- All 4 LLDP neighbors visible from DUT (`show lldp table`)
- `sonic-mgmt lldp/test_lldp` passes with `--neighbor_type sonic`
- All 4 BGP sessions remain Established
- CPU usage unchanged (~1% per container)

## Related PRs
- sonic-mgmt #22680 — CONFIG_DB BGP config for cSONiC neighbors
- sonic-buildimage #25764 — Add bgpcfgd to docker-sonic-vs