### PR TITLE
Fix DNS in containers by preserving resolv.conf symlink during image …

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -891,8 +891,6 @@ sudo mkdir -p $FILESYSTEM_ROOT/var/lib/docker
 ## Clear DNS configuration inherited from the build server
 sudo rm -f $FILESYSTEM_ROOT/etc/resolvconf/resolv.conf.d/original
 sudo cp files/image_config/resolv-config/resolv.conf.head $FILESYSTEM_ROOT/etc/resolvconf/resolv.conf.d/head
-sudo rm -f $FILESYSTEM_ROOT/etc/resolv.conf
-sudo touch $FILESYSTEM_ROOT/etc/resolv.conf
 
 ## Optimize filesystem size
 if [ "$BUILD_REDUCE_IMAGE_SIZE" = "y" ]; then


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->


#### Dependency
This PR depends on https://github.com/sonic-net/sonic-utilities/pull/4365. The other PR should be merged first before this one can be merged.

#### Why I did it

After installing SONiC 202511 from ONIE, 10 out of 15 docker containers have empty `/etc/resolv.conf` and no DNS resolution. This is a regression from 202412.

The Trixie base image upgrade introduced two lines in `build_debian.sh` that destroy the `/etc/resolv.conf` symlink (created by the `resolvconf` package) and replace it with a regular empty file:

```bash
sudo rm -f $FILESYSTEM_ROOT/etc/resolv.conf
sudo touch $FILESYSTEM_ROOT/etc/resolv.conf
```

This breaks the DNS propagation chain to docker containers because `/etc/resolvconf/update.d/libc` checks whether `/etc/resolv.conf` is a symlink to `/run/resolvconf/resolv.conf` before notifying downstream consumers (including `update-libc.d/update-containers`). When the symlink is missing, DHCP-obtained DNS is never propagated to containers.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Replaced `sudo touch` with `sudo ln -sf /run/resolvconf/resolv.conf` to preserve the symlink that the `resolvconf` package expects:

```bash
sudo rm -f $FILESYSTEM_ROOT/etc/resolv.conf
sudo ln -sf /run/resolvconf/resolv.conf $FILESYSTEM_ROOT/etc/resolv.conf
```

This is consistent with what `resolv-config.sh` does at runtime (`ln -sf /run/resolvconf/resolv.conf /etc/resolv.conf`) and matches the behavior of all SONiC releases prior to 202511.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->


1. Install from ONIE on a switch
2. After boot, verify:
   ```bash
   # Host resolv.conf should be a symlink
   ls -la /etc/resolv.conf
   # Expected: /etc/resolv.conf -> /run/resolvconf/resolv.conf

   # All containers should have DNS
   for c in $(docker ps --format '{{.Names}}'); do
     echo "=== $c ==="
     docker exec $c cat /etc/resolv.conf
   done
   ```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

