### PR TITLE
[cherry-pick][202511] Fix IMAGE_VERSION unset in final stage of multi-stage Docker builds

### DIFF
--- a/dockers/docker-auditd/Dockerfile.j2
+++ b/dockers/docker-auditd/Dockerfile.j2
@@ -21,6 +21,8 @@ RUN chmod +x /usr/bin/config_checker.py
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 # Make apt-get non-interactive

--- a/dockers/docker-bmp-watchdog/Dockerfile.j2
+++ b/dockers/docker-bmp-watchdog/Dockerfile.j2
@@ -39,6 +39,8 @@ RUN chmod +x /usr/bin/bmp_watchdog
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 # Make apt-get non-interactive

--- a/dockers/docker-dhcp-relay/Dockerfile.j2
+++ b/dockers/docker-dhcp-relay/Dockerfile.j2
@@ -46,6 +46,8 @@ COPY ["cli", "/cli/"]
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 # Pass the image_version to container

--- a/dockers/docker-dhcp-server/Dockerfile.j2
+++ b/dockers/docker-dhcp-server/Dockerfile.j2
@@ -50,6 +50,8 @@ COPY ["cli", "/cli/"]
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 # Pass the image_version to container

--- a/dockers/docker-eventd/Dockerfile.j2
+++ b/dockers/docker-eventd/Dockerfile.j2
@@ -44,6 +44,8 @@ RUN rm -f /etc/rsyslog.d/rsyslog_plugin_conf/syncd_events_info.json
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 # Pass the image_version to container

--- a/dockers/docker-lldp/Dockerfile.j2
+++ b/dockers/docker-lldp/Dockerfile.j2
@@ -43,6 +43,8 @@ COPY ["critical_processes", "/etc/supervisor"]
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 # Pass the image_version to container

--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -110,6 +110,8 @@ RUN chmod 755 /usr/bin/docker_init.sh
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 # Pass the image_version to container

--- a/dockers/docker-router-advertiser/Dockerfile.j2
+++ b/dockers/docker-router-advertiser/Dockerfile.j2
@@ -33,6 +33,8 @@ COPY ["critical_processes", "/etc/supervisor"]
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 # Pass the image_version to container

--- a/dockers/docker-snmp/Dockerfile.j2
+++ b/dockers/docker-snmp/Dockerfile.j2
@@ -67,6 +67,8 @@ RUN chmod +x /usr/bin/docker-snmp-init.sh
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 # Enable -O for all Python calls

--- a/dockers/docker-sonic-bmp/Dockerfile.j2
+++ b/dockers/docker-sonic-bmp/Dockerfile.j2
@@ -40,7 +40,12 @@ RUN chmod +x /usr/bin/bmp.sh
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
+
+# Pass the image_version to container
+ENV IMAGE_VERSION=$image_version
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-sonic-gnmi/Dockerfile.j2
+++ b/dockers/docker-sonic-gnmi/Dockerfile.j2
@@ -29,6 +29,8 @@ COPY ["critical_processes", "/etc/supervisor"]
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 ## Make apt-get non-interactive

--- a/dockers/docker-sonic-otel/Dockerfile.j2
+++ b/dockers/docker-sonic-otel/Dockerfile.j2
@@ -62,6 +62,8 @@ COPY ["critical_processes", "/etc/supervisor"]
 
 FROM $BASE
 
+ARG image_version
+
 RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=/proc --exclude=/dev --exclude=resolv.conf /changes-to-image/ /
 
 ## Make apt-get non-interactive

--- a/dockers/docker-sonic-telemetry/Dockerfile.j2
+++ b/dockers/docker-sonic-telemetry/Dockerfile.j2
@@ -30,6 +30,8 @@ COPY ["docker-telemetry-entry.sh", "/usr/local/bin/"]
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 ## Make apt-get non-interactive

--- a/dockers/docker-telemetry-sidecar/Dockerfile.j2
+++ b/dockers/docker-telemetry-sidecar/Dockerfile.j2
@@ -26,6 +26,8 @@ RUN chmod +x /usr/bin/systemd_stub.py
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 # Make apt-get non-interactive

--- a/dockers/docker-telemetry-watchdog/Dockerfile.j2
+++ b/dockers/docker-telemetry-watchdog/Dockerfile.j2
@@ -40,6 +40,8 @@ COPY --from=builder /watchdog/src/cmd_list.json /cmd_list.json
 
 FROM $BASE
 
+ARG image_version
+
 {{ rsync_from_builder_stage() }}
 
 # Make apt-get non-interactive


### PR DESCRIPTION
## [cherry-pick] Fix IMAGE_VERSION unset in final stage of multi-stage Docker builds

Cherry-pick of #25907 to 202511 branch.

### Description

In Docker multi-stage builds, `ARG` declarations are scoped to the build stage they appear in. All affected Dockerfiles declare `ARG image_version` only in the first (builder) stage but not in the final stage. Since `rsync_from_builder_stage()` copies only filesystem content (not Docker ENV metadata), `ENV IMAGE_VERSION=$image_version` in the final stage resolves to an empty string.

This causes `container_startup.py` to fail with:
```
error: argument -v/--version: expected one argument
```

### Fix

Add `ARG image_version` after the final `FROM $BASE` in all affected Dockerfiles (15 files on 202511), and add missing `ENV IMAGE_VERSION=$image_version` in `docker-sonic-bmp` where it was absent from the final stage.

Note: `docker-restapi-sidecar` was removed in 202511 branch, so only 15 files are affected (vs 16 on master).

#### How I did it
Added `ARG image_version` in the final build stage of each multi-stage Dockerfile so that `ENV IMAGE_VERSION=$image_version` resolves correctly.

#### How to verify it
```bash
docker inspect <container> --format '{{.Config.Env}}' | grep IMAGE_VERSION
```
Should show the actual image version instead of empty string.

#### Which release branch to backport
- [x] 202511