### PR TITLE
possibility to enable INCLUDE_ICCPD over env

### DIFF
--- a/rules/config
+++ b/rules/config
@@ -169,7 +169,7 @@ INCLUDE_SYSTEM_TELEMETRY = n
 INCLUDE_SYSTEM_OTEL = y
 
 # INCLUDE_ICCPD - build docker-iccpd for mclag support
-INCLUDE_ICCPD = n
+INCLUDE_ICCPD ?= n
 
 # INCLUDE_SFLOW - build docker-sflow for sFlow support
 INCLUDE_SFLOW = y


### PR DESCRIPTION
#### Why I did it
Customers want enable feature INCLUDE_ICCPD, but it is "hardcoded" =n
This patch gives possibility to build image with INCLUDE_ICCPD=y over shell-environment variable

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Keep default 'n', but use INCLUDE_ICCPD ?= n

#### How to verify it
Build with  "INCLUDE_ICCPD=y make ..." and check INCLUDE_ICCPD=y in configuration report.

#### Which release branch to backport (provide reason below if selected)
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202505
- [X] 202511

#### Tested branch (Please provide the tested image version)
#### Description for the changelog
#### Link to config_db schema for YANG module changes
#### A picture of a cute animal (not mandatory but encouraged)
