### PR TITLE
[Arista] Enable interrupts on all cores

### DIFF
--- a/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/0/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/0/sai_postinit_cmd.soc
@@ -1,29 +1,61 @@
-INTeRrupt ENAble id=2209
-INTeRrupt ENAble id=2210
-INTeRrupt ENAble id=2211
-INTeRrupt ENAble id=2212
-INTeRrupt ENAble id=2213
-INTeRrupt ENAble id=2214
-INTeRrupt ENAble id=2215
-INTeRrupt ENAble id=2216
-INTeRrupt ENAble id=2217
-INTeRrupt ENAble id=2218
-INTeRrupt ENAble id=2219
-INTeRrupt ENAble id=2220
-INTeRrupt ENAble id=2221
-INTeRrupt ENAble id=2222
-INTeRrupt ENAble id=2223
-INTeRrupt ENAble id=2224
-INTeRrupt ENAble id=2225
-INTeRrupt ENAble id=2226
+# Core=0
+INTeRrupt ENAble id=2209 p=0
+INTeRrupt ENAble id=2210 p=0
+INTeRrupt ENAble id=2211 p=0
+INTeRrupt ENAble id=2212 p=0
+INTeRrupt ENAble id=2213 p=0
+INTeRrupt ENAble id=2214 p=0
+INTeRrupt ENAble id=2215 p=0
+INTeRrupt ENAble id=2216 p=0
+INTeRrupt ENAble id=2217 p=0
+INTeRrupt ENAble id=2218 p=0
+INTeRrupt ENAble id=2219 p=0
+INTeRrupt ENAble id=2220 p=0
+INTeRrupt ENAble id=2221 p=0
+INTeRrupt ENAble id=2222 p=0
+INTeRrupt ENAble id=2223 p=0
+INTeRrupt ENAble id=2224 p=0
+INTeRrupt ENAble id=2225 p=0
+INTeRrupt ENAble id=2226 p=0
 
-INTeRrupt ENAble id=482
-INTeRrupt ENAble id=483
-INTeRrupt ENAble id=484
-INTeRrupt ENAble id=485
-INTeRrupt ENAble id=486
-INTeRrupt ENAble id=487
-INTeRrupt ENAble id=488
+INTeRrupt ENAble id=482 p=0
+INTeRrupt ENAble id=483 p=0
+INTeRrupt ENAble id=484 p=0
+INTeRrupt ENAble id=485 p=0
+INTeRrupt ENAble id=486 p=0
+INTeRrupt ENAble id=487 p=0
+INTeRrupt ENAble id=488 p=0
 
-INTeRrupt ENAble id=1597
+INTeRrupt ENAble id=1597 p=0
+
+# Core=1
+INTeRrupt ENAble id=2209 p=1
+INTeRrupt ENAble id=2210 p=1
+INTeRrupt ENAble id=2211 p=1
+INTeRrupt ENAble id=2212 p=1
+INTeRrupt ENAble id=2213 p=1
+INTeRrupt ENAble id=2214 p=1
+INTeRrupt ENAble id=2215 p=1
+INTeRrupt ENAble id=2216 p=1
+INTeRrupt ENAble id=2217 p=1
+INTeRrupt ENAble id=2218 p=1
+INTeRrupt ENAble id=2219 p=1
+INTeRrupt ENAble id=2220 p=1
+INTeRrupt ENAble id=2221 p=1
+INTeRrupt ENAble id=2222 p=1
+INTeRrupt ENAble id=2223 p=1
+INTeRrupt ENAble id=2224 p=1
+INTeRrupt ENAble id=2225 p=1
+INTeRrupt ENAble id=2226 p=1
+
+INTeRrupt ENAble id=482 p=1
+INTeRrupt ENAble id=483 p=1
+INTeRrupt ENAble id=484 p=1
+INTeRrupt ENAble id=485 p=1
+INTeRrupt ENAble id=486 p=1
+INTeRrupt ENAble id=487 p=1
+INTeRrupt ENAble id=488 p=1
+
+INTeRrupt ENAble id=1597 p=1
+
 debug intr error

--- a/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/1/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/1/sai_postinit_cmd.soc
@@ -1,29 +1,61 @@
-INTeRrupt ENAble id=2209
-INTeRrupt ENAble id=2210
-INTeRrupt ENAble id=2211
-INTeRrupt ENAble id=2212
-INTeRrupt ENAble id=2213
-INTeRrupt ENAble id=2214
-INTeRrupt ENAble id=2215
-INTeRrupt ENAble id=2216
-INTeRrupt ENAble id=2217
-INTeRrupt ENAble id=2218
-INTeRrupt ENAble id=2219
-INTeRrupt ENAble id=2220
-INTeRrupt ENAble id=2221
-INTeRrupt ENAble id=2222
-INTeRrupt ENAble id=2223
-INTeRrupt ENAble id=2224
-INTeRrupt ENAble id=2225
-INTeRrupt ENAble id=2226
+# Core=0
+INTeRrupt ENAble id=2209 p=0
+INTeRrupt ENAble id=2210 p=0
+INTeRrupt ENAble id=2211 p=0
+INTeRrupt ENAble id=2212 p=0
+INTeRrupt ENAble id=2213 p=0
+INTeRrupt ENAble id=2214 p=0
+INTeRrupt ENAble id=2215 p=0
+INTeRrupt ENAble id=2216 p=0
+INTeRrupt ENAble id=2217 p=0
+INTeRrupt ENAble id=2218 p=0
+INTeRrupt ENAble id=2219 p=0
+INTeRrupt ENAble id=2220 p=0
+INTeRrupt ENAble id=2221 p=0
+INTeRrupt ENAble id=2222 p=0
+INTeRrupt ENAble id=2223 p=0
+INTeRrupt ENAble id=2224 p=0
+INTeRrupt ENAble id=2225 p=0
+INTeRrupt ENAble id=2226 p=0
 
-INTeRrupt ENAble id=482
-INTeRrupt ENAble id=483
-INTeRrupt ENAble id=484
-INTeRrupt ENAble id=485
-INTeRrupt ENAble id=486
-INTeRrupt ENAble id=487
-INTeRrupt ENAble id=488
+INTeRrupt ENAble id=482 p=0
+INTeRrupt ENAble id=483 p=0
+INTeRrupt ENAble id=484 p=0
+INTeRrupt ENAble id=485 p=0
+INTeRrupt ENAble id=486 p=0
+INTeRrupt ENAble id=487 p=0
+INTeRrupt ENAble id=488 p=0
 
