### PR TITLE
Add missing [Install] section to container service templates

### DIFF
--- a/files/build_templates/gnmi.service.j2
+++ b/files/build_templates/gnmi.service.j2
@@ -13,3 +13,6 @@ ExecStartPre=/usr/local/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/local/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/local/bin/{{docker_container_name}}.sh stop
 RestartSec=30
+
+[Install]
+WantedBy=sonic.target

--- a/files/build_templates/mgmt-framework.service.j2
+++ b/files/build_templates/mgmt-framework.service.j2
@@ -10,3 +10,6 @@ User={{ sonicadmin_user }}
 ExecStartPre=/usr/local/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/local/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/local/bin/{{docker_container_name}}.sh stop
+
+[Install]
+WantedBy=sonic.target

--- a/files/build_templates/otel.service.j2
+++ b/files/build_templates/otel.service.j2
@@ -13,3 +13,6 @@ ExecStartPre=/usr/local/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/local/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/local/bin/{{docker_container_name}}.sh stop
 RestartSec=30
+
+[Install]
+WantedBy=sonic.target

--- a/files/build_templates/per_namespace/bmp.service.j2
+++ b/files/build_templates/per_namespace/bmp.service.j2
@@ -15,3 +15,6 @@ ExecStartPre=/usr/local/bin/{{docker_container_name}}.sh start{% if multi_instan
 ExecStart=/usr/local/bin/{{docker_container_name}}.sh wait{% if multi_instance == 'true' %} %i{% endif %}
 ExecStop=/usr/local/bin/{{docker_container_name}}.sh stop{% if multi_instance == 'true' %} %i{% endif %}
 RestartSec=30
+
+[Install]
+WantedBy=sonic.target

--- a/files/build_templates/per_namespace/lldp.service.j2
+++ b/files/build_templates/per_namespace/lldp.service.j2
@@ -20,3 +20,6 @@ ExecStartPre=/usr/local/bin/{{docker_container_name}}.sh start{% if multi_instan
 ExecStart=/usr/local/bin/{{docker_container_name}}.sh wait{% if multi_instance == 'true' %} %i{% endif %}
 ExecStop=/usr/local/bin/{{docker_container_name}}.sh stop{% if multi_instance == 'true' %} %i{% endif %}
 RestartSec=30
+
+[Install]
+WantedBy=sonic.target

--- a/files/build_templates/pmon.service.j2
+++ b/files/build_templates/pmon.service.j2
@@ -13,3 +13,6 @@ ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
 RestartSec=30
+
+[Install]
+WantedBy=sonic.target

--- a/files/build_templates/sflow.service.j2
+++ b/files/build_templates/sflow.service.j2
@@ -13,3 +13,6 @@ ExecStartPre=/usr/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/bin/{{docker_container_name}}.sh stop
 RestartSec=30
+
+[Install]
+WantedBy=sonic.target

--- a/files/build_templates/snmp.service.j2
+++ b/files/build_templates/snmp.service.j2
@@ -14,3 +14,6 @@ ExecStartPre=/usr/local/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/local/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/local/bin/{{docker_container_name}}.sh stop
 RestartSec=30
+
+[Install]
+WantedBy=sonic.target

--- a/files/build_templates/telemetry.service.j2
+++ b/files/build_templates/telemetry.service.j2
@@ -13,3 +13,6 @@ ExecStartPre=/usr/local/bin/{{docker_container_name}}.sh start
 ExecStart=/usr/local/bin/{{docker_container_name}}.sh wait
 ExecStop=/usr/local/bin/{{docker_container_name}}.sh stop
 RestartSec=30
+
+[Install]
+WantedBy=sonic.target


### PR DESCRIPTION
#### Why I did it

After the systemd-sonic-generator rework (PR #23340), the generator only creates `sonic.target.wants/` symlinks for services that have an explicit `[Install]` section with `WantedBy=`. Nine container services (pmon, lldp, gnmi, snmp, telemetry, otel, sflow, bmp, mgmt-framework) use `BindsTo=sonic.target` in `[Unit]` but lacked an `[Install]` section, so the generator skipped creating symlinks for them.

This caused two problems:
1. `_reset_failed_services()` in sonic-utilities iterates `systemctl list-dependencies --plain sonic.target` and never resets rate limits for these services, causing `start-limit-hit` after multiple config reloads.
2. `featured` daemon checks `unit_file_state == 'enabled'` but these services now report `static` (no `[Install]` = static), causing redundant `systemctl start` calls on every reload.

The most visible symptom is pmon hitting `start-limit-hit` during tests that perform multiple config reloads (e.g., `test_load_minigraph_with_golden_config`).

Fixes #25931

##### Work item tracking
- Microsoft ADO: 36811868

#### How I did it

Added `[Install]` section with `WantedBy=sonic.target` to all 9 affected service templates, consistent with other container services (dhcp_relay, swss, syncd, teamd, etc.) that already have this section.

Affected templates:
- `files/build_templates/pmon.service.j2`
- `files/build_templates/gnmi.service.j2`
- `files/build_templates/snmp.service.j2`
- `files/build_templates/telemetry.service.j2`
- `files/build_templates/otel.service.j2`
- `files/build_templates/sflow.service.j2`
- `files/build_templates/mgmt-framework.service.j2`
- `files/build_templates/per_namespace/lldp.service.j2`
- `files/build_templates/per_namespace/bmp.service.j2`

#### How to verify it

1. Build an image with this change
2. On a DUT, verify services appear in `sonic.target` dependencies:
   `systemctl list-dependencies --plain sonic.target | grep pmon`
3. Verify `UnitFileState` is no longer `static`:
   `systemctl show pmon.service --property=UnitFileState`
4. Run `test_load_minigraph_with_golden_config` — pmon should not hit `start-limit-hit`

**Workaround verified on testbed**: Manually creating the symlinks on a live DUT confirmed the fix resolves the issue.

#### Which release branch to backport (provide reason below if selected)

- [x] 202511

The bug was introduced by the systemd-sonic-generator rework cherry-picked to 202511 via PR #24988.

#### Tested branch (Please provide the tested image version)

- [x] Workaround verified on 20251110.12 (202511)

#### Description for the changelog

Add missing [Install] WantedBy=sonic.target to 9 container service templates to fix start-limit-hit failures after config reloads.

#### A picture of a cute animal (not mandatory but encouraged)

:hedgehog: