### PR TITLE
[trixie] Replace j2cli with jinjanator for Python 3.13 compatibility

### DIFF
--- a/dockers/docker-base-trixie/Dockerfile.j2
+++ b/dockers/docker-base-trixie/Dockerfile.j2
@@ -67,7 +67,7 @@ COPY ["pip.conf", "/etc/pip.conf"]
 {% endif %}
 
 # For templating
-RUN pip3 install j2cli
+RUN pip3 install jinjanator
 
 # Add support for supervisord to handle startup dependencies
 RUN pip3 install supervisord-dependent-startup==1.4.0


### PR DESCRIPTION
## Description
Replace `j2cli` with `jinjanator` in `docker-base-trixie/Dockerfile.j2`.

`j2cli` imports the `imp` module which was removed in Python 3.12 ([PEP 594](https://peps.python.org/pep-0594/)). On Trixie (Python 3.13), any container using `j2` for Jinja2 template rendering crashes with `ModuleNotFoundError: No module named 'imp'`.

[`jinjanator`](https://github.com/kpfleming/jinjanator) is the maintained community fork providing the same `j2` CLI interface without the deprecated import.

**Scope:** Only affects `docker-base-trixie`. `docker-base-bookworm` continues using `j2cli` (Python 3.11 still has `imp`).

## Motivation
Forward-compatibility for Debian Trixie migration (Python 3.13).

## Testing
- `j2 --version` works in Trixie container after this change
- Template rendering produces identical output to j2cli
- Bookworm build unaffected (different Dockerfile)
