### PR TITLE
s360: Resolve library vulnerabilty

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -99,22 +99,28 @@ RUN apt-get update          \
         wireshark-common    \
         freeradius          \
         quilt               \
-    {% if CONFIGURED_ARCH == "armhf" %}
-    && GRPCURL_ARCH=linux_armv6 \
-    {% elif CONFIGURED_ARCH == "arm64" %}
-    && GRPCURL_ARCH=linux_arm64 \
-    {% else %}
-    && GRPCURL_ARCH=linux_x86_64 \
-    {% endif %}
-    && GRPCURL_VERSION=1.9.3 && \
-    curl -L "https://github.com/fullstorydev/grpcurl/releases/download/v${GRPCURL_VERSION}/grpcurl_${GRPCURL_VERSION}_${GRPCURL_ARCH}.tar.gz" \
-      -o /tmp/grpcurl_${GRPCURL_VERSION}_${GRPCURL_ARCH}.tar.gz && \
-    cd /tmp && \
-    tar xvf grpcurl_${GRPCURL_VERSION}_${GRPCURL_ARCH}.tar.gz && \
-    mv grpcurl /usr/local/bin/grpcurl && \
-    chmod +x /usr/local/bin/grpcurl && \
-    rm -f /tmp/grpcurl_${GRPCURL_VERSION}_${GRPCURL_ARCH}.tar.gz && \
-    rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Go toolchain for building grpcurl and gnoic from source
+# to ensure they use a patched Go stdlib (GO-2026-4337: crypto/tls)
+{% if CONFIGURED_ARCH == "armhf" %}
+RUN GO_ARCH=armv6l \
+{% elif CONFIGURED_ARCH == "arm64" %}
+RUN GO_ARCH=arm64 \
+{% else %}
+RUN GO_ARCH=amd64 \
+{% endif %}
+    && GO_VERSION=1.25.8 \
+    && curl -L "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz" -o /tmp/go.tar.gz \
+    && tar -C /usr/local -xzf /tmp/go.tar.gz \
+    && rm /tmp/go.tar.gz
+
+ENV PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
+
+# Build grpcurl from source with patched Go (GO-2026-4337)
+RUN go install github.com/fullstorydev/grpcurl/cmd/grpcurl@v1.9.3 \
+    && mv "$(go env GOPATH)/bin/grpcurl" /usr/local/bin/grpcurl \
+    && chmod +x /usr/local/bin/grpcurl
 # Security fixes: upgrade vulnerable system packages (S360 scan remediation)
 RUN apt-get update && apt-get install -y --only-upgrade \
         telnet               \
@@ -299,11 +305,11 @@ RUN pip3 install Flask   \
     && pip3 install jinja2
 
 # gnxi/gnmi_cli_py ships pre-generated _pb2.py stubs; they are
-# Pin to 6.31.1 to match grpcio-tools keep a known-good version.
+# Pin to 6.33.5 to match grpcio-tools keep a known-good version.
 RUN set -e; \
     . /etc/os-release; \
     if [ "$VERSION_CODENAME" = "bookworm" ]; then \
-        pip install protobuf==6.31.1; \
+        pip install protobuf==6.33.5; \
     else \
         pip install protobuf; \
     fi
@@ -348,7 +354,7 @@ RUN cd gnxi \
     && quilt push -a \
     && cd gnmi_cli_py \
     && pip install -r requirements.txt \
-    && pip3 install protobuf==6.31.1 --no-binary=protobuf
+    && pip3 install protobuf==6.33.5 --no-binary=protobuf
 {% else %}
 
 # Since gnxi were generated with proto 3.x we need to regenerate _pb2 with the new proto version
@@ -365,22 +371,17 @@ RUN cd gnxi \
 # Deactivating a virtualenv.
 # ENV PATH="$BACKUP_OF_PATH"
 
-# Install gnoic tool
-# Without specifying the version there is a failure
-# to determine the latest version automatically.
-#
-# root@a2014cb5bc54:~/gnoic# ./install.sh
-# Warning: Failed to verify the package: https://api.github.com/repos/karimra/gnoic/releases/latest, the version is not specified
-# Could not determine the latest release
-# Failed to install gnoic
-# For support, go to https://github.com/karimra/gnoic/issues
+# Build gnoic from source with patched Go (GO-2026-4337)
 RUN git clone https://github.com/karimra/gnoic.git \
     && cd gnoic \
     && git checkout 27bc5a6 \
-    && chmod +x install.sh \
-    && ./install.sh --version 0.2.1 \
+    && go build -o /usr/local/bin/gnoic . \
     && cd .. \
     && rm -rf gnoic
+
+# Remove Go toolchain to reduce image size
+RUN rm -rf /usr/local/go "$(go env GOPATH 2>/dev/null || echo $HOME/go)"
+ENV PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 {% if PTF_ENV_PY_VER == "py3" %}
 # Install the python-saithrift into the virtual environment

--- a/dockers/docker-ptf/gnxi-patches/0005-Enhance-gnmi_cli_py-4.patch
+++ b/dockers/docker-ptf/gnxi-patches/0005-Enhance-gnmi_cli_py-4.patch
@@ -320,7 +320,7 @@ index dab2db6..e32b3ff 100644
 -grpcio-tools==1.15.0
 +grpcio==1.41.1
 +grpcio-tools==1.41.1
- protobuf==6.31.1 --no-binary=protobuf
+ protobuf==6.33.5 --no-binary=protobuf
  six==1.12.0
 -- 
 2.48.1.windows.1

--- a/dockers/dockerfile-macros.j2
+++ b/dockers/dockerfile-macros.j2
@@ -41,7 +41,7 @@ COPY \
 {% macro install_offending_packages(packages) -%}
     {%- for pkg in packages %}
         RUN pip3 install {{ pkg }}
-        RUN pip3 install setuptools==65.5.1
+        RUN pip3 install setuptools
     {%- endfor %}
 {%- endmacro %}
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

After https://github.com/sonic-net/sonic-buildimage/pull/25876, there are still some left over vulnerabilities. Majority is gnoic and go library. Some new introduces by the upgrade of  protobuf==6.31.1. 

This PR will try to address them

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

