### PR TITLE
Fix multi-ASIC SDK race condition by adding per-ASIC isolation to sdk_dbg volume mount

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -689,6 +689,7 @@ start() {
 {%- if docker_container_name == "syncd" %}
     if [[ $DEV != "" ]]; then
         mkdir -p /dev/shm/asic$DEV
+        mkdir -p /var/log/sdk_dbg/$DEV
         ASIC_MNT="-v /dev/sxdevs/sxcdev$(($DEV+1)):/dev/sxdevs/sxcdev:rw \
             -v /dev/sxdevs/bfdcdev$(($DEV+1)):/dev/sxdevs/bfdcdev:rw \
             -v /dev/shm/asic$DEV:/dev/shm/:rw"
@@ -721,7 +722,7 @@ start() {
 {%- if sonic_asic_platform == "mellanox" %}
 {%- if docker_container_name == "syncd" %}
         -v /var/log/mellanox:/var/log/mellanox:rw \
-        -v /var/log/sdk_dbg:/var/log/sdk_dbg:rw \
+        -v /var/log/sdk_dbg/$DEV:/var/log/sdk_dbg:rw \
         -v mlnx_sdk_socket$DEV:/var/run/sx_sdk \
         -v /tmp/nv-syncd-shared/$DEV:/tmp \
         -v /var/log/sai_failure_dump:/var/log/sai_failure_dump:rw \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

On multi-ASIC platforms , all syncd containers bind-mount the same host directory `/var/log/sdk_dbg` with read-write access. 
This causes two problems:
1. Race condition during boot: When all syncd containers initialize their SDK simultaneously at boot time, each container's sniffer cleanup scans the shared directory and spawns a gzip thread targeting the same leftover `.pcap` files. The first container to finish deletes the file successfully; the remaining containers fail with `ENOENT`, producing ERR-level syslog messages:
   ```
   ERR syncd#SDK: [SNIFFER.ERR] Failed to remove gzip /var/log/sdk_dbg/sx_sdk_<timestamp>_0.pcap No such file or directory
   ```

2. Cross-ASIC sniffer data corruption: Since pcap filenames contain no ASIC identifier and all containers share the same directory, one ASIC's cleanup can delete another ASIC's debug captures. This reduces the effectiveness of the sniffer for post-mortem debugging.


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Append `$DEV` as a subdirectory to the `sdk_dbg` volume mount source path in `docker_image_ctl.j2`:

Each syncd container now gets its own isolated host directory:
- `syncd0` → `/var/log/sdk_dbg/0`
- `syncd1` → `/var/log/sdk_dbg/1`
- `syncd2` → `/var/log/sdk_dbg/2`
- `syncd3` → `/var/log/sdk_dbg/3`

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

1. Verify each syncd container has its own isolated directory:
   ```bash
   for i in 0 1 2 3; do
       echo "=== syncd$i ==="
       docker exec syncd$i ls -la /var/log/sdk_dbg/
   done
   ```
2. Confirm the host has per-ASIC subdirectories:
   ```bash
   ls -la /var/log/sdk_dbg/
   # Expected: directories 0/ 1/ 2/ 3/
   ```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