-INTeRrupt ENAble id=1597
+INTeRrupt ENAble id=1597 p=0
+
+# Core=1
+INTeRrupt ENAble id=2209 p=1
+INTeRrupt ENAble id=2210 p=1
+INTeRrupt ENAble id=2211 p=1
+INTeRrupt ENAble id=2212 p=1
+INTeRrupt ENAble id=2213 p=1
+INTeRrupt ENAble id=2214 p=1
+INTeRrupt ENAble id=2215 p=1
+INTeRrupt ENAble id=2216 p=1
+INTeRrupt ENAble id=2217 p=1
+INTeRrupt ENAble id=2218 p=1
+INTeRrupt ENAble id=2219 p=1
+INTeRrupt ENAble id=2220 p=1
+INTeRrupt ENAble id=2221 p=1
+INTeRrupt ENAble id=2222 p=1
+INTeRrupt ENAble id=2223 p=1
+INTeRrupt ENAble id=2224 p=1
+INTeRrupt ENAble id=2225 p=1
+INTeRrupt ENAble id=2226 p=1
+
+INTeRrupt ENAble id=482 p=1
+INTeRrupt ENAble id=483 p=1
+INTeRrupt ENAble id=484 p=1
+INTeRrupt ENAble id=485 p=1
+INTeRrupt ENAble id=486 p=1
+INTeRrupt ENAble id=487 p=1
+INTeRrupt ENAble id=488 p=1
+
+INTeRrupt ENAble id=1597 p=1
+
 debug intr error

--- a/device/arista/x86_64-arista_7280r4_32qf_32df/Arista-7280R4-32QF-32DF-64O/q3d-a7280R4-32QFx400G-32DFx400G.config.bcm
+++ b/device/arista/x86_64-arista_7280r4_32qf_32df/Arista-7280R4-32QF-32DF-64O/q3d-a7280R4-32QFx400G-32DFx400G.config.bcm
@@ -2,6 +2,7 @@ soc_family=BCM8887X
 system_ref_core_clock_khz=1600000
 
 dpp_db_path=/usr/share/bcm/db
+sai_postinit_cmd_file=/usr/share/sonic/hwsku/sai_postinit_cmd.soc
 ####################################################
 ##Reference applications related properties - Start
 ####################################################

