### PR TITLE
[build] Avoid using jsonpath_ng v1.8.0 in sonic slave image. 

### DIFF
--- a/sonic-slave-bookworm/Dockerfile.j2
+++ b/sonic-slave-bookworm/Dockerfile.j2
@@ -561,7 +561,9 @@ RUN patch -p1 -i /disable-non-manylinux.patch /usr/local/lib/python3.11/dist-pac
 RUN pip3 install fastentrypoints mock
 
 # For DASH BMv2
-RUN pip3 install jsonpath_ng
+# Exclude jsonpath_ng 1.8.0 because it causes DASH pipeline failures
+# In version 1.8.0, dict is flattened to a list, which causes type error in DASH.
+RUN pip3 install jsonpath_ng!=1.8.0
 RUN pip3 install pyyaml-include
 
 # For building sonic_ycabled

--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -568,7 +568,9 @@ RUN eatmydata apt-get install -y golang-go \
 RUN pip3 install fastentrypoints mock
 
 # For DASH BMv2
-RUN pip3 install jsonpath_ng pyyaml-include
+# Exclude jsonpath_ng 1.8.0 because it causes DASH pipeline failures
+# In version 1.8.0, dict is flattened to a list, which causes type error in DASH.
+RUN pip3 install jsonpath_ng!=1.8.0 pyyaml-include
 
 # For building sonic_ycabled
 # Note: Match version in trixie


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When the version of jsonpath_ng is 1.8.0, the build fails on ` target/debs/bookworm/libsai_1.0.0_amd64.deb`
```
./sai_api_gen.py \
	/bmv2/dash_pipeline.bmv2/dash_pipeline_p4rt.json \
	--ir /bmv2/dash_pipeline.bmv2/dash_pipeline_ir.json \
	--ignore-tables=underlay_mac,eni_meter,slb_decap \
	--sai-spec-dir=specs \
	dash
Traceback (most recent call last):
  File "/sonic/src/dash-sai/DASH/dash-pipeline/SAI/./sai_api_gen.py", line 44, in <module>
    var_ref_graph = P4VarRefGraph(p4ir)
                    ^^^^^^^^^^^^^^^^^^^
  File "/sonic/src/dash-sai/DASH/dash-pipeline/SAI/utils/p4ir/p4ir_var_ref_graph.py", line 15, in __init__
    self.__build_graph()
  File "/sonic/src/dash-sai/DASH/dash-pipeline/SAI/utils/p4ir/p4ir_var_ref_graph.py", line 18, in __build_graph
    self.__build_counter_list()
  File "/sonic/src/dash-sai/DASH/dash-pipeline/SAI/utils/p4ir/p4ir_var_ref_graph.py", line 28, in __build_counter_list
    self.ir.walk(
  File "/sonic/src/dash-sai/DASH/dash-pipeline/SAI/utils/p4ir/p4ir_tree.py", line 18, in walk
    on_match(match)
  File "/sonic/src/dash-sai/DASH/dash-pipeline/SAI/utils/p4ir/p4ir_var_ref_graph.py", line 24, in on_counter_definition
    ir_value = P4IRVarInfo.from_ir(match.value)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/sonic/src/dash-sai/DASH/dash-pipeline/SAI/utils/p4ir/p4ir_var_info.py", line 11, in from_ir
    ir_def_node["Source_Info"]["source_fragment"],
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
TypeError: list indices must be integers or slices, not str
```
In the version 1.8.0, dict is flattened to a list, which causes the above TypeError
With this change, jsonpath_ng is pinned to exclude 1.8.0 release
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

