### PR TITLE
[snmpd] Fix Trixie build: t64 package names and missing patch dir

### DIFF
--- a/src/snmpd/Makefile
+++ b/src/snmpd/Makefile
@@ -4,19 +4,26 @@ SHELL = /bin/bash
 
 MAIN_TARGET = libsnmp-base_$(SNMPD_VERSION_FULL)_all.deb
 ifneq (,$(findstring 5.9,$(SNMPD_VERSION)))
+# Common targets for all 5.9.x versions
 DERIVED_TARGETS = snmptrapd_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  snmptrapd-dbgsym_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  snmp_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  snmpd_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  snmp-dbgsym_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  snmpd-dbgsym_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
-		  libsnmp40_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
-		  libsnmp40-dbgsym_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
-		  libnetsnmptrapd40_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  libsnmp-dev_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  libsnmp-perl_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  libsnmp-perl-dbgsym_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  tkmib_$(SNMPD_VERSION_FULL)_all.deb
+# Trixie uses t64 suffixed library package names
+ifeq ($(BLDENV),trixie)
+DERIVED_TARGETS += libsnmp40t64_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
+		  libsnmp40t64-dbgsym_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb
+else
+DERIVED_TARGETS += libsnmp40_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
+		  libsnmp40-dbgsym_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
+		  libnetsnmptrapd40_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb
+endif
 
 SNMPD_MAKE_JOBS_NUM = $(SONIC_CONFIG_MAKE_JOBS)
 else

--- a/src/snmpd/patch-5.9.4+dfsg/0001-SNMP-Stop-spamming-logs-with-statfs-permission-denie.patch
+++ b/src/snmpd/patch-5.9.4+dfsg/0001-SNMP-Stop-spamming-logs-with-statfs-permission-denie.patch
@@ -1,0 +1,25 @@
+From 8bb8849524aba2124be3279a5197ad5fbfe166b2 Mon Sep 17 00:00:00 2001
+From: pavel-shirshov <pavelsh@microsoft.com>
+Date: Mon, 27 Aug 2018 16:50:16 +0800
+Subject: [PATCH] [SNMP] Stop spamming logs with statfs permission denied log
+
+---
+ agent/mibgroup/hardware/fsys/fsys_mntctl.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/agent/mibgroup/hardware/fsys/fsys_mntctl.c b/agent/mibgroup/hardware/fsys/fsys_mntctl.c
+index 782c8ed..7819fe4 100644
+--- a/agent/mibgroup/hardware/fsys/fsys_mntctl.c
++++ b/agent/mibgroup/hardware/fsys/fsys_mntctl.c
+@@ -167,8 +167,6 @@ netsnmp_fsys_arch_load( void )
+             continue;
+ 
+         if ( statfs( entry->path, &stat_buf ) < 0 ) {
+-            snprintf( tmpbuf, sizeof(tmpbuf), "Cannot statfs %s", entry->path );
+-            snmp_log_perror( tmpbuf );
+             continue;
+         }
+         entry->units =  stat_buf.f_bsize;
+-- 
+2.18.0
+

--- a/src/snmpd/patch-5.9.4+dfsg/0008-Enable-macro-DEB_BUILD_ARCH_OS-in-order-to-build-ipv.patch
+++ b/src/snmpd/patch-5.9.4+dfsg/0008-Enable-macro-DEB_BUILD_ARCH_OS-in-order-to-build-ipv.patch
@@ -1,0 +1,25 @@
+From bd7d6d79217da6b5a2eb3a3ee1d409c175a61e41 Mon Sep 17 00:00:00 2001
+From: Qi Luo <qiluo-msft@users.noreply.github.com>
+Date: Fri, 20 Sep 2019 00:42:19 +0000
+Subject: [PATCH] Enable macro DEB_BUILD_ARCH_OS in order to build ipv6 feature
+
+---
+ debian/rules | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/debian/rules b/debian/rules
+index 34d8509..496be59 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -4,6 +4,8 @@
+ export DEB_BUILD_MAINT_OPTIONS := hardening=+all
+ include /usr/share/dpkg/architecture.mk
+ include /usr/share/dpkg/buildtools.mk
++DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
++DEB_BUILD_ARCH_OS  ?= $(shell dpkg-architecture -qDEB_BUILD_ARCH_OS)
+ 
+ LIB_VERSION = 40t64
+ 
+-- 
+2.18.0
+