--- a/device/arista/x86_64-arista_7280r4_32qf_32df/Arista-7280R4-32QF-32DF-64O/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7280r4_32qf_32df/Arista-7280R4-32QF-32DF-64O/sai_postinit_cmd.soc
@@ -1,0 +1,217 @@
+# Core=0
+INTeRrupt ENAble id=2249 p=0
+INTeRrupt ENAble id=2250 p=0
+INTeRrupt ENAble id=2251 p=0
+INTeRrupt ENAble id=2252 p=0
+INTeRrupt ENAble id=2253 p=0
+INTeRrupt ENAble id=2254 p=0
+INTeRrupt ENAble id=2255 p=0
+INTeRrupt ENAble id=2256 p=0
+INTeRrupt ENAble id=2257 p=0
+INTeRrupt ENAble id=2258 p=0
+INTeRrupt ENAble id=2259 p=0
+INTeRrupt ENAble id=2260 p=0
+INTeRrupt ENAble id=2261 p=0
+INTeRrupt ENAble id=2262 p=0
+INTeRrupt ENAble id=2263 p=0
+
+INTeRrupt ENAble id=540 p=0
+INTeRrupt ENAble id=541 p=0
+INTeRrupt ENAble id=542 p=0
+INTeRrupt ENAble id=543 p=0
+INTeRrupt ENAble id=544 p=0
+INTeRrupt ENAble id=545 p=0
+INTeRrupt ENAble id=546 p=0
+
+INTeRrupt ENAble id=1529 p=0
+
+# Core=1
+INTeRrupt ENAble id=2249 p=1
+INTeRrupt ENAble id=2250 p=1
+INTeRrupt ENAble id=2251 p=1
+INTeRrupt ENAble id=2252 p=1
+INTeRrupt ENAble id=2253 p=1
+INTeRrupt ENAble id=2254 p=1
+INTeRrupt ENAble id=2255 p=1
+INTeRrupt ENAble id=2256 p=1
+INTeRrupt ENAble id=2257 p=1
+INTeRrupt ENAble id=2258 p=1
+INTeRrupt ENAble id=2259 p=1
+INTeRrupt ENAble id=2260 p=1
+INTeRrupt ENAble id=2261 p=1
+INTeRrupt ENAble id=2262 p=1
+INTeRrupt ENAble id=2263 p=1
+
+INTeRrupt ENAble id=540 p=1
+INTeRrupt ENAble id=541 p=1
+INTeRrupt ENAble id=542 p=1
+INTeRrupt ENAble id=543 p=1
+INTeRrupt ENAble id=544 p=1
+INTeRrupt ENAble id=545 p=1
+INTeRrupt ENAble id=546 p=1
+
+INTeRrupt ENAble id=1529 p=1
+
+# Core=2
+INTeRrupt ENAble id=2249 p=2
+INTeRrupt ENAble id=2250 p=2
+INTeRrupt ENAble id=2251 p=2
+INTeRrupt ENAble id=2252 p=2
+INTeRrupt ENAble id=2253 p=2
+INTeRrupt ENAble id=2254 p=2
+INTeRrupt ENAble id=2255 p=2
+INTeRrupt ENAble id=2256 p=2
+INTeRrupt ENAble id=2257 p=2
+INTeRrupt ENAble id=2258 p=2
+INTeRrupt ENAble id=2259 p=2
+INTeRrupt ENAble id=2260 p=2
+INTeRrupt ENAble id=2261 p=2
+INTeRrupt ENAble id=2262 p=2
+INTeRrupt ENAble id=2263 p=2
+
+INTeRrupt ENAble id=540 p=2
+INTeRrupt ENAble id=541 p=2
+INTeRrupt ENAble id=542 p=2
+INTeRrupt ENAble id=543 p=2
+INTeRrupt ENAble id=544 p=2
+INTeRrupt ENAble id=545 p=2
+INTeRrupt ENAble id=546 p=2
+
+INTeRrupt ENAble id=1529 p=2
+
+# Core=3
+INTeRrupt ENAble id=2249 p=3
+INTeRrupt ENAble id=2250 p=3
+INTeRrupt ENAble id=2251 p=3
+INTeRrupt ENAble id=2252 p=3
+INTeRrupt ENAble id=2253 p=3
+INTeRrupt ENAble id=2254 p=3
+INTeRrupt ENAble id=2255 p=3
+INTeRrupt ENAble id=2256 p=3
+INTeRrupt ENAble id=2257 p=3
+INTeRrupt ENAble id=2258 p=3
+INTeRrupt ENAble id=2259 p=3
+INTeRrupt ENAble id=2260 p=3
+INTeRrupt ENAble id=2261 p=3
+INTeRrupt ENAble id=2262 p=3
+INTeRrupt ENAble id=2263 p=3
+
+INTeRrupt ENAble id=540 p=3
+INTeRrupt ENAble id=541 p=3
+INTeRrupt ENAble id=542 p=3
+INTeRrupt ENAble id=543 p=3
+INTeRrupt ENAble id=544 p=3
+INTeRrupt ENAble id=545 p=3
+INTeRrupt ENAble id=546 p=3
+
+INTeRrupt ENAble id=1529 p=3
+
+# Core=4
+INTeRrupt ENAble id=2249 p=4
+INTeRrupt ENAble id=2250 p=4
+INTeRrupt ENAble id=2251 p=4
+INTeRrupt ENAble id=2252 p=4
+INTeRrupt ENAble id=2253 p=4
+INTeRrupt ENAble id=2254 p=4
+INTeRrupt ENAble id=2255 p=4
+INTeRrupt ENAble id=2256 p=4
+INTeRrupt ENAble id=2257 p=4
+INTeRrupt ENAble id=2258 p=4
+INTeRrupt ENAble id=2259 p=4
+INTeRrupt ENAble id=2260 p=4
+INTeRrupt ENAble id=2261 p=4
+INTeRrupt ENAble id=2262 p=4
+INTeRrupt ENAble id=2263 p=4
+
+INTeRrupt ENAble id=540 p=4
+INTeRrupt ENAble id=541 p=4
+INTeRrupt ENAble id=542 p=4
+INTeRrupt ENAble id=543 p=4
+INTeRrupt ENAble id=544 p=4
+INTeRrupt ENAble id=545 p=4
+INTeRrupt ENAble id=546 p=4
+
+INTeRrupt ENAble id=1529 p=4
+
+# Core=5
+INTeRrupt ENAble id=2249 p=5
+INTeRrupt ENAble id=2250 p=5
+INTeRrupt ENAble id=2251 p=5
+INTeRrupt ENAble id=2252 p=5
+INTeRrupt ENAble id=2253 p=5
+INTeRrupt ENAble id=2254 p=5
+INTeRrupt ENAble id=2255 p=5
+INTeRrupt ENAble id=2256 p=5
+INTeRrupt ENAble id=2257 p=5
+INTeRrupt ENAble id=2258 p=5
+INTeRrupt ENAble id=2259 p=5
+INTeRrupt ENAble id=2260 p=5
+INTeRrupt ENAble id=2261 p=5
+INTeRrupt ENAble id=2262 p=5
+INTeRrupt ENAble id=2263 p=5
+
+INTeRrupt ENAble id=540 p=5
+INTeRrupt ENAble id=541 p=5
+INTeRrupt ENAble id=542 p=5
+INTeRrupt ENAble id=543 p=5
+INTeRrupt ENAble id=544 p=5
+INTeRrupt ENAble id=545 p=5
+INTeRrupt ENAble id=546 p=5
+
+INTeRrupt ENAble id=1529 p=5
+
+# Core=6
+INTeRrupt ENAble id=2249 p=6
+INTeRrupt ENAble id=2250 p=6
+INTeRrupt ENAble id=2251 p=6
+INTeRrupt ENAble id=2252 p=6
+INTeRrupt ENAble id=2253 p=6
+INTeRrupt ENAble id=2254 p=6
+INTeRrupt ENAble id=2255 p=6
+INTeRrupt ENAble id=2256 p=6
+INTeRrupt ENAble id=2257 p=6
+INTeRrupt ENAble id=2258 p=6
+INTeRrupt ENAble id=2259 p=6
+INTeRrupt ENAble id=2260 p=6
+INTeRrupt ENAble id=2261 p=6
+INTeRrupt ENAble id=2262 p=6
+INTeRrupt ENAble id=2263 p=6
+
+INTeRrupt ENAble id=540 p=6
+INTeRrupt ENAble id=541 p=6
+INTeRrupt ENAble id=542 p=6
+INTeRrupt ENAble id=543 p=6
+INTeRrupt ENAble id=544 p=6
+INTeRrupt ENAble id=545 p=6
+INTeRrupt ENAble id=546 p=6
+
+INTeRrupt ENAble id=1529 p=6
+
+# Core=7
+INTeRrupt ENAble id=2249 p=7
+INTeRrupt ENAble id=2250 p=7
+INTeRrupt ENAble id=2251 p=7
+INTeRrupt ENAble id=2252 p=7
+INTeRrupt ENAble id=2253 p=7
+INTeRrupt ENAble id=2254 p=7
+INTeRrupt ENAble id=2255 p=7
+INTeRrupt ENAble id=2256 p=7
+INTeRrupt ENAble id=2257 p=7
+INTeRrupt ENAble id=2258 p=7
+INTeRrupt ENAble id=2259 p=7
+INTeRrupt ENAble id=2260 p=7
+INTeRrupt ENAble id=2261 p=7
+INTeRrupt ENAble id=2262 p=7
+INTeRrupt ENAble id=2263 p=7
+
+INTeRrupt ENAble id=540 p=7
+INTeRrupt ENAble id=541 p=7
+INTeRrupt ENAble id=542 p=7
+INTeRrupt ENAble id=543 p=7
+INTeRrupt ENAble id=544 p=7
+INTeRrupt ENAble id=545 p=7
+INTeRrupt ENAble id=546 p=7
+
+INTeRrupt ENAble id=1529 p=7
+
+debug intr error

