### PR TITLE
Fix dash-hadpu containers startup.

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -661,9 +661,11 @@ start() {
         # /var/run/redis1 ---> mounted as --> /var/run/redis1
         # redis_dir_list is a string of form "/var/run/redis0/ /var/run/redis1/ /var/run/redis2/"
         if [ -n "$redis_dir_list" ]; then
-            id=`expr $DEV + 1`
-            redis_dir=`echo $redis_dir_list | cut -d " " -f $id`
-            REDIS_MNT=$REDIS_MNT" -v $redis_dir:$redis_dir:rw "
+            if [[ "$DEV" != dpu* ]]; then
+                id=`expr $DEV + 1`
+                redis_dir=`echo $redis_dir_list | cut -d " " -f $id`
+                REDIS_MNT=$REDIS_MNT" -v $redis_dir:$redis_dir:rw "
+            fi
         fi
 
         {%- if docker_container_name == "database" %}

--- a/rules/docker-dash-ha.mk
+++ b/rules/docker-dash-ha.mk
@@ -34,7 +34,7 @@ endif
 $(DOCKER_DASH_HA)_CONTAINER_NAME = dash-ha
 $(DOCKER_DASH_HA)_RUN_OPT += -t
 $(DOCKER_DASH_HA)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
-$(DOCKER_DASH_HA)_RUN_OPT += -v /etc/timezone:/etc/timezone:ro
+$(DOCKER_DASH_HA)_RUN_OPT += -v /etc/localtime:/etc/localtime:ro
 
 SONIC_BOOKWORM_DOCKERS += $(DOCKER_DASH_HA)
 SONIC_BOOKWORM_DBG_DOCKERS += $(DOCKER_DASH_HA_DBG)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Upgrade to docker version 28.2.2  exposed a bug in dash-hadpuX container creation and startup. Previously "REDIS_MNT=$REDIS_MNT" -v $redis_dir:$redis_dir:rw " was evaluating to "-v ::rw" which was tolerated on older docker version. But on this newer version it causes a failure at creation. Additionally, /etc/timezone has been deprecated and needs to be removed.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Skip the unused mount for hadpu containers, move from /etc/timezone to /etc/localtime. 

#### How to verify it
Load Smartswitch image and check that the dash-hadpuX containers come up successfully.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

