### PR TITLE
Fix IMAGE_VERSION unset in final stage of multi-stage Docker builds

### DIFF
--- a/dockers/docker-bmp-watchdog/Dockerfile.j2
+++ b/dockers/docker-bmp-watchdog/Dockerfile.j2
@@ -39,6 +39,8 @@ RUN chmod +x /usr/bin/bmp_watchdog
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 # Make apt-get non-interactive

--- a/dockers/docker-dhcp-relay/Dockerfile.j2
+++ b/dockers/docker-dhcp-relay/Dockerfile.j2
@@ -47,6 +47,8 @@ COPY ["cli", "/cli/"]
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 # Pass the image_version to container

--- a/dockers/docker-dhcp-server/Dockerfile.j2
+++ b/dockers/docker-dhcp-server/Dockerfile.j2
@@ -50,6 +50,8 @@ COPY ["cli", "/cli/"]
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 # Pass the image_version to container

--- a/dockers/docker-eventd/Dockerfile.j2
+++ b/dockers/docker-eventd/Dockerfile.j2
@@ -44,6 +44,8 @@ RUN rm -f /etc/rsyslog.d/rsyslog_plugin_conf/syncd_events_info.json
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 # Pass the image_version to container

--- a/dockers/docker-gnmi-sidecar/Dockerfile.j2
+++ b/dockers/docker-gnmi-sidecar/Dockerfile.j2
@@ -27,6 +27,8 @@ RUN chmod +x /usr/bin/systemd_stub.py /usr/share/sonic/scripts/k8s_pod_control.s
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 # Make apt-get non-interactive

--- a/dockers/docker-lldp/Dockerfile.j2
+++ b/dockers/docker-lldp/Dockerfile.j2
@@ -43,6 +43,8 @@ COPY ["critical_processes", "/etc/supervisor"]
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 # Pass the image_version to container

--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -110,6 +110,8 @@ RUN chmod 755 /usr/bin/docker_init.sh
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 # Pass the image_version to container

--- a/dockers/docker-restapi-sidecar/Dockerfile.j2
+++ b/dockers/docker-restapi-sidecar/Dockerfile.j2
@@ -41,6 +41,8 @@ RUN chmod +x /usr/bin/systemd_stub.py /usr/share/sonic/scripts/k8s_pod_control.s
 
 FROM $BASE
 
+ARG image_version
+
 RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=/proc --exclude=/dev --exclude=resolv.conf /changes-to-image/ /
 
 # Make apt-get non-interactive

--- a/dockers/docker-router-advertiser/Dockerfile.j2
+++ b/dockers/docker-router-advertiser/Dockerfile.j2
@@ -33,6 +33,8 @@ COPY ["critical_processes", "/etc/supervisor"]
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 # Pass the image_version to container

--- a/dockers/docker-snmp/Dockerfile.j2
+++ b/dockers/docker-snmp/Dockerfile.j2
@@ -67,6 +67,8 @@ RUN chmod +x /usr/bin/docker-snmp-init.sh
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 # Enable -O for all Python calls

--- a/dockers/docker-sonic-bmp/Dockerfile.j2
+++ b/dockers/docker-sonic-bmp/Dockerfile.j2
@@ -40,7 +40,12 @@ RUN chmod +x /usr/bin/bmp.sh
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
+
+# Pass the image_version to container
+ENV IMAGE_VERSION=$image_version
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-sonic-gnmi/Dockerfile.j2
+++ b/dockers/docker-sonic-gnmi/Dockerfile.j2
@@ -29,6 +29,8 @@ COPY ["critical_processes", "/etc/supervisor"]
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 ## Make apt-get non-interactive

--- a/dockers/docker-sonic-otel/Dockerfile.j2
+++ b/dockers/docker-sonic-otel/Dockerfile.j2
@@ -62,6 +62,8 @@ COPY ["critical_processes", "/etc/supervisor"]
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 ## Make apt-get non-interactive