--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/sai_postinit_cmd.soc
@@ -1,28 +1,59 @@
-INTeRrupt ENAble id=1550
-INTeRrupt ENAble id=1551
-INTeRrupt ENAble id=1552
-INTeRrupt ENAble id=1553
-INTeRrupt ENAble id=1554
-INTeRrupt ENAble id=1555
-INTeRrupt ENAble id=1556
-INTeRrupt ENAble id=1557
-INTeRrupt ENAble id=1558
-INTeRrupt ENAble id=1559
-INTeRrupt ENAble id=1560
-INTeRrupt ENAble id=1561
-INTeRrupt ENAble id=1562
-INTeRrupt ENAble id=1563
-INTeRrupt ENAble id=1564
-INTeRrupt ENAble id=1565
-INTeRrupt ENAble id=1566
-INTeRrupt ENAble id=1567
+# Core=0
+INTeRrupt ENAble id=1550 p=0
+INTeRrupt ENAble id=1551 p=0
+INTeRrupt ENAble id=1552 p=0
+INTeRrupt ENAble id=1553 p=0
+INTeRrupt ENAble id=1554 p=0
+INTeRrupt ENAble id=1555 p=0
+INTeRrupt ENAble id=1556 p=0
+INTeRrupt ENAble id=1557 p=0
+INTeRrupt ENAble id=1558 p=0
+INTeRrupt ENAble id=1559 p=0
+INTeRrupt ENAble id=1560 p=0
+INTeRrupt ENAble id=1561 p=0
+INTeRrupt ENAble id=1562 p=0
+INTeRrupt ENAble id=1563 p=0
+INTeRrupt ENAble id=1564 p=0
+INTeRrupt ENAble id=1565 p=0
+INTeRrupt ENAble id=1566 p=0
+INTeRrupt ENAble id=1567 p=0
 
-INTeRrupt ENAble id=1296
-INTeRrupt ENAble id=1297
-INTeRrupt ENAble id=1298
-INTeRrupt ENAble id=1299
-INTeRrupt ENAble id=1661
-INTeRrupt ENAble id=1662
+INTeRrupt ENAble id=1296 p=0
+INTeRrupt ENAble id=1297 p=0
+INTeRrupt ENAble id=1298 p=0
+INTeRrupt ENAble id=1299 p=0
+INTeRrupt ENAble id=1661 p=0
+INTeRrupt ENAble id=1662 p=0
 
-INTeRrupt ENAble id=1093
+INTeRrupt ENAble id=1093 p=0
+
+# Core=1
+INTeRrupt ENAble id=1550 p=1
+INTeRrupt ENAble id=1551 p=1
+INTeRrupt ENAble id=1552 p=1
+INTeRrupt ENAble id=1553 p=1
+INTeRrupt ENAble id=1554 p=1
+INTeRrupt ENAble id=1555 p=1
+INTeRrupt ENAble id=1556 p=1
+INTeRrupt ENAble id=1557 p=1
+INTeRrupt ENAble id=1558 p=1
+INTeRrupt ENAble id=1559 p=1
+INTeRrupt ENAble id=1560 p=1
+INTeRrupt ENAble id=1561 p=1
+INTeRrupt ENAble id=1562 p=1
+INTeRrupt ENAble id=1563 p=1
+INTeRrupt ENAble id=1564 p=1
+INTeRrupt ENAble id=1565 p=1
+INTeRrupt ENAble id=1566 p=1
+INTeRrupt ENAble id=1567 p=1
+
+INTeRrupt ENAble id=1296 p=1
+INTeRrupt ENAble id=1297 p=1
+INTeRrupt ENAble id=1298 p=1
+INTeRrupt ENAble id=1299 p=1
+INTeRrupt ENAble id=1661 p=1
+INTeRrupt ENAble id=1662 p=1
+
+INTeRrupt ENAble id=1093 p=1
+
 debug intr error

--- a/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/sai_postinit_cmd.soc
@@ -1,28 +1,59 @@
-INTeRrupt ENAble id=1550
-INTeRrupt ENAble id=1551
-INTeRrupt ENAble id=1552
-INTeRrupt ENAble id=1553
-INTeRrupt ENAble id=1554
-INTeRrupt ENAble id=1555
-INTeRrupt ENAble id=1556
-INTeRrupt ENAble id=1557
-INTeRrupt ENAble id=1558
-INTeRrupt ENAble id=1559
-INTeRrupt ENAble id=1560
-INTeRrupt ENAble id=1561
-INTeRrupt ENAble id=1562
-INTeRrupt ENAble id=1563
-INTeRrupt ENAble id=1564
-INTeRrupt ENAble id=1565
-INTeRrupt ENAble id=1566
-INTeRrupt ENAble id=1567
+# Core=0
+INTeRrupt ENAble id=1550 p=0
+INTeRrupt ENAble id=1551 p=0
+INTeRrupt ENAble id=1552 p=0
+INTeRrupt ENAble id=1553 p=0
+INTeRrupt ENAble id=1554 p=0
+INTeRrupt ENAble id=1555 p=0
+INTeRrupt ENAble id=1556 p=0
+INTeRrupt ENAble id=1557 p=0
+INTeRrupt ENAble id=1558 p=0
+INTeRrupt ENAble id=1559 p=0
+INTeRrupt ENAble id=1560 p=0
+INTeRrupt ENAble id=1561 p=0
+INTeRrupt ENAble id=1562 p=0
+INTeRrupt ENAble id=1563 p=0
+INTeRrupt ENAble id=1564 p=0
+INTeRrupt ENAble id=1565 p=0
+INTeRrupt ENAble id=1566 p=0
+INTeRrupt ENAble id=1567 p=0
 
-INTeRrupt ENAble id=1296
-INTeRrupt ENAble id=1297
-INTeRrupt ENAble id=1298
-INTeRrupt ENAble id=1299
-INTeRrupt ENAble id=1661
-INTeRrupt ENAble id=1662
+INTeRrupt ENAble id=1296 p=0
+INTeRrupt ENAble id=1297 p=0
+INTeRrupt ENAble id=1298 p=0
+INTeRrupt ENAble id=1299 p=0
+INTeRrupt ENAble id=1661 p=0
+INTeRrupt ENAble id=1662 p=0
 
