### PR TITLE
[lldp] Fix transient MAC address Port ID during LLDP daemon startup

### DIFF
--- a/dockers/docker-lldp/lldpd.conf.j2
+++ b/dockers/docker-lldp/lldpd.conf.j2
@@ -19,15 +19,22 @@ configure ports eth0 lldp portidsubtype local {{ mgmt_if.port_name }}
 configure system ip management pattern {{ mgmt_if.ipv4 }}
 {% endif %}
 configure system hostname {{ DEVICE_METADATA['localhost']['hostname'] }}
-{# Configure port ID subtype for all front-panel ports at startup.
+{# Configure port ID subtype for front-panel ports at startup.
    Without this, lldpd uses MAC address as default Port ID. When lldpd
    auto-resumes after config processing, the first LLDP frame would carry
    MAC-based Port IDs. Peers see a transient MSAP change when lldpmgrd
-   later reconfigures portidsubtype, causing unnecessary neighbor flaps. #}
+   later reconfigures portidsubtype, causing unnecessary neighbor flaps.
+   Special ports (inband/recirculation/backplane) are excluded to match
+   lldpmgrd behavior which skips these port types. #}
 {% if PORT %}
-{% for port_name in PORT %}
-{% if PORT[port_name].alias is defined and PORT[port_name].alias %}
-configure ports {{ port_name }} lldp portidsubtype local {{ PORT[port_name].alias }}
+{% for port_name in PORT|sort %}
+{% if not port_name.startswith('Ethernet-IB') and not port_name.startswith('Ethernet-Rec') and not port_name.startswith('Ethernet-BP') %}
+{% set port_alias = PORT[port_name].alias|default('') %}
+{% if port_alias %}
+configure ports {{ port_name }} lldp portidsubtype local {{ port_alias }}
+{% else %}
+configure ports {{ port_name }} lldp portidsubtype local {{ port_name }}
+{% endif %}
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/src/sonic-config-engine/tests/data/lldp/mgmt_iface_ipv4_with_ports.json
+++ b/src/sonic-config-engine/tests/data/lldp/mgmt_iface_ipv4_with_ports.json
@@ -1,0 +1,41 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "hostname": "switch-t0"
+        }
+    },
+    "MGMT_INTERFACE": {
+        "eth0|10.0.0.100/24": {
+            "gwaddr": "10.0.0.100"
+        }
+    },
+    "PORT": {
+        "Ethernet0": {
+            "alias": "Ethernet1/1",
+            "speed": "100000"
+        },
+        "Ethernet4": {
+            "alias": "Ethernet2/1",
+            "speed": "100000"
+        },
+        "Ethernet8": {
+            "alias": "",
+            "speed": "100000"
+        },
+        "Ethernet12": {
+            "speed": "100000"
+        },
+        "Ethernet-IB0": {
+            "alias": "Ethernet-IB0",
+            "speed": "400000"
+        },
+        "Ethernet-Rec0": {
+            "alias": "Ethernet-Rec0",
+            "speed": "400000"
+        },
+        "Ethernet-BP0": {
+            "alias": "Ethernet-BP0",
+            "speed": "400000"
+        }
+    }
+}

--- a/src/sonic-config-engine/tests/sample_output/py3/lldp_conf/lldpd-ipv4-iface-with-ports.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/lldp_conf/lldpd-ipv4-iface-with-ports.conf
@@ -1,0 +1,8 @@
+configure ports eth0 lldp portidsubtype local eth0
+configure system ip management pattern 10.0.0.100
+configure system hostname switch-t0
+configure ports Ethernet0 lldp portidsubtype local Ethernet1/1
+configure ports Ethernet12 lldp portidsubtype local Ethernet12
+configure ports Ethernet4 lldp portidsubtype local Ethernet2/1
+configure ports Ethernet8 lldp portidsubtype local Ethernet8
+pause

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -259,6 +259,13 @@ class TestJ2Files(TestCase):
         self.run_script(argument, output_file=self.output_file)
         self.assertTrue(utils.cmp(expected_mgmt_ipv6, self.output_file))
 
+        # Test generation of lldpd.conf with PORT table (aliases, special ports, missing alias)
+        mgmt_iface_ipv4_with_ports_json = os.path.join(self.test_dir, "data", "lldp", "mgmt_iface_ipv4_with_ports.json")
+        expected_mgmt_ipv4_with_ports = os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR, 'lldp_conf', 'lldpd-ipv4-iface-with-ports.conf')
+        argument = ['-j', mgmt_iface_ipv4_with_ports_json, '-t', lldpd_conf_template]
+        self.run_script(argument, output_file=self.output_file)
+        self.assertTrue(utils.cmp(expected_mgmt_ipv4_with_ports, self.output_file))
+
     def test_ipinip(self):
         ipinip_file = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-orchagent', 'ipinip.json.j2')
         argument = ['-m', self.t0_minigraph, '-p', self.t0_port_config, '-t', ipinip_file]


