### PR TITLE
Use makedumpfile 1.7.7 compatible with 6.12 kernel

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -361,7 +361,6 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     cgroup-tools            \
     ipmitool                \
     ndisc6                  \
-    makedumpfile            \
     conntrack               \
     python3                 \
     python3-pip             \

--- a/files/build/versions-public/default/versions-web
+++ b/files/build/versions-public/default/versions-web
@@ -8,6 +8,8 @@ http://deb.debian.org/debian/pool/main/i/isc-dhcp/isc-dhcp_4.4.3-P1-2.debian.tar
 http://deb.debian.org/debian/pool/main/i/isc-dhcp/isc-dhcp_4.4.3-P1-2.dsc==9f39c78ebbf7d66194de179dc12de49e
 http://deb.debian.org/debian/pool/main/i/isc-dhcp/isc-dhcp_4.4.3-P1.orig.tar.gz==36c6ca77212373b0cff478ae9e5d32af
 http://deb.debian.org/debian/pool/main/i/isc-dhcp/isc-dhcp_4.4.3-P1.orig.tar.gz.asc==6db320501d5766198bc2da9515c62bbb
+https://deb.debian.org/debian/pool/main/m/makedumpfile/makedumpfile_1.7.7-1+b1_amd64.deb==11fb98ea2921b2d334f110aa5c2893f4
+https://deb.debian.org/debian/pool/main/m/makedumpfile/makedumpfile_1.7.7-1+b1_arm64.deb==e1409c5608fc8dbff7137b117e96d0c0
 http://deb.debian.org/debian/pool/main/l/lm-sensors/lm-sensors_3.6.0-7.1.debian.tar.xz==2dfa6e22972d0af32fd7afe99734a304
 http://deb.debian.org/debian/pool/main/l/lm-sensors/lm-sensors_3.6.0-7.1.dsc==efbde3517ddc5ac129532871651444af
 http://deb.debian.org/debian/pool/main/l/lm-sensors/lm-sensors_3.6.0.orig.tar.gz==f60e47b5eb50bbeed48a9f43bb08dd5e

--- a/files/build/versions-public/host-image/versions-deb-trixie
+++ b/files/build/versions-public/host-image/versions-deb-trixie
@@ -331,7 +331,6 @@ locales==2.41-12+deb13u1
 logrotate==3.22.0-1+b2
 logsave==1.47.2-3+b7
 lsof==4.99.4+dfsg-2
-makedumpfile==1:1.7.6-1+b1
 media-types==13.0.0
 mft==4.34.0-145
 mft-fwtrace-cfg==1.0.0

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -336,6 +336,11 @@ install_deb_package $debs_path/libnss-radius_*.deb
 #sudo LANG=C chroot $FILESYSTEM_ROOT pam-auth-update --remove radius tacplus
 sudo sed -i -e '/^passwd/s/ radius//' $FILESYSTEM_ROOT/etc/nsswitch.conf
 
+# Install makedumpfile 1.7.7 (newer than Trixie's 1.7.6, required for kernel 6.12+)
+if [[ $CONFIGURED_ARCH == amd64 || $CONFIGURED_ARCH == arm64 ]]; then
+    install_deb_package $debs_path/makedumpfile_*.deb
+fi
+
 # Install a custom version of kdump-tools  (and its dependencies via 'apt-get -y install -f')
 if [[ $CONFIGURED_ARCH == amd64 || $CONFIGURED_ARCH == arm64 ]]; then
     install_deb_package $debs_path/kdump-tools_*.deb

--- a/rules/makedumpfile.mk
+++ b/rules/makedumpfile.mk
@@ -1,0 +1,5 @@
+MAKEDUMPFILE_VERSION = 1.7.7-1+b1
+MAKEDUMPFILE = makedumpfile_$(MAKEDUMPFILE_VERSION)_$(CONFIGURED_ARCH).deb
+$(MAKEDUMPFILE)_URL = https://deb.debian.org/debian/pool/main/m/makedumpfile/makedumpfile_$(MAKEDUMPFILE_VERSION)_$(CONFIGURED_ARCH).deb
+SONIC_ONLINE_DEBS += $(MAKEDUMPFILE)
+export MAKEDUMPFILE