-INTeRrupt ENAble id=1093
+INTeRrupt ENAble id=1093 p=0
+
+# Core=1
+INTeRrupt ENAble id=1550 p=1
+INTeRrupt ENAble id=1551 p=1
+INTeRrupt ENAble id=1552 p=1
+INTeRrupt ENAble id=1553 p=1
+INTeRrupt ENAble id=1554 p=1
+INTeRrupt ENAble id=1555 p=1
+INTeRrupt ENAble id=1556 p=1
+INTeRrupt ENAble id=1557 p=1
+INTeRrupt ENAble id=1558 p=1
+INTeRrupt ENAble id=1559 p=1
+INTeRrupt ENAble id=1560 p=1
+INTeRrupt ENAble id=1561 p=1
+INTeRrupt ENAble id=1562 p=1
+INTeRrupt ENAble id=1563 p=1
+INTeRrupt ENAble id=1564 p=1
+INTeRrupt ENAble id=1565 p=1
+INTeRrupt ENAble id=1566 p=1
+INTeRrupt ENAble id=1567 p=1
+
+INTeRrupt ENAble id=1296 p=1
+INTeRrupt ENAble id=1297 p=1
+INTeRrupt ENAble id=1298 p=1
+INTeRrupt ENAble id=1299 p=1
+INTeRrupt ENAble id=1661 p=1
+INTeRrupt ENAble id=1662 p=1
+
+INTeRrupt ENAble id=1093 p=1
+
 debug intr error

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/sai_postinit_cmd.soc
@@ -1,29 +1,61 @@
-INTeRrupt ENAble id=2209
-INTeRrupt ENAble id=2210
-INTeRrupt ENAble id=2211
-INTeRrupt ENAble id=2212
-INTeRrupt ENAble id=2213
-INTeRrupt ENAble id=2214
-INTeRrupt ENAble id=2215
-INTeRrupt ENAble id=2216
-INTeRrupt ENAble id=2217
-INTeRrupt ENAble id=2218
-INTeRrupt ENAble id=2219
-INTeRrupt ENAble id=2220
-INTeRrupt ENAble id=2221
-INTeRrupt ENAble id=2222
-INTeRrupt ENAble id=2223
-INTeRrupt ENAble id=2224
-INTeRrupt ENAble id=2225
-INTeRrupt ENAble id=2226
+# Core=0
+INTeRrupt ENAble id=2209 p=0
+INTeRrupt ENAble id=2210 p=0
+INTeRrupt ENAble id=2211 p=0
+INTeRrupt ENAble id=2212 p=0
+INTeRrupt ENAble id=2213 p=0
+INTeRrupt ENAble id=2214 p=0
+INTeRrupt ENAble id=2215 p=0
+INTeRrupt ENAble id=2216 p=0
+INTeRrupt ENAble id=2217 p=0
+INTeRrupt ENAble id=2218 p=0
+INTeRrupt ENAble id=2219 p=0
+INTeRrupt ENAble id=2220 p=0
+INTeRrupt ENAble id=2221 p=0
+INTeRrupt ENAble id=2222 p=0
+INTeRrupt ENAble id=2223 p=0
+INTeRrupt ENAble id=2224 p=0
+INTeRrupt ENAble id=2225 p=0
+INTeRrupt ENAble id=2226 p=0
 
-INTeRrupt ENAble id=482
-INTeRrupt ENAble id=483
-INTeRrupt ENAble id=484
-INTeRrupt ENAble id=485
-INTeRrupt ENAble id=486
-INTeRrupt ENAble id=487
-INTeRrupt ENAble id=488
+INTeRrupt ENAble id=482 p=0
+INTeRrupt ENAble id=483 p=0
+INTeRrupt ENAble id=484 p=0
+INTeRrupt ENAble id=485 p=0
+INTeRrupt ENAble id=486 p=0
+INTeRrupt ENAble id=487 p=0
+INTeRrupt ENAble id=488 p=0
 
-INTeRrupt ENAble id=1597
+INTeRrupt ENAble id=1597 p=0
+
+# Core=1
+INTeRrupt ENAble id=2209 p=1
+INTeRrupt ENAble id=2210 p=1
+INTeRrupt ENAble id=2211 p=1
+INTeRrupt ENAble id=2212 p=1
+INTeRrupt ENAble id=2213 p=1
+INTeRrupt ENAble id=2214 p=1
+INTeRrupt ENAble id=2215 p=1
+INTeRrupt ENAble id=2216 p=1
+INTeRrupt ENAble id=2217 p=1
+INTeRrupt ENAble id=2218 p=1
+INTeRrupt ENAble id=2219 p=1
+INTeRrupt ENAble id=2220 p=1
+INTeRrupt ENAble id=2221 p=1
+INTeRrupt ENAble id=2222 p=1
+INTeRrupt ENAble id=2223 p=1
+INTeRrupt ENAble id=2224 p=1
+INTeRrupt ENAble id=2225 p=1
+INTeRrupt ENAble id=2226 p=1
+
+INTeRrupt ENAble id=482 p=1
+INTeRrupt ENAble id=483 p=1
+INTeRrupt ENAble id=484 p=1
+INTeRrupt ENAble id=485 p=1
+INTeRrupt ENAble id=486 p=1
+INTeRrupt ENAble id=487 p=1
+INTeRrupt ENAble id=488 p=1
+
+INTeRrupt ENAble id=1597 p=1
+
 debug intr error

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/sai_postinit_cmd.soc
@@ -1,29 +1,61 @@
-INTeRrupt ENAble id=2209
-INTeRrupt ENAble id=2210
-INTeRrupt ENAble id=2211
-INTeRrupt ENAble id=2212
-INTeRrupt ENAble id=2213
-INTeRrupt ENAble id=2214
-INTeRrupt ENAble id=2215
-INTeRrupt ENAble id=2216
-INTeRrupt ENAble id=2217
-INTeRrupt ENAble id=2218
-INTeRrupt ENAble id=2219
-INTeRrupt ENAble id=2220
-INTeRrupt ENAble id=2221
-INTeRrupt ENAble id=2222
-INTeRrupt ENAble id=2223
-INTeRrupt ENAble id=2224
-INTeRrupt ENAble id=2225
-INTeRrupt ENAble id=2226
+# Core=0
+INTeRrupt ENAble id=2209 p=0
+INTeRrupt ENAble id=2210 p=0
+INTeRrupt ENAble id=2211 p=0
+INTeRrupt ENAble id=2212 p=0
+INTeRrupt ENAble id=2213 p=0
+INTeRrupt ENAble id=2214 p=0
+INTeRrupt ENAble id=2215 p=0
+INTeRrupt ENAble id=2216 p=0
+INTeRrupt ENAble id=2217 p=0
+INTeRrupt ENAble id=2218 p=0
+INTeRrupt ENAble id=2219 p=0
+INTeRrupt ENAble id=2220 p=0
+INTeRrupt ENAble id=2221 p=0
+INTeRrupt ENAble id=2222 p=0
+INTeRrupt ENAble id=2223 p=0
+INTeRrupt ENAble id=2224 p=0
+INTeRrupt ENAble id=2225 p=0
+INTeRrupt ENAble id=2226 p=0
 
