### PR TITLE
[arp_update] Remove PID from arp_update logger output

### DIFF
--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -248,9 +248,11 @@ while /bin/true; do
       ip="$( cut -d ':' -f 3- <<< "$neigh" )"
       if [[ $intf == *"Vlan"* ]]; then
           if [[ $ip == *"."* ]] && [[ ! $KERNEIGH4 =~ "${ip},${intf}" ]]; then
+              logger "mismatch arp entry, pinging ${ip} on ${intf}"
               run_with_retry_cmd "db/kernel mismatch ping to ${ip} on ${intf}" \
                 timeout 0.2 ping -I "$intf" -n -q -i 0 -c 1 -W 1 "$ip" >/dev/null 2>&1
           elif [[ $ip == *":"* ]] && [[ ! $KERNEIGH6 =~ "${ip},${intf}" ]]; then
+              logger "mismatch v6 nbr entry, pinging ${ip} on ${intf}"
               run_with_retry_cmd "db/kernel mismatch ping6 to ${ip} on ${intf}" \
                 timeout 0.2 ping6 -I "$intf" -n -q -i 0 -c 1 -W 1 "$ip" >/dev/null 2>&1
           fi


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
arp_update logs for static routes showed entries like:
    98 static route nexthop not resolved ...
which could be misinterpreted as 98 unreachable servers. 

This change modifies the logger() function to remove PID argument.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- PID in `arp_update` logs is not needed.
- Keeping only tag makes logs cleaner while preserving filterability (`-t arp_update`).
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