--- a/dockers/docker-sonic-telemetry/Dockerfile.j2
+++ b/dockers/docker-sonic-telemetry/Dockerfile.j2
@@ -30,6 +30,8 @@ COPY ["docker-telemetry-entry.sh", "/usr/local/bin/"]
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 ## Make apt-get non-interactive

--- a/dockers/docker-telemetry-sidecar/Dockerfile.j2
+++ b/dockers/docker-telemetry-sidecar/Dockerfile.j2
@@ -29,6 +29,8 @@ RUN chmod +x /usr/bin/systemd_stub.py /usr/share/sonic/scripts/k8s_pod_control.s
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 # Make apt-get non-interactive

--- a/dockers/docker-telemetry-watchdog/Dockerfile.j2
+++ b/dockers/docker-telemetry-watchdog/Dockerfile.j2
@@ -40,6 +40,8 @@ COPY --from=builder /watchdog/src/cmd_list.json /cmd_list.json
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 # Make apt-get non-interactive


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fix IMAGE_VERSION being empty in all multi-stage Docker container builds.

In Docker multi-stage builds, `ARG` values **do not carry over between stages** — each `FROM` resets the ARG scope. All 15 container Dockerfiles that use `rsync_from_builder_stage()` declare `ARG image_version` in the builder stage but not in the final stage. The `ENV IMAGE_VERSION=$image_version` in the final stage therefore resolves to an empty string.

When `container_startup.py` is invoked with `-v ${IMAGE_VERSION}` and `IMAGE_VERSION` is empty, argparse fails with:
```
container_startup.py: error: argument -v/--version: expected one argument
```

This causes the container init to abort, leading to container health check failures.

**Root cause:** Missing `ARG image_version` in the final build stage of multi-stage Dockerfiles.

**Fix:** Add `ARG image_version` after the final `FROM $BASE` in all 15 affected Dockerfile.j2 files:
- docker-bmp-watchdog
- docker-dhcp-relay
- docker-dhcp-server
- docker-eventd
- docker-gnmi-sidecar
- docker-lldp
- docker-platform-monitor (pmon)
- docker-router-advertiser
- docker-snmp
- docker-sonic-bmp
- docker-sonic-gnmi
- docker-sonic-otel
- docker-sonic-telemetry
- docker-telemetry-sidecar
- docker-telemetry-watchdog

Fixes #25683

Supersedes #25684 (which only added a `:-0.0.0` default to pmon's docker_init.j2 — a symptom-level fix for one container)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New feature
- [ ] Test case (new/improvement)

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202511

### Approach
#### What is the motivation for this PR?
Container init scripts fail when `IMAGE_VERSION` is unset because `container_startup.py -v` receives no argument.

#### How did you do it?
Added `ARG image_version` in the final build stage of each affected Dockerfile.j2, right after `FROM $BASE`. This ensures the Docker build-arg `image_version` is available when `ENV IMAGE_VERSION=$image_version` is evaluated in the final stage.

#### How did you verify/test it?
Verified that the Dockerfile pattern matches the Docker multi-stage build ARG scoping rules per [Docker documentation](https://docs.docker.com/reference/dockerfile/#understand-how-arg-and-from-interact).

Example — before (broken):
```dockerfile
FROM $BASE AS base
ARG image_version            # scoped to 'base' stage only
ENV IMAGE_VERSION=$image_version  # works here
...
FROM $BASE                   # new stage — ARGs reset
{{ rsync_from_builder_stage() }}
ENV IMAGE_VERSION=$image_version  # $image_version is EMPTY
```

After (fixed):
```dockerfile
FROM $BASE AS base
ARG image_version
ENV IMAGE_VERSION=$image_version
...
FROM $BASE
ARG image_version            # re-declared in final stage
{{ rsync_from_builder_stage() }}
ENV IMAGE_VERSION=$image_version  # now resolves correctly
```

#### Any platform specific information?
No — affects all platforms.

#### Supported testbed topology if it's a new test case?
N/A
