### PR TITLE
[armhf] Add libauparse0t64 dependency for audisp-tacacs

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -317,6 +317,8 @@ install_deb_package $debs_path/libnss-tacplus_*.deb
 # Install bash-tacplus
 install_deb_package $debs_path/bash-tacplus_*.deb
 # Install audisp-tacplus
+# Install audisp-tacplus (depends on libauparse0 |libauparse0t64 ; ensure it is installed for Trixie/time64)
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install libauparse0t64
 install_deb_package $debs_path/audisp-tacplus_*.deb
 # Disable tacplus and LDAP by default
 ## NOTE: this syntax of pam-auth-update is meant to be used when the package gets removed, not for specifying

--- a/src/tacacs/audisp/patches/0005-Trixie-libauparse0t64-dependency.patch
+++ b/src/tacacs/audisp/patches/0005-Trixie-libauparse0t64-dependency.patch
@@ -1,0 +1,13 @@
+Index: audisp-tacplus/debian/control
+===================================================================
+--- audisp-tacplus.orig/debian/control
++++ audisp-tacplus/debian/control
+@@ -12,7 +12,7 @@ Homepage: https://github.com/daveolson53
+ Package: audisp-tacplus
+ Architecture: any
+ Depends: ${shlibs:Depends}, ${misc:Depends}, libpam-tacplus, libtac2 (>= 1.4.1~),
+-	libauparse0, libaudit1, auditd
++	libauparse0 | libauparse0t64, libaudit1, auditd
+ Description: audisp module for TACACS+ accounting
+ 	This audisp module is an audisp auditd plugin. It is designed to do TACACS+
+     accounting for commands run by TACACS+ authenticated sessions.

--- a/src/tacacs/audisp/patches/series
+++ b/src/tacacs/audisp/patches/series
@@ -2,3 +2,4 @@
 0002-Remove-user-secret-from-accounting-log.patch
 0003-Add-local-accounting.patch
 0004-Trixie-fixes.patch
+0005-Trixie-libauparse0t64-dependency.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
 audisp-tacplus package is not installed on armhf platforms

```
admin@ixs-7215-pizza-GA-4:~$ dpkg -s audisp-tacplus
Package: audisp-tacplus
Status: deinstall ok config-files
Priority: optional
Section: admin
Installed-Size: 95
Maintainer: Dave Olson <olson@cumulusnetworks.com>
Architecture: armhf
Version: 1.0.2
Depends: libauparse0t64 (>= 1:2.2.1), libc6 (>= 2.34), libtac2 (>= 1.4.1~), libpam-tacplus, libauparse0, libaudit1, auditd
Conffiles:
/etc/audit/plugins.d/audisp-tacplus.conf newconffile
/etc/audit/rules.d/audisp-tacplus.rules newconffile
Description: audisp module for TACACS+ accounting
This audisp module is an audisp auditd plugin. It is designed to do TACACS+
   accounting for commands run by TACACS+ authenticated sessions.
It requires an updated version of pam_tacplus and the libtac library from
   that package to communicate with the TACACS+ server(s).
Homepage: https://github.com/daveolson53/audisp_tacplus
```
This package is generally installed during build time. but in case of armhf build this package is failing to install due to a missing dependency 

```
+ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot ./fsroot-marvell-prestera dpkg -i audisp-tacplus_1.0.2_armhf.deb
Selecting previously unselected package audisp-tacplus.
(Reading database ... 57519 files and directories currently installed.)
Preparing to unpack audisp-tacplus_1.0.2_armhf.deb ...
Unpacking audisp-tacplus (1.0.2) ...
dpkg: dependency problems prevent configuration of audisp-tacplus:
audisp-tacplus depends on libauparse0; however:
  Package libauparse0 is not installed.
 
dpkg: error processing package audisp-tacplus (--install):
dependency problems - leaving unconfigured
```


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
On armhf, audisp-tacplus failed to install because it depends on libauparse0, which is not available on 32-bit Trixie. On amd64/arm64, libauparse0t64 provides libauparse0, so the dependency is satisfied; on armhf it does not.

The audisp-tacplus package dependency was updated in debian/control from libauparse0 to libauparse0 | libauparse0t64 so that either package satisfies the dependency. On armhf only libauparse0t64 exists, so the dependency is now met.

#### How to verify it
After fix the audisp-tacplus is not installed successfully on armhf

```
admin@sonic:~$ dpkg -s audisp-tacplus
Package: audisp-tacplus
Status: install ok installed
Priority: optional
Section: admin
Installed-Size: 95
Maintainer: Dave Olson <olson@cumulusnetworks.com>
Architecture: armhf
Version: 1.0.2
Depends: libauparse0t64 (>= 1:2.2.1), libc6 (>= 2.34), libtac2 (>= 1.4.1~), libpam-tacplus, libaudit1, auditd
Conffiles:
/etc/audit/plugins.d/audisp-tacplus.conf c944ba4af1c370a966af321de5d2a4ce
/etc/audit/rules.d/audisp-tacplus.rules f1ed1411a60e82322f714f7f8b17f5d3
Description: audisp module for TACACS+ accounting
This audisp module is an audisp auditd plugin. It is designed to do TACACS+
    accounting for commands run by TACACS+ authenticated sessions.
It requires an updated version of pam_tacplus and the libtac library from
    that package to communicate with the TACACS+ server(s).
Homepage: https://github.com/daveolson53/audisp_tacplus
admin@sonic:~$ [  OK  ] Started docker-7bc8daa2b98189adf2620f0106b2c2d6df59c74ae6ae83fb2c6948a5118273db.scâ€¦ntainer container 7bc8daa2b98189adf2620f0106b2c2d6df59c74ae6ae83fb2c6948a5118273db.
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