### PR DESCRIPTION
#### Why I did it

When lldpd starts (or restarts), it sends the first LLDP frames with **MAC addresses as Port IDs** instead of the configured interface aliases (e.g., `Ethernet1/1`). This is because:

1. lldpd starts in paused state and loads its config file (`/etc/lldpd.conf`)
2. The config file only configures the management port (`eth0`) portidsubtype — no front-panel port configs exist
3. After processing all config lines, lldpd internally **auto-resumes** (hardcoded behavior in lldpd's internal lldpcli)
4. The first LLDP frames are sent with default MAC-based Port IDs
5. lldpmgrd starts 2-3 seconds later and reconfigures each port with the correct alias via `lldpcli`
6. This triggers an **MSAP change** (shutdown frame + new frame with correct Port ID) on every port

Peers see transient neighbor flapping: a MAC-based entry appears briefly, then gets replaced by the correct interface name entry. This can trigger monitoring alerts and confuse network management systems (e.g., LLDP-based topology discovery, automated cabling validation).

Related issues:
- Fixes #1488
- Fixes #1457

##### Work item tracking
- Microsoft ADO **37084792**:

#### How I did it

Added port ID subtype configuration for **all front-panel ports** directly in the `lldpd.conf.j2` Jinja2 template. The template iterates over the `PORT` table from ConfigDB and generates `configure ports <name> lldp portidsubtype local <alias>` lines for every port that has an alias defined.

These configuration lines are processed by lldpd during startup config loading, **before** the internal auto-resume fires. This ensures the very first LLDP frame already carries the correct interface alias as Port ID, eliminating the transient MAC-based Port ID window entirely.

The change is additive — lldpmgrd continues to handle dynamic port configuration changes at runtime. When lldpmgrd later processes the same ports, the portidsubtype is already correct, so no MSAP change occurs (only the port description gets added, which is expected).

**Key technical findings from investigation:**
- lldpd starts paused by default (the `pause` directive in config is actually redundant)
- lldpd's internal lldpcli auto-resumes after ALL config file lines are processed — this cannot be prevented via config
- The `resume` call in `waitfor_lldp_ready.sh` (from PR #5493) fires after auto-resume, so it's also redundant
- The `PORT` variable is available in sonic-cfggen template context from ConfigDB's PORT table

#### How to verify it

**Tested on:** Arista-7260CX3-C64 running SONiC.20251110.15 (64 front-panel ports)

**Test procedure:**
1. Applied the template change inside the lldp container
2. Verified template rendering: `sonic-cfggen -d -t /usr/share/sonic/templates/lldpd.conf.j2` — confirmed 67 portidsubtype lines (1 eth0 + 66 Ethernet ports)
3. Started tcpdump on Ethernet0: `tcpdump -i Ethernet0 -e ether proto 0x88cc -v`
4. Restarted lldp service: `systemctl restart lldp`
5. Captured the **very first** LLDP frame from the DUT

**tcpdump results — first frame after restart:**
```
07:38:41.610005 LLDP, length 233
  Chassis ID TLV (1), length 7
    Subtype MAC address (4): ec:8a:48:3c:e4:a8
  Port ID TLV (2), length 12
    Subtype Local (7): Ethernet1/1        <-- CORRECT from first frame!
  Time to Live TLV (3), length 2: TTL 120s
  System Name TLV (5), length 14: bjw-can-7260-8
```

**Before this fix**, the first frame showed:
```
  Port ID TLV (2), length 8
    Subtype MAC address (3): ec:8a:48:3c:e4:a8   <-- MAC address, WRONG
```

**Before:** MAC address as Port ID for 2-3 seconds → MSAP change → correct alias
**After:** Correct alias (`Ethernet1/1`) from the very first LLDP frame → no MSAP change

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505
- [x] 202511

**Reason:** This race condition affects all SONiC versions using lldpd with the current startup architecture. The transient MAC-based Port ID causes neighbor flapping visible to peers on every LLDP container restart or device boot, which can trigger false alerts in production monitoring systems.

#### Tested branch (Please provide the tested image version)

- [x] SONiC.20251110.15 (master-based, Arista-7260CX3-C64)

#### Description for the changelog

Fix LLDP Port ID showing MAC address instead of interface name during daemon startup by pre-configuring portidsubtype in lldpd.conf.j2 template.

#### Link to config_db schema for YANG module changes

N/A — no ConfigDB or YANG schema changes.

#### A picture of a cute animal (not mandatory but encouraged)

🦔
