### PR TITLE
[coredump] fix container detection when process is reaped before script runs

### DIFF
--- a/files/image_config/sysctl/90-sonic.conf
+++ b/files/image_config/sysctl/90-sonic.conf
@@ -51,5 +51,8 @@ kernel.panic=10
 # Kill tasks that have been stuck for 5 minutes
 kernel.hung_task_timeout_secs=300
 
+# Max concurrent coredump pipe handlers; kernel keeps dumped process until handler runs so /proc/<pid> is available.
+kernel.core_pipe_limit=16
+
 vm.panic_on_oom=2
 fs.suid_dumpable=2


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Sometimes coredump-compress didn't receive valid /proc/{pid} when SIGABRT was sent from docker. By default (when kernel.core_pipe_limit=0) kernel won't wait for the script to finish before removing /proc/{pid}
We need to wait until program is finished refore removing /proc/{pid}

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
specify kernel.core_pipe_limit parameter so this param > 0

#### How to verify it
1) We need to have a script core_file_generator.sh:
```
root@sonic:/# cat core_file_generator.sh
sleep 10 & kill -6 $!
echo $?
```
2) put this script into docker (teamd for e.g)
3) run a lot of iterations (20-30 in a row should be enought):
 `root@sonic:/# ./core_file_generator.sh`
4) When everything is ok we have syslog like this:
`2026 Feb 27 19:12:06.743250 sonic INFO teamd#supervisord 2026-02-27 19:12:06,742 INFO reaped unknown pid 2567 `
when issue is reproduced we don't have SIGABRT in syslog.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

