### PR TITLE
[trixie-prep] Remove dead Python 2 dependency pins

### DIFF
--- a/src/sonic-bgpcfgd/setup.py
+++ b/src/sonic-bgpcfgd/setup.py
@@ -20,7 +20,6 @@ setuptools.setup(
         'jinja2>=2.10',
         'netaddr==0.8.0',
         'pyyaml==6.0.1',
-        'ipaddress==1.0.23'
     ],
     setup_requires = [
         'pytest-runner',

--- a/src/sonic-bmpcfgd/setup.py
+++ b/src/sonic-bmpcfgd/setup.py
@@ -23,7 +23,6 @@ setuptools.setup(
         'jinja2>=2.10',
         'netaddr==0.8.0',
         'pyyaml==6.0.1',
-        'ipaddress==1.0.23'
     ],
     entry_points={
         'console_scripts': [

--- a/src/sonic-config-engine/setup.py
+++ b/src/sonic-config-engine/setup.py
@@ -12,7 +12,6 @@ sonic_dependencies = ['sonic-py-common']
 # Common dependencies for Python 2 and 3
 dependencies = [
     'bitarray==2.8.1',
-    'ipaddress==1.0.23',
     'lxml>=4.9.1',
     'netaddr==0.8.0',
 ]
@@ -39,9 +38,6 @@ else:
         'future',
         'Jinja2<3.0.0',
         'pyangbind==0.6.0',
-        'zipp==1.2.0',  # importlib-resources needs zipp and seems to have a bug where it will try to install too new of a version for Python 2
-        'importlib-resources==3.3.1',  # importlib-resources v4.0.0 was released 2020-12-23 and drops support for Python 2
-        'contextlib2==0.6.0.post1',
         # PyYAML 6.0 and newer dropped support for Python 2.7
         'pyyaml==5.4.1',
     ]

--- a/src/sonic-frr-mgmt-framework/setup.py
+++ b/src/sonic-frr-mgmt-framework/setup.py
@@ -15,7 +15,6 @@ setuptools.setup(
         'jinja2>=2.10',
         'netaddr==0.8.0',
         'pyyaml==6.0.1',
-        'zipp==1.2.0', # importlib-resources needs zipp and seems to have a bug where it will try to import too new of a version for Python 2
     ],
     setup_requires = [
         'pytest-runner',


### PR DESCRIPTION
## Description
Remove Python 2 era dependency pins that are dead code on Python 3:

- `ipaddress==1.0.23` — stdlib backport, built-in since Python 3.3
- `zipp==1.2.0` — Python 2 compat shim for importlib-resources  
- `importlib-resources==3.3.1` — Python 2 backport, stdlib since 3.9
- `contextlib2==0.6.0.post1` — Python 2 backport, stdlib since 3.2

These pins are in the Python 2 branch of `setup.py` or unconditionally pinned but unused on Python 3. They conflict with Debian Trixie (Python 3.13) system packages and serve no purpose on Bookworm (Python 3.11) either.

**Files changed:**
- `src/sonic-config-engine/setup.py` — remove ipaddress, zipp, importlib-resources, contextlib2
- `src/sonic-bgpcfgd/setup.py` — remove ipaddress
- `src/sonic-bmpcfgd/setup.py` — remove ipaddress
- `src/sonic-frr-mgmt-framework/setup.py` — remove zipp

## Motivation
Forward-compatibility for Debian Trixie migration. These dead pins cause pip conflicts when Trixie system packages provide newer versions.

## Testing
- Verified no runtime code imports these packages on Python 3
- `pip install` of all four packages succeeds without these pins
- Bookworm build unaffected (pins were dead code)
