### PR TITLE
BROADCOM_LEGACY_SAI_COMPAT: Allow platforms to disable sai_query_stats_st_capability at runtime

### DIFF
--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/sai.profile
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/sai.profile
@@ -1,2 +1,5 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th-a7060-cx32s-32x100G-t1.config.bcm
 SAI_NUM_ECMP_MEMBERS=64
+# BROADCOM_LEGACY_SAI_COMPAT: TH1 (BCM56960) has no streaming telemetry platform driver;
+# sai_query_stats_st_capability crashes in brcm_sai_st_pd_ctr_cap_list_get.
+SAI_STATS_ST_CAPABILITY_SUPPORTED=0

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-D48C8/sai.profile
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-D48C8/sai.profile
@@ -1,2 +1,5 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th-a7060-cx32s-8x100G+48x50G.config.bcm
 SAI_NUM_ECMP_MEMBERS=64
+# BROADCOM_LEGACY_SAI_COMPAT: TH1 (BCM56960) has no streaming telemetry platform driver;
+# sai_query_stats_st_capability crashes in brcm_sai_st_pd_ctr_cap_list_get.
+SAI_STATS_ST_CAPABILITY_SUPPORTED=0

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q24C8/sai.profile
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q24C8/sai.profile
@@ -1,2 +1,5 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th-a7060-cx32s-8x100G+24x40G.config.bcm
 SAI_NUM_ECMP_MEMBERS=64
+# BROADCOM_LEGACY_SAI_COMPAT: TH1 (BCM56960) has no streaming telemetry platform driver;
+# sai_query_stats_st_capability crashes in brcm_sai_st_pd_ctr_cap_list_get.
+SAI_STATS_ST_CAPABILITY_SUPPORTED=0

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-T96C8/sai.profile
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-T96C8/sai.profile
@@ -1,2 +1,5 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th-a7060-cx32s-8x100G+96x25G.config.bcm
 SAI_NUM_ECMP_MEMBERS=64
+# BROADCOM_LEGACY_SAI_COMPAT: TH1 (BCM56960) has no streaming telemetry platform driver;
+# sai_query_stats_st_capability crashes in brcm_sai_st_pd_ctr_cap_list_get.
+SAI_STATS_ST_CAPABILITY_SUPPORTED=0

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S/sai.profile
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S/sai.profile
@@ -1,1 +1,4 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/platform/th-a7060-cx32s-flex-all.config.bcm
+# BROADCOM_LEGACY_SAI_COMPAT: TH1 (BCM56960) has no streaming telemetry platform driver;
+# sai_query_stats_st_capability crashes in brcm_sai_st_pd_ctr_cap_list_get.
+SAI_STATS_ST_CAPABILITY_SUPPORTED=0


### PR DESCRIPTION
#### Why I did it

On Arista 7060cx (BCM56960/Tomahawk-1) running the broadcom-legacy image, syncd crashes with SIGSEGV inside `brcm_sai_st_pd_ctr_cap_list_get` on startup. The legacy SAI binary does not initialize `p_pdapi_st->vtable` for TH1, so dereferencing it at offset +0x10 causes a segfault.

Root cause: sonic-sairedis commit `4f1d7d99` restored `sai_query_stats_st_capability` to `AC_CHECK_FUNCS`. Because the XGS SAI headers are used for all broadcom syncd builds, the symbol is found at compile time and called at runtime on TH1 — where it crashes.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Add `SAI_STATS_ST_CAPABILITY_SUPPORTED=0` to `sai.profile` for all Arista 7060cx HWSKUs (BCM56960/Tomahawk-1). The runtime guard in syncd (sonic-sairedis PR #1788) reads this key during `apiInitialize()` and nulls the `query_stats_st_capability` function pointer, preventing the crash.

Files changed:
- `device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S/sai.profile`
- `device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/sai.profile`
- `device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-D48C8/sai.profile`
- `device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q24C8/sai.profile`
- `device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-T96C8/sai.profile`

#### How to verify it

1. Build a broadcom-legacy SONiC image for Arista 7060cx
2. Boot the device — syncd should start without crashing
3. Confirm `show platform summary` and `show interface status` work normally

#### Which release branch to backport (provide reason below if selected)

These are bug fixes for broadcom-legacy platform (TH1). The crashes are present in 202511.

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

- [x] <!-- image version 1 --> 20251110.15 (broadcom-legacy, Arista 7060cx)

#### Description for the changelog

BROADCOM_LEGACY_SAI_COMPAT: Add sai.profile key to disable sai_query_stats_st_capability on Arista 7060cx (TH1) to prevent syncd SIGSEGV on broadcom-legacy image.

#### Link to config_db schema for YANG module changes

N/A — sai.profile change only, no config_db schema impact.

#### A picture of a cute animal (not mandatory but encouraged)

🐧