-INTeRrupt ENAble id=482
-INTeRrupt ENAble id=483
-INTeRrupt ENAble id=484
-INTeRrupt ENAble id=485
-INTeRrupt ENAble id=486
-INTeRrupt ENAble id=487
-INTeRrupt ENAble id=488
+INTeRrupt ENAble id=482 p=0
+INTeRrupt ENAble id=483 p=0
+INTeRrupt ENAble id=484 p=0
+INTeRrupt ENAble id=485 p=0
+INTeRrupt ENAble id=486 p=0
+INTeRrupt ENAble id=487 p=0
+INTeRrupt ENAble id=488 p=0
 
-INTeRrupt ENAble id=1597
+INTeRrupt ENAble id=1597 p=0
+
+# Core=1
+INTeRrupt ENAble id=2209 p=1
+INTeRrupt ENAble id=2210 p=1
+INTeRrupt ENAble id=2211 p=1
+INTeRrupt ENAble id=2212 p=1
+INTeRrupt ENAble id=2213 p=1
+INTeRrupt ENAble id=2214 p=1
+INTeRrupt ENAble id=2215 p=1
+INTeRrupt ENAble id=2216 p=1
+INTeRrupt ENAble id=2217 p=1
+INTeRrupt ENAble id=2218 p=1
+INTeRrupt ENAble id=2219 p=1
+INTeRrupt ENAble id=2220 p=1
+INTeRrupt ENAble id=2221 p=1
+INTeRrupt ENAble id=2222 p=1
+INTeRrupt ENAble id=2223 p=1
+INTeRrupt ENAble id=2224 p=1
+INTeRrupt ENAble id=2225 p=1
+INTeRrupt ENAble id=2226 p=1
+
+INTeRrupt ENAble id=482 p=1
+INTeRrupt ENAble id=483 p=1
+INTeRrupt ENAble id=484 p=1
+INTeRrupt ENAble id=485 p=1
+INTeRrupt ENAble id=486 p=1
+INTeRrupt ENAble id=487 p=1
+INTeRrupt ENAble id=488 p=1
+
+INTeRrupt ENAble id=1597 p=1
+
 debug intr error

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/sai_postinit_cmd.soc
@@ -1,29 +1,61 @@
-INTeRrupt ENAble id=2209
-INTeRrupt ENAble id=2210
-INTeRrupt ENAble id=2211
-INTeRrupt ENAble id=2212
-INTeRrupt ENAble id=2213
-INTeRrupt ENAble id=2214
-INTeRrupt ENAble id=2215
-INTeRrupt ENAble id=2216
-INTeRrupt ENAble id=2217
-INTeRrupt ENAble id=2218
-INTeRrupt ENAble id=2219
-INTeRrupt ENAble id=2220
-INTeRrupt ENAble id=2221
-INTeRrupt ENAble id=2222
-INTeRrupt ENAble id=2223
-INTeRrupt ENAble id=2224
-INTeRrupt ENAble id=2225
-INTeRrupt ENAble id=2226
+# Core=0
+INTeRrupt ENAble id=2209 p=0
+INTeRrupt ENAble id=2210 p=0
+INTeRrupt ENAble id=2211 p=0
+INTeRrupt ENAble id=2212 p=0
+INTeRrupt ENAble id=2213 p=0
+INTeRrupt ENAble id=2214 p=0
+INTeRrupt ENAble id=2215 p=0
+INTeRrupt ENAble id=2216 p=0
+INTeRrupt ENAble id=2217 p=0
+INTeRrupt ENAble id=2218 p=0
+INTeRrupt ENAble id=2219 p=0
+INTeRrupt ENAble id=2220 p=0
+INTeRrupt ENAble id=2221 p=0
+INTeRrupt ENAble id=2222 p=0
+INTeRrupt ENAble id=2223 p=0
+INTeRrupt ENAble id=2224 p=0
+INTeRrupt ENAble id=2225 p=0
+INTeRrupt ENAble id=2226 p=0
 
-INTeRrupt ENAble id=482
-INTeRrupt ENAble id=483
-INTeRrupt ENAble id=484
-INTeRrupt ENAble id=485
-INTeRrupt ENAble id=486
-INTeRrupt ENAble id=487
-INTeRrupt ENAble id=488
+INTeRrupt ENAble id=482 p=0
+INTeRrupt ENAble id=483 p=0
+INTeRrupt ENAble id=484 p=0
+INTeRrupt ENAble id=485 p=0
+INTeRrupt ENAble id=486 p=0
+INTeRrupt ENAble id=487 p=0
+INTeRrupt ENAble id=488 p=0
 
