### PR TITLE
[Mellanox] Remove subport field from hwsku.json and port_config.ini

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D24C52/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D24C52/hwsku.json
@@ -1,308 +1,232 @@
 {
     "interfaces": {
         "Ethernet0":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet4":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet8":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet12":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet16":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet20":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet24":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet28":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet32":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet34":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet36":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet38":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet40":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet42":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet44":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet46":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet48":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet52":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet56":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet60":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet64":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet68":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet72":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet76":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet80":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet84":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet88":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet92":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet96":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet100":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet104":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet106":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet108":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet110":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet112":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet116":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet120":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet124":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet128":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet132":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet136":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet140":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet144":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet148":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet152":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet156":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet160":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet164":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet168":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet172":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet176":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet178":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet180":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet182":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet184":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet186":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet188":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet190":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet192":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet196":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet200":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet204":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet208":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet212":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet216":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet220":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet224":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet228":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet232":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet236":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet240":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet242":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet244":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet246":{
-            "default_brkout_mode": "2x50G[25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x50G[25G,10G,1G]"
         },
         "Ethernet248":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         },
         "Ethernet252":{
-            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]",
-            "subport": "0"
+            "default_brkout_mode": "1x100G[50G,40G,25G,10G,1G]"
         }
     }
 }

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-C128/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-C128/hwsku.json
@@ -1,516 +1,388 @@
 {
     "interfaces": {
         "Ethernet0": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet2": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet4": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet6": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet8": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet10": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet12": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet14": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet16": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet18": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet20": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet22": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet24": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet26": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet28": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet30": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet32": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet34": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet36": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet38": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet40": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet42": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet44": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet46": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet48": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet50": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet52": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet54": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet56": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet58": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet60": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet62": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet64": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet66": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet68": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet70": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet72": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet74": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet76": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet78": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet80": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet82": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet84": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet86": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet88": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet90": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet92": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet94": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet96": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet98": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet100": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet102": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet104": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet106": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet108": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet110": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet112": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet114": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet116": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet118": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet120": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet122": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet124": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet126": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet128": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet130": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet132": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet134": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet136": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet138": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet140": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet142": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet144": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet146": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet148": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet150": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet152": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet154": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet156": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet158": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet160": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet162": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet164": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet166": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet168": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet170": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet172": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet174": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet176": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet178": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet180": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet182": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet184": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet186": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet188": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet190": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet192": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet194": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet196": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet198": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet200": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet202": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet204": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet206": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet208": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet210": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet212": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet214": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet216": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet218": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet220": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet222": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet224": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet226": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet228": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet230": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet232": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet234": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet236": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet238": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet240": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet242": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet244": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet246": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet248": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet250": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet252": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet254": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         }
     }
 }

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O28/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O28/hwsku.json
@@ -1,138 +1,106 @@
 {
     "interfaces": {
         "Ethernet0": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet8": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet16": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet24": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet32": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet40": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet48": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet56": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet64": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet72": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet80": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet88": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet96": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet104": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet112": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet120": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet128": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet136": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet144": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet152": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet160": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet168": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet176": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet184": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet192": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet200": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet208": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet216": {
-            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet224": {
             "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "on",
             "role": "Dpc"
         },
         "Ethernet232": {
             "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "on",
             "role": "Dpc"
         },
         "Ethernet240": {
             "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "on",
             "role": "Dpc"
         },
         "Ethernet248": {
             "default_brkout_mode": "1x200G[400G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "on",
             "role": "Dpc"
         }

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8C48/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8C48/hwsku.json
@@ -2,282 +2,226 @@
     "interfaces": {
         "Ethernet0": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet4": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet8": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet12": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet16": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet20": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet24": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet28": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet32": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet36": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet40": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet44": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet48": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet52": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet56": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet60": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet64": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet68": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet72": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet76": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet80": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet84": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet88": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet92": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet96": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet104": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet112": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet120": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet128": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet136": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet144": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet152": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet160": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet164": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet168": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet172": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet176": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet180": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet184": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet188": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet192": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet196": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet200": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet204": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet208": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet212": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet216": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet220": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet224": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet228": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet232": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet236": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet240": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet244": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet248": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet252": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         }
     }

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8V48/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-O8V48/hwsku.json
@@ -2,282 +2,226 @@
     "interfaces": {
         "Ethernet0": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet4": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet8": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet12": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet16": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet20": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet24": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet28": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet32": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet36": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet40": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet44": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet48": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet52": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet56": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet60": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet64": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet68": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet72": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet76": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet80": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet84": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet88": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet92": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet96": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet104": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet112": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet120": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet128": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet136": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet144": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet152": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet160": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet164": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet168": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet172": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet176": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet180": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet184": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet188": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet192": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet196": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet200": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet204": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet208": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet212": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet216": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet220": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet224": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet228": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet232": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet236": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet240": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet244": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet248": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet252": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         }
     }

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V48C32/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V48C32/hwsku.json
@@ -1,324 +1,244 @@
 {
     "interfaces": {
         "Ethernet0": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet4": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet8": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet12": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet16": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet20": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet24": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet28": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet32": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet36": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet40": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet44": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet48": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet52": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet56": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet60": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet64": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet68": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet72": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet76": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet80": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet84": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet88": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet92": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet96": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet100": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet104": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet108": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet112": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet116": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet120": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet124": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet128": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet132": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet136": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet140": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet144": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet148": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet152": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet156": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet160": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet164": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet168": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet172": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet176": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet180": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet184": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet188": {
-            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]"
         },
         "Ethernet192": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet194": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet196": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet198": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet200": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet202": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet204": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet206": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet208": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet210": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet212": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet214": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet216": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet218": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet220": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet222": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet224": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet226": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet228": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet230": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet232": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet234": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet236": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet238": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet240": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet242": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet244": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet246": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet248": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet250": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet252": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         },
         "Ethernet254": {
-            "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4"
+            "default_brkout_mode": "4x100G[50G,25G,10G,1G]"
         }
     }
 }

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/hwsku.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/Mellanox-SN4700-V64/hwsku.json
@@ -2,322 +2,258 @@
     "interfaces": {
         "Ethernet0": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet4": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet8": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet12": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet16": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet20": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet24": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet28": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet32": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet36": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet40": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet44": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet48": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet52": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet56": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet60": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet64": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet68": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet72": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet76": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet80": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet84": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet88": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet92": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet96": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet100": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet104": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet108": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet112": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet116": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet120": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet124": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet128": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet132": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet136": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet140": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet144": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet148": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet152": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet156": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet160": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet164": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet168": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet172": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet176": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet180": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet184": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet188": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet192": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet196": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet200": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet204": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet208": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet212": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet216": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet220": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet224": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet228": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet232": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet236": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet240": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet244": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet248": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet252": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         }
     }

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-C48/hwsku.json
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-C48/hwsku.json
@@ -2,265 +2,213 @@
     "interfaces": {
         "Ethernet0": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet4": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet8": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet12": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet16": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet20": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet24": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet28": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet32": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet36": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet40": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet44": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet48": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet52": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet56": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet60": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet64": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet68": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet72": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet76": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet80": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet84": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet88": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet92": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet96": {
             "default_brkout_mode": "1x100G[400G,200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet104": {
             "default_brkout_mode": "1x100G[400G,200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet112": {
             "default_brkout_mode": "1x100G[400G,200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet120": {
             "default_brkout_mode": "1x100G[400G,200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet128": {
             "default_brkout_mode": "1x100G[400G,200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet136": {
             "default_brkout_mode": "1x100G[400G,200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet144": {
             "default_brkout_mode": "1x100G[400G,200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet152": {
             "default_brkout_mode": "1x100G[400G,200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet160": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet164": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet168": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet172": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet176": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet180": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet184": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet188": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet192": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet196": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet200": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet204": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet208": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet212": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet216": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet220": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet224": {
             "default_brkout_mode": "1x400G",
-            "subport": "1",
             "autoneg": "on",
             "role"   : "Dpc"
         },
         "Ethernet232": {
             "default_brkout_mode": "1x400G",
-            "subport": "1",
             "autoneg": "on",
             "role"   : "Dpc"
         },
         "Ethernet240": {
             "default_brkout_mode": "1x400G",
-            "subport": "1",
             "autoneg": "on",
             "role"   : "Dpc"
         },
         "Ethernet248": {
             "default_brkout_mode": "1x400G",
-            "subport": "1",
             "autoneg": "on",
             "role"   : "Dpc"
         }

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O28/hwsku.json
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O28/hwsku.json
@@ -2,165 +2,133 @@
     "interfaces": {
         "Ethernet0": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet8": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet16": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet24": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet32": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet40": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet48": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet56": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet64": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet72": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet80": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet88": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet96": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet104": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet112": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet120": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet128": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet136": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet144": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet152": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet160": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet168": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet176": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet184": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet192": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet200": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet208": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet216": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet224": {
             "default_brkout_mode": "1x400G",
-            "subport": "1",
             "autoneg": "on",
             "role": "Dpc"
         },
         "Ethernet232": {
             "default_brkout_mode": "1x400G",
-            "subport": "1",
             "autoneg": "on",
             "role": "Dpc"
         },
         "Ethernet240": {
             "default_brkout_mode": "1x400G",
-            "subport": "1",
             "autoneg": "on",
             "role": "Dpc"
         },
         "Ethernet248": {
             "default_brkout_mode": "1x400G",
-            "subport": "1",
             "autoneg": "on",
             "role": "Dpc"
         }

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/hwsku.json
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C40/hwsku.json
@@ -2,265 +2,213 @@
     "interfaces": {
         "Ethernet0": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet4": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet8": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet12": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet16": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet20": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet24": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet28": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet32": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet36": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet40": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet44": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet48": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet52": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet56": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet60": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet64": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet68": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet72": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet76": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet80": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet84": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet88": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet92": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet96": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet104": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet112": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet120": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet128": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet136": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet144": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet152": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet160": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet164": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet168": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet172": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet176": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet180": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet184": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet188": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet192": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet196": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet200": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet204": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet208": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet212": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet216": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet220": {
             "default_brkout_mode": "2x100G[200G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet224": {
             "default_brkout_mode": "1x400G",
-            "subport": "1",
             "autoneg": "on",
             "role"   : "Dpc"
         },
         "Ethernet232": {
             "default_brkout_mode": "1x400G",
-            "subport": "1",
             "autoneg": "on",
             "role"   : "Dpc"
         },
         "Ethernet240": {
             "default_brkout_mode": "1x400G",
-            "subport": "1",
             "autoneg": "on",
             "role"   : "Dpc"
         },
         "Ethernet248": {
             "default_brkout_mode": "1x400G",
-            "subport": "1",
             "autoneg": "on",
             "role"   : "Dpc"
         }

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C80/hwsku.json
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8C80/hwsku.json
@@ -2,465 +2,373 @@
     "interfaces": {
         "Ethernet0": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet2": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet4": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet6": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet8": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet10": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet12": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet14": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet16": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet18": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet20": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet22": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet24": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet26": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet28": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet30": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet32": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet34": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet36": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet38": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet40": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet42": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet44": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet46": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet48": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet50": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet52": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet54": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet56": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet58": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet60": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet62": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet64": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet66": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet68": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet70": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet72": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet74": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet76": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet78": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet80": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet82": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet84": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet86": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet88": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet90": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet92": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet94": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet96": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet104": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet112": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet120": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet128": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet136": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet144": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet152": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet160": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet162": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet164": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet166": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet168": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet170": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet172": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet174": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet176": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet178": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet180": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet182": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet184": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet186": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet188": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet190": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet192": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet194": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet196": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet198": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet200": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet202": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet204": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet206": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet208": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet210": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet212": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet214": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet216": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet218": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet220": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet222": {
             "default_brkout_mode": "4x100G[50G,25G,10G,1G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet224": {
             "default_brkout_mode": "1x400G",
-            "subport": "1",
             "autoneg": "on",
             "role": "Dpc"
         },
         "Ethernet232": {
             "default_brkout_mode": "1x400G",
-            "subport": "1",
             "autoneg": "on",
             "role": "Dpc"
         },
         "Ethernet240": {
             "default_brkout_mode": "1x400G",
-            "subport": "1",
             "autoneg": "on",
             "role": "Dpc"
         },
         "Ethernet248": {
             "default_brkout_mode": "1x400G",
-            "subport": "1",
             "autoneg": "on",
             "role": "Dpc"
         }

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8V40/hwsku.json
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/Mellanox-SN4280-O8V40/hwsku.json
@@ -2,265 +2,213 @@
     "interfaces": {
         "Ethernet0": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet4": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet8": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet12": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet16": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet20": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet24": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet28": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet32": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet36": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet40": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet44": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet48": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet52": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet56": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet60": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet64": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet68": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet72": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet76": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet80": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet84": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet88": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet92": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet96": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet104": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet112": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet120": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet128": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet136": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet144": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet152": {
             "default_brkout_mode": "1x400G[200G,100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet160": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet164": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet168": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet172": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet176": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet180": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet184": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet188": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet192": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet196": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet200": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet204": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet208": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet212": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet216": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet220": {
             "default_brkout_mode": "2x200G[100G,50G,40G,25G,10G,1G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet224": {
             "default_brkout_mode": "1x400G",
-            "subport": "1",
             "autoneg": "on",
             "role"   : "Dpc"
         },
         "Ethernet232": {
             "default_brkout_mode": "1x400G",
-            "subport": "1",
             "autoneg": "on",
             "role"   : "Dpc"
         },
         "Ethernet240": {
             "default_brkout_mode": "1x400G",
-            "subport": "1",
             "autoneg": "on",
             "role"   : "Dpc"
         },
         "Ethernet248": {
             "default_brkout_mode": "1x400G",
-            "subport": "1",
             "autoneg": "on",
             "role"   : "Dpc"
         }

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C224O8/port_config.ini
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C224O8/port_config.ini
@@ -1,6 +1,6 @@
 ##
 ## SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-## Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+## Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 ## Apache-2.0
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,237 +16,237 @@
 ## limitations under the License.
 ##
 
-# name         lanes                                  alias     index    speed    autoneg subport
-Ethernet0      0                                      etp1a     1        100000   off     1
-Ethernet1      1                                      etp1b     1        100000   off     2
-Ethernet2      2                                      etp1c     1        100000   off     3
-Ethernet3      3                                      etp1d     1        100000   off     4
-Ethernet4      4                                      etp1e     1        100000   off     5
-Ethernet5      5                                      etp1f     1        100000   off     6
-Ethernet6      6                                      etp1g     1        100000   off     7
-Ethernet7      7                                      etp1h     1        100000   off     8
-Ethernet16     16                                     etp3a     3        100000   off     1
-Ethernet17     17                                     etp3b     3        100000   off     2
-Ethernet18     18                                     etp3c     3        100000   off     3
-Ethernet19     19                                     etp3d     3        100000   off     4
-Ethernet20     20                                     etp3e     3        100000   off     5
-Ethernet21     21                                     etp3f     3        100000   off     6
-Ethernet22     22                                     etp3g     3        100000   off     7
-Ethernet23     23                                     etp3h     3        100000   off     8
-Ethernet32     32                                     etp5a     5        100000   off     1
-Ethernet33     33                                     etp5b     5        100000   off     2
-Ethernet34     34                                     etp5c     5        100000   off     3
-Ethernet35     35                                     etp5d     5        100000   off     4
-Ethernet36     36                                     etp5e     5        100000   off     5
-Ethernet37     37                                     etp5f     5        100000   off     6
-Ethernet38     38                                     etp5g     5        100000   off     7
-Ethernet39     39                                     etp5h     5        100000   off     8
-Ethernet48     48                                     etp7a     7        100000   off     1
-Ethernet49     49                                     etp7b     7        100000   off     2
-Ethernet50     50                                     etp7c     7        100000   off     3
-Ethernet51     51                                     etp7d     7        100000   off     4
-Ethernet52     52                                     etp7e     7        100000   off     5
-Ethernet53     53                                     etp7f     7        100000   off     6
-Ethernet54     54                                     etp7g     7        100000   off     7
-Ethernet55     55                                     etp7h     7        100000   off     8
-Ethernet64     64                                     etp9a     9        100000   off     1
-Ethernet65     65                                     etp9b     9        100000   off     2
-Ethernet66     66                                     etp9c     9        100000   off     3
-Ethernet67     67                                     etp9d     9        100000   off     4
-Ethernet68     68                                     etp9e     9        100000   off     5
-Ethernet69     69                                     etp9f     9        100000   off     6
-Ethernet70     70                                     etp9g     9        100000   off     7
-Ethernet71     71                                     etp9h     9        100000   off     8
-Ethernet80     80                                     etp11a    11       100000   off     1
-Ethernet81     81                                     etp11b    11       100000   off     2
-Ethernet82     82                                     etp11c    11       100000   off     3
-Ethernet83     83                                     etp11d    11       100000   off     4
-Ethernet84     84                                     etp11e    11       100000   off     5
-Ethernet85     85                                     etp11f    11       100000   off     6
-Ethernet86     86                                     etp11g    11       100000   off     7
-Ethernet87     87                                     etp11h    11       100000   off     8
-Ethernet96     96,97,98,99                            etp13a    13       400000   off     1
-Ethernet100    100,101,102,103                        etp13b    13       400000   off     2
-Ethernet112    112                                    etp15a    15       100000   off     1
-Ethernet113    113                                    etp15b    15       100000   off     2
-Ethernet114    114                                    etp15c    15       100000   off     3
-Ethernet115    115                                    etp15d    15       100000   off     4
-Ethernet116    116                                    etp15e    15       100000   off     5
-Ethernet117    117                                    etp15f    15       100000   off     6
-Ethernet118    118                                    etp15g    15       100000   off     7
-Ethernet119    119                                    etp15h    15       100000   off     8
-Ethernet128    128,129,130,131                        etp17a    17       400000   off     1
-Ethernet132    132,133,134,135                        etp17b    17       400000   off     2
-Ethernet144    144                                    etp19a    19       100000   off     1
-Ethernet145    145                                    etp19b    19       100000   off     2
-Ethernet146    146                                    etp19c    19       100000   off     3
-Ethernet147    147                                    etp19d    19       100000   off     4
-Ethernet148    148                                    etp19e    19       100000   off     5
-Ethernet149    149                                    etp19f    19       100000   off     6
-Ethernet150    150                                    etp19g    19       100000   off     7
-Ethernet151    151                                    etp19h    19       100000   off     8
-Ethernet160    160                                    etp21a    21       100000   off     1
-Ethernet161    161                                    etp21b    21       100000   off     2
-Ethernet162    162                                    etp21c    21       100000   off     3
-Ethernet163    163                                    etp21d    21       100000   off     4
-Ethernet164    164                                    etp21e    21       100000   off     5
-Ethernet165    165                                    etp21f    21       100000   off     6
-Ethernet166    166                                    etp21g    21       100000   off     7
-Ethernet167    167                                    etp21h    21       100000   off     8
-Ethernet176    176                                    etp23a    23       100000   off     1
-Ethernet177    177                                    etp23b    23       100000   off     2
-Ethernet178    178                                    etp23c    23       100000   off     3
-Ethernet179    179                                    etp23d    23       100000   off     4
-Ethernet180    180                                    etp23e    23       100000   off     5
-Ethernet181    181                                    etp23f    23       100000   off     6
-Ethernet182    182                                    etp23g    23       100000   off     7
-Ethernet183    183                                    etp23h    23       100000   off     8
-Ethernet192    192                                    etp25a    25       100000   off     1
-Ethernet193    193                                    etp25b    25       100000   off     2
-Ethernet194    194                                    etp25c    25       100000   off     3
-Ethernet195    195                                    etp25d    25       100000   off     4
-Ethernet196    196                                    etp25e    25       100000   off     5
-Ethernet197    197                                    etp25f    25       100000   off     6
-Ethernet198    198                                    etp25g    25       100000   off     7
-Ethernet199    199                                    etp25h    25       100000   off     8
-Ethernet208    208                                    etp27a    27       100000   off     1
-Ethernet209    209                                    etp27b    27       100000   off     2
-Ethernet210    210                                    etp27c    27       100000   off     3
-Ethernet211    211                                    etp27d    27       100000   off     4
-Ethernet212    212                                    etp27e    27       100000   off     5
-Ethernet213    213                                    etp27f    27       100000   off     6
-Ethernet214    214                                    etp27g    27       100000   off     7
-Ethernet215    215                                    etp27h    27       100000   off     8
-Ethernet224    224                                    etp29a    29       100000   off     1
-Ethernet225    225                                    etp29b    29       100000   off     2
-Ethernet226    226                                    etp29c    29       100000   off     3
-Ethernet227    227                                    etp29d    29       100000   off     4
-Ethernet228    228                                    etp29e    29       100000   off     5
-Ethernet229    229                                    etp29f    29       100000   off     6
-Ethernet230    230                                    etp29g    29       100000   off     7
-Ethernet231    231                                    etp29h    29       100000   off     8
-Ethernet240    240                                    etp31a    31       100000   off     1
-Ethernet241    241                                    etp31b    31       100000   off     2
-Ethernet242    242                                    etp31c    31       100000   off     3
-Ethernet243    243                                    etp31d    31       100000   off     4
-Ethernet244    244                                    etp31e    31       100000   off     5
-Ethernet245    245                                    etp31f    31       100000   off     6
-Ethernet246    246                                    etp31g    31       100000   off     7
-Ethernet247    247                                    etp31h    31       100000   off     8
-Ethernet256    256                                    etp33a    33       100000   off     1
-Ethernet257    257                                    etp33b    33       100000   off     2
-Ethernet258    258                                    etp33c    33       100000   off     3
-Ethernet259    259                                    etp33d    33       100000   off     4
-Ethernet260    260                                    etp33e    33       100000   off     5
-Ethernet261    261                                    etp33f    33       100000   off     6
-Ethernet262    262                                    etp33g    33       100000   off     7
-Ethernet263    263                                    etp33h    33       100000   off     8
-Ethernet272    272                                    etp35a    35       100000   off     1
-Ethernet273    273                                    etp35b    35       100000   off     2
-Ethernet274    274                                    etp35c    35       100000   off     3
-Ethernet275    275                                    etp35d    35       100000   off     4
-Ethernet276    276                                    etp35e    35       100000   off     5
-Ethernet277    277                                    etp35f    35       100000   off     6
-Ethernet278    278                                    etp35g    35       100000   off     7
-Ethernet279    279                                    etp35h    35       100000   off     8
-Ethernet288    288                                    etp37a    37       100000   off     1
-Ethernet289    289                                    etp37b    37       100000   off     2
-Ethernet290    290                                    etp37c    37       100000   off     3
-Ethernet291    291                                    etp37d    37       100000   off     4
-Ethernet292    292                                    etp37e    37       100000   off     5
-Ethernet293    293                                    etp37f    37       100000   off     6
-Ethernet294    294                                    etp37g    37       100000   off     7
-Ethernet295    295                                    etp37h    37       100000   off     8
-Ethernet304    304                                    etp39a    39       100000   off     1
-Ethernet305    305                                    etp39b    39       100000   off     2
-Ethernet306    306                                    etp39c    39       100000   off     3
-Ethernet307    307                                    etp39d    39       100000   off     4
-Ethernet308    308                                    etp39e    39       100000   off     5
-Ethernet309    309                                    etp39f    39       100000   off     6
-Ethernet310    310                                    etp39g    39       100000   off     7
-Ethernet311    311                                    etp39h    39       100000   off     8
-Ethernet320    320                                    etp41a    41       100000   off     1
-Ethernet321    321                                    etp41b    41       100000   off     2
-Ethernet322    322                                    etp41c    41       100000   off     3
-Ethernet323    323                                    etp41d    41       100000   off     4
-Ethernet324    324                                    etp41e    41       100000   off     5
-Ethernet325    325                                    etp41f    41       100000   off     6
-Ethernet326    326                                    etp41g    41       100000   off     7
-Ethernet327    327                                    etp41h    41       100000   off     8
-Ethernet336    336                                    etp43a    43       100000   off     1
-Ethernet337    337                                    etp43b    43       100000   off     2
-Ethernet338    338                                    etp43c    43       100000   off     3
-Ethernet339    339                                    etp43d    43       100000   off     4
-Ethernet340    340                                    etp43e    43       100000   off     5
-Ethernet341    341                                    etp43f    43       100000   off     6
-Ethernet342    342                                    etp43g    43       100000   off     7
-Ethernet343    343                                    etp43h    43       100000   off     8
-Ethernet352    352,353,354,355                        etp45a    45       400000   off     1
-Ethernet356    356,357,358,359                        etp45b    45       400000   off     2
-Ethernet368    368                                    etp47a    47       100000   off     1
-Ethernet369    369                                    etp47b    47       100000   off     2
-Ethernet370    370                                    etp47c    47       100000   off     3
-Ethernet371    371                                    etp47d    47       100000   off     4
-Ethernet372    372                                    etp47e    47       100000   off     5
-Ethernet373    373                                    etp47f    47       100000   off     6
-Ethernet374    374                                    etp47g    47       100000   off     7
-Ethernet375    375                                    etp47h    47       100000   off     8
-Ethernet384    384,385,386,387                        etp49a    49       400000   off     1
-Ethernet388    388,389,390,391                        etp49b    49       400000   off     2
-Ethernet400    400                                    etp51a    51       100000   off     1
-Ethernet401    401                                    etp51b    51       100000   off     2
-Ethernet402    402                                    etp51c    51       100000   off     3
-Ethernet403    403                                    etp51d    51       100000   off     4
-Ethernet404    404                                    etp51e    51       100000   off     5
-Ethernet405    405                                    etp51f    51       100000   off     6
-Ethernet406    406                                    etp51g    51       100000   off     7
-Ethernet407    407                                    etp51h    51       100000   off     8
-Ethernet416    416                                    etp53a    53       100000   off     1
-Ethernet417    417                                    etp53b    53       100000   off     2
-Ethernet418    418                                    etp53c    53       100000   off     3
-Ethernet419    419                                    etp53d    53       100000   off     4
-Ethernet420    420                                    etp53e    53       100000   off     5
-Ethernet421    421                                    etp53f    53       100000   off     6
-Ethernet422    422                                    etp53g    53       100000   off     7
-Ethernet423    423                                    etp53h    53       100000   off     8
-Ethernet432    432                                    etp55a    55       100000   off     1
-Ethernet433    433                                    etp55b    55       100000   off     2
-Ethernet434    434                                    etp55c    55       100000   off     3
-Ethernet435    435                                    etp55d    55       100000   off     4
-Ethernet436    436                                    etp55e    55       100000   off     5
-Ethernet437    437                                    etp55f    55       100000   off     6
-Ethernet438    438                                    etp55g    55       100000   off     7
-Ethernet439    439                                    etp55h    55       100000   off     8
-Ethernet448    448                                    etp57a    57       100000   off     1
-Ethernet449    449                                    etp57b    57       100000   off     2
-Ethernet450    450                                    etp57c    57       100000   off     3
-Ethernet451    451                                    etp57d    57       100000   off     4
-Ethernet452    452                                    etp57e    57       100000   off     5
-Ethernet453    453                                    etp57f    57       100000   off     6
-Ethernet454    454                                    etp57g    57       100000   off     7
-Ethernet455    455                                    etp57h    57       100000   off     8
-Ethernet464    464                                    etp59a    59       100000   off     1
-Ethernet465    465                                    etp59b    59       100000   off     2
-Ethernet466    466                                    etp59c    59       100000   off     3
-Ethernet467    467                                    etp59d    59       100000   off     4
-Ethernet468    468                                    etp59e    59       100000   off     5
-Ethernet469    469                                    etp59f    59       100000   off     6
-Ethernet470    470                                    etp59g    59       100000   off     7
-Ethernet471    471                                    etp59h    59       100000   off     8
-Ethernet480    480                                    etp61a    61       100000   off     1
-Ethernet481    481                                    etp61b    61       100000   off     2
-Ethernet482    482                                    etp61c    61       100000   off     3
-Ethernet483    483                                    etp61d    61       100000   off     4
-Ethernet484    484                                    etp61e    61       100000   off     5
-Ethernet485    485                                    etp61f    61       100000   off     6
-Ethernet486    486                                    etp61g    61       100000   off     7
-Ethernet487    487                                    etp61h    61       100000   off     8
-Ethernet496    496                                    etp63a    63       100000   off     1
-Ethernet497    497                                    etp63b    63       100000   off     2
-Ethernet498    498                                    etp63c    63       100000   off     3
-Ethernet499    499                                    etp63d    63       100000   off     4
-Ethernet500    500                                    etp63e    63       100000   off     5
-Ethernet501    501                                    etp63f    63       100000   off     6
-Ethernet502    502                                    etp63g    63       100000   off     7
-Ethernet503    503                                    etp63h    63       100000   off     8
+# name         lanes                                  alias     index    speed    autoneg
+Ethernet0      0                                      etp1a     1        100000   off
+Ethernet1      1                                      etp1b     1        100000   off
+Ethernet2      2                                      etp1c     1        100000   off
+Ethernet3      3                                      etp1d     1        100000   off
+Ethernet4      4                                      etp1e     1        100000   off
+Ethernet5      5                                      etp1f     1        100000   off
+Ethernet6      6                                      etp1g     1        100000   off
+Ethernet7      7                                      etp1h     1        100000   off
+Ethernet16     16                                     etp3a     3        100000   off
+Ethernet17     17                                     etp3b     3        100000   off
+Ethernet18     18                                     etp3c     3        100000   off
+Ethernet19     19                                     etp3d     3        100000   off
+Ethernet20     20                                     etp3e     3        100000   off
+Ethernet21     21                                     etp3f     3        100000   off
+Ethernet22     22                                     etp3g     3        100000   off
+Ethernet23     23                                     etp3h     3        100000   off
+Ethernet32     32                                     etp5a     5        100000   off
+Ethernet33     33                                     etp5b     5        100000   off
+Ethernet34     34                                     etp5c     5        100000   off
+Ethernet35     35                                     etp5d     5        100000   off
+Ethernet36     36                                     etp5e     5        100000   off
+Ethernet37     37                                     etp5f     5        100000   off
+Ethernet38     38                                     etp5g     5        100000   off
+Ethernet39     39                                     etp5h     5        100000   off
+Ethernet48     48                                     etp7a     7        100000   off
+Ethernet49     49                                     etp7b     7        100000   off
+Ethernet50     50                                     etp7c     7        100000   off
+Ethernet51     51                                     etp7d     7        100000   off
+Ethernet52     52                                     etp7e     7        100000   off
+Ethernet53     53                                     etp7f     7        100000   off
+Ethernet54     54                                     etp7g     7        100000   off
+Ethernet55     55                                     etp7h     7        100000   off
+Ethernet64     64                                     etp9a     9        100000   off
+Ethernet65     65                                     etp9b     9        100000   off
+Ethernet66     66                                     etp9c     9        100000   off
+Ethernet67     67                                     etp9d     9        100000   off
+Ethernet68     68                                     etp9e     9        100000   off
+Ethernet69     69                                     etp9f     9        100000   off
+Ethernet70     70                                     etp9g     9        100000   off
+Ethernet71     71                                     etp9h     9        100000   off
+Ethernet80     80                                     etp11a    11       100000   off
+Ethernet81     81                                     etp11b    11       100000   off
+Ethernet82     82                                     etp11c    11       100000   off
+Ethernet83     83                                     etp11d    11       100000   off
+Ethernet84     84                                     etp11e    11       100000   off
+Ethernet85     85                                     etp11f    11       100000   off
+Ethernet86     86                                     etp11g    11       100000   off
+Ethernet87     87                                     etp11h    11       100000   off
+Ethernet96     96,97,98,99                            etp13a    13       400000   off
+Ethernet100    100,101,102,103                        etp13b    13       400000   off
+Ethernet112    112                                    etp15a    15       100000   off
+Ethernet113    113                                    etp15b    15       100000   off
+Ethernet114    114                                    etp15c    15       100000   off
+Ethernet115    115                                    etp15d    15       100000   off
+Ethernet116    116                                    etp15e    15       100000   off
+Ethernet117    117                                    etp15f    15       100000   off
+Ethernet118    118                                    etp15g    15       100000   off
+Ethernet119    119                                    etp15h    15       100000   off
+Ethernet128    128,129,130,131                        etp17a    17       400000   off
+Ethernet132    132,133,134,135                        etp17b    17       400000   off
+Ethernet144    144                                    etp19a    19       100000   off
+Ethernet145    145                                    etp19b    19       100000   off
+Ethernet146    146                                    etp19c    19       100000   off
+Ethernet147    147                                    etp19d    19       100000   off
+Ethernet148    148                                    etp19e    19       100000   off
+Ethernet149    149                                    etp19f    19       100000   off
+Ethernet150    150                                    etp19g    19       100000   off
+Ethernet151    151                                    etp19h    19       100000   off
+Ethernet160    160                                    etp21a    21       100000   off
+Ethernet161    161                                    etp21b    21       100000   off
+Ethernet162    162                                    etp21c    21       100000   off
+Ethernet163    163                                    etp21d    21       100000   off
+Ethernet164    164                                    etp21e    21       100000   off
+Ethernet165    165                                    etp21f    21       100000   off
+Ethernet166    166                                    etp21g    21       100000   off
+Ethernet167    167                                    etp21h    21       100000   off
+Ethernet176    176                                    etp23a    23       100000   off
+Ethernet177    177                                    etp23b    23       100000   off
+Ethernet178    178                                    etp23c    23       100000   off
+Ethernet179    179                                    etp23d    23       100000   off
+Ethernet180    180                                    etp23e    23       100000   off
+Ethernet181    181                                    etp23f    23       100000   off
+Ethernet182    182                                    etp23g    23       100000   off
+Ethernet183    183                                    etp23h    23       100000   off
+Ethernet192    192                                    etp25a    25       100000   off
+Ethernet193    193                                    etp25b    25       100000   off
+Ethernet194    194                                    etp25c    25       100000   off
+Ethernet195    195                                    etp25d    25       100000   off
+Ethernet196    196                                    etp25e    25       100000   off
+Ethernet197    197                                    etp25f    25       100000   off
+Ethernet198    198                                    etp25g    25       100000   off
+Ethernet199    199                                    etp25h    25       100000   off
+Ethernet208    208                                    etp27a    27       100000   off
+Ethernet209    209                                    etp27b    27       100000   off
+Ethernet210    210                                    etp27c    27       100000   off
+Ethernet211    211                                    etp27d    27       100000   off
+Ethernet212    212                                    etp27e    27       100000   off
+Ethernet213    213                                    etp27f    27       100000   off
+Ethernet214    214                                    etp27g    27       100000   off
+Ethernet215    215                                    etp27h    27       100000   off
+Ethernet224    224                                    etp29a    29       100000   off
+Ethernet225    225                                    etp29b    29       100000   off
+Ethernet226    226                                    etp29c    29       100000   off
+Ethernet227    227                                    etp29d    29       100000   off
+Ethernet228    228                                    etp29e    29       100000   off
+Ethernet229    229                                    etp29f    29       100000   off
+Ethernet230    230                                    etp29g    29       100000   off
+Ethernet231    231                                    etp29h    29       100000   off
+Ethernet240    240                                    etp31a    31       100000   off
+Ethernet241    241                                    etp31b    31       100000   off
+Ethernet242    242                                    etp31c    31       100000   off
+Ethernet243    243                                    etp31d    31       100000   off
+Ethernet244    244                                    etp31e    31       100000   off
+Ethernet245    245                                    etp31f    31       100000   off
+Ethernet246    246                                    etp31g    31       100000   off
+Ethernet247    247                                    etp31h    31       100000   off
+Ethernet256    256                                    etp33a    33       100000   off
+Ethernet257    257                                    etp33b    33       100000   off
+Ethernet258    258                                    etp33c    33       100000   off
+Ethernet259    259                                    etp33d    33       100000   off
+Ethernet260    260                                    etp33e    33       100000   off
+Ethernet261    261                                    etp33f    33       100000   off
+Ethernet262    262                                    etp33g    33       100000   off
+Ethernet263    263                                    etp33h    33       100000   off
+Ethernet272    272                                    etp35a    35       100000   off
+Ethernet273    273                                    etp35b    35       100000   off
+Ethernet274    274                                    etp35c    35       100000   off
+Ethernet275    275                                    etp35d    35       100000   off
+Ethernet276    276                                    etp35e    35       100000   off
+Ethernet277    277                                    etp35f    35       100000   off
+Ethernet278    278                                    etp35g    35       100000   off
+Ethernet279    279                                    etp35h    35       100000   off
+Ethernet288    288                                    etp37a    37       100000   off
+Ethernet289    289                                    etp37b    37       100000   off
+Ethernet290    290                                    etp37c    37       100000   off
+Ethernet291    291                                    etp37d    37       100000   off
+Ethernet292    292                                    etp37e    37       100000   off
+Ethernet293    293                                    etp37f    37       100000   off
+Ethernet294    294                                    etp37g    37       100000   off
+Ethernet295    295                                    etp37h    37       100000   off
+Ethernet304    304                                    etp39a    39       100000   off
+Ethernet305    305                                    etp39b    39       100000   off
+Ethernet306    306                                    etp39c    39       100000   off
+Ethernet307    307                                    etp39d    39       100000   off
+Ethernet308    308                                    etp39e    39       100000   off
+Ethernet309    309                                    etp39f    39       100000   off
+Ethernet310    310                                    etp39g    39       100000   off
+Ethernet311    311                                    etp39h    39       100000   off
+Ethernet320    320                                    etp41a    41       100000   off
+Ethernet321    321                                    etp41b    41       100000   off
+Ethernet322    322                                    etp41c    41       100000   off
+Ethernet323    323                                    etp41d    41       100000   off
+Ethernet324    324                                    etp41e    41       100000   off
+Ethernet325    325                                    etp41f    41       100000   off
+Ethernet326    326                                    etp41g    41       100000   off
+Ethernet327    327                                    etp41h    41       100000   off
+Ethernet336    336                                    etp43a    43       100000   off
+Ethernet337    337                                    etp43b    43       100000   off
+Ethernet338    338                                    etp43c    43       100000   off
+Ethernet339    339                                    etp43d    43       100000   off
+Ethernet340    340                                    etp43e    43       100000   off
+Ethernet341    341                                    etp43f    43       100000   off
+Ethernet342    342                                    etp43g    43       100000   off
+Ethernet343    343                                    etp43h    43       100000   off
+Ethernet352    352,353,354,355                        etp45a    45       400000   off
+Ethernet356    356,357,358,359                        etp45b    45       400000   off
+Ethernet368    368                                    etp47a    47       100000   off
+Ethernet369    369                                    etp47b    47       100000   off
+Ethernet370    370                                    etp47c    47       100000   off
+Ethernet371    371                                    etp47d    47       100000   off
+Ethernet372    372                                    etp47e    47       100000   off
+Ethernet373    373                                    etp47f    47       100000   off
+Ethernet374    374                                    etp47g    47       100000   off
+Ethernet375    375                                    etp47h    47       100000   off
+Ethernet384    384,385,386,387                        etp49a    49       400000   off
+Ethernet388    388,389,390,391                        etp49b    49       400000   off
+Ethernet400    400                                    etp51a    51       100000   off
+Ethernet401    401                                    etp51b    51       100000   off
+Ethernet402    402                                    etp51c    51       100000   off
+Ethernet403    403                                    etp51d    51       100000   off
+Ethernet404    404                                    etp51e    51       100000   off
+Ethernet405    405                                    etp51f    51       100000   off
+Ethernet406    406                                    etp51g    51       100000   off
+Ethernet407    407                                    etp51h    51       100000   off
+Ethernet416    416                                    etp53a    53       100000   off
+Ethernet417    417                                    etp53b    53       100000   off
+Ethernet418    418                                    etp53c    53       100000   off
+Ethernet419    419                                    etp53d    53       100000   off
+Ethernet420    420                                    etp53e    53       100000   off
+Ethernet421    421                                    etp53f    53       100000   off
+Ethernet422    422                                    etp53g    53       100000   off
+Ethernet423    423                                    etp53h    53       100000   off
+Ethernet432    432                                    etp55a    55       100000   off
+Ethernet433    433                                    etp55b    55       100000   off
+Ethernet434    434                                    etp55c    55       100000   off
+Ethernet435    435                                    etp55d    55       100000   off
+Ethernet436    436                                    etp55e    55       100000   off
+Ethernet437    437                                    etp55f    55       100000   off
+Ethernet438    438                                    etp55g    55       100000   off
+Ethernet439    439                                    etp55h    55       100000   off
+Ethernet448    448                                    etp57a    57       100000   off
+Ethernet449    449                                    etp57b    57       100000   off
+Ethernet450    450                                    etp57c    57       100000   off
+Ethernet451    451                                    etp57d    57       100000   off
+Ethernet452    452                                    etp57e    57       100000   off
+Ethernet453    453                                    etp57f    57       100000   off
+Ethernet454    454                                    etp57g    57       100000   off
+Ethernet455    455                                    etp57h    57       100000   off
+Ethernet464    464                                    etp59a    59       100000   off
+Ethernet465    465                                    etp59b    59       100000   off
+Ethernet466    466                                    etp59c    59       100000   off
+Ethernet467    467                                    etp59d    59       100000   off
+Ethernet468    468                                    etp59e    59       100000   off
+Ethernet469    469                                    etp59f    59       100000   off
+Ethernet470    470                                    etp59g    59       100000   off
+Ethernet471    471                                    etp59h    59       100000   off
+Ethernet480    480                                    etp61a    61       100000   off
+Ethernet481    481                                    etp61b    61       100000   off
+Ethernet482    482                                    etp61c    61       100000   off
+Ethernet483    483                                    etp61d    61       100000   off
+Ethernet484    484                                    etp61e    61       100000   off
+Ethernet485    485                                    etp61f    61       100000   off
+Ethernet486    486                                    etp61g    61       100000   off
+Ethernet487    487                                    etp61h    61       100000   off
+Ethernet496    496                                    etp63a    63       100000   off
+Ethernet497    497                                    etp63b    63       100000   off
+Ethernet498    498                                    etp63c    63       100000   off
+Ethernet499    499                                    etp63d    63       100000   off
+Ethernet500    500                                    etp63e    63       100000   off
+Ethernet501    501                                    etp63f    63       100000   off
+Ethernet502    502                                    etp63g    63       100000   off
+Ethernet503    503                                    etp63h    63       100000   off
 Ethernet512    512                                    etp65     65        10000

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/port_config.ini
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/port_config.ini
@@ -1,6 +1,6 @@
 ##
 ## SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-## Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+## Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 ## Apache-2.0
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,263 +14,262 @@
 ## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
-##
 
-# name         lanes                                  alias     index    speed    autoneg subport
-Ethernet0      0                                      etp1a     1        100000   off     1
-Ethernet1      1                                      etp1b     1        100000   off     2
-Ethernet2      2                                      etp1c     1        100000   off     3
-Ethernet3      3                                      etp1d     1        100000   off     4
-Ethernet4      4                                      etp1e     1        100000   off     5
-Ethernet5      5                                      etp1f     1        100000   off     6
-Ethernet6      6                                      etp1g     1        100000   off     7
-Ethernet7      7                                      etp1h     1        100000   off     8
-Ethernet16     16                                     etp3a     3        100000   off     1
-Ethernet17     17                                     etp3b     3        100000   off     2
-Ethernet18     18                                     etp3c     3        100000   off     3
-Ethernet19     19                                     etp3d     3        100000   off     4
-Ethernet20     20                                     etp3e     3        100000   off     5
-Ethernet21     21                                     etp3f     3        100000   off     6
-Ethernet22     22                                     etp3g     3        100000   off     7
-Ethernet23     23                                     etp3h     3        100000   off     8
-Ethernet32     32                                     etp5a     5        100000   off     1
-Ethernet33     33                                     etp5b     5        100000   off     2
-Ethernet34     34                                     etp5c     5        100000   off     3
-Ethernet35     35                                     etp5d     5        100000   off     4
-Ethernet36     36                                     etp5e     5        100000   off     5
-Ethernet37     37                                     etp5f     5        100000   off     6
-Ethernet38     38                                     etp5g     5        100000   off     7
-Ethernet39     39                                     etp5h     5        100000   off     8
-Ethernet48     48                                     etp7a     7        100000   off     1
-Ethernet49     49                                     etp7b     7        100000   off     2
-Ethernet50     50                                     etp7c     7        100000   off     3
-Ethernet51     51                                     etp7d     7        100000   off     4
-Ethernet52     52                                     etp7e     7        100000   off     5
-Ethernet53     53                                     etp7f     7        100000   off     6
-Ethernet54     54                                     etp7g     7        100000   off     7
-Ethernet55     55                                     etp7h     7        100000   off     8
-Ethernet64     64                                     etp9a     9        100000   off     1
-Ethernet65     65                                     etp9b     9        100000   off     2
-Ethernet66     66                                     etp9c     9        100000   off     3
-Ethernet67     67                                     etp9d     9        100000   off     4
-Ethernet68     68                                     etp9e     9        100000   off     5
-Ethernet69     69                                     etp9f     9        100000   off     6
-Ethernet70     70                                     etp9g     9        100000   off     7
-Ethernet71     71                                     etp9h     9        100000   off     8
-Ethernet80     80                                     etp11a    11       100000   off     1
-Ethernet81     81                                     etp11b    11       100000   off     2
-Ethernet82     82                                     etp11c    11       100000   off     3
-Ethernet83     83                                     etp11d    11       100000   off     4
-Ethernet84     84                                     etp11e    11       100000   off     5
-Ethernet85     85                                     etp11f    11       100000   off     6
-Ethernet86     86                                     etp11g    11       100000   off     7
-Ethernet87     87                                     etp11h    11       100000   off     8
-Ethernet96     96                                     etp13a    13       100000   off     1
-Ethernet97     97                                     etp13b    13       100000   off     2
-Ethernet98     98                                     etp13c    13       100000   off     3
-Ethernet99     99                                     etp13d    13       100000   off     4
-Ethernet100    100                                    etp13e    13       100000   off     5
-Ethernet101    101                                    etp13f    13       100000   off     6
-Ethernet102    102                                    etp13g    13       100000   off     7
-Ethernet103    103                                    etp13h    13       100000   off     8
-Ethernet112    112                                    etp15a    15       100000   off     1
-Ethernet113    113                                    etp15b    15       100000   off     2
-Ethernet114    114                                    etp15c    15       100000   off     3
-Ethernet115    115                                    etp15d    15       100000   off     4
-Ethernet116    116                                    etp15e    15       100000   off     5
-Ethernet117    117                                    etp15f    15       100000   off     6
-Ethernet118    118                                    etp15g    15       100000   off     7
-Ethernet119    119                                    etp15h    15       100000   off     8
-Ethernet128    128                                    etp17a    17       100000   off     1
-Ethernet129    129                                    etp17b    17       100000   off     2
-Ethernet130    130                                    etp17c    17       100000   off     3
-Ethernet131    131                                    etp17d    17       100000   off     4
-Ethernet132    132                                    etp17e    17       100000   off     5
-Ethernet133    133                                    etp17f    17       100000   off     6
-Ethernet134    134                                    etp17g    17       100000   off     7
-Ethernet135    135                                    etp17h    17       100000   off     8
-Ethernet144    144                                    etp19a    19       100000   off     1
-Ethernet145    145                                    etp19b    19       100000   off     2
-Ethernet146    146                                    etp19c    19       100000   off     3
-Ethernet147    147                                    etp19d    19       100000   off     4
-Ethernet148    148                                    etp19e    19       100000   off     5
-Ethernet149    149                                    etp19f    19       100000   off     6
-Ethernet150    150                                    etp19g    19       100000   off     7
-Ethernet151    151                                    etp19h    19       100000   off     8
-Ethernet160    160                                    etp21a    21       100000   off     1
-Ethernet161    161                                    etp21b    21       100000   off     2
-Ethernet162    162                                    etp21c    21       100000   off     3
-Ethernet163    163                                    etp21d    21       100000   off     4
-Ethernet164    164                                    etp21e    21       100000   off     5
-Ethernet165    165                                    etp21f    21       100000   off     6
-Ethernet166    166                                    etp21g    21       100000   off     7
-Ethernet167    167                                    etp21h    21       100000   off     8
-Ethernet176    176                                    etp23a    23       100000   off     1
-Ethernet177    177                                    etp23b    23       100000   off     2
-Ethernet178    178                                    etp23c    23       100000   off     3
-Ethernet179    179                                    etp23d    23       100000   off     4
-Ethernet180    180                                    etp23e    23       100000   off     5
-Ethernet181    181                                    etp23f    23       100000   off     6
-Ethernet182    182                                    etp23g    23       100000   off     7
-Ethernet183    183                                    etp23h    23       100000   off     8
-Ethernet192    192                                    etp25a    25       100000   off     1
-Ethernet193    193                                    etp25b    25       100000   off     2
-Ethernet194    194                                    etp25c    25       100000   off     3
-Ethernet195    195                                    etp25d    25       100000   off     4
-Ethernet196    196                                    etp25e    25       100000   off     5
-Ethernet197    197                                    etp25f    25       100000   off     6
-Ethernet198    198                                    etp25g    25       100000   off     7
-Ethernet199    199                                    etp25h    25       100000   off     8
-Ethernet208    208                                    etp27a    27       100000   off     1
-Ethernet209    209                                    etp27b    27       100000   off     2
-Ethernet210    210                                    etp27c    27       100000   off     3
-Ethernet211    211                                    etp27d    27       100000   off     4
-Ethernet212    212                                    etp27e    27       100000   off     5
-Ethernet213    213                                    etp27f    27       100000   off     6
-Ethernet214    214                                    etp27g    27       100000   off     7
-Ethernet215    215                                    etp27h    27       100000   off     8
-Ethernet224    224                                    etp29a    29       100000   off     1
-Ethernet225    225                                    etp29b    29       100000   off     2
-Ethernet226    226                                    etp29c    29       100000   off     3
-Ethernet227    227                                    etp29d    29       100000   off     4
-Ethernet228    228                                    etp29e    29       100000   off     5
-Ethernet229    229                                    etp29f    29       100000   off     6
-Ethernet230    230                                    etp29g    29       100000   off     7
-Ethernet231    231                                    etp29h    29       100000   off     8
-Ethernet240    240                                    etp31a    31       100000   off     1
-Ethernet241    241                                    etp31b    31       100000   off     2
-Ethernet242    242                                    etp31c    31       100000   off     3
-Ethernet243    243                                    etp31d    31       100000   off     4
-Ethernet244    244                                    etp31e    31       100000   off     5
-Ethernet245    245                                    etp31f    31       100000   off     6
-Ethernet246    246                                    etp31g    31       100000   off     7
-Ethernet247    247                                    etp31h    31       100000   off     8
-Ethernet256    256                                    etp33a    33       100000   off     1
-Ethernet257    257                                    etp33b    33       100000   off     2
-Ethernet258    258                                    etp33c    33       100000   off     3
-Ethernet259    259                                    etp33d    33       100000   off     4
-Ethernet260    260                                    etp33e    33       100000   off     5
-Ethernet261    261                                    etp33f    33       100000   off     6
-Ethernet262    262                                    etp33g    33       100000   off     7
-Ethernet263    263                                    etp33h    33       100000   off     8
-Ethernet272    272                                    etp35a    35       100000   off     1
-Ethernet273    273                                    etp35b    35       100000   off     2
-Ethernet274    274                                    etp35c    35       100000   off     3
-Ethernet275    275                                    etp35d    35       100000   off     4
-Ethernet276    276                                    etp35e    35       100000   off     5
-Ethernet277    277                                    etp35f    35       100000   off     6
-Ethernet278    278                                    etp35g    35       100000   off     7
-Ethernet279    279                                    etp35h    35       100000   off     8
-Ethernet288    288                                    etp37a    37       100000   off     1
-Ethernet289    289                                    etp37b    37       100000   off     2
-Ethernet290    290                                    etp37c    37       100000   off     3
-Ethernet291    291                                    etp37d    37       100000   off     4
-Ethernet292    292                                    etp37e    37       100000   off     5
-Ethernet293    293                                    etp37f    37       100000   off     6
-Ethernet294    294                                    etp37g    37       100000   off     7
-Ethernet295    295                                    etp37h    37       100000   off     8
-Ethernet304    304                                    etp39a    39       100000   off     1
-Ethernet305    305                                    etp39b    39       100000   off     2
-Ethernet306    306                                    etp39c    39       100000   off     3
-Ethernet307    307                                    etp39d    39       100000   off     4
-Ethernet308    308                                    etp39e    39       100000   off     5
-Ethernet309    309                                    etp39f    39       100000   off     6
-Ethernet310    310                                    etp39g    39       100000   off     7
-Ethernet311    311                                    etp39h    39       100000   off     8
-Ethernet320    320                                    etp41a    41       100000   off     1
-Ethernet321    321                                    etp41b    41       100000   off     2
-Ethernet322    322                                    etp41c    41       100000   off     3
-Ethernet323    323                                    etp41d    41       100000   off     4
-Ethernet324    324                                    etp41e    41       100000   off     5
-Ethernet325    325                                    etp41f    41       100000   off     6
-Ethernet326    326                                    etp41g    41       100000   off     7
-Ethernet327    327                                    etp41h    41       100000   off     8
-Ethernet336    336                                    etp43a    43       100000   off     1
-Ethernet337    337                                    etp43b    43       100000   off     2
-Ethernet338    338                                    etp43c    43       100000   off     3
-Ethernet339    339                                    etp43d    43       100000   off     4
-Ethernet340    340                                    etp43e    43       100000   off     5
-Ethernet341    341                                    etp43f    43       100000   off     6
-Ethernet342    342                                    etp43g    43       100000   off     7
-Ethernet343    343                                    etp43h    43       100000   off     8
-Ethernet352    352                                    etp45a    45       100000   off     1
-Ethernet353    353                                    etp45b    45       100000   off     2
-Ethernet354    354                                    etp45c    45       100000   off     3
-Ethernet355    355                                    etp45d    45       100000   off     4
-Ethernet356    356                                    etp45e    45       100000   off     5
-Ethernet357    357                                    etp45f    45       100000   off     6
-Ethernet358    358                                    etp45g    45       100000   off     7
-Ethernet359    359                                    etp45h    45       100000   off     8
-Ethernet368    368                                    etp47a    47       100000   off     1
-Ethernet369    369                                    etp47b    47       100000   off     2
-Ethernet370    370                                    etp47c    47       100000   off     3
-Ethernet371    371                                    etp47d    47       100000   off     4
-Ethernet372    372                                    etp47e    47       100000   off     5
-Ethernet373    373                                    etp47f    47       100000   off     6
-Ethernet374    374                                    etp47g    47       100000   off     7
-Ethernet375    375                                    etp47h    47       100000   off     8
-Ethernet384    384                                    etp49a    49       100000   off     1
-Ethernet385    385                                    etp49b    49       100000   off     2
-Ethernet386    386                                    etp49c    49       100000   off     3
-Ethernet387    387                                    etp49d    49       100000   off     4
-Ethernet388    388                                    etp49e    49       100000   off     5
-Ethernet389    389                                    etp49f    49       100000   off     6
-Ethernet390    390                                    etp49g    49       100000   off     7
-Ethernet391    391                                    etp49h    49       100000   off     8
-Ethernet400    400                                    etp51a    51       100000   off     1
-Ethernet401    401                                    etp51b    51       100000   off     2
-Ethernet402    402                                    etp51c    51       100000   off     3
-Ethernet403    403                                    etp51d    51       100000   off     4
-Ethernet404    404                                    etp51e    51       100000   off     5
-Ethernet405    405                                    etp51f    51       100000   off     6
-Ethernet406    406                                    etp51g    51       100000   off     7
-Ethernet407    407                                    etp51h    51       100000   off     8
-Ethernet416    416                                    etp53a    53       100000   off     1
-Ethernet417    417                                    etp53b    53       100000   off     2
-Ethernet418    418                                    etp53c    53       100000   off     3
-Ethernet419    419                                    etp53d    53       100000   off     4
-Ethernet420    420                                    etp53e    53       100000   off     5
-Ethernet421    421                                    etp53f    53       100000   off     6
-Ethernet422    422                                    etp53g    53       100000   off     7
-Ethernet423    423                                    etp53h    53       100000   off     8
-Ethernet432    432                                    etp55a    55       100000   off     1
-Ethernet433    433                                    etp55b    55       100000   off     2
-Ethernet434    434                                    etp55c    55       100000   off     3
-Ethernet435    435                                    etp55d    55       100000   off     4
-Ethernet436    436                                    etp55e    55       100000   off     5
-Ethernet437    437                                    etp55f    55       100000   off     6
-Ethernet438    438                                    etp55g    55       100000   off     7
-Ethernet439    439                                    etp55h    55       100000   off     8
-Ethernet448    448                                    etp57a    57       100000   off     1
-Ethernet449    449                                    etp57b    57       100000   off     2
-Ethernet450    450                                    etp57c    57       100000   off     3
-Ethernet451    451                                    etp57d    57       100000   off     4
-Ethernet452    452                                    etp57e    57       100000   off     5
-Ethernet453    453                                    etp57f    57       100000   off     6
-Ethernet454    454                                    etp57g    57       100000   off     7
-Ethernet455    455                                    etp57h    57       100000   off     8
-Ethernet464    464                                    etp59a    59       100000   off     1
-Ethernet465    465                                    etp59b    59       100000   off     2
-Ethernet466    466                                    etp59c    59       100000   off     3
-Ethernet467    467                                    etp59d    59       100000   off     4
-Ethernet468    468                                    etp59e    59       100000   off     5
-Ethernet469    469                                    etp59f    59       100000   off     6
-Ethernet470    470                                    etp59g    59       100000   off     7
-Ethernet471    471                                    etp59h    59       100000   off     8
-Ethernet480    480                                    etp61a    61       100000   off     1
-Ethernet481    481                                    etp61b    61       100000   off     2
-Ethernet482    482                                    etp61c    61       100000   off     3
-Ethernet483    483                                    etp61d    61       100000   off     4
-Ethernet484    484                                    etp61e    61       100000   off     5
-Ethernet485    485                                    etp61f    61       100000   off     6
-Ethernet486    486                                    etp61g    61       100000   off     7
-Ethernet487    487                                    etp61h    61       100000   off     8
-Ethernet496    496                                    etp63a    63       100000   off     1
-Ethernet497    497                                    etp63b    63       100000   off     2
-Ethernet498    498                                    etp63c    63       100000   off     3
-Ethernet499    499                                    etp63d    63       100000   off     4
-Ethernet500    500                                    etp63e    63       100000   off     5
-Ethernet501    501                                    etp63f    63       100000   off     6
-Ethernet502    502                                    etp63g    63       100000   off     7
-Ethernet503    503                                    etp63h    63       100000   off     8
-Ethernet512    512                                    etp65     65        10000
+# name         lanes                                  alias     index    speed    autoneg
+Ethernet0      0                                      etp1a     1        100000   off
+Ethernet1      1                                      etp1b     1        100000   off
+Ethernet2      2                                      etp1c     1        100000   off
+Ethernet3      3                                      etp1d     1        100000   off
+Ethernet4      4                                      etp1e     1        100000   off
+Ethernet5      5                                      etp1f     1        100000   off
+Ethernet6      6                                      etp1g     1        100000   off
+Ethernet7      7                                      etp1h     1        100000   off
+Ethernet16     16                                     etp3a     3        100000   off
+Ethernet17     17                                     etp3b     3        100000   off
+Ethernet18     18                                     etp3c     3        100000   off
+Ethernet19     19                                     etp3d     3        100000   off
+Ethernet20     20                                     etp3e     3        100000   off
+Ethernet21     21                                     etp3f     3        100000   off
+Ethernet22     22                                     etp3g     3        100000   off
+Ethernet23     23                                     etp3h     3        100000   off
+Ethernet32     32                                     etp5a     5        100000   off
+Ethernet33     33                                     etp5b     5        100000   off
+Ethernet34     34                                     etp5c     5        100000   off
+Ethernet35     35                                     etp5d     5        100000   off
+Ethernet36     36                                     etp5e     5        100000   off
+Ethernet37     37                                     etp5f     5        100000   off
+Ethernet38     38                                     etp5g     5        100000   off
+Ethernet39     39                                     etp5h     5        100000   off
+Ethernet48     48                                     etp7a     7        100000   off
+Ethernet49     49                                     etp7b     7        100000   off
+Ethernet50     50                                     etp7c     7        100000   off
+Ethernet51     51                                     etp7d     7        100000   off
+Ethernet52     52                                     etp7e     7        100000   off
+Ethernet53     53                                     etp7f     7        100000   off
+Ethernet54     54                                     etp7g     7        100000   off
+Ethernet55     55                                     etp7h     7        100000   off
+Ethernet64     64                                     etp9a     9        100000   off
+Ethernet65     65                                     etp9b     9        100000   off
+Ethernet66     66                                     etp9c     9        100000   off
+Ethernet67     67                                     etp9d     9        100000   off
+Ethernet68     68                                     etp9e     9        100000   off
+Ethernet69     69                                     etp9f     9        100000   off
+Ethernet70     70                                     etp9g     9        100000   off
+Ethernet71     71                                     etp9h     9        100000   off
+Ethernet80     80                                     etp11a    11       100000   off
+Ethernet81     81                                     etp11b    11       100000   off
+Ethernet82     82                                     etp11c    11       100000   off
+Ethernet83     83                                     etp11d    11       100000   off
+Ethernet84     84                                     etp11e    11       100000   off
+Ethernet85     85                                     etp11f    11       100000   off
+Ethernet86     86                                     etp11g    11       100000   off
+Ethernet87     87                                     etp11h    11       100000   off
+Ethernet96     96                                     etp13a    13       100000   off
+Ethernet97     97                                     etp13b    13       100000   off
+Ethernet98     98                                     etp13c    13       100000   off
+Ethernet99     99                                     etp13d    13       100000   off
+Ethernet100    100                                    etp13e    13       100000   off
+Ethernet101    101                                    etp13f    13       100000   off
+Ethernet102    102                                    etp13g    13       100000   off
+Ethernet103    103                                    etp13h    13       100000   off
+Ethernet112    112                                    etp15a    15       100000   off
+Ethernet113    113                                    etp15b    15       100000   off
+Ethernet114    114                                    etp15c    15       100000   off
+Ethernet115    115                                    etp15d    15       100000   off
+Ethernet116    116                                    etp15e    15       100000   off
+Ethernet117    117                                    etp15f    15       100000   off
+Ethernet118    118                                    etp15g    15       100000   off
+Ethernet119    119                                    etp15h    15       100000   off
+Ethernet128    128                                    etp17a    17       100000   off
+Ethernet129    129                                    etp17b    17       100000   off
+Ethernet130    130                                    etp17c    17       100000   off
+Ethernet131    131                                    etp17d    17       100000   off
+Ethernet132    132                                    etp17e    17       100000   off
+Ethernet133    133                                    etp17f    17       100000   off
+Ethernet134    134                                    etp17g    17       100000   off
+Ethernet135    135                                    etp17h    17       100000   off
+Ethernet144    144                                    etp19a    19       100000   off
+Ethernet145    145                                    etp19b    19       100000   off
+Ethernet146    146                                    etp19c    19       100000   off
+Ethernet147    147                                    etp19d    19       100000   off
+Ethernet148    148                                    etp19e    19       100000   off
+Ethernet149    149                                    etp19f    19       100000   off
+Ethernet150    150                                    etp19g    19       100000   off
+Ethernet151    151                                    etp19h    19       100000   off
+Ethernet160    160                                    etp21a    21       100000   off
+Ethernet161    161                                    etp21b    21       100000   off
+Ethernet162    162                                    etp21c    21       100000   off
+Ethernet163    163                                    etp21d    21       100000   off
+Ethernet164    164                                    etp21e    21       100000   off
+Ethernet165    165                                    etp21f    21       100000   off
+Ethernet166    166                                    etp21g    21       100000   off
+Ethernet167    167                                    etp21h    21       100000   off
+Ethernet176    176                                    etp23a    23       100000   off
+Ethernet177    177                                    etp23b    23       100000   off
+Ethernet178    178                                    etp23c    23       100000   off
+Ethernet179    179                                    etp23d    23       100000   off
+Ethernet180    180                                    etp23e    23       100000   off
+Ethernet181    181                                    etp23f    23       100000   off
+Ethernet182    182                                    etp23g    23       100000   off
+Ethernet183    183                                    etp23h    23       100000   off
+Ethernet192    192                                    etp25a    25       100000   off
+Ethernet193    193                                    etp25b    25       100000   off
+Ethernet194    194                                    etp25c    25       100000   off
+Ethernet195    195                                    etp25d    25       100000   off
+Ethernet196    196                                    etp25e    25       100000   off
+Ethernet197    197                                    etp25f    25       100000   off
+Ethernet198    198                                    etp25g    25       100000   off
+Ethernet199    199                                    etp25h    25       100000   off
+Ethernet208    208                                    etp27a    27       100000   off
+Ethernet209    209                                    etp27b    27       100000   off
+Ethernet210    210                                    etp27c    27       100000   off
+Ethernet211    211                                    etp27d    27       100000   off
+Ethernet212    212                                    etp27e    27       100000   off
+Ethernet213    213                                    etp27f    27       100000   off
+Ethernet214    214                                    etp27g    27       100000   off
+Ethernet215    215                                    etp27h    27       100000   off
+Ethernet224    224                                    etp29a    29       100000   off
+Ethernet225    225                                    etp29b    29       100000   off
+Ethernet226    226                                    etp29c    29       100000   off
+Ethernet227    227                                    etp29d    29       100000   off
+Ethernet228    228                                    etp29e    29       100000   off
+Ethernet229    229                                    etp29f    29       100000   off
+Ethernet230    230                                    etp29g    29       100000   off
+Ethernet231    231                                    etp29h    29       100000   off
+Ethernet240    240                                    etp31a    31       100000   off
+Ethernet241    241                                    etp31b    31       100000   off
+Ethernet242    242                                    etp31c    31       100000   off
+Ethernet243    243                                    etp31d    31       100000   off
+Ethernet244    244                                    etp31e    31       100000   off
+Ethernet245    245                                    etp31f    31       100000   off
+Ethernet246    246                                    etp31g    31       100000   off
+Ethernet247    247                                    etp31h    31       100000   off
+Ethernet256    256                                    etp33a    33       100000   off
+Ethernet257    257                                    etp33b    33       100000   off
+Ethernet258    258                                    etp33c    33       100000   off
+Ethernet259    259                                    etp33d    33       100000   off
+Ethernet260    260                                    etp33e    33       100000   off
+Ethernet261    261                                    etp33f    33       100000   off
+Ethernet262    262                                    etp33g    33       100000   off
+Ethernet263    263                                    etp33h    33       100000   off
+Ethernet272    272                                    etp35a    35       100000   off
+Ethernet273    273                                    etp35b    35       100000   off
+Ethernet274    274                                    etp35c    35       100000   off
+Ethernet275    275                                    etp35d    35       100000   off
+Ethernet276    276                                    etp35e    35       100000   off
+Ethernet277    277                                    etp35f    35       100000   off
+Ethernet278    278                                    etp35g    35       100000   off
+Ethernet279    279                                    etp35h    35       100000   off
+Ethernet288    288                                    etp37a    37       100000   off
+Ethernet289    289                                    etp37b    37       100000   off
+Ethernet290    290                                    etp37c    37       100000   off
+Ethernet291    291                                    etp37d    37       100000   off
+Ethernet292    292                                    etp37e    37       100000   off
+Ethernet293    293                                    etp37f    37       100000   off
+Ethernet294    294                                    etp37g    37       100000   off
+Ethernet295    295                                    etp37h    37       100000   off
+Ethernet304    304                                    etp39a    39       100000   off
+Ethernet305    305                                    etp39b    39       100000   off
+Ethernet306    306                                    etp39c    39       100000   off
+Ethernet307    307                                    etp39d    39       100000   off
+Ethernet308    308                                    etp39e    39       100000   off
+Ethernet309    309                                    etp39f    39       100000   off
+Ethernet310    310                                    etp39g    39       100000   off
+Ethernet311    311                                    etp39h    39       100000   off
+Ethernet320    320                                    etp41a    41       100000   off
+Ethernet321    321                                    etp41b    41       100000   off
+Ethernet322    322                                    etp41c    41       100000   off
+Ethernet323    323                                    etp41d    41       100000   off
+Ethernet324    324                                    etp41e    41       100000   off
+Ethernet325    325                                    etp41f    41       100000   off
+Ethernet326    326                                    etp41g    41       100000   off
+Ethernet327    327                                    etp41h    41       100000   off
+Ethernet336    336                                    etp43a    43       100000   off
+Ethernet337    337                                    etp43b    43       100000   off
+Ethernet338    338                                    etp43c    43       100000   off
+Ethernet339    339                                    etp43d    43       100000   off
+Ethernet340    340                                    etp43e    43       100000   off
+Ethernet341    341                                    etp43f    43       100000   off
+Ethernet342    342                                    etp43g    43       100000   off
+Ethernet343    343                                    etp43h    43       100000   off
+Ethernet352    352                                    etp45a    45       100000   off
+Ethernet353    353                                    etp45b    45       100000   off
+Ethernet354    354                                    etp45c    45       100000   off
+Ethernet355    355                                    etp45d    45       100000   off
+Ethernet356    356                                    etp45e    45       100000   off
+Ethernet357    357                                    etp45f    45       100000   off
+Ethernet358    358                                    etp45g    45       100000   off
+Ethernet359    359                                    etp45h    45       100000   off
+Ethernet368    368                                    etp47a    47       100000   off
+Ethernet369    369                                    etp47b    47       100000   off
+Ethernet370    370                                    etp47c    47       100000   off
+Ethernet371    371                                    etp47d    47       100000   off
+Ethernet372    372                                    etp47e    47       100000   off
+Ethernet373    373                                    etp47f    47       100000   off
+Ethernet374    374                                    etp47g    47       100000   off
+Ethernet375    375                                    etp47h    47       100000   off
+Ethernet384    384                                    etp49a    49       100000   off
+Ethernet385    385                                    etp49b    49       100000   off
+Ethernet386    386                                    etp49c    49       100000   off
+Ethernet387    387                                    etp49d    49       100000   off
+Ethernet388    388                                    etp49e    49       100000   off
+Ethernet389    389                                    etp49f    49       100000   off
+Ethernet390    390                                    etp49g    49       100000   off
+Ethernet391    391                                    etp49h    49       100000   off
+Ethernet400    400                                    etp51a    51       100000   off
+Ethernet401    401                                    etp51b    51       100000   off
+Ethernet402    402                                    etp51c    51       100000   off
+Ethernet403    403                                    etp51d    51       100000   off
+Ethernet404    404                                    etp51e    51       100000   off
+Ethernet405    405                                    etp51f    51       100000   off
+Ethernet406    406                                    etp51g    51       100000   off
+Ethernet407    407                                    etp51h    51       100000   off
+Ethernet416    416                                    etp53a    53       100000   off
+Ethernet417    417                                    etp53b    53       100000   off
+Ethernet418    418                                    etp53c    53       100000   off
+Ethernet419    419                                    etp53d    53       100000   off
+Ethernet420    420                                    etp53e    53       100000   off
+Ethernet421    421                                    etp53f    53       100000   off
+Ethernet422    422                                    etp53g    53       100000   off
+Ethernet423    423                                    etp53h    53       100000   off
+Ethernet432    432                                    etp55a    55       100000   off
+Ethernet433    433                                    etp55b    55       100000   off
+Ethernet434    434                                    etp55c    55       100000   off
+Ethernet435    435                                    etp55d    55       100000   off
+Ethernet436    436                                    etp55e    55       100000   off
+Ethernet437    437                                    etp55f    55       100000   off
+Ethernet438    438                                    etp55g    55       100000   off
+Ethernet439    439                                    etp55h    55       100000   off
+Ethernet448    448                                    etp57a    57       100000   off
+Ethernet449    449                                    etp57b    57       100000   off
+Ethernet450    450                                    etp57c    57       100000   off
+Ethernet451    451                                    etp57d    57       100000   off
+Ethernet452    452                                    etp57e    57       100000   off
+Ethernet453    453                                    etp57f    57       100000   off
+Ethernet454    454                                    etp57g    57       100000   off
+Ethernet455    455                                    etp57h    57       100000   off
+Ethernet464    464                                    etp59a    59       100000   off
+Ethernet465    465                                    etp59b    59       100000   off
+Ethernet466    466                                    etp59c    59       100000   off
+Ethernet467    467                                    etp59d    59       100000   off
+Ethernet468    468                                    etp59e    59       100000   off
+Ethernet469    469                                    etp59f    59       100000   off
+Ethernet470    470                                    etp59g    59       100000   off
+Ethernet471    471                                    etp59h    59       100000   off
+Ethernet480    480                                    etp61a    61       100000   off
+Ethernet481    481                                    etp61b    61       100000   off
+Ethernet482    482                                    etp61c    61       100000   off
+Ethernet483    483                                    etp61d    61       100000   off
+Ethernet484    484                                    etp61e    61       100000   off
+Ethernet485    485                                    etp61f    61       100000   off
+Ethernet486    486                                    etp61g    61       100000   off
+Ethernet487    487                                    etp61h    61       100000   off
+Ethernet496    496                                    etp63a    63       100000   off
+Ethernet497    497                                    etp63b    63       100000   off
+Ethernet498    498                                    etp63c    63       100000   off
+Ethernet499    499                                    etp63d    63       100000   off
+Ethernet500    500                                    etp63e    63       100000   off
+Ethernet501    501                                    etp63f    63       100000   off
+Ethernet502    502                                    etp63g    63       100000   off
+Ethernet503    503                                    etp63h    63       100000   off
+Ethernet512    512                                    etp65     65        10

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-O128/hwsku.json
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-O128/hwsku.json
@@ -2,642 +2,514 @@
     "interfaces": {
         "Ethernet0": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet4": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet8": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet12": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet16": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet20": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet24": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet28": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet32": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet36": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet40": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet44": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet48": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet52": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet56": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet60": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet64": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet68": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet72": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet76": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet80": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet84": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet88": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet92": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet96": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet100": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet104": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet108": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet112": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet116": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet120": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet124": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet128": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet132": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet136": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet140": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet144": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet148": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet152": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet156": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet160": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet164": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet168": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet172": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet176": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet180": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet184": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet188": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet192": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet196": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet200": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet204": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet208": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet212": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet216": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet220": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet224": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet228": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet232": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet236": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet240": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet244": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet248": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet252": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet256": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet260": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet264": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet268": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet272": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet276": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet280": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet284": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet288": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet292": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet296": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet300": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet304": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet308": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet312": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet316": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet320": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet324": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet328": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet332": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet336": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet340": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet344": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet348": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet352": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet356": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet360": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet364": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet368": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet372": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet376": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet380": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet384": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet388": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet392": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet396": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet400": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet404": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet408": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet412": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet416": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet420": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet424": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet428": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet432": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet436": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet440": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet444": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet448": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet452": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet456": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet460": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet464": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet468": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet472": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet476": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet480": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet484": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet488": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet492": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet496": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet500": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet504": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet508": {
             "default_brkout_mode": "2x400G[200G,100G,50G,40G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet512": {

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-V256/hwsku.json
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-V256/hwsku.json
@@ -2,1282 +2,1026 @@
     "interfaces": {
         "Ethernet0": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet2": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet4": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet6": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet8": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet10": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet12": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet14": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet16": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet18": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet20": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet22": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet24": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet26": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet28": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet30": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet32": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet34": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet36": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet38": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet40": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet42": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet44": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet46": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet48": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet50": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet52": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet54": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet56": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet58": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet60": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet62": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet64": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet66": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet68": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet70": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet72": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet74": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet76": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet78": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet80": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet82": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet84": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet86": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet88": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet90": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet92": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet94": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet96": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet98": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet100": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet102": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet104": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet106": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet108": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet110": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet112": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet114": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet116": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet118": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet120": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet122": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet124": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet126": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet128": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet130": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet132": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet134": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet136": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet138": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet140": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet142": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet144": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet146": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet148": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet150": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet152": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet154": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet156": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet158": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet160": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet162": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet164": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet166": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet168": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet170": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet172": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet174": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet176": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet178": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet180": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet182": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet184": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet186": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet188": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet190": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet192": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet194": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet196": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet198": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet200": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet202": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet204": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet206": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet208": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet210": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet212": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet214": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet216": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet218": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet220": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet222": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet224": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet226": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet228": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet230": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet232": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet234": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet236": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet238": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet240": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet242": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet244": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet246": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet248": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet250": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet252": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet254": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet256": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet258": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet260": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet262": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet264": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet266": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet268": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet270": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet272": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet274": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet276": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet278": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet280": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet282": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet284": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet286": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet288": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet290": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet292": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet294": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet296": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet298": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet300": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet302": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet304": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet306": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet308": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet310": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet312": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet314": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet316": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet318": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet320": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet322": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet324": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet326": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet328": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet330": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet332": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet334": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet336": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet338": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet340": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet342": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet344": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet346": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet348": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet350": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet352": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet354": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet356": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet358": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet360": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet362": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet364": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet366": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet368": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet370": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet372": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet374": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet376": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet378": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet380": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet382": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet384": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet386": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet388": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet390": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet392": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet394": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet396": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet398": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet400": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet402": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet404": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet406": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet408": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet410": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet412": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet414": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet416": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet418": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet420": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet422": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet424": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet426": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet428": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet430": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet432": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet434": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet436": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet438": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet440": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet442": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet444": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet446": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet448": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet450": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet452": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet454": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet456": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet458": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet460": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet462": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet464": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet466": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet468": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet470": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet472": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet474": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet476": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet478": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet480": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet482": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet484": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet486": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet488": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet490": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet492": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet494": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet496": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet498": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet500": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet502": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet504": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet506": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet508": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet510": {
             "default_brkout_mode": "4x200G[100G,50G,25G,10G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet512": {

--- a/device/mellanox/x86_64-nvidia_sn5610n-r0/Mellanox-SN5610N-C224O8/port_config.ini
+++ b/device/mellanox/x86_64-nvidia_sn5610n-r0/Mellanox-SN5610N-C224O8/port_config.ini
@@ -1,6 +1,6 @@
 ##
 ## SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-## Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+## Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 ## Apache-2.0
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,238 +16,238 @@
 ## limitations under the License.
 ##
 
-# name         lanes                                  alias     index    speed      autoneg subport
-Ethernet0      0                                      etp1a     1        100000     off     1
-Ethernet1      1                                      etp1b     1        100000     off     2
-Ethernet2      2                                      etp1c     1        100000     off     3
-Ethernet3      3                                      etp1d     1        100000     off     4
-Ethernet4      4                                      etp1e     1        100000     off     5
-Ethernet5      5                                      etp1f     1        100000     off     6
-Ethernet6      6                                      etp1g     1        100000     off     7
-Ethernet7      7                                      etp1h     1        100000     off     8
-Ethernet16     16                                     etp3a     3        100000     off     1
-Ethernet17     17                                     etp3b     3        100000     off     2
-Ethernet18     18                                     etp3c     3        100000     off     3
-Ethernet19     19                                     etp3d     3        100000     off     4
-Ethernet20     20                                     etp3e     3        100000     off     5
-Ethernet21     21                                     etp3f     3        100000     off     6
-Ethernet22     22                                     etp3g     3        100000     off     7
-Ethernet23     23                                     etp3h     3        100000     off     8
-Ethernet32     32                                     etp5a     5        100000     off     1
-Ethernet33     33                                     etp5b     5        100000     off     2
-Ethernet34     34                                     etp5c     5        100000     off     3
-Ethernet35     35                                     etp5d     5        100000     off     4
-Ethernet36     36                                     etp5e     5        100000     off     5
-Ethernet37     37                                     etp5f     5        100000     off     6
-Ethernet38     38                                     etp5g     5        100000     off     7
-Ethernet39     39                                     etp5h     5        100000     off     8
-Ethernet48     48                                     etp7a     7        100000     off     1
-Ethernet49     49                                     etp7b     7        100000     off     2
-Ethernet50     50                                     etp7c     7        100000     off     3
-Ethernet51     51                                     etp7d     7        100000     off     4
-Ethernet52     52                                     etp7e     7        100000     off     5
-Ethernet53     53                                     etp7f     7        100000     off     6
-Ethernet54     54                                     etp7g     7        100000     off     7
-Ethernet55     55                                     etp7h     7        100000     off     8
-Ethernet64     64                                     etp9a     9        100000     off     1
-Ethernet65     65                                     etp9b     9        100000     off     2
-Ethernet66     66                                     etp9c     9        100000     off     3
-Ethernet67     67                                     etp9d     9        100000     off     4
-Ethernet68     68                                     etp9e     9        100000     off     5
-Ethernet69     69                                     etp9f     9        100000     off     6
-Ethernet70     70                                     etp9g     9        100000     off     7
-Ethernet71     71                                     etp9h     9        100000     off     8
-Ethernet80     80                                     etp11a    11       100000     off     1
-Ethernet81     81                                     etp11b    11       100000     off     2
-Ethernet82     82                                     etp11c    11       100000     off     3
-Ethernet83     83                                     etp11d    11       100000     off     4
-Ethernet84     84                                     etp11e    11       100000     off     5
-Ethernet85     85                                     etp11f    11       100000     off     6
-Ethernet86     86                                     etp11g    11       100000     off     7
-Ethernet87     87                                     etp11h    11       100000     off     8
-Ethernet96     96,97,98,99                            etp13a    13       400000     off     1
-Ethernet100    100,101,102,103                        etp13b    13       400000     off     2
-Ethernet112    112                                    etp15a    15       100000     off     1
-Ethernet113    113                                    etp15b    15       100000     off     2
-Ethernet114    114                                    etp15c    15       100000     off     3
-Ethernet115    115                                    etp15d    15       100000     off     4
-Ethernet116    116                                    etp15e    15       100000     off     5
-Ethernet117    117                                    etp15f    15       100000     off     6
-Ethernet118    118                                    etp15g    15       100000     off     7
-Ethernet119    119                                    etp15h    15       100000     off     8
-Ethernet128    128,129,130,131                        etp17a    17       400000     off     1
-Ethernet132    132,133,134,135                        etp17b    17       400000     off     2
-Ethernet144    144                                    etp19a    19       100000     off     1
-Ethernet145    145                                    etp19b    19       100000     off     2
-Ethernet146    146                                    etp19c    19       100000     off     3
-Ethernet147    147                                    etp19d    19       100000     off     4
-Ethernet148    148                                    etp19e    19       100000     off     5
-Ethernet149    149                                    etp19f    19       100000     off     6
-Ethernet150    150                                    etp19g    19       100000     off     7
-Ethernet151    151                                    etp19h    19       100000     off     8
-Ethernet160    160                                    etp21a    21       100000     off     1
-Ethernet161    161                                    etp21b    21       100000     off     2
-Ethernet162    162                                    etp21c    21       100000     off     3
-Ethernet163    163                                    etp21d    21       100000     off     4
-Ethernet164    164                                    etp21e    21       100000     off     5
-Ethernet165    165                                    etp21f    21       100000     off     6
-Ethernet166    166                                    etp21g    21       100000     off     7
-Ethernet167    167                                    etp21h    21       100000     off     8
-Ethernet176    176                                    etp23a    23       100000     off     1
-Ethernet177    177                                    etp23b    23       100000     off     2
-Ethernet178    178                                    etp23c    23       100000     off     3
-Ethernet179    179                                    etp23d    23       100000     off     4
-Ethernet180    180                                    etp23e    23       100000     off     5
-Ethernet181    181                                    etp23f    23       100000     off     6
-Ethernet182    182                                    etp23g    23       100000     off     7
-Ethernet183    183                                    etp23h    23       100000     off     8
-Ethernet192    192                                    etp25a    25       100000     off     1
-Ethernet193    193                                    etp25b    25       100000     off     2
-Ethernet194    194                                    etp25c    25       100000     off     3
-Ethernet195    195                                    etp25d    25       100000     off     4
-Ethernet196    196                                    etp25e    25       100000     off     5
-Ethernet197    197                                    etp25f    25       100000     off     6
-Ethernet198    198                                    etp25g    25       100000     off     7
-Ethernet199    199                                    etp25h    25       100000     off     8
-Ethernet208    208                                    etp27a    27       100000     off     1
-Ethernet209    209                                    etp27b    27       100000     off     2
-Ethernet210    210                                    etp27c    27       100000     off     3
-Ethernet211    211                                    etp27d    27       100000     off     4
-Ethernet212    212                                    etp27e    27       100000     off     5
-Ethernet213    213                                    etp27f    27       100000     off     6
-Ethernet214    214                                    etp27g    27       100000     off     7
-Ethernet215    215                                    etp27h    27       100000     off     8
-Ethernet224    224                                    etp29a    29       100000     off     1
-Ethernet225    225                                    etp29b    29       100000     off     2
-Ethernet226    226                                    etp29c    29       100000     off     3
-Ethernet227    227                                    etp29d    29       100000     off     4
-Ethernet228    228                                    etp29e    29       100000     off     5
-Ethernet229    229                                    etp29f    29       100000     off     6
-Ethernet230    230                                    etp29g    29       100000     off     7
-Ethernet231    231                                    etp29h    29       100000     off     8
-Ethernet240    240                                    etp31a    31       100000     off     1
-Ethernet241    241                                    etp31b    31       100000     off     2
-Ethernet242    242                                    etp31c    31       100000     off     3
-Ethernet243    243                                    etp31d    31       100000     off     4
-Ethernet244    244                                    etp31e    31       100000     off     5
-Ethernet245    245                                    etp31f    31       100000     off     6
-Ethernet246    246                                    etp31g    31       100000     off     7
-Ethernet247    247                                    etp31h    31       100000     off     8
-Ethernet256    256                                    etp33a    33       100000     off     1
-Ethernet257    257                                    etp33b    33       100000     off     2
-Ethernet258    258                                    etp33c    33       100000     off     3
-Ethernet259    259                                    etp33d    33       100000     off     4
-Ethernet260    260                                    etp33e    33       100000     off     5
-Ethernet261    261                                    etp33f    33       100000     off     6
-Ethernet262    262                                    etp33g    33       100000     off     7
-Ethernet263    263                                    etp33h    33       100000     off     8
-Ethernet272    272                                    etp35a    35       100000     off     1
-Ethernet273    273                                    etp35b    35       100000     off     2
-Ethernet274    274                                    etp35c    35       100000     off     3
-Ethernet275    275                                    etp35d    35       100000     off     4
-Ethernet276    276                                    etp35e    35       100000     off     5
-Ethernet277    277                                    etp35f    35       100000     off     6
-Ethernet278    278                                    etp35g    35       100000     off     7
-Ethernet279    279                                    etp35h    35       100000     off     8
-Ethernet288    288                                    etp37a    37       100000     off     1
-Ethernet289    289                                    etp37b    37       100000     off     2
-Ethernet290    290                                    etp37c    37       100000     off     3
-Ethernet291    291                                    etp37d    37       100000     off     4
-Ethernet292    292                                    etp37e    37       100000     off     5
-Ethernet293    293                                    etp37f    37       100000     off     6
-Ethernet294    294                                    etp37g    37       100000     off     7
-Ethernet295    295                                    etp37h    37       100000     off     8
-Ethernet304    304                                    etp39a    39       100000     off     1
-Ethernet305    305                                    etp39b    39       100000     off     2
-Ethernet306    306                                    etp39c    39       100000     off     3
-Ethernet307    307                                    etp39d    39       100000     off     4
-Ethernet308    308                                    etp39e    39       100000     off     5
-Ethernet309    309                                    etp39f    39       100000     off     6
-Ethernet310    310                                    etp39g    39       100000     off     7
-Ethernet311    311                                    etp39h    39       100000     off     8
-Ethernet320    320                                    etp41a    41       100000     off     1
-Ethernet321    321                                    etp41b    41       100000     off     2
-Ethernet322    322                                    etp41c    41       100000     off     3
-Ethernet323    323                                    etp41d    41       100000     off     4
-Ethernet324    324                                    etp41e    41       100000     off     5
-Ethernet325    325                                    etp41f    41       100000     off     6
-Ethernet326    326                                    etp41g    41       100000     off     7
-Ethernet327    327                                    etp41h    41       100000     off     8
-Ethernet336    336                                    etp43a    43       100000     off     1
-Ethernet337    337                                    etp43b    43       100000     off     2
-Ethernet338    338                                    etp43c    43       100000     off     3
-Ethernet339    339                                    etp43d    43       100000     off     4
-Ethernet340    340                                    etp43e    43       100000     off     5
-Ethernet341    341                                    etp43f    43       100000     off     6
-Ethernet342    342                                    etp43g    43       100000     off     7
-Ethernet343    343                                    etp43h    43       100000     off     8
-Ethernet352    352,353,354,355                        etp45a    45       400000     off     1
-Ethernet356    356,357,358,359                        etp45b    45       400000     off     2
-Ethernet368    368                                    etp47a    47       100000     off     1
-Ethernet369    369                                    etp47b    47       100000     off     2
-Ethernet370    370                                    etp47c    47       100000     off     3
-Ethernet371    371                                    etp47d    47       100000     off     4
-Ethernet372    372                                    etp47e    47       100000     off     5
-Ethernet373    373                                    etp47f    47       100000     off     6
-Ethernet374    374                                    etp47g    47       100000     off     7
-Ethernet375    375                                    etp47h    47       100000     off     8
-Ethernet384    384,385,386,387                        etp49a    49       400000     off     1
-Ethernet388    388,389,390,391                        etp49b    49       400000     off     2
-Ethernet400    400                                    etp51a    51       100000     off     1
-Ethernet401    401                                    etp51b    51       100000     off     2
-Ethernet402    402                                    etp51c    51       100000     off     3
-Ethernet403    403                                    etp51d    51       100000     off     4
-Ethernet404    404                                    etp51e    51       100000     off     5
-Ethernet405    405                                    etp51f    51       100000     off     6
-Ethernet406    406                                    etp51g    51       100000     off     7
-Ethernet407    407                                    etp51h    51       100000     off     8
-Ethernet416    416                                    etp53a    53       100000     off     1
-Ethernet417    417                                    etp53b    53       100000     off     2
-Ethernet418    418                                    etp53c    53       100000     off     3
-Ethernet419    419                                    etp53d    53       100000     off     4
-Ethernet420    420                                    etp53e    53       100000     off     5
-Ethernet421    421                                    etp53f    53       100000     off     6
-Ethernet422    422                                    etp53g    53       100000     off     7
-Ethernet423    423                                    etp53h    53       100000     off     8
-Ethernet432    432                                    etp55a    55       100000     off     1
-Ethernet433    433                                    etp55b    55       100000     off     2
-Ethernet434    434                                    etp55c    55       100000     off     3
-Ethernet435    435                                    etp55d    55       100000     off     4
-Ethernet436    436                                    etp55e    55       100000     off     5
-Ethernet437    437                                    etp55f    55       100000     off     6
-Ethernet438    438                                    etp55g    55       100000     off     7
-Ethernet439    439                                    etp55h    55       100000     off     8
-Ethernet448    448                                    etp57a    57       100000     off     1
-Ethernet449    449                                    etp57b    57       100000     off     2
-Ethernet450    450                                    etp57c    57       100000     off     3
-Ethernet451    451                                    etp57d    57       100000     off     4
-Ethernet452    452                                    etp57e    57       100000     off     5
-Ethernet453    453                                    etp57f    57       100000     off     6
-Ethernet454    454                                    etp57g    57       100000     off     7
-Ethernet455    455                                    etp57h    57       100000     off     8
-Ethernet464    464                                    etp59a    59       100000     off     1
-Ethernet465    465                                    etp59b    59       100000     off     2
-Ethernet466    466                                    etp59c    59       100000     off     3
-Ethernet467    467                                    etp59d    59       100000     off     4
-Ethernet468    468                                    etp59e    59       100000     off     5
-Ethernet469    469                                    etp59f    59       100000     off     6
-Ethernet470    470                                    etp59g    59       100000     off     7
-Ethernet471    471                                    etp59h    59       100000     off     8
-Ethernet480    480                                    etp61a    61       100000     off     1
-Ethernet481    481                                    etp61b    61       100000     off     2
-Ethernet482    482                                    etp61c    61       100000     off     3
-Ethernet483    483                                    etp61d    61       100000     off     4
-Ethernet484    484                                    etp61e    61       100000     off     5
-Ethernet485    485                                    etp61f    61       100000     off     6
-Ethernet486    486                                    etp61g    61       100000     off     7
-Ethernet487    487                                    etp61h    61       100000     off     8
-Ethernet496    496                                    etp63a    63       100000     off     1
-Ethernet497    497                                    etp63b    63       100000     off     2
-Ethernet498    498                                    etp63c    63       100000     off     3
-Ethernet499    499                                    etp63d    63       100000     off     4
-Ethernet500    500                                    etp63e    63       100000     off     5
-Ethernet501    501                                    etp63f    63       100000     off     6
-Ethernet502    502                                    etp63g    63       100000     off     7
-Ethernet503    503                                    etp63h    63       100000     off     8
+# name         lanes                                  alias     index    speed      autoneg
+Ethernet0      0                                      etp1a     1        100000     off
+Ethernet1      1                                      etp1b     1        100000     off
+Ethernet2      2                                      etp1c     1        100000     off
+Ethernet3      3                                      etp1d     1        100000     off
+Ethernet4      4                                      etp1e     1        100000     off
+Ethernet5      5                                      etp1f     1        100000     off
+Ethernet6      6                                      etp1g     1        100000     off
+Ethernet7      7                                      etp1h     1        100000     off
+Ethernet16     16                                     etp3a     3        100000     off
+Ethernet17     17                                     etp3b     3        100000     off
+Ethernet18     18                                     etp3c     3        100000     off
+Ethernet19     19                                     etp3d     3        100000     off
+Ethernet20     20                                     etp3e     3        100000     off
+Ethernet21     21                                     etp3f     3        100000     off
+Ethernet22     22                                     etp3g     3        100000     off
+Ethernet23     23                                     etp3h     3        100000     off
+Ethernet32     32                                     etp5a     5        100000     off
+Ethernet33     33                                     etp5b     5        100000     off
+Ethernet34     34                                     etp5c     5        100000     off
+Ethernet35     35                                     etp5d     5        100000     off
+Ethernet36     36                                     etp5e     5        100000     off
+Ethernet37     37                                     etp5f     5        100000     off
+Ethernet38     38                                     etp5g     5        100000     off
+Ethernet39     39                                     etp5h     5        100000     off
+Ethernet48     48                                     etp7a     7        100000     off
+Ethernet49     49                                     etp7b     7        100000     off
+Ethernet50     50                                     etp7c     7        100000     off
+Ethernet51     51                                     etp7d     7        100000     off
+Ethernet52     52                                     etp7e     7        100000     off
+Ethernet53     53                                     etp7f     7        100000     off
+Ethernet54     54                                     etp7g     7        100000     off
+Ethernet55     55                                     etp7h     7        100000     off
+Ethernet64     64                                     etp9a     9        100000     off
+Ethernet65     65                                     etp9b     9        100000     off
+Ethernet66     66                                     etp9c     9        100000     off
+Ethernet67     67                                     etp9d     9        100000     off
+Ethernet68     68                                     etp9e     9        100000     off
+Ethernet69     69                                     etp9f     9        100000     off
+Ethernet70     70                                     etp9g     9        100000     off
+Ethernet71     71                                     etp9h     9        100000     off
+Ethernet80     80                                     etp11a    11       100000     off
+Ethernet81     81                                     etp11b    11       100000     off
+Ethernet82     82                                     etp11c    11       100000     off
+Ethernet83     83                                     etp11d    11       100000     off
+Ethernet84     84                                     etp11e    11       100000     off
+Ethernet85     85                                     etp11f    11       100000     off
+Ethernet86     86                                     etp11g    11       100000     off
+Ethernet87     87                                     etp11h    11       100000     off
+Ethernet96     96,97,98,99                            etp13a    13       400000     off
+Ethernet100    100,101,102,103                        etp13b    13       400000     off
+Ethernet112    112                                    etp15a    15       100000     off
+Ethernet113    113                                    etp15b    15       100000     off
+Ethernet114    114                                    etp15c    15       100000     off
+Ethernet115    115                                    etp15d    15       100000     off
+Ethernet116    116                                    etp15e    15       100000     off
+Ethernet117    117                                    etp15f    15       100000     off
+Ethernet118    118                                    etp15g    15       100000     off
+Ethernet119    119                                    etp15h    15       100000     off
+Ethernet128    128,129,130,131                        etp17a    17       400000     off
+Ethernet132    132,133,134,135                        etp17b    17       400000     off
+Ethernet144    144                                    etp19a    19       100000     off
+Ethernet145    145                                    etp19b    19       100000     off
+Ethernet146    146                                    etp19c    19       100000     off
+Ethernet147    147                                    etp19d    19       100000     off
+Ethernet148    148                                    etp19e    19       100000     off
+Ethernet149    149                                    etp19f    19       100000     off
+Ethernet150    150                                    etp19g    19       100000     off
+Ethernet151    151                                    etp19h    19       100000     off
+Ethernet160    160                                    etp21a    21       100000     off
+Ethernet161    161                                    etp21b    21       100000     off
+Ethernet162    162                                    etp21c    21       100000     off
+Ethernet163    163                                    etp21d    21       100000     off
+Ethernet164    164                                    etp21e    21       100000     off
+Ethernet165    165                                    etp21f    21       100000     off
+Ethernet166    166                                    etp21g    21       100000     off
+Ethernet167    167                                    etp21h    21       100000     off
+Ethernet176    176                                    etp23a    23       100000     off
+Ethernet177    177                                    etp23b    23       100000     off
+Ethernet178    178                                    etp23c    23       100000     off
+Ethernet179    179                                    etp23d    23       100000     off
+Ethernet180    180                                    etp23e    23       100000     off
+Ethernet181    181                                    etp23f    23       100000     off
+Ethernet182    182                                    etp23g    23       100000     off
+Ethernet183    183                                    etp23h    23       100000     off
+Ethernet192    192                                    etp25a    25       100000     off
+Ethernet193    193                                    etp25b    25       100000     off
+Ethernet194    194                                    etp25c    25       100000     off
+Ethernet195    195                                    etp25d    25       100000     off
+Ethernet196    196                                    etp25e    25       100000     off
+Ethernet197    197                                    etp25f    25       100000     off
+Ethernet198    198                                    etp25g    25       100000     off
+Ethernet199    199                                    etp25h    25       100000     off
+Ethernet208    208                                    etp27a    27       100000     off
+Ethernet209    209                                    etp27b    27       100000     off
+Ethernet210    210                                    etp27c    27       100000     off
+Ethernet211    211                                    etp27d    27       100000     off
+Ethernet212    212                                    etp27e    27       100000     off
+Ethernet213    213                                    etp27f    27       100000     off
+Ethernet214    214                                    etp27g    27       100000     off
+Ethernet215    215                                    etp27h    27       100000     off
+Ethernet224    224                                    etp29a    29       100000     off
+Ethernet225    225                                    etp29b    29       100000     off
+Ethernet226    226                                    etp29c    29       100000     off
+Ethernet227    227                                    etp29d    29       100000     off
+Ethernet228    228                                    etp29e    29       100000     off
+Ethernet229    229                                    etp29f    29       100000     off
+Ethernet230    230                                    etp29g    29       100000     off
+Ethernet231    231                                    etp29h    29       100000     off
+Ethernet240    240                                    etp31a    31       100000     off
+Ethernet241    241                                    etp31b    31       100000     off
+Ethernet242    242                                    etp31c    31       100000     off
+Ethernet243    243                                    etp31d    31       100000     off
+Ethernet244    244                                    etp31e    31       100000     off
+Ethernet245    245                                    etp31f    31       100000     off
+Ethernet246    246                                    etp31g    31       100000     off
+Ethernet247    247                                    etp31h    31       100000     off
+Ethernet256    256                                    etp33a    33       100000     off
+Ethernet257    257                                    etp33b    33       100000     off
+Ethernet258    258                                    etp33c    33       100000     off
+Ethernet259    259                                    etp33d    33       100000     off
+Ethernet260    260                                    etp33e    33       100000     off
+Ethernet261    261                                    etp33f    33       100000     off
+Ethernet262    262                                    etp33g    33       100000     off
+Ethernet263    263                                    etp33h    33       100000     off
+Ethernet272    272                                    etp35a    35       100000     off
+Ethernet273    273                                    etp35b    35       100000     off
+Ethernet274    274                                    etp35c    35       100000     off
+Ethernet275    275                                    etp35d    35       100000     off
+Ethernet276    276                                    etp35e    35       100000     off
+Ethernet277    277                                    etp35f    35       100000     off
+Ethernet278    278                                    etp35g    35       100000     off
+Ethernet279    279                                    etp35h    35       100000     off
+Ethernet288    288                                    etp37a    37       100000     off
+Ethernet289    289                                    etp37b    37       100000     off
+Ethernet290    290                                    etp37c    37       100000     off
+Ethernet291    291                                    etp37d    37       100000     off
+Ethernet292    292                                    etp37e    37       100000     off
+Ethernet293    293                                    etp37f    37       100000     off
+Ethernet294    294                                    etp37g    37       100000     off
+Ethernet295    295                                    etp37h    37       100000     off
+Ethernet304    304                                    etp39a    39       100000     off
+Ethernet305    305                                    etp39b    39       100000     off
+Ethernet306    306                                    etp39c    39       100000     off
+Ethernet307    307                                    etp39d    39       100000     off
+Ethernet308    308                                    etp39e    39       100000     off
+Ethernet309    309                                    etp39f    39       100000     off
+Ethernet310    310                                    etp39g    39       100000     off
+Ethernet311    311                                    etp39h    39       100000     off
+Ethernet320    320                                    etp41a    41       100000     off
+Ethernet321    321                                    etp41b    41       100000     off
+Ethernet322    322                                    etp41c    41       100000     off
+Ethernet323    323                                    etp41d    41       100000     off
+Ethernet324    324                                    etp41e    41       100000     off
+Ethernet325    325                                    etp41f    41       100000     off
+Ethernet326    326                                    etp41g    41       100000     off
+Ethernet327    327                                    etp41h    41       100000     off
+Ethernet336    336                                    etp43a    43       100000     off
+Ethernet337    337                                    etp43b    43       100000     off
+Ethernet338    338                                    etp43c    43       100000     off
+Ethernet339    339                                    etp43d    43       100000     off
+Ethernet340    340                                    etp43e    43       100000     off
+Ethernet341    341                                    etp43f    43       100000     off
+Ethernet342    342                                    etp43g    43       100000     off
+Ethernet343    343                                    etp43h    43       100000     off
+Ethernet352    352,353,354,355                        etp45a    45       400000     off
+Ethernet356    356,357,358,359                        etp45b    45       400000     off
+Ethernet368    368                                    etp47a    47       100000     off
+Ethernet369    369                                    etp47b    47       100000     off
+Ethernet370    370                                    etp47c    47       100000     off
+Ethernet371    371                                    etp47d    47       100000     off
+Ethernet372    372                                    etp47e    47       100000     off
+Ethernet373    373                                    etp47f    47       100000     off
+Ethernet374    374                                    etp47g    47       100000     off
+Ethernet375    375                                    etp47h    47       100000     off
+Ethernet384    384,385,386,387                        etp49a    49       400000     off
+Ethernet388    388,389,390,391                        etp49b    49       400000     off
+Ethernet400    400                                    etp51a    51       100000     off
+Ethernet401    401                                    etp51b    51       100000     off
+Ethernet402    402                                    etp51c    51       100000     off
+Ethernet403    403                                    etp51d    51       100000     off
+Ethernet404    404                                    etp51e    51       100000     off
+Ethernet405    405                                    etp51f    51       100000     off
+Ethernet406    406                                    etp51g    51       100000     off
+Ethernet407    407                                    etp51h    51       100000     off
+Ethernet416    416                                    etp53a    53       100000     off
+Ethernet417    417                                    etp53b    53       100000     off
+Ethernet418    418                                    etp53c    53       100000     off
+Ethernet419    419                                    etp53d    53       100000     off
+Ethernet420    420                                    etp53e    53       100000     off
+Ethernet421    421                                    etp53f    53       100000     off
+Ethernet422    422                                    etp53g    53       100000     off
+Ethernet423    423                                    etp53h    53       100000     off
+Ethernet432    432                                    etp55a    55       100000     off
+Ethernet433    433                                    etp55b    55       100000     off
+Ethernet434    434                                    etp55c    55       100000     off
+Ethernet435    435                                    etp55d    55       100000     off
+Ethernet436    436                                    etp55e    55       100000     off
+Ethernet437    437                                    etp55f    55       100000     off
+Ethernet438    438                                    etp55g    55       100000     off
+Ethernet439    439                                    etp55h    55       100000     off
+Ethernet448    448                                    etp57a    57       100000     off
+Ethernet449    449                                    etp57b    57       100000     off
+Ethernet450    450                                    etp57c    57       100000     off
+Ethernet451    451                                    etp57d    57       100000     off
+Ethernet452    452                                    etp57e    57       100000     off
+Ethernet453    453                                    etp57f    57       100000     off
+Ethernet454    454                                    etp57g    57       100000     off
+Ethernet455    455                                    etp57h    57       100000     off
+Ethernet464    464                                    etp59a    59       100000     off
+Ethernet465    465                                    etp59b    59       100000     off
+Ethernet466    466                                    etp59c    59       100000     off
+Ethernet467    467                                    etp59d    59       100000     off
+Ethernet468    468                                    etp59e    59       100000     off
+Ethernet469    469                                    etp59f    59       100000     off
+Ethernet470    470                                    etp59g    59       100000     off
+Ethernet471    471                                    etp59h    59       100000     off
+Ethernet480    480                                    etp61a    61       100000     off
+Ethernet481    481                                    etp61b    61       100000     off
+Ethernet482    482                                    etp61c    61       100000     off
+Ethernet483    483                                    etp61d    61       100000     off
+Ethernet484    484                                    etp61e    61       100000     off
+Ethernet485    485                                    etp61f    61       100000     off
+Ethernet486    486                                    etp61g    61       100000     off
+Ethernet487    487                                    etp61h    61       100000     off
+Ethernet496    496                                    etp63a    63       100000     off
+Ethernet497    497                                    etp63b    63       100000     off
+Ethernet498    498                                    etp63c    63       100000     off
+Ethernet499    499                                    etp63d    63       100000     off
+Ethernet500    500                                    etp63e    63       100000     off
+Ethernet501    501                                    etp63f    63       100000     off
+Ethernet502    502                                    etp63g    63       100000     off
+Ethernet503    503                                    etp63h    63       100000     off
 Ethernet512    512                                    etp65     65        10000
 Ethernet520    520                                    etp66     66        10000

--- a/device/mellanox/x86_64-nvidia_sn5610n-r0/Mellanox-SN5610N-C256S2/port_config.ini
+++ b/device/mellanox/x86_64-nvidia_sn5610n-r0/Mellanox-SN5610N-C256S2/port_config.ini
@@ -1,6 +1,6 @@
 ##
 ## SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-## Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+## Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 ## Apache-2.0
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,262 +16,261 @@
 ## limitations under the License.
 ##
 
-# name         lanes   alias     index    speed      autoneg subport
-Ethernet0      0       etp1a     1        100000     off     1
-Ethernet1      1       etp1b     1        100000     off     2
-Ethernet2      2       etp1c     1        100000     off     3
-Ethernet3      3       etp1d     1        100000     off     4
-Ethernet4      4       etp1e     1        100000     off     5
-Ethernet5      5       etp1f     1        100000     off     6
-Ethernet6      6       etp1g     1        100000     off     7
-Ethernet7      7       etp1h     1        100000     off     8
-Ethernet16     16      etp3a     3        100000     off     1
-Ethernet17     17      etp3b     3        100000     off     2
-Ethernet18     18      etp3c     3        100000     off     3
-Ethernet19     19      etp3d     3        100000     off     4
-Ethernet20     20      etp3e     3        100000     off     5
-Ethernet21     21      etp3f     3        100000     off     6
-Ethernet22     22      etp3g     3        100000     off     7
-Ethernet23     23      etp3h     3        100000     off     8
-Ethernet32     32      etp5a     5        100000     off     1
-Ethernet33     33      etp5b     5        100000     off     2
-Ethernet34     34      etp5c     5        100000     off     3
-Ethernet35     35      etp5d     5        100000     off     4
-Ethernet36     36      etp5e     5        100000     off     5
-Ethernet37     37      etp5f     5        100000     off     6
-Ethernet38     38      etp5g     5        100000     off     7
-Ethernet39     39      etp5h     5        100000     off     8
-Ethernet48     48      etp7a     7        100000     off     1
-Ethernet49     49      etp7b     7        100000     off     2
-Ethernet50     50      etp7c     7        100000     off     3
-Ethernet51     51      etp7d     7        100000     off     4
-Ethernet52     52      etp7e     7        100000     off     5
-Ethernet53     53      etp7f     7        100000     off     6
-Ethernet54     54      etp7g     7        100000     off     7
-Ethernet55     55      etp7h     7        100000     off     8
-Ethernet64     64      etp9a     9        100000     off     1
-Ethernet65     65      etp9b     9        100000     off     2
-Ethernet66     66      etp9c     9        100000     off     3
-Ethernet67     67      etp9d     9        100000     off     4
-Ethernet68     68      etp9e     9        100000     off     5
-Ethernet69     69      etp9f     9        100000     off     6
-Ethernet70     70      etp9g     9        100000     off     7
-Ethernet71     71      etp9h     9        100000     off     8
-Ethernet80     80      etp11a    11       100000     off     1
-Ethernet81     81      etp11b    11       100000     off     2
-Ethernet82     82      etp11c    11       100000     off     3
-Ethernet83     83      etp11d    11       100000     off     4
-Ethernet84     84      etp11e    11       100000     off     5
-Ethernet85     85      etp11f    11       100000     off     6
-Ethernet86     86      etp11g    11       100000     off     7
-Ethernet87     87      etp11h    11       100000     off     8
-Ethernet96     96      etp13a    13       100000     off     1
-Ethernet97     97      etp13b    13       100000     off     2
-Ethernet98     98      etp13c    13       100000     off     3
-Ethernet99     99      etp13d    13       100000     off     4
-Ethernet100    100     etp13e    13       100000     off     5
-Ethernet101    101     etp13f    13       100000     off     6
-Ethernet102    102     etp13g    13       100000     off     7
-Ethernet103    103     etp13h    13       100000     off     8
-Ethernet112    112     etp15a    15       100000     off     1
-Ethernet113    113     etp15b    15       100000     off     2
-Ethernet114    114     etp15c    15       100000     off     3
-Ethernet115    115     etp15d    15       100000     off     4
-Ethernet116    116     etp15e    15       100000     off     5
-Ethernet117    117     etp15f    15       100000     off     6
-Ethernet118    118     etp15g    15       100000     off     7
-Ethernet119    119     etp15h    15       100000     off     8
-Ethernet128    128     etp17a    17       100000     off     1
-Ethernet129    129     etp17b    17       100000     off     2
-Ethernet130    130     etp17c    17       100000     off     3
-Ethernet131    131     etp17d    17       100000     off     4
-Ethernet132    132     etp17e    17       100000     off     5
-Ethernet133    133     etp17f    17       100000     off     6
-Ethernet134    134     etp17g    17       100000     off     7
-Ethernet135    135     etp17h    17       100000     off     8
-Ethernet144    144     etp19a    19       100000     off     1
-Ethernet145    145     etp19b    19       100000     off     2
-Ethernet146    146     etp19c    19       100000     off     3
-Ethernet147    147     etp19d    19       100000     off     4
-Ethernet148    148     etp19e    19       100000     off     5
-Ethernet149    149     etp19f    19       100000     off     6
-Ethernet150    150     etp19g    19       100000     off     7
-Ethernet151    151     etp19h    19       100000     off     8
-Ethernet160    160     etp21a    21       100000     off     1
-Ethernet161    161     etp21b    21       100000     off     2
-Ethernet162    162     etp21c    21       100000     off     3
-Ethernet163    163     etp21d    21       100000     off     4
-Ethernet164    164     etp21e    21       100000     off     5
-Ethernet165    165     etp21f    21       100000     off     6
-Ethernet166    166     etp21g    21       100000     off     7
-Ethernet167    167     etp21h    21       100000     off     8
-Ethernet176    176     etp23a    23       100000     off     1
-Ethernet177    177     etp23b    23       100000     off     2
-Ethernet178    178     etp23c    23       100000     off     3
-Ethernet179    179     etp23d    23       100000     off     4
-Ethernet180    180     etp23e    23       100000     off     5
-Ethernet181    181     etp23f    23       100000     off     6
-Ethernet182    182     etp23g    23       100000     off     7
-Ethernet183    183     etp23h    23       100000     off     8
-Ethernet192    192     etp25a    25       100000     off     1
-Ethernet193    193     etp25b    25       100000     off     2
-Ethernet194    194     etp25c    25       100000     off     3
-Ethernet195    195     etp25d    25       100000     off     4
-Ethernet196    196     etp25e    25       100000     off     5
-Ethernet197    197     etp25f    25       100000     off     6
-Ethernet198    198     etp25g    25       100000     off     7
-Ethernet199    199     etp25h    25       100000     off     8
-Ethernet208    208     etp27a    27       100000     off     1
-Ethernet209    209     etp27b    27       100000     off     2
-Ethernet210    210     etp27c    27       100000     off     3
-Ethernet211    211     etp27d    27       100000     off     4
-Ethernet212    212     etp27e    27       100000     off     5
-Ethernet213    213     etp27f    27       100000     off     6
-Ethernet214    214     etp27g    27       100000     off     7
-Ethernet215    215     etp27h    27       100000     off     8
-Ethernet224    224     etp29a    29       100000     off     1
-Ethernet225    225     etp29b    29       100000     off     2
-Ethernet226    226     etp29c    29       100000     off     3
-Ethernet227    227     etp29d    29       100000     off     4
-Ethernet228    228     etp29e    29       100000     off     5
-Ethernet229    229     etp29f    29       100000     off     6
-Ethernet230    230     etp29g    29       100000     off     7
-Ethernet231    231     etp29h    29       100000     off     8
-Ethernet240    240     etp31a    31       100000     off     1
-Ethernet241    241     etp31b    31       100000     off     2
-Ethernet242    242     etp31c    31       100000     off     3
-Ethernet243    243     etp31d    31       100000     off     4
-Ethernet244    244     etp31e    31       100000     off     5
-Ethernet245    245     etp31f    31       100000     off     6
-Ethernet246    246     etp31g    31       100000     off     7
-Ethernet247    247     etp31h    31       100000     off     8
-Ethernet256    256     etp33a    33       100000     off     1
-Ethernet257    257     etp33b    33       100000     off     2
-Ethernet258    258     etp33c    33       100000     off     3
-Ethernet259    259     etp33d    33       100000     off     4
-Ethernet260    260     etp33e    33       100000     off     5
-Ethernet261    261     etp33f    33       100000     off     6
-Ethernet262    262     etp33g    33       100000     off     7
-Ethernet263    263     etp33h    33       100000     off     8
-Ethernet272    272     etp35a    35       100000     off     1
-Ethernet273    273     etp35b    35       100000     off     2
-Ethernet274    274     etp35c    35       100000     off     3
-Ethernet275    275     etp35d    35       100000     off     4
-Ethernet276    276     etp35e    35       100000     off     5
-Ethernet277    277     etp35f    35       100000     off     6
-Ethernet278    278     etp35g    35       100000     off     7
-Ethernet279    279     etp35h    35       100000     off     8
-Ethernet288    288     etp37a    37       100000     off     1
-Ethernet289    289     etp37b    37       100000     off     2
-Ethernet290    290     etp37c    37       100000     off     3
-Ethernet291    291     etp37d    37       100000     off     4
-Ethernet292    292     etp37e    37       100000     off     5
-Ethernet293    293     etp37f    37       100000     off     6
-Ethernet294    294     etp37g    37       100000     off     7
-Ethernet295    295     etp37h    37       100000     off     8
-Ethernet304    304     etp39a    39       100000     off     1
-Ethernet305    305     etp39b    39       100000     off     2
-Ethernet306    306     etp39c    39       100000     off     3
-Ethernet307    307     etp39d    39       100000     off     4
-Ethernet308    308     etp39e    39       100000     off     5
-Ethernet309    309     etp39f    39       100000     off     6
-Ethernet310    310     etp39g    39       100000     off     7
-Ethernet311    311     etp39h    39       100000     off     8
-Ethernet320    320     etp41a    41       100000     off     1
-Ethernet321    321     etp41b    41       100000     off     2
-Ethernet322    322     etp41c    41       100000     off     3
-Ethernet323    323     etp41d    41       100000     off     4
-Ethernet324    324     etp41e    41       100000     off     5
-Ethernet325    325     etp41f    41       100000     off     6
-Ethernet326    326     etp41g    41       100000     off     7
-Ethernet327    327     etp41h    41       100000     off     8
-Ethernet336    336     etp43a    43       100000     off     1
-Ethernet337    337     etp43b    43       100000     off     2
-Ethernet338    338     etp43c    43       100000     off     3
-Ethernet339    339     etp43d    43       100000     off     4
-Ethernet340    340     etp43e    43       100000     off     5
-Ethernet341    341     etp43f    43       100000     off     6
-Ethernet342    342     etp43g    43       100000     off     7
-Ethernet343    343     etp43h    43       100000     off     8
-Ethernet352    352     etp45a    45       100000     off     1
-Ethernet353    353     etp45b    45       100000     off     2
-Ethernet354    354     etp45c    45       100000     off     3
-Ethernet355    355     etp45d    45       100000     off     4
-Ethernet356    356     etp45e    45       100000     off     5
-Ethernet357    357     etp45f    45       100000     off     6
-Ethernet358    358     etp45g    45       100000     off     7
-Ethernet359    359     etp45h    45       100000     off     8
-Ethernet368    368     etp47a    47       100000     off     1
-Ethernet369    369     etp47b    47       100000     off     2
-Ethernet370    370     etp47c    47       100000     off     3
-Ethernet371    371     etp47d    47       100000     off     4
-Ethernet372    372     etp47e    47       100000     off     5
-Ethernet373    373     etp47f    47       100000     off     6
-Ethernet374    374     etp47g    47       100000     off     7
-Ethernet375    375     etp47h    47       100000     off     8
-Ethernet384    384     etp49a    49       100000     off     1
-Ethernet385    385     etp49b    49       100000     off     2
-Ethernet386    386     etp49c    49       100000     off     3
-Ethernet387    387     etp49d    49       100000     off     4
-Ethernet388    388     etp49e    49       100000     off     5
-Ethernet389    389     etp49f    49       100000     off     6
-Ethernet390    390     etp49g    49       100000     off     7
-Ethernet391    391     etp49h    49       100000     off     8
-Ethernet400    400     etp51a    51       100000     off     1
-Ethernet401    401     etp51b    51       100000     off     2
-Ethernet402    402     etp51c    51       100000     off     3
-Ethernet403    403     etp51d    51       100000     off     4
-Ethernet404    404     etp51e    51       100000     off     5
-Ethernet405    405     etp51f    51       100000     off     6
-Ethernet406    406     etp51g    51       100000     off     7
-Ethernet407    407     etp51h    51       100000     off     8
-Ethernet416    416     etp53a    53       100000     off     1
-Ethernet417    417     etp53b    53       100000     off     2
-Ethernet418    418     etp53c    53       100000     off     3
-Ethernet419    419     etp53d    53       100000     off     4
-Ethernet420    420     etp53e    53       100000     off     5
-Ethernet421    421     etp53f    53       100000     off     6
-Ethernet422    422     etp53g    53       100000     off     7
-Ethernet423    423     etp53h    53       100000     off     8
-Ethernet432    432     etp55a    55       100000     off     1
-Ethernet433    433     etp55b    55       100000     off     2
-Ethernet434    434     etp55c    55       100000     off     3
-Ethernet435    435     etp55d    55       100000     off     4
-Ethernet436    436     etp55e    55       100000     off     5
-Ethernet437    437     etp55f    55       100000     off     6
-Ethernet438    438     etp55g    55       100000     off     7
-Ethernet439    439     etp55h    55       100000     off     8
-Ethernet448    448     etp57a    57       100000     off     1
-Ethernet449    449     etp57b    57       100000     off     2
-Ethernet450    450     etp57c    57       100000     off     3
-Ethernet451    451     etp57d    57       100000     off     4
-Ethernet452    452     etp57e    57       100000     off     5
-Ethernet453    453     etp57f    57       100000     off     6
-Ethernet454    454     etp57g    57       100000     off     7
-Ethernet455    455     etp57h    57       100000     off     8
-Ethernet464    464     etp59a    59       100000     off     1
-Ethernet465    465     etp59b    59       100000     off     2
-Ethernet466    466     etp59c    59       100000     off     3
-Ethernet467    467     etp59d    59       100000     off     4
-Ethernet468    468     etp59e    59       100000     off     5
-Ethernet469    469     etp59f    59       100000     off     6
-Ethernet470    470     etp59g    59       100000     off     7
-Ethernet471    471     etp59h    59       100000     off     8
-Ethernet480    480     etp61a    61       100000     off     1
-Ethernet481    481     etp61b    61       100000     off     2
-Ethernet482    482     etp61c    61       100000     off     3
-Ethernet483    483     etp61d    61       100000     off     4
-Ethernet484    484     etp61e    61       100000     off     5
-Ethernet485    485     etp61f    61       100000     off     6
-Ethernet486    486     etp61g    61       100000     off     7
-Ethernet487    487     etp61h    61       100000     off     8
-Ethernet496    496     etp63a    63       100000     off     1
-Ethernet497    497     etp63b    63       100000     off     2
-Ethernet498    498     etp63c    63       100000     off     3
-Ethernet499    499     etp63d    63       100000     off     4
-Ethernet500    500     etp63e    63       100000     off     5
-Ethernet501    501     etp63f    63       100000     off     6
-Ethernet502    502     etp63g    63       100000     off     7
-Ethernet503    503     etp63h    63       100000     off     8
+# name         lanes   alias     index    speed      autthernet0      0       etp1a     1        100000     off
+Ethernet1      1       etp1b     1        100000     off
+Ethernet2      2       etp1c     1        100000     off
+Ethernet3      3       etp1d     1        100000     off
+Ethernet4      4       etp1e     1        100000     off
+Ethernet5      5       etp1f     1        100000     off
+Ethernet6      6       etp1g     1        100000     off
+Ethernet7      7       etp1h     1        100000     off
+Ethernet16     16      etp3a     3        100000     off
+Ethernet17     17      etp3b     3        100000     off
+Ethernet18     18      etp3c     3        100000     off
+Ethernet19     19      etp3d     3        100000     off
+Ethernet20     20      etp3e     3        100000     off
+Ethernet21     21      etp3f     3        100000     off
+Ethernet22     22      etp3g     3        100000     off
+Ethernet23     23      etp3h     3        100000     off
+Ethernet32     32      etp5a     5        100000     off
+Ethernet33     33      etp5b     5        100000     off
+Ethernet34     34      etp5c     5        100000     off
+Ethernet35     35      etp5d     5        100000     off
+Ethernet36     36      etp5e     5        100000     off
+Ethernet37     37      etp5f     5        100000     off
+Ethernet38     38      etp5g     5        100000     off
+Ethernet39     39      etp5h     5        100000     off
+Ethernet48     48      etp7a     7        100000     off
+Ethernet49     49      etp7b     7        100000     off
+Ethernet50     50      etp7c     7        100000     off
+Ethernet51     51      etp7d     7        100000     off
+Ethernet52     52      etp7e     7        100000     off
+Ethernet53     53      etp7f     7        100000     off
+Ethernet54     54      etp7g     7        100000     off
+Ethernet55     55      etp7h     7        100000     off
+Ethernet64     64      etp9a     9        100000     off
+Ethernet65     65      etp9b     9        100000     off
+Ethernet66     66      etp9c     9        100000     off
+Ethernet67     67      etp9d     9        100000     off
+Ethernet68     68      etp9e     9        100000     off
+Ethernet69     69      etp9f     9        100000     off
+Ethernet70     70      etp9g     9        100000     off
+Ethernet71     71      etp9h     9        100000     off
+Ethernet80     80      etp11a    11       100000     off
+Ethernet81     81      etp11b    11       100000     off
+Ethernet82     82      etp11c    11       100000     off
+Ethernet83     83      etp11d    11       100000     off
+Ethernet84     84      etp11e    11       100000     off
+Ethernet85     85      etp11f    11       100000     off
+Ethernet86     86      etp11g    11       100000     off
+Ethernet87     87      etp11h    11       100000     off
+Ethernet96     96      etp13a    13       100000     off
+Ethernet97     97      etp13b    13       100000     off
+Ethernet98     98      etp13c    13       100000     off
+Ethernet99     99      etp13d    13       100000     off
+Ethernet100    100     etp13e    13       100000     off
+Ethernet101    101     etp13f    13       100000     off
+Ethernet102    102     etp13g    13       100000     off
+Ethernet103    103     etp13h    13       100000     off
+Ethernet112    112     etp15a    15       100000     off
+Ethernet113    113     etp15b    15       100000     off
+Ethernet114    114     etp15c    15       100000     off
+Ethernet115    115     etp15d    15       100000     off
+Ethernet116    116     etp15e    15       100000     off
+Ethernet117    117     etp15f    15       100000     off
+Ethernet118    118     etp15g    15       100000     off
+Ethernet119    119     etp15h    15       100000     off
+Ethernet128    128     etp17a    17       100000     off
+Ethernet129    129     etp17b    17       100000     off
+Ethernet130    130     etp17c    17       100000     off
+Ethernet131    131     etp17d    17       100000     off
+Ethernet132    132     etp17e    17       100000     off
+Ethernet133    133     etp17f    17       100000     off
+Ethernet134    134     etp17g    17       100000     off
+Ethernet135    135     etp17h    17       100000     off
+Ethernet144    144     etp19a    19       100000     off
+Ethernet145    145     etp19b    19       100000     off
+Ethernet146    146     etp19c    19       100000     off
+Ethernet147    147     etp19d    19       100000     off
+Ethernet148    148     etp19e    19       100000     off
+Ethernet149    149     etp19f    19       100000     off
+Ethernet150    150     etp19g    19       100000     off
+Ethernet151    151     etp19h    19       100000     off
+Ethernet160    160     etp21a    21       100000     off
+Ethernet161    161     etp21b    21       100000     off
+Ethernet162    162     etp21c    21       100000     off
+Ethernet163    163     etp21d    21       100000     off
+Ethernet164    164     etp21e    21       100000     off
+Ethernet165    165     etp21f    21       100000     off
+Ethernet166    166     etp21g    21       100000     off
+Ethernet167    167     etp21h    21       100000     off
+Ethernet176    176     etp23a    23       100000     off
+Ethernet177    177     etp23b    23       100000     off
+Ethernet178    178     etp23c    23       100000     off
+Ethernet179    179     etp23d    23       100000     off
+Ethernet180    180     etp23e    23       100000     off
+Ethernet181    181     etp23f    23       100000     off
+Ethernet182    182     etp23g    23       100000     off
+Ethernet183    183     etp23h    23       100000     off
+Ethernet192    192     etp25a    25       100000     off
+Ethernet193    193     etp25b    25       100000     off
+Ethernet194    194     etp25c    25       100000     off
+Ethernet195    195     etp25d    25       100000     off
+Ethernet196    196     etp25e    25       100000     off
+Ethernet197    197     etp25f    25       100000     off
+Ethernet198    198     etp25g    25       100000     off
+Ethernet199    199     etp25h    25       100000     off
+Ethernet208    208     etp27a    27       100000     off
+Ethernet209    209     etp27b    27       100000     off
+Ethernet210    210     etp27c    27       100000     off
+Ethernet211    211     etp27d    27       100000     off
+Ethernet212    212     etp27e    27       100000     off
+Ethernet213    213     etp27f    27       100000     off
+Ethernet214    214     etp27g    27       100000     off
+Ethernet215    215     etp27h    27       100000     off
+Ethernet224    224     etp29a    29       100000     off
+Ethernet225    225     etp29b    29       100000     off
+Ethernet226    226     etp29c    29       100000     off
+Ethernet227    227     etp29d    29       100000     off
+Ethernet228    228     etp29e    29       100000     off
+Ethernet229    229     etp29f    29       100000     off
+Ethernet230    230     etp29g    29       100000     off
+Ethernet231    231     etp29h    29       100000     off
+Ethernet240    240     etp31a    31       100000     off
+Ethernet241    241     etp31b    31       100000     off
+Ethernet242    242     etp31c    31       100000     off
+Ethernet243    243     etp31d    31       100000     off
+Ethernet244    244     etp31e    31       100000     off
+Ethernet245    245     etp31f    31       100000     off
+Ethernet246    246     etp31g    31       100000     off
+Ethernet247    247     etp31h    31       100000     off
+Ethernet256    256     etp33a    33       100000     off
+Ethernet257    257     etp33b    33       100000     off
+Ethernet258    258     etp33c    33       100000     off
+Ethernet259    259     etp33d    33       100000     off
+Ethernet260    260     etp33e    33       100000     off
+Ethernet261    261     etp33f    33       100000     off
+Ethernet262    262     etp33g    33       100000     off
+Ethernet263    263     etp33h    33       100000     off
+Ethernet272    272     etp35a    35       100000     off
+Ethernet273    273     etp35b    35       100000     off
+Ethernet274    274     etp35c    35       100000     off
+Ethernet275    275     etp35d    35       100000     off
+Ethernet276    276     etp35e    35       100000     off
+Ethernet277    277     etp35f    35       100000     off
+Ethernet278    278     etp35g    35       100000     off
+Ethernet279    279     etp35h    35       100000     off
+Ethernet288    288     etp37a    37       100000     off
+Ethernet289    289     etp37b    37       100000     off
+Ethernet290    290     etp37c    37       100000     off
+Ethernet291    291     etp37d    37       100000     off
+Ethernet292    292     etp37e    37       100000     off
+Ethernet293    293     etp37f    37       100000     off
+Ethernet294    294     etp37g    37       100000     off
+Ethernet295    295     etp37h    37       100000     off
+Ethernet304    304     etp39a    39       100000     off
+Ethernet305    305     etp39b    39       100000     off
+Ethernet306    306     etp39c    39       100000     off
+Ethernet307    307     etp39d    39       100000     off
+Ethernet308    308     etp39e    39       100000     off
+Ethernet309    309     etp39f    39       100000     off
+Ethernet310    310     etp39g    39       100000     off
+Ethernet311    311     etp39h    39       100000     off
+Ethernet320    320     etp41a    41       100000     off
+Ethernet321    321     etp41b    41       100000     off
+Ethernet322    322     etp41c    41       100000     off
+Ethernet323    323     etp41d    41       100000     off
+Ethernet324    324     etp41e    41       100000     off
+Ethernet325    325     etp41f    41       100000     off
+Ethernet326    326     etp41g    41       100000     off
+Ethernet327    327     etp41h    41       100000     off
+Ethernet336    336     etp43a    43       100000     off
+Ethernet337    337     etp43b    43       100000     off
+Ethernet338    338     etp43c    43       100000     off
+Ethernet339    339     etp43d    43       100000     off
+Ethernet340    340     etp43e    43       100000     off
+Ethernet341    341     etp43f    43       100000     off
+Ethernet342    342     etp43g    43       100000     off
+Ethernet343    343     etp43h    43       100000     off
+Ethernet352    352     etp45a    45       100000     off
+Ethernet353    353     etp45b    45       100000     off
+Ethernet354    354     etp45c    45       100000     off
+Ethernet355    355     etp45d    45       100000     off
+Ethernet356    356     etp45e    45       100000     off
+Ethernet357    357     etp45f    45       100000     off
+Ethernet358    358     etp45g    45       100000     off
+Ethernet359    359     etp45h    45       100000     off
+Ethernet368    368     etp47a    47       100000     off
+Ethernet369    369     etp47b    47       100000     off
+Ethernet370    370     etp47c    47       100000     off
+Ethernet371    371     etp47d    47       100000     off
+Ethernet372    372     etp47e    47       100000     off
+Ethernet373    373     etp47f    47       100000     off
+Ethernet374    374     etp47g    47       100000     off
+Ethernet375    375     etp47h    47       100000     off
+Ethernet384    384     etp49a    49       100000     off
+Ethernet385    385     etp49b    49       100000     off
+Ethernet386    386     etp49c    49       100000     off
+Ethernet387    387     etp49d    49       100000     off
+Ethernet388    388     etp49e    49       100000     off
+Ethernet389    389     etp49f    49       100000     off
+Ethernet390    390     etp49g    49       100000     off
+Ethernet391    391     etp49h    49       100000     off
+Ethernet400    400     etp51a    51       100000     off
+Ethernet401    401     etp51b    51       100000     off
+Ethernet402    402     etp51c    51       100000     off
+Ethernet403    403     etp51d    51       100000     off
+Ethernet404    404     etp51e    51       100000     off
+Ethernet405    405     etp51f    51       100000     off
+Ethernet406    406     etp51g    51       100000     off
+Ethernet407    407     etp51h    51       100000     off
+Ethernet416    416     etp53a    53       100000     off
+Ethernet417    417     etp53b    53       100000     off
+Ethernet418    418     etp53c    53       100000     off
+Ethernet419    419     etp53d    53       100000     off
+Ethernet420    420     etp53e    53       100000     off
+Ethernet421    421     etp53f    53       100000     off
+Ethernet422    422     etp53g    53       100000     off
+Ethernet423    423     etp53h    53       100000     off
+Ethernet432    432     etp55a    55       100000     off
+Ethernet433    433     etp55b    55       100000     off
+Ethernet434    434     etp55c    55       100000     off
+Ethernet435    435     etp55d    55       100000     off
+Ethernet436    436     etp55e    55       100000     off
+Ethernet437    437     etp55f    55       100000     off
+Ethernet438    438     etp55g    55       100000     off
+Ethernet439    439     etp55h    55       100000     off
+Ethernet448    448     etp57a    57       100000     off
+Ethernet449    449     etp57b    57       100000     off
+Ethernet450    450     etp57c    57       100000     off
+Ethernet451    451     etp57d    57       100000     off
+Ethernet452    452     etp57e    57       100000     off
+Ethernet453    453     etp57f    57       100000     off
+Ethernet454    454     etp57g    57       100000     off
+Ethernet455    455     etp57h    57       100000     off
+Ethernet464    464     etp59a    59       100000     off
+Ethernet465    465     etp59b    59       100000     off
+Ethernet466    466     etp59c    59       100000     off
+Ethernet467    467     etp59d    59       100000     off
+Ethernet468    468     etp59e    59       100000     off
+Ethernet469    469     etp59f    59       100000     off
+Ethernet470    470     etp59g    59       100000     off
+Ethernet471    471     etp59h    59       100000     off
+Ethernet480    480     etp61a    61       100000     off
+Ethernet481    481     etp61b    61       100000     off
+Ethernet482    482     etp61c    61       100000     off
+Ethernet483    483     etp61d    61       100000     off
+Ethernet484    484     etp61e    61       100000     off
+Ethernet485    485     etp61f    61       100000     off
+Ethernet486    486     etp61g    61       100000     off
+Ethernet487    487     etp61h    61       100000     off
+Ethernet496    496     etp63a    63       100000     off
+Ethernet497    497     etp63b    63       100000     off
+Ethernet498    498     etp63c    63       100000     off
+Ethernet499    499     etp63d    63       100000     off
+Ethernet500    500     etp63e    63       100000     off
+Ethernet501    501     etp63f    63       100000     off
+Ethernet502    502     etp63g    63       100000     off
+Ethernet503    503     etp63h    63       100000     off
 Ethernet512    512     etp65     65        10000
 Ethernet520    520     etp66     66        10000

--- a/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C448O16/hwsku.json
+++ b/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C448O16/hwsku.json
@@ -2,2322 +2,1858 @@
     "interfaces": {
         "Ethernet0": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet1": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet2": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet3": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet4": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet5": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet6": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet7": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet8": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet9": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet10": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet11": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet12": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet13": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet14": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet15": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet16": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet17": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet18": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet19": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet20": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet21": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet22": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet23": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet24": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet25": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet26": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet27": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet28": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet29": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet30": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet31": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet32": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet33": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet34": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet35": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet36": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet37": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet38": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet39": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet40": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet41": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet42": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet43": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet44": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet45": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet46": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet47": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet48": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet49": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet50": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet51": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet52": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet53": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet54": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet55": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet56": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet57": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet58": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet59": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet60": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet61": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet62": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet63": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet64": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet65": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet66": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet67": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet68": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet69": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet70": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet71": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet72": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet73": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet74": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet75": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet76": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet77": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet78": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet79": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet80": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet81": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet82": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet83": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet84": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet85": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet86": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet87": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet88": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet89": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet90": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet91": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet92": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet93": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet94": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet95": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet96": {
             "default_brkout_mode": "2x400G[200G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet100": {
             "default_brkout_mode": "2x400G[200G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet104": {
             "default_brkout_mode": "2x400G[200G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet108": {
             "default_brkout_mode": "2x400G[200G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet112": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet113": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet114": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet115": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet116": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet117": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet118": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet119": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet120": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet121": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet122": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet123": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet124": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet125": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet126": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet127": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet128": {
             "default_brkout_mode": "2x400G[200G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet132": {
             "default_brkout_mode": "2x400G[200G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet136": {
             "default_brkout_mode": "2x400G[200G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet140": {
             "default_brkout_mode": "2x400G[200G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet144": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet145": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet146": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet147": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet148": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet149": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet150": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet151": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet152": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet153": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet154": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet155": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet156": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet157": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet158": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet159": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet160": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet161": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet162": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet163": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet164": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet165": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet166": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet167": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet168": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet169": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet170": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet171": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet172": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet173": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet174": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet175": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet176": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet177": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet178": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet179": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet180": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet181": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet182": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet183": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet184": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet185": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet186": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet187": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet188": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet189": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet190": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet191": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet192": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet193": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet194": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet195": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet196": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet197": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet198": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet199": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet200": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet201": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet202": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet203": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet204": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet205": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet206": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet207": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet208": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet209": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet210": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet211": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet212": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet213": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet214": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet215": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet216": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet217": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet218": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet219": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet220": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet221": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet222": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet223": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet224": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet225": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet226": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet227": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet228": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet229": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet230": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet231": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet232": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet233": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet234": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet235": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet236": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet237": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet238": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet239": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet240": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet241": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet242": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet243": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet244": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet245": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet246": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet247": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet248": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet249": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet250": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet251": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet252": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet253": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet254": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet255": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet256": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet257": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet258": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet259": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet260": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet261": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet262": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet263": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet264": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet265": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet266": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet267": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet268": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet269": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet270": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet271": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet272": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet273": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet274": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet275": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet276": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet277": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet278": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet279": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet280": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet281": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet282": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet283": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet284": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet285": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet286": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet287": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet288": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet289": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet290": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet291": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet292": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet293": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet294": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet295": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet296": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet297": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet298": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet299": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet300": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet301": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet302": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet303": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet304": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet305": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet306": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet307": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet308": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet309": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet310": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet311": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet312": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet313": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet314": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet315": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet316": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet317": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet318": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet319": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet320": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet321": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet322": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet323": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet324": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet325": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet326": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet327": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet328": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet329": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet330": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet331": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet332": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet333": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet334": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet335": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet336": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet337": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet338": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet339": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet340": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet341": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet342": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet343": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet344": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet345": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet346": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet347": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet348": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet349": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet350": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet351": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet352": {
             "default_brkout_mode": "2x400G[200G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet356": {
             "default_brkout_mode": "2x400G[200G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet360": {
             "default_brkout_mode": "2x400G[200G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet364": {
             "default_brkout_mode": "2x400G[200G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet368": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet369": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet370": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet371": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet372": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet373": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet374": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet375": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet376": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet377": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet378": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet379": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet380": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet381": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet382": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet383": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet384": {
             "default_brkout_mode": "2x400G[200G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet388": {
             "default_brkout_mode": "2x400G[200G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet392": {
             "default_brkout_mode": "2x400G[200G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet396": {
             "default_brkout_mode": "2x400G[200G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet400": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet401": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet402": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet403": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet404": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet405": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet406": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet407": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet408": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet409": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet410": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet411": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet412": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet413": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet414": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet415": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet416": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet417": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet418": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet419": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet420": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet421": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet422": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet423": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet424": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet425": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet426": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet427": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet428": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet429": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet430": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet431": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet432": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet433": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet434": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet435": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet436": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet437": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet438": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet439": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet440": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet441": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet442": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet443": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet444": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet445": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet446": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet447": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet448": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet449": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet450": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet451": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet452": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet453": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet454": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet455": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet456": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet457": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet458": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet459": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet460": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet461": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet462": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet463": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet464": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet465": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet466": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet467": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet468": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet469": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet470": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet471": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet472": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet473": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet474": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet475": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet476": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet477": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet478": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet479": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet480": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet481": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet482": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet483": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet484": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet485": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet486": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet487": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet488": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet489": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet490": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet491": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet492": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet493": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet494": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet495": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet496": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet497": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet498": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet499": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet500": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet501": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet502": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet503": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet504": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet505": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet506": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet507": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet508": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet509": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet510": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet511": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet512": {

--- a/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C512S2/hwsku.json
+++ b/device/mellanox/x86_64-nvidia_sn5640-r0/Mellanox-SN5640-C512S2/hwsku.json
@@ -2,2562 +2,2050 @@
     "interfaces": {
         "Ethernet0": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet1": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet2": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet3": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet4": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet5": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet6": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet7": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet8": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet9": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet10": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet11": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet12": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet13": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet14": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet15": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet16": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet17": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet18": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet19": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet20": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet21": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet22": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet23": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet24": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet25": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet26": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet27": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet28": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet29": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet30": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet31": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet32": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet33": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet34": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet35": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet36": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet37": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet38": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet39": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet40": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet41": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet42": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet43": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet44": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet45": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet46": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet47": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet48": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet49": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet50": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet51": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet52": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet53": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet54": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet55": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet56": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet57": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet58": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet59": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet60": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet61": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet62": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet63": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet64": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet65": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet66": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet67": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet68": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet69": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet70": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet71": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet72": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet73": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet74": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet75": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet76": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet77": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet78": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet79": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet80": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet81": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet82": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet83": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet84": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet85": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet86": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet87": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet88": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet89": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet90": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet91": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet92": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet93": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet94": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet95": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet96": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet97": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet98": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet99": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet100": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet101": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet102": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet103": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet104": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet105": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet106": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet107": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet108": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet109": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet110": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet111": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet112": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet113": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet114": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet115": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet116": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet117": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet118": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet119": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet120": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet121": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet122": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet123": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet124": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet125": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet126": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet127": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet128": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet129": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet130": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet131": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet132": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet133": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet134": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet135": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet136": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet137": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet138": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet139": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet140": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet141": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet142": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet143": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet144": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet145": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet146": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet147": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet148": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet149": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet150": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet151": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet152": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet153": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet154": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet155": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet156": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet157": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet158": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet159": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet160": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet161": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet162": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet163": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet164": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet165": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet166": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet167": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet168": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet169": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet170": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet171": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet172": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet173": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet174": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet175": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet176": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet177": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet178": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet179": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet180": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet181": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet182": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet183": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet184": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet185": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet186": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet187": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet188": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet189": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet190": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet191": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet192": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet193": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet194": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet195": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet196": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet197": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet198": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet199": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet200": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet201": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet202": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet203": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet204": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet205": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet206": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet207": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet208": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet209": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet210": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet211": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet212": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet213": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet214": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet215": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet216": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet217": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet218": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet219": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet220": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet221": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet222": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet223": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet224": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet225": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet226": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet227": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet228": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet229": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet230": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet231": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet232": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet233": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet234": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet235": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet236": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet237": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet238": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet239": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet240": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet241": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet242": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet243": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet244": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet245": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet246": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet247": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet248": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet249": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet250": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet251": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet252": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet253": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet254": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet255": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet256": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet257": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet258": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet259": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet260": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet261": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet262": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet263": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet264": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet265": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet266": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet267": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet268": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet269": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet270": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet271": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet272": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet273": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet274": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet275": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet276": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet277": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet278": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet279": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet280": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet281": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet282": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet283": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet284": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet285": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet286": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet287": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet288": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet289": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet290": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet291": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet292": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet293": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet294": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet295": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet296": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet297": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet298": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet299": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet300": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet301": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet302": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet303": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet304": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet305": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet306": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet307": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet308": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet309": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet310": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet311": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet312": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet313": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet314": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet315": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet316": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet317": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet318": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet319": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet320": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet321": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet322": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet323": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet324": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet325": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet326": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet327": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet328": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet329": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet330": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet331": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet332": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet333": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet334": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet335": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet336": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet337": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet338": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet339": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet340": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet341": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet342": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet343": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet344": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet345": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet346": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet347": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet348": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet349": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet350": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet351": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet352": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet353": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet354": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet355": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet356": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet357": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet358": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet359": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet360": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet361": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet362": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet363": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet364": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet365": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet366": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet367": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet368": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet369": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet370": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet371": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet372": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet373": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet374": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet375": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet376": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet377": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet378": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet379": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet380": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet381": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet382": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet383": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet384": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet385": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet386": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet387": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet388": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet389": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet390": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet391": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet392": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet393": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet394": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet395": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet396": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet397": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet398": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet399": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet400": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet401": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet402": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet403": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet404": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet405": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet406": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet407": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet408": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet409": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet410": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet411": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet412": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet413": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet414": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet415": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet416": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet417": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet418": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet419": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet420": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet421": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet422": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet423": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet424": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet425": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet426": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet427": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet428": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet429": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet430": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet431": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet432": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet433": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet434": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet435": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet436": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet437": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet438": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet439": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet440": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet441": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet442": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet443": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet444": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet445": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet446": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet447": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet448": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet449": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet450": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet451": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet452": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet453": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet454": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet455": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet456": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet457": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet458": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet459": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet460": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet461": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet462": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet463": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet464": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet465": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet466": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet467": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet468": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet469": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet470": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet471": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet472": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet473": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet474": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet475": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet476": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet477": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet478": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet479": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet480": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet481": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet482": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet483": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet484": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet485": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet486": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet487": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet488": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet489": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet490": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet491": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet492": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet493": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet494": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet495": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet496": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet497": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet498": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet499": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet500": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet501": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet502": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet503": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet504": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "1",
             "autoneg": "off"
         },
         "Ethernet505": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "2",
             "autoneg": "off"
         },
         "Ethernet506": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet507": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "4",
             "autoneg": "off"
         },
         "Ethernet508": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "5",
             "autoneg": "off"
         },
         "Ethernet509": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "6",
             "autoneg": "off"
         },
         "Ethernet510": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "7",
             "autoneg": "off"
         },
         "Ethernet511": {
             "default_brkout_mode": "8x100G[50G]",
-            "subport": "8",
             "autoneg": "off"
         },
         "Ethernet512": {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Since SONiC already generates subport field automatically, we don't need hard-coded subport.

#### How I did it
Remove hard coded subport field

#### How to verify it
- sonic-2-sonic installation
- clean installation
- deploy minigraph
- sonic-cfggen upgarde HwSKU

in each of the above, make sure subport is generated properly. 
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

