### PR TITLE
[202511][Mellanox] Added inotify mechanism for vpd_data file creation

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,6 +46,7 @@ RJ45_TYPE = "RJ45"
 
 VPD_DATA_FILE = "/var/run/hw-management/eeprom/vpd_data"
 REVISION = "REV"
+VPD_DATA_WAIT_TIMEOUT = 60  # Timeout in seconds for waiting for VPD data file
 
 HWMGMT_SYSTEM_ROOT = '/var/run/hw-management/system/'
 
@@ -978,10 +979,13 @@ class Chassis(ChassisBase):
         result = {}
         try:
             if not os.access(filename, os.R_OK):
-                return result
+                logger.log_info("VPD data file {} not accessible, waiting for creation".format(filename))
+                if not utils.wait_for_file_creation(filename, VPD_DATA_WAIT_TIMEOUT):
+                    logger.log_error("VPD data file {} not available after timeout".format(filename))
+                    return result
 
             result = utils.read_key_value_file(filename, delimeter=": ")
-                
+
         except Exception as e:
             logger.log_error("Fail to decode vpd_data {} due to {}".format(filename, repr(e)))
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2020-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +24,12 @@ import sys
 import threading
 import time
 import os
+
+# Inotify causes an exception when DEBUG env variable is set to a non-integer convertible
+# https://github.com/dsoprea/PyInotify/blob/0.2.10/inotify/adapters.py#L37
+os.environ['DEBUG'] = '0'
+import inotify.adapters
+import inotify.constants
 from sonic_py_common import device_info
 from sonic_py_common.logger import Logger
 
@@ -297,6 +303,53 @@ def extract_RJ45_ports_index(num_of_asics=1):
 
 def extract_cpo_ports_index(num_of_asics=1):
     return _extract_ports_index_by_type(CPO_PORT_TYPE, num_of_asics)
+
+
+# Use this function only for files that have user read permission.
+def wait_for_file_creation(file_path, timeout):
+    """
+    Wait for a file to be created using inotify
+
+    Args:
+        file_path: Path to the file to wait for
+        timeout: Timeout in seconds
+
+    Returns:
+        True if file was created/copied from a temporary file, and is readable, False otherwise
+    """
+    # If file already exists and is readable, return immediately
+    if os.access(file_path, os.R_OK):
+        return True
+
+    dir_path = os.path.dirname(file_path)
+    file_name = os.path.basename(file_path)
+
+    if not os.path.exists(dir_path):
+        logger.log_debug("Directory {} does not exist".format(dir_path))
+        return False
+
+    try:
+        notifier = inotify.adapters.Inotify()
+        notifier.add_watch(dir_path,
+                           mask=(inotify.constants.IN_CREATE
+                                 | inotify.constants.IN_CLOSE_WRITE
+                                 | inotify.constants.IN_MOVED_TO))
+
+        for event in notifier.event_gen(timeout_s=timeout, yield_nones=False):
+            (_, type_names, path, filename) = event
+            if filename == file_name:
+                if "IN_CREATE" in type_names or "IN_CLOSE_WRITE" in type_names or "IN_MOVED_TO" in type_names:
+                    if os.access(file_path, os.R_OK):
+                        logger.log_info("File {} created and readable".format(file_path))
+                        return True
+
+    except Exception as e:
+        logger.log_error("Inotify error while waiting for {}: {}".format(file_path, repr(e)))
+
+    if os.access(file_path, os.R_OK):
+        return True
+
+    return False
 
 
 def wait_until(predict, timeout, interval=1, *args, **kwargs):

--- a/platform/mellanox/mlnx-platform-api/tests/test_utils.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_utils.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -326,6 +326,59 @@ class TestUtils:
         assert utils.wait_until_conditions(conditions, 1)
         conditions = [lambda: False]
         assert not utils.wait_until_conditions(conditions, 1)