-INTeRrupt ENAble id=1597
+INTeRrupt ENAble id=1597 p=0
+
+# Core=1
+INTeRrupt ENAble id=2209 p=1
+INTeRrupt ENAble id=2210 p=1
+INTeRrupt ENAble id=2211 p=1
+INTeRrupt ENAble id=2212 p=1
+INTeRrupt ENAble id=2213 p=1
+INTeRrupt ENAble id=2214 p=1
+INTeRrupt ENAble id=2215 p=1
+INTeRrupt ENAble id=2216 p=1
+INTeRrupt ENAble id=2217 p=1
+INTeRrupt ENAble id=2218 p=1
+INTeRrupt ENAble id=2219 p=1
+INTeRrupt ENAble id=2220 p=1
+INTeRrupt ENAble id=2221 p=1
+INTeRrupt ENAble id=2222 p=1
+INTeRrupt ENAble id=2223 p=1
+INTeRrupt ENAble id=2224 p=1
+INTeRrupt ENAble id=2225 p=1
+INTeRrupt ENAble id=2226 p=1
+
+INTeRrupt ENAble id=482 p=1
+INTeRrupt ENAble id=483 p=1
+INTeRrupt ENAble id=484 p=1
+INTeRrupt ENAble id=485 p=1
+INTeRrupt ENAble id=486 p=1
+INTeRrupt ENAble id=487 p=1
+INTeRrupt ENAble id=488 p=1
+
+INTeRrupt ENAble id=1597 p=1
+
 debug intr error

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/sai_postinit_cmd.soc
@@ -1,29 +1,61 @@
-INTeRrupt ENAble id=2209
-INTeRrupt ENAble id=2210
-INTeRrupt ENAble id=2211
-INTeRrupt ENAble id=2212
-INTeRrupt ENAble id=2213
-INTeRrupt ENAble id=2214
-INTeRrupt ENAble id=2215
-INTeRrupt ENAble id=2216
-INTeRrupt ENAble id=2217
-INTeRrupt ENAble id=2218
-INTeRrupt ENAble id=2219
-INTeRrupt ENAble id=2220
-INTeRrupt ENAble id=2221
-INTeRrupt ENAble id=2222
-INTeRrupt ENAble id=2223
-INTeRrupt ENAble id=2224
-INTeRrupt ENAble id=2225
-INTeRrupt ENAble id=2226
+# Core=0
+INTeRrupt ENAble id=2209 p=0
+INTeRrupt ENAble id=2210 p=0
+INTeRrupt ENAble id=2211 p=0
+INTeRrupt ENAble id=2212 p=0
+INTeRrupt ENAble id=2213 p=0
+INTeRrupt ENAble id=2214 p=0
+INTeRrupt ENAble id=2215 p=0
+INTeRrupt ENAble id=2216 p=0
+INTeRrupt ENAble id=2217 p=0
+INTeRrupt ENAble id=2218 p=0
+INTeRrupt ENAble id=2219 p=0
+INTeRrupt ENAble id=2220 p=0
+INTeRrupt ENAble id=2221 p=0
+INTeRrupt ENAble id=2222 p=0
+INTeRrupt ENAble id=2223 p=0
+INTeRrupt ENAble id=2224 p=0
+INTeRrupt ENAble id=2225 p=0
+INTeRrupt ENAble id=2226 p=0
 
-INTeRrupt ENAble id=482
-INTeRrupt ENAble id=483
-INTeRrupt ENAble id=484
-INTeRrupt ENAble id=485
-INTeRrupt ENAble id=486
-INTeRrupt ENAble id=487
-INTeRrupt ENAble id=488
+INTeRrupt ENAble id=482 p=0
+INTeRrupt ENAble id=483 p=0
+INTeRrupt ENAble id=484 p=0
+INTeRrupt ENAble id=485 p=0
+INTeRrupt ENAble id=486 p=0
+INTeRrupt ENAble id=487 p=0
+INTeRrupt ENAble id=488 p=0
 
-INTeRrupt ENAble id=1597
+INTeRrupt ENAble id=1597 p=0
+
+# Core=1
+INTeRrupt ENAble id=2209 p=1
+INTeRrupt ENAble id=2210 p=1
+INTeRrupt ENAble id=2211 p=1
+INTeRrupt ENAble id=2212 p=1
+INTeRrupt ENAble id=2213 p=1
+INTeRrupt ENAble id=2214 p=1
+INTeRrupt ENAble id=2215 p=1
+INTeRrupt ENAble id=2216 p=1
+INTeRrupt ENAble id=2217 p=1
+INTeRrupt ENAble id=2218 p=1
+INTeRrupt ENAble id=2219 p=1
+INTeRrupt ENAble id=2220 p=1
+INTeRrupt ENAble id=2221 p=1
+INTeRrupt ENAble id=2222 p=1
+INTeRrupt ENAble id=2223 p=1
+INTeRrupt ENAble id=2224 p=1
+INTeRrupt ENAble id=2225 p=1
+INTeRrupt ENAble id=2226 p=1
+
+INTeRrupt ENAble id=482 p=1
+INTeRrupt ENAble id=483 p=1
+INTeRrupt ENAble id=484 p=1
+INTeRrupt ENAble id=485 p=1
+INTeRrupt ENAble id=486 p=1
+INTeRrupt ENAble id=487 p=1
+INTeRrupt ENAble id=488 p=1
+
+INTeRrupt ENAble id=1597 p=1
+
 debug intr error

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/sai_postinit_cmd.soc
@@ -1,29 +1,61 @@
-INTeRrupt ENAble id=2209
-INTeRrupt ENAble id=2210
-INTeRrupt ENAble id=2211
-INTeRrupt ENAble id=2212
-INTeRrupt ENAble id=2213
-INTeRrupt ENAble id=2214
-INTeRrupt ENAble id=2215
-INTeRrupt ENAble id=2216
-INTeRrupt ENAble id=2217
-INTeRrupt ENAble id=2218
-INTeRrupt ENAble id=2219
-INTeRrupt ENAble id=2220
-INTeRrupt ENAble id=2221
-INTeRrupt ENAble id=2222
-INTeRrupt ENAble id=2223
-INTeRrupt ENAble id=2224
-INTeRrupt ENAble id=2225
-INTeRrupt ENAble id=2226
+# Core=0
+INTeRrupt ENAble id=2209 p=0
+INTeRrupt ENAble id=2210 p=0
+INTeRrupt ENAble id=2211 p=0
+INTeRrupt ENAble id=2212 p=0
+INTeRrupt ENAble id=2213 p=0
+INTeRrupt ENAble id=2214 p=0
+INTeRrupt ENAble id=2215 p=0
+INTeRrupt ENAble id=2216 p=0
+INTeRrupt ENAble id=2217 p=0
+INTeRrupt ENAble id=2218 p=0
+INTeRrupt ENAble id=2219 p=0
+INTeRrupt ENAble id=2220 p=0
+INTeRrupt ENAble id=2221 p=0
+INTeRrupt ENAble id=2222 p=0
+INTeRrupt ENAble id=2223 p=0
+INTeRrupt ENAble id=2224 p=0
+INTeRrupt ENAble id=2225 p=0
+INTeRrupt ENAble id=2226 p=0
 
-INTeRrupt ENAble id=482
-INTeRrupt ENAble id=483
-INTeRrupt ENAble id=484
-INTeRrupt ENAble id=485
-INTeRrupt ENAble id=486
-INTeRrupt ENAble id=487
-INTeRrupt ENAble id=488
+INTeRrupt ENAble id=482 p=0
+INTeRrupt ENAble id=483 p=0
+INTeRrupt ENAble id=484 p=0
+INTeRrupt ENAble id=485 p=0
+INTeRrupt ENAble id=486 p=0
+INTeRrupt ENAble id=487 p=0
+INTeRrupt ENAble id=488 p=0
 
