### PR TITLE
[pmon] Remove redundant python3-jsonschema from apt-get

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -25,7 +25,6 @@ RUN apt-get update &&   \
         dmidecode       \
         i2c-tools       \
         psmisc          \
-        python3-jsonschema \
         python3-netifaces \
         libpci3         \
         iputils-ping    \


### PR DESCRIPTION
## Description
Remove `python3-jsonschema` from `apt-get install` in `docker-platform-monitor/Dockerfile.j2`.

The `docker-swss-layer` base image already provides `jsonschema` via pip (with RECORD file for proper package tracking). Installing `python3-jsonschema` via apt on top of this overwrites the pip-managed files without a RECORD, which causes `pip uninstall` failures later.

On Debian Trixie, the version mismatch (apt `4.19.2` vs pip's version) triggers harder dependency resolution conflicts.

## Motivation
- Fix pip package tracking conflict (benefits master today)
- Forward-compatibility for Debian Trixie migration

## Testing
- `python3 -c "import jsonschema; print(jsonschema.__version__)"` works in the container
- Platform monitor functionality unchanged — jsonschema is still available from the base image
