### PR TITLE
Fix APT warning about debian.sources.back invalid filename extension

### DIFF
--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -123,13 +123,14 @@ set_reproducible_mirrors()
         expression2="/^#*deb.*$REPR_MIRROR_URL_PATTERN/! s/^#\s*(#*deb)/\1/"
         expression3="/#SET_REPR_MIRRORS/d"
     fi
-    # Move debian.sources to /tmp to avoid APT warnings about invalid filename extension
+    # Move debian.sources out of sources.list.d/ to avoid APT warnings about invalid filename extension
     # APT only recognizes files with .list or .sources extensions in sources.list.d/
+    # Using /etc/apt/ (root-owned directory) instead of /tmp for security
     if [[ "$1" != "-d" ]] && [ -f /etc/apt/sources.list.d/debian.sources ]; then
-        $SUDO mv /etc/apt/sources.list.d/debian.sources /tmp/debian.sources.disabled
+        $SUDO mv /etc/apt/sources.list.d/debian.sources /etc/apt/debian.sources.disabled
     fi
-    if [[ "$1" == "-d" ]] && [ -f /tmp/debian.sources.disabled ]; then
-        $SUDO mv /tmp/debian.sources.disabled /etc/apt/sources.list.d/debian.sources
+    if [[ "$1" == "-d" ]] && [ -f /etc/apt/debian.sources.disabled ]; then
+        $SUDO mv /etc/apt/debian.sources.disabled /etc/apt/sources.list.d/debian.sources
     fi
 
     local mirrors="/etc/apt/sources.list $(find /etc/apt/sources.list.d/ -type f)"


### PR DESCRIPTION
### Description
This PR fixes issue #25969 where APT repeatedly warns about 'debian.sources.back' having an invalid filename extension during builds.

### Problem
The `buildinfo_base.sh` script temporarily renames `/etc/apt/sources.list.d/debian.sources` to `debian.sources.back` to disable it during reproducible mirror setup. However, APT scans all files in `sources.list.d/` and only recognizes files with `.list` or `.sources` extensions, causing it to emit warnings:
N: Ignoring file 'debian.sources.back' in directory '/etc/apt/sources.list.d/'
as it has an invalid filename extension


These warnings appear repeatedly during the build process, cluttering the build logs.

### Solution
- Move the backup file to `/tmp/debian.sources.disabled` instead of keeping it in `/etc/apt/sources.list.d/` with a `.back` extension
- This prevents APT from scanning the backup file and eliminates the warnings
- The functionality remains the same - the file is still temporarily disabled and restored when needed

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Testing
- Build process should complete without APT warnings about debian.sources.back
- Reproducible mirror functionality should work as before
- The file should be properly restored after the build

### Why I did it
To eliminate unnecessary APT warnings during the build process that clutter build logs and may cause confusion.

### How I did it
Modified `src/sonic-build-hooks/scripts/buildinfo_base.sh` to move the backup file to `/tmp/` instead of renaming it in the same directory.

### How to verify it
1. Run a build and check that there are no APT warnings about `debian.sources.back`
2. Verify that reproducible mirror setup still works correctly
3. Confirm that the debian.sources file is properly restored after the build

### Which release branch to backport (provide reason below if selected)
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

**Reason:** This is a minor build warning fix that doesn't affect functionality. Backporting is optional but recommended to clean up build logs in stable branches.

### Tested branch (Please provide the tested image version)
- [ ] <!-- Add image version after testing -->

### Description for the changelog
Fix APT warning about invalid filename extension for debian.sources.back during build

### Link to config_db schema for YANG module changes
N/A - No config_db schema changes

Fixes: #25969