-INTeRrupt ENAble id=1597
+INTeRrupt ENAble id=1597 p=0
+
+# Core=1
+INTeRrupt ENAble id=2209 p=1
+INTeRrupt ENAble id=2210 p=1
+INTeRrupt ENAble id=2211 p=1
+INTeRrupt ENAble id=2212 p=1
+INTeRrupt ENAble id=2213 p=1
+INTeRrupt ENAble id=2214 p=1
+INTeRrupt ENAble id=2215 p=1
+INTeRrupt ENAble id=2216 p=1
+INTeRrupt ENAble id=2217 p=1
+INTeRrupt ENAble id=2218 p=1
+INTeRrupt ENAble id=2219 p=1
+INTeRrupt ENAble id=2220 p=1
+INTeRrupt ENAble id=2221 p=1
+INTeRrupt ENAble id=2222 p=1
+INTeRrupt ENAble id=2223 p=1
+INTeRrupt ENAble id=2224 p=1
+INTeRrupt ENAble id=2225 p=1
+INTeRrupt ENAble id=2226 p=1
+
+INTeRrupt ENAble id=482 p=1
+INTeRrupt ENAble id=483 p=1
+INTeRrupt ENAble id=484 p=1
+INTeRrupt ENAble id=485 p=1
+INTeRrupt ENAble id=486 p=1
+INTeRrupt ENAble id=487 p=1
+INTeRrupt ENAble id=488 p=1
+
+INTeRrupt ENAble id=1597 p=1
+
 debug intr error

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/sai_postinit_cmd.soc
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/sai_postinit_cmd.soc
@@ -1,29 +1,61 @@
-INTeRrupt ENAble id=2209
-INTeRrupt ENAble id=2210
-INTeRrupt ENAble id=2211
-INTeRrupt ENAble id=2212
-INTeRrupt ENAble id=2213
-INTeRrupt ENAble id=2214
-INTeRrupt ENAble id=2215
-INTeRrupt ENAble id=2216
-INTeRrupt ENAble id=2217
-INTeRrupt ENAble id=2218
-INTeRrupt ENAble id=2219
-INTeRrupt ENAble id=2220
-INTeRrupt ENAble id=2221
-INTeRrupt ENAble id=2222
-INTeRrupt ENAble id=2223
-INTeRrupt ENAble id=2224
-INTeRrupt ENAble id=2225
-INTeRrupt ENAble id=2226
+# Core=0
+INTeRrupt ENAble id=2209 p=0
+INTeRrupt ENAble id=2210 p=0
+INTeRrupt ENAble id=2211 p=0
+INTeRrupt ENAble id=2212 p=0
+INTeRrupt ENAble id=2213 p=0
+INTeRrupt ENAble id=2214 p=0
+INTeRrupt ENAble id=2215 p=0
+INTeRrupt ENAble id=2216 p=0
+INTeRrupt ENAble id=2217 p=0
+INTeRrupt ENAble id=2218 p=0
+INTeRrupt ENAble id=2219 p=0
+INTeRrupt ENAble id=2220 p=0
+INTeRrupt ENAble id=2221 p=0
+INTeRrupt ENAble id=2222 p=0
+INTeRrupt ENAble id=2223 p=0
+INTeRrupt ENAble id=2224 p=0
+INTeRrupt ENAble id=2225 p=0
+INTeRrupt ENAble id=2226 p=0
 
-INTeRrupt ENAble id=482
-INTeRrupt ENAble id=483
-INTeRrupt ENAble id=484
-INTeRrupt ENAble id=485
-INTeRrupt ENAble id=486
-INTeRrupt ENAble id=487
-INTeRrupt ENAble id=488
+INTeRrupt ENAble id=482 p=0
+INTeRrupt ENAble id=483 p=0
+INTeRrupt ENAble id=484 p=0
+INTeRrupt ENAble id=485 p=0
+INTeRrupt ENAble id=486 p=0
+INTeRrupt ENAble id=487 p=0
+INTeRrupt ENAble id=488 p=0
 
-INTeRrupt ENAble id=1597
+INTeRrupt ENAble id=1597 p=0
+
+# Core=1
+INTeRrupt ENAble id=2209 p=1
+INTeRrupt ENAble id=2210 p=1
+INTeRrupt ENAble id=2211 p=1
+INTeRrupt ENAble id=2212 p=1
+INTeRrupt ENAble id=2213 p=1
+INTeRrupt ENAble id=2214 p=1
+INTeRrupt ENAble id=2215 p=1
+INTeRrupt ENAble id=2216 p=1
+INTeRrupt ENAble id=2217 p=1
+INTeRrupt ENAble id=2218 p=1
+INTeRrupt ENAble id=2219 p=1
+INTeRrupt ENAble id=2220 p=1
+INTeRrupt ENAble id=2221 p=1
+INTeRrupt ENAble id=2222 p=1
+INTeRrupt ENAble id=2223 p=1
+INTeRrupt ENAble id=2224 p=1
+INTeRrupt ENAble id=2225 p=1
+INTeRrupt ENAble id=2226 p=1
+
+INTeRrupt ENAble id=482 p=1
+INTeRrupt ENAble id=483 p=1
+INTeRrupt ENAble id=484 p=1
+INTeRrupt ENAble id=485 p=1
+INTeRrupt ENAble id=486 p=1
+INTeRrupt ENAble id=487 p=1
+INTeRrupt ENAble id=488 p=1
+
+INTeRrupt ENAble id=1597 p=1
+
 debug intr error


### PR DESCRIPTION
We noticed the interrupt enabling commands in the `sai_postinit_cmd.soc` were only enabling them on core=0.
```
bcmcmd -n 0 "show interrupt all" | grep 2209
| RQP_PACKET_REASSEMBLY_CdcPktSizeErr[0]                                   | 2209 | 1              | 0  | 0     |
| RQP_PACKET_REASSEMBLY_CdcPktSizeErr[1]                                   | 2209 | 0              | 0  | 0     |
```

If we add `p=<core>` to the command it enables it on the core.
```
bcmcmd -n 0 "show interrupt all" | grep 2209
| RQP_PACKET_REASSEMBLY_CdcPktSizeErr[0]                                   | 2209 | 1              | 0  | 0     |
| RQP_PACKET_REASSEMBLY_CdcPktSizeErr[1]                                   | 2209 | 1              | 0  | 0     |
```


#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] msft-202503
- [ ] 202505
- [x] 202511

