### PR TITLE
[Influxdb][PTF]: Install influxdb in PTF container for HFT E2E test 

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -135,13 +135,11 @@ RUN set -eux \
 {% endif %}
     && INFLUXDB_VERSION=2.8.0 \
     && cd /tmp \
-    && curl --fail --show-error --location --retry 3 --retry-delay 5 -O "https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB_VERSION}_${INFLUXDB_ARCH}.tar.gz" \
-    && curl --fail --show-error --location --retry 3 --retry-delay 5 -O "https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXDB_VERSION}_${INFLUXDB_ARCH}.tar.gz.sha256" \
-    && sha256sum -c "influxdb2-${INFLUXDB_VERSION}_${INFLUXDB_ARCH}.tar.gz.sha256" \
+    && curl --fail --show-error --location --retry 3 --retry-delay 5 -O "https://dl.influxdata.com/influxdb/releases/v${INFLUXDB_VERSION}/influxdb2-${INFLUXDB_VERSION}_${INFLUXDB_ARCH}.tar.gz" \
     && tar xzf "influxdb2-${INFLUXDB_VERSION}_${INFLUXDB_ARCH}.tar.gz" \
     && mv "influxdb2-${INFLUXDB_VERSION}/influxd" /usr/local/bin/influxd \
     && chmod +x /usr/local/bin/influxd \
-    && rm -f "influxdb2-${INFLUXDB_VERSION}_${INFLUXDB_ARCH}.tar.gz" "influxdb2-${INFLUXDB_VERSION}_${INFLUXDB_ARCH}.tar.gz.sha256" \
+    && rm -f "influxdb2-${INFLUXDB_VERSION}_${INFLUXDB_ARCH}.tar.gz" \
     && rm -rf "/tmp/influxdb2-${INFLUXDB_VERSION}"
 {% endif %}
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Adds InfluxDB to the docker-ptf container image so PTF-based HFT E2E tests can run with an InfluxDB instance available inside the container.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Download and install the InfluxDB 2.x influxd binary into the PTF container during image build.
﻿Use Jinja2 template conditionals on CONFIGURED_ARCH to select the correct InfluxDB release tarball architecture.
#### How to verify it
Verified it in ptf container:
```
admin@ptf:~/influxdb2-2.8.0$ ./influxd
2026-03-23T05:24:31.089933Z     info    Welcome to InfluxDB     {"log_id": "11nIH2xG000", "version": "v2.8.0", "commit": "40a633239e", "build_date": "2025-12-02T20:35:00Z", "log_level": "info"}
2026-03-23T05:24:31.110260Z     info    Resources opened        {"log_id": "11nIH2xG000", "service": "bolt", "path": "/home/janetcui/.influxdbv2/influxd.bolt"}
2026-03-23T05:24:31.110352Z     info    Resources opened        {"log_id": "11nIH2xG000", "service": "sqlite", "path": "/home/janetcui/.influxdbv2/influxd.sqlite"}
2026-03-23T05:24:31.114860Z     info    Bringing up metadata migrations {"log_id": "11nIH2xG000", "service": "KV migrations", "migration_count": 21}
2026-03-23T05:24:31.591523Z     info    Bringing up metadata migrations {"log_id": "11nIH2xG000", "service": "SQL migrations", "migration_count": 8}
2026-03-23T05:24:31.740554Z     info    Using data dir  {"log_id": "11nIH2xG000", "service": "storage-engine", "service": "store", "path": "/home/janetcui/.influxdbv2/engine/data"}
2026-03-23T05:24:31.740654Z     info    Compaction settings     {"log_id": "11nIH2xG000", "service": "storage-engine", "service": "store", "max_concurrent_compactions": 8, "throughput_bytes_per_second": 50331648, "throughput_bytes_per_second_burst": 50331648}
2026-03-23T05:24:31.740675Z     info    Open store (start)      {"log_id": "11nIH2xG000", "service": "storage-engine", "service": "store", "op_name": "tsdb_open", "op_event": "start"}
2026-03-23T05:24:31.740759Z     info    Open store (end)        {"log_id": "11nIH2xG000", "service": "storage-engine", "service": "store", "op_name": "tsdb_open", "op_event": "end", "op_elapsed": "0.086ms"}
2026-03-23T05:24:31.740793Z     info    Starting retention policy enforcement service   {"log_id": "11nIH2xG000", "service": "retention", "check_interval": "30m"}
2026-03-23T05:24:31.740816Z     info    Starting precreation service    {"log_id": "11nIH2xG000", "service": "shard-precreation", "check_interval": "10m", "advance_period": "30m"}
2026-03-23T05:24:31.741432Z     info    Starting query controller       {"log_id": "11nIH2xG000", "service": "storage-reads", "concurrency_quota": 1024, "initial_memory_bytes_quota_per_query": 9223372036854775807, "memory_bytes_quota_per_query": 9223372036854775807, "max_memory_bytes": 0, "queue_size": 1024}
2026-03-23T05:24:31.744928Z     info    Configuring InfluxQL statement executor (zeros indicate unlimited).     {"log_id": "11nIH2xG000", "max_select_point": 0, "max_select_series": 0, "max_select_buckets": 0}
2026-03-23T05:24:31.763104Z     info    Starting        {"log_id": "11nIH2xG000", "service": "telemetry", "interval": "8h"}
2026-03-23T05:24:31.763240Z     info    Listening       {"log_id": "11nIH2xG000", "service": "tcp-listener", "transport": "http", "addr": ":8086", "port": 8086}
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

