### PR TITLE
[docker] Remove --no-remove from apt-get fallback in dockerfile-macros

### DIFF
--- a/dockers/dockerfile-macros.j2
+++ b/dockers/dockerfile-macros.j2
@@ -2,7 +2,7 @@
 RUN dpkg -i \
 {%- for deb in packages %}
     /debs/{{ deb }} {%- if not loop.last %} \ {%- endif %}
-{%- endfor %} || apt-get -y install -f --no-remove
+{%- endfor %} || apt-get -y install -f
 {%- endmacro %}
 
 {% macro install_python2_wheels(packages) -%}


### PR DESCRIPTION
## Description
Remove `--no-remove` flag from the `apt-get install -f` fallback in `dockerfile-macros.j2`.

### What I did
Removed `--no-remove` from the dpkg install fallback: `apt-get -y install -f --no-remove` → `apt-get -y install -f`

### Why I did it
The `--no-remove` flag prevents apt from removing conflicting packages during dependency resolution. This blocks the iptables package transition in Debian Trixie, where `iptables` needs to replace `xtables-addons-common`.

The fallback only runs when `dpkg -i` fails (i.e., dependencies are broken), so `apt-get install -f` needs full authority to resolve conflicts — including removing obsolete packages.

This does not affect bookworm builds since bookworm packages have no such transitions.

### How I verified it
Successfully built all Docker images under Trixie with this change. Bookworm builds unaffected.

## Type of change
- Bug fix