--- a/slave.mk
+++ b/slave.mk
@@ -1453,6 +1453,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
                 $(SONIC_DEVICE_DATA) \
                 $(IFUPDOWN2) \
                 $(KDUMP_TOOLS) \
+                $(MAKEDUMPFILE) \
                 $(LIBPAM_RADIUS) \
                 $(LIBNSS_RADIUS) \
                 $(LIBPAM_TACPLUS) \


### PR DESCRIPTION
#### Why I did it

Kdump takes a long time to complete because makedumpfile is version 1.7.6 which is not compatible with 6.12
([ref](https://github.com/makedumpfile/makedumpfile/releases/tag/1.7.6)). It incorrectly classifies free pages as in use by kernel, resulting in extremely large core dump file and taking a long time to generate. On 6.1, makedumpfile is 1.7.2.


On 6.12., core dump is large with no `FREE` pages

```
$ uname -a
Linux gold404 6.12.41+deb13-sonic-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.12.41-1 (2025-08-12) x86_64 GNU/Linux

$ ls -l /var/crash/202602262349/
total 7412984
-rw------- 1 root root     304964 Feb 26 23:49 dmesg.202602262349
-rw-r--r-- 1 root root 7590581090 Feb 26 23:53 kdump.202602262349

$ dpkg -l makedumpfile
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name           Version      Architecture Description
+++-==============-============-============-=================================
ii  makedumpfile   1:1.7.6-1    amd64        VMcore extraction tool

$ sudo makedumpfile --mem-usage /proc/kcore
The kernel version is not supported.
The makedumpfile operation may be incomplete.
TYPE		PAGES			EXCLUDABLE	DESCRIPTION
----------------------------------------------------------------------
ZERO		89343           	yes		Pages filled with zero
NON_PRI_CACHE	646424          	yes		Cache pages without private flag
PRI_CACHE	65827           	yes		Cache pages with private flag
USER		666096          	yes		User process pages
FREE		0               	yes		Free pages
KERN_DATA	6885323         	no		Dumpable kernel data
page size:		4096
Total pages on system:	8353013
Total size on system:	34213941248      Byte
```

On 6.1, core dump is much smaller

```
$ ls -l /var/crash/202602262359/
total 153752
-rw------- 1 root root    267051 Feb 26 23:59 dmesg.202602262359
-rw-r--r-- 1 root root 157169130 Feb 26 23:59 kdump.202602262359

$ dpkg -l makedumpfile
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name           Version      Architecture Description
+++-==============-============-============-=================================
ii  makedumpfile   1:1.7.2-1    amd64        VMcore extraction tool

$ sudo makedumpfile --mem-usage /proc/kcore
The kernel version is not supported.
The makedumpfile operation may be incomplete.
TYPE		PAGES			EXCLUDABLE	DESCRIPTION
----------------------------------------------------------------------
ZERO		95856           	yes		Pages filled with zero
NON_PRI_CACHE	615186          	yes		Cache pages without private flag
PRI_CACHE	15085           	yes		Cache pages with private flag
USER		877145          	yes		User process pages
FREE		6354174         	yes		Free pages
KERN_DATA	266543          	no		Dumpable kernel data
page size:		4096
Total pages on system:	8223989
Total size on system:	33685458944      Byte
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Include makedumpfile 1.7.7
([ref](https://github.com/makedumpfile/makedumpfile/releases/tag/1.7.7)) in the build image, which has support for 6.12 kernel and fixes an issue specific to 6.12.

#### How to verify it

Using the new image, trigger a kernel panic `echo c > /proc/sysrq-trigger`. The kdump takes ~10 seconds with small core dump

```
$ ls -l /var/crash/202602281944/
total 170784
-rw------- 1 root root    303989 Feb 28 19:44 dmesg.202602281944
-rw-r--r-- 1 root root 174572131 Feb 28 19:44 kdump.202602281944

$ dpkg -l makedumpfile
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name           Version      Architecture Description
+++-==============-============-============-=================================
ii  makedumpfile   1:1.7.7-1    amd64        VMcore extraction tool
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

