### PR TITLE
Bash completions not working

### DIFF
--- a/files/image_config/bash/bash.bashrc
+++ b/files/image_config/bash/bash.bashrc
@@ -34,6 +34,10 @@ if ! shopt -oq posix; then
       . /usr/share/bash-completion/bash_completion
     elif [ -f /etc/bash_completion ]; then
       . /etc/bash_completion
+    elif [ -d /etc/bash_completion.d ]; then
+      for f in /etc/bash_completion.d/*; do
+        [ -f "$f" ] && . "$f"
+      done
     fi
 fi
 


### PR DESCRIPTION
#### Why I did it
Bash completions are not working

##### Issue
Fixes https://github.com/sonic-net/sonic-buildimage/issues/24594

#### How I did it
The 2 current paths in bashrc, do not exist

root@sonic:/home/admin# ls -l /usr/share/bash-completion/bash_completion
ls: cannot access '/usr/share/bash-completion/bash_completion': No such file or directory
root@sonic:/home/admin# ls -l /etc/bash_completion
ls: cannot access '/etc/bash_completion': No such file or directory
root@sonic:/home/admin# 

However, /etc/bash_completion.d/ exists.
root@sonic:/home/admin# ls -l /etc/bash_completion.d/
total 23
-rw-r--r-- 1 root root 695 Sep 17  2020 acl-loader
-rw-r--r-- 1 root root 671 Sep 17  2020 config
-rw-r--r-- 1 root root 677 Sep 17  2020 connect
-rw-r--r-- 1 root root 683 Sep 17  2020 consutil
-rw-r--r-- 1 root root 653 Sep 17  2020 crm
-rw-r--r-- 1 root root 659 Sep 17  2020 dump
-rw-r--r-- 1 root root 683 Sep 17  2020 pcieutil
-rw-r--r-- 1 root root 707 Sep 17  2020 pddf_fanutil
-rw-r--r-- 1 root root 707 Sep 17  2020 pddf_ledutil
-rw-r--r-- 1 root root 707 Sep 17  2020 pddf_psuutil
-rw-r--r-- 1 root root 731 Sep 17  2020 pddf_thermalutil
-rw-r--r-- 1 root root 653 Sep 17  2020 pfc
-rw-r--r-- 1 root root 665 Sep 17  2020 pfcwd
-rw-r--r-- 1 root root 665 Sep 17  2020 rexec
-rw-r--r-- 1 root root 671 Sep 17  2020 rshell
-rw-r--r-- 1 root root 659 Sep 17  2020 show
-rw-r--r-- 1 root root 701 Sep 17  2020 sonic-clear
-rw-r--r-- 1 root root 713 Sep 17  2020 sonic-cli-gen
-rw-r--r-- 1 root root 725 Sep 17  2020 sonic-installer
-rw-r--r-- 1 root root 725 Sep 17  2020 sonic_installer
-rw-r--r-- 1 root root 761 Sep 17  2020 sonic-package-manager
-rw-r--r-- 1 root root 653 Sep 17  2020 spm
-rw-r--r-- 1 root root 707 Sep 17  2020 watchdogutil

As a result, the bash autocompletion was not working. It was only working if /etc/bash_completion.d/* was sourced.

#### How to verify it

root@sonic:/home/admin# show i             
icmp        interfaces  ip          ipv6            
root@sonic:/home/admin# config i                    
interface              interface_naming_mode  ipv6  

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

- [x] 202511
- [x] master 