+
+    @mock.patch('sonic_platform.utils.inotify.adapters.Inotify')
+    @mock.patch('os.access')
+    def test_wait_for_file_creation_immediate(self, mock_access, mock_inotify):
+        mock_access.return_value = True
+        assert utils.wait_for_file_creation('/tmp/test.file', timeout=1)
+        mock_inotify.assert_not_called()
+
+    @mock.patch('sonic_platform.utils.logger.log_debug')
+    @mock.patch('os.path.exists')
+    @mock.patch('os.access')
+    def test_wait_for_file_creation_dir_missing(self, mock_access, mock_exists, mock_log_debug):
+        """When directory does not exist, return False immediately (no wait)."""
+        mock_access.return_value = False
+        mock_exists.return_value = False
+        assert not utils.wait_for_file_creation('/tmp/test.file', timeout=1)
+        mock_log_debug.assert_called_once()
+
+    @pytest.mark.parametrize("event_type", [
+        "IN_CREATE",
+        "IN_CLOSE_WRITE",
+        "IN_MOVED_TO",
+    ])
+    @mock.patch('sonic_platform.utils.logger.log_info')
+    @mock.patch('os.path.exists')
+    @mock.patch('os.access')
+    def test_wait_for_file_creation_inotify_event(self, mock_access, mock_exists, mock_log_info, event_type):
+        """All inotify event types that indicate file creation are handled."""
+        # First os.access: file not readable at start; second: readable when inotify event is processed
+        mock_access.side_effect = [False, True]
+        mock_exists.return_value = True
+
+        mock_notifier = mock.MagicMock()
+        mock_notifier.event_gen.return_value = [
+            (None, [event_type], "/tmp", "test.file")
+        ]
+
+        with mock.patch('sonic_platform.utils.inotify.adapters.Inotify', return_value=mock_notifier):
+            assert utils.wait_for_file_creation('/tmp/test.file', timeout=1)
+
+        mock_log_info.assert_called_once()
+
+    @mock.patch('sonic_platform.utils.logger.log_error')
+    @mock.patch('os.path.exists')
+    @mock.patch('os.access')
+    def test_wait_for_file_creation_inotify_error(self, mock_access, mock_exists, mock_log_error):
+        mock_access.side_effect = [False, False]
+        mock_exists.return_value = True
+
+        with mock.patch('sonic_platform.utils.inotify.adapters.Inotify', side_effect=Exception('boom')):
+            assert not utils.wait_for_file_creation('/tmp/test.file', timeout=1)
+
+        mock_log_error.assert_called_once()
 
     def test_timer(self):
         timer = utils.Timer()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

This PR is a dedicated PR to 202511 branch
original PR:
https://github.com/sonic-net/sonic-buildimage/pull/25879

#### Why I did it
This fixes a race condition bug where chassis.py attempts to access the VPD data file before it's available during system initialization. When the file doesn't exist yet, _parse_vpd_data() returns an empty dictionary, causing the revision field to be populated with "N/A" in Redis instead of the actual hardware revision value.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Update _parse_vpd_data() to use inotify mechanism to wait for VPD data file generation
before accessing it.

#### How to verify it
The following command was used to check the chassis revision:
```bash
python3 -c "
import sonic_platform.platform
chassis = sonic_platform.platform.Platform().get_chassis()
rev = chassis.get_revision()
print('revision:', rev)
"
```
Tested the following scenarios:
1. VPD file already exists
    With the vpd_data file present, the revision is returned immediately.
    Expected output example:
    revision: A6
2. VPD file missing
    Removed the vpd_data file and ran the command.
    After ~60 seconds, the revision returned N/A.
    An error message was logged in syslog.
    Expected output:
    revision: N/A
3. VPD file created after startup
    Moved the vpd_data file to /tmp.
    Ran the test without the file present.
    Restored the file to its original location.
    The revision was detected immediately after the file was restored.
    Expected output example:
    revision: A6

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

