### PR TITLE
Add kms directory to gbsyncd-agera2 for syncd to initialize KMS server

### DIFF
--- a/platform/components/docker-gbsyncd-agera2/start.sh
+++ b/platform/components/docker-gbsyncd-agera2/start.sh
@@ -3,6 +3,7 @@
 HWSKU_DIR=/usr/share/sonic/hwsku
 
 mkdir -p /etc/sai.d/
+mkdir -p /var/run/kms
 
 # Create/Copy the psai.profile to /etc/sai.d/psai.profile
 if [ -f $HWSKU_DIR/psai.profile.j2 ]; then


### PR DESCRIPTION
#### Why I did it

Add directory for key management server in gbsyncd container to mute the error logs.
```
Failure log is coming due from syncd process from
#define KMS_KEK_SOCKET_PATH "/var/run/kms/kek.sock"
...
if (kms_init_server(KMS_KEK_SOCKET_PATH, &m_kmsCtx) != KMS_SUCCESS) {
    SWSS_LOG_ERROR("Failed to initialize KMS server on %s", KMS_KEK_SOCKET_PATH);
}
```

#### How I did it
Create directory in start.sh of gbsyncd-agera2

#### How to verify it
Validated on a full image, after init the kms error logs do not come.

```
root@humm119:/home/admin# grep "kms_init_server" /var/log/syslog
2026 Mar  2 23:11:00.401346 humm119 INFO syncd#syncd: [kms_init_server:525] KMS server initialized and thread started successfully on /var/run/kms/kek.sock
2026 Mar  2 23:11:01.036917 humm119 INFO gbsyncd#syncd: [kms_init_server:525] KMS server initialized and thread started successfully on /var/run/kms/kek.sock
```

##### Work item tracking
- Microsoft ADO **(number only)**:


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