--- a/src/snmpd/patch-5.9.4+dfsg/0013-enable-parallel-build-for-net-snmp.patch
+++ b/src/snmpd/patch-5.9.4+dfsg/0013-enable-parallel-build-for-net-snmp.patch
@@ -1,0 +1,18 @@
+diff --git a/debian/rules b/debian/rules
+index 496be59..939e1a4 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -37,10 +37,6 @@ endif
+ %:
+ 	dh $@
+ 
+-# The net-snmp Makefiles cannot handle parallel builds
+-override_dh_auto_build:
+-	dh_auto_build --no-parallel
+-
+ override_dh_auto_configure:
+ 	dh_auto_configure -- --prefix=/usr --sysconfdir=/etc --mandir=/usr/share/man \
+ 	  --with-persistent-directory=/var/lib/snmp \
+-- 
+2.18.0
+

--- a/src/snmpd/patch-5.9.4+dfsg/cross-compile-changes.patch
+++ b/src/snmpd/patch-5.9.4+dfsg/cross-compile-changes.patch
@@ -1,0 +1,20 @@
+diff --git a/debian/rules b/debian/rules
+index 939e1a4..efd323e 100755
+--- a/debian/rules
++++ b/debian/rules
+@@ -7,6 +7,12 @@ include /usr/share/dpkg/buildtools.mk
+ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
+ DEB_BUILD_ARCH_OS  ?= $(shell dpkg-architecture -qDEB_BUILD_ARCH_OS)
+ 
++DEB_BUILD_MULTIARCH  ?= $(shell dpkg-architecture -qDEB_BUILD_MULTIARCH)
++
++ifneq ($(DEB_BUILD_MULTIARCH),$(DEB_HOST_MULTIARCH))
++export PERL5OPT := -I/usr/lib/$(DEB_HOST_MULTIARCH)/perl/cross-config
++endif
++
+ LIB_VERSION = 40t64
+ 
+ MIB_MODULES = smux ucd-snmp/dlmod mibII/mta_sendmail disman/event-mib
+-- 
+2.18.0
+

--- a/src/snmpd/patch-5.9.4+dfsg/series
+++ b/src/snmpd/patch-5.9.4+dfsg/series
@@ -1,0 +1,4 @@
+0001-SNMP-Stop-spamming-logs-with-statfs-permission-denie.patch
+0008-Enable-macro-DEB_BUILD_ARCH_OS-in-order-to-build-ipv.patch
+0013-enable-parallel-build-for-net-snmp.patch
+cross-compile-changes.patch


### PR DESCRIPTION
## Description
[agent]
Fix snmpd build under Trixie slave container.

### What I did
1. **t64 package renames**: Debian Trixie renames shared library packages as part of the 64-bit time_t transition. Make `DERIVED_TARGETS` in `src/snmpd/Makefile` conditional on `BLDENV`:
   - `libsnmp40` → `libsnmp40t64` (trixie)
   - `libsnmp40-dbgsym` → `libsnmp40t64-dbgsym` (trixie)
   - `libnetsnmptrapd40` dropped in trixie (merged into libsnmp40t64)

2. **Missing patch directory**: Add `patch-5.9.4+dfsg/` for the Trixie snmpd version (5.9.4). Without this, `stg import -s ../patch-$(SNMPD_VERSION)/series` fails. Patches are copied from 5.9.3 (apply cleanly to 5.9.4).

### Why I did it
`rules/snmpd.mk` already has per-BLDENV t64 conditional names, but `src/snmpd/Makefile` did not — causing the `mv $(DERIVED_TARGETS)` command to fail when the actual .deb files have t64 suffixed names.

The missing `patch-5.9.4+dfsg/` directory causes an immediate build failure in the Trixie phase.

### How I verified it
Built snmpd successfully under the trixie-only build branch.
Bookworm path is unchanged (hits the `else` branch).

## Type of change
- Bug fix