### PR TITLE
Fix an issue that 40G copper cables can't link up in some ports of Arista-7260CX3-Q64 and Arista-7060CX-32S-Q32

### DIFF
--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/media_settings.json
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q32/media_settings.json
@@ -1,26 +1,30 @@
 {
     "GLOBAL_MEDIA_SETTINGS": {
         "1-6": {
-            ".*": {
+            "COPPER10": {
+                   "unreliable_los": "off"
+            },
+            "OPTICAL10": {
                    "interface_type": "sr4",
                    "unreliable_los": "on"
-
             }
-
         },
         "11-22": {
-            ".*": {
+            "COPPER10": {
+                   "unreliable_los": "off"
+            },
+            "OPTICAL10": {
                    "interface_type": "sr4",
                    "unreliable_los": "on"
-
             }
-
         },
         "27-30": {
-            ".*": {
+            "COPPER10": {
+                   "unreliable_los": "off"
+            },
+            "OPTICAL10": {
                    "interface_type": "sr4",
                    "unreliable_los": "on"
-
             }
         }
     }

--- a/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/media_settings.json
+++ b/device/arista/x86_64-arista_7260cx3_64/Arista-7260CX3-Q64/media_settings.json
@@ -1,18 +1,21 @@
 {
     "GLOBAL_MEDIA_SETTINGS": {
         "1-12": {
-            ".*": {
+            "COPPER10": {
+                   "unreliable_los": "off"
+            },
+            "OPTICAL10": {
                    "interface_type": "sr4",
                    "unreliable_los": "on"
-
             }
-
         },
         "21-64": {
-            ".*": {
+            "COPPER10": {
+                   "unreliable_los": "off"
+            },
+            "OPTICAL10": {
                    "interface_type": "sr4",
                    "unreliable_los": "on"
-
             }
         }
     }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Unreliable los settings were added in https://github.com/sonic-net/sonic-buildimage/pull/17652 to some ports of `Arista-7260CX3-Q64` and `Arista-7060CX-32S-Q32`. However, these settings are only applicable to optics. With these settings, copper cables may fail to link up. 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Adding new media setting keys to make sure unreliable los settings will be applied to optics only.

#### How to verify it

Tested with this change and confirmed the copper links that were failed to link up now can link up

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202511
- [x] master

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

