### PR TITLE
[202511][Mellanox]Add back mst driver start during firmware upgrade

### DIFF
--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -70,6 +70,8 @@ SYSLOG_LOGGER="${NO_PARAM}"
 VERBOSE_LEVEL="${VERBOSE_MIN}"
 MFT_DIAGNOSIS_FLAGS=""
 RESET_CONFIG="${NO_PARAM}"
+MST_STARTED="${NO_PARAM}"
+IGNORE_MST_START_FAILURE="${NO_PARAM}"
 
 function PrintHelp() {
     echo
@@ -81,6 +83,7 @@ function PrintHelp() {
     echo "  -v, --verbose  Verbose mode (enabled when -u|--upgrade)"
     echo "  -d, --dry-run  Compare the FW versions without installation. Return code "0" means the FW is up-to-date, return code "10" means an upgrade is required, otherwise an error is detected."
     echo "  -c, --clear-semaphore   Clear hw resources before updating firmware"
+    echo "  -m, --ignore-mst-start-failure   Do not exit if 'mst start' fails"
 {% if sonic_asic_platform == "nvidia-bluefield" %}
     echo "  -r, --reset    Reset firmware configuration (NVIDIA BlueField platform only)"
 {% endif %}
@@ -116,6 +119,9 @@ function ParseArguments() {
             ;;
             -c|--clear-semaphore)
                 CLEAR_SEMAPHORE="${YES_PARAM}"
+            ;;
+            -m|--ignore-mst-start-failure)
+                IGNORE_MST_START_FAILURE="${YES_PARAM}"
             ;;
 {% if sonic_asic_platform == "nvidia-bluefield" %}
             -r|--reset)
@@ -406,6 +412,14 @@ function UpgradeFW() {
         fi
 
         LogNotice "firmware upgrade is required. Installing compatible version..."
+        LogInfo "Starting MST with i2cdev"
+        MST_STARTED="${YES_PARAM}"
+        if [[ "${IGNORE_MST_START_FAILURE}" != "${YES_PARAM}" ]]; then
+            RunCmd "/usr/bin/mst start --with_i2cdev"
+        else
+            /usr/bin/mst start --with_i2cdev || true
+        fi
+
 
         if [[ "${_MST_DEVICE}" = "${UNKN_MST}" ]]; then
             LogWarning "could not find fastest mst device, using default device"
@@ -456,6 +470,10 @@ function ExitIfQEMU() {
 }
 
 function Cleanup() {
+    if [[ "${MST_STARTED}" = "${YES_PARAM}" ]]; then
+        LogInfo "Stopping MST service"
+        /usr/bin/mst stop || true
+    fi
     if [[ -n "${LOCKFD}" ]]; then
         UnlockStateChange
     fi

--- a/platform/nvidia-bluefield/installer/install.sh.j2
+++ b/platform/nvidia-bluefield/installer/install.sh.j2
@@ -244,7 +244,6 @@ if [[ $SKIP_FIRMWARE_UPGRADE != "true" ]]; then
 
 	ex ln -s /mnt/$image_dir/platform/fw/asic/fw-BF3.mfa /etc/mlnx/fw-BF3.mfa
 
-	ex mst start
 
         cp -R $sonic_fs_mountpoint/usr/bin/asic_detect/ /usr/bin/
 
@@ -253,13 +252,13 @@ if [[ $SKIP_FIRMWARE_UPGRADE != "true" ]]; then
 		bfb_pre_fw_install
 	fi
 
-	ex $sonic_fs_mountpoint/usr/bin/mlnx-fw-upgrade.sh -v
+	ex $sonic_fs_mountpoint/usr/bin/mlnx-fw-upgrade.sh -m -v
 	if [[ $? != 0 ]]; then
 		log "ERROR: FW update failed"
 	fi
 
 	if [[ $FORCE_FW_CONFIG_RESET == "true" ]]; then
-		ex $sonic_fs_mountpoint/usr/bin/mlnx-fw-upgrade.sh -v -r
+		ex $sonic_fs_mountpoint/usr/bin/mlnx-fw-upgrade.sh -m -v -r
 	fi
 
 	ex umount $sonic_fs_mountpoint


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Firmware upgrade was experiencing **degradation in time** when the MST (Mellanox Software Tools) service was not already running. Starting MST explicitly before the upgrade (with `--with_i2cdev`) and stopping it after the upgrade completes ensures predictable, faster firmware upgrade times on Mellanox/NVIDIA Spectrum and BlueField platforms.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

**platform/mellanox/mlnx-fw-upgrade.j2:**
- Start MST with `/usr/bin/mst start --with_i2cdev` only when a firmware upgrade is actually required (inside `UpgradeFW()`, before `RunFwUpdateCmd`).
- Introduced `MST_STARTED` variable (default `NO_PARAM`); set to `YES_PARAM` only when this script starts MST.
- In `Cleanup()` (invoked on script exit via `trap Cleanup EXIT`), run `mst stop` only if `MST_STARTED` is `YES_PARAM`, so we do not stop MST when the script did not start it (e.g. when FW was already up to date, dry-run, or early exit).
- Ensures MST is stopped after upgrade completion irrespective of success or failure, while avoiding unnecessary `mst stop` when MST was never started by the script.
- Added **ignore MST start failure** option: `-m` / `--ignore-mst-start-failure` and variable `IGNORE_MST_START_FAILURE`. When set, a failed `mst start` does not exit the script (`mst start ... || true`); when not set, `RunCmd` is used and the script exits on failure. This allows environments (e.g. BlueField driver install) where MST/driver may not be ready to still attempt firmware upgrade without failing the whole flow.

**platform/nvidia-bluefield/installer/install.sh.j2:**
- Invoke firmware upgrade with `-m -v`: `mlnx-fw-upgrade.sh -m -v` (and `mlnx-fw-upgrade.sh -m -v -r` for config reset). The `-m` flag ignores MST start failure so that if the driver/MST is not ready during install, the script does not exit and the upgrade can still proceed or fail on actual FW update rather than on driver start.

#### How to verify it

1. **Mellanox Spectrum:** Run firmware upgrade (e.g. `mlnx-fw-upgrade.sh -v` or image upgrade flow). Confirm upgrade time is improved when MST is not pre-started; confirm `mst stop` runs after upgrade (check logs). Run with FW already up to date and confirm `mst stop` is not executed.
2. **NVIDIA BlueField:** Run BFB install/upgrade that triggers `mlnx-fw-upgrade.sh -m -v`. Verify firmware upgrade completes in expected time; if MST start fails (e.g. driver not ready), script should continue and not exit until actual FW update is attempted. Confirm MST is started/stopped when start succeeds.
3. **Ignore MST start failure:** Run `mlnx-fw-upgrade.sh -m -v` in an environment where `mst start` can fail; script should not exit on that failure and should proceed to FW upgrade (or fail on upgrade itself).
4. **Dry-run / no-upgrade paths:** Run `mlnx-fw-upgrade.sh -d` or on QEMU/SimX; confirm script exits without calling `mst stop`.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Start MST before Mellanox/NVIDIA firmware upgrade and stop it after completion to fix upgrade time degradation; add -m to ignore MST start failure (used by BlueField installer).

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
N/A – no YANG/config_db changes.

#### A picture of a cute animal (not mandatory but encouraged)
