### PR TITLE
marvell-prestera warmboot master sync from 202511

### DIFF
--- a/platform/marvell-prestera/docker-saiserver-mrvl-prestera.mk
+++ b/platform/marvell-prestera/docker-saiserver-mrvl-prestera.mk
@@ -12,3 +12,4 @@ $(DOCKER_SAISERVER_MRVL)_RUN_OPT += --privileged -t
 $(DOCKER_SAISERVER_MRVL)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SAISERVER_MRVL)_RUN_OPT += -v /var/run/docker-saiserver:/var/run/sswsyncd
 $(DOCKER_SAISERVER_MRVL)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
+$(DOCKER_SAISERVER_MRVL)_RUN_OPT += -v /host/warmboot:/var/warmboot

--- a/platform/marvell-prestera/docker-syncd-mrvl-prestera-rpc.mk
+++ b/platform/marvell-prestera/docker-syncd-mrvl-prestera-rpc.mk
@@ -23,5 +23,6 @@ $(DOCKER_SYNCD_MRVL_RPC)_MACHINE = marvell-prestera
 $(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += --privileged -t
 $(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
+$(DOCKER_SYNCD_MRVL_RPC)_RUN_OPT += -v /host/warmboot:/var/warmboot
 
 SONIC_BOOKWORM_DOCKERS += $(DOCKER_SYNCD_MRVL_RPC)

--- a/platform/marvell-prestera/docker-syncd-mrvl-prestera.mk
+++ b/platform/marvell-prestera/docker-syncd-mrvl-prestera.mk
@@ -15,3 +15,4 @@ $(DOCKER_SYNCD_BASE)_VERSION = 1.0.0
 $(DOCKER_SYNCD_BASE)_PACKAGE_NAME = syncd
 $(DOCKER_SYNCD_BASE)_MACHINE = marvell-prestera
 
+$(DOCKER_SYNCD_BASE)_RUN_OPT += -v /host/warmboot:/var/warmboot


### PR DESCRIPTION
#### Why I did it
platform/marvell-prestera have loss
$(DOCKER_SAISERVER_MRVL)_RUN_OPT += -v /host/warmboot:/var/warmboot
on the <master> branch vs the <202511> having this declaration.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add/Sync the line into platform/marvell-prestera/docker-*-mrvl-prestera.mk

#### How to verify it
na

#### Which release branch to backport (provide reason below if selected)
NO backport (the problem and fix is on <master> ONLY)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)
na

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
#### Link to config_db schema for YANG module changes
#### A picture of a cute animal (not mandatory but encouraged)

