### PR TITLE
Increase BCM scache stable_size

### DIFF
--- a/device/dell/x86_64-dellemc_n3248pxe_c3338-r0/DELLEMC-N3248PXE/td3-x5-n3248pxe-48x10GCU+4x25G-2x100G.config.bcm
+++ b/device/dell/x86_64-dellemc_n3248pxe_c3338-r0/DELLEMC-N3248PXE/td3-x5-n3248pxe-48x10GCU+4x25G-2x100G.config.bcm
@@ -338,7 +338,7 @@ max_vp_lags=0
 schan_intr_enable=0
 tdma_timeout_usec=5000000
 
-stable_size=0x5500000
+stable_size=0x8000000
 
 #Default L3 profile
 l2_mem_entries=40960

--- a/device/dell/x86_64-dellemc_n3248te_c3338-r0/DellEMC-N3248TE/hx5-n3248te-48x1G+4x10G.config.bcm
+++ b/device/dell/x86_64-dellemc_n3248te_c3338-r0/DellEMC-N3248TE/hx5-n3248te-48x1G+4x10G.config.bcm
@@ -21,7 +21,7 @@ memlist_enable=1
 reglist_enable=1
 scache_filename=/tmp/brcm_bcm_scache
 schan_intr_enable=0
-stable_size=0x5500000
+stable_size=0x8000000
 tdma_timeout_usec=3000000
 
 pfc_deadlock_seq_control=1


### PR DESCRIPTION
#### Why I did it

Sonic would not start on dell N3248TE-ON for all version(202511,202505,master) that I have tried.  

BCM SDK 6.5.34-SP1's flowtracker module needs more scache than the old stable_size=0x5500000 (85MB) provides. During init bcm, the scache fills up (85MB used of 85MB max), the flowtracker can't allocate its 4MB, and the entire ASIC initialization fails — crashing orchagent and taking down swss, bgp, teamd, and radv.


#### How I did it

Built a SONiC master image (master.1058234-715b234f7) and deployed it on a Dell NT3248TE-ON switch. After boot, all dependent containers (swss, bgp, teamd, radv) were exiting. Investigated the syslog and found orchagent was crashing with SIGABRT due to SAI_STATUS_FAILURE on switch creation. Traced the failure through syncd logs to the BCM SDK output which showed:

Scache out of space.max=89128960 bytes, used=85077604 bytes, alloc_size=4209712 bytes _bcm_modules_init: bcm_init failed in flowtracker (No resources for operation)

The BCM SDK 6.5.34-SP1 flowtracker module requires more scache than the configured stable_size=0x5500000 (85MB) allows. Increased stable_size to 0x8000000 (128MB) for both the N3248TE and N3248PXE platforms, which share the same SDK and are susceptible to the same issue.

#### How to verify it

1. Build a SONiC image with this change for the x86_64-dellemc_n3248te_c3338-r0 or x86_64-dellemc_n3248pxe_c3338-r0 platform
2. Install and boot on a Dell N3248TE-ON (or N3248PXE) switch
3. Verify all containers come up and stay running:
`docker ps -a`
3. Confirm swss, syncd, bgp, teamd, radv all show status Up
4. Verify interfaces are populated:
`show interface status`
4. Should list all 48x1G + 4x10G ports
5. Confirm no scache errors in syslog:
`grep -i "scache\|init bcm.*failed\|flowtracker" /var/log/syslog`
5. Should return no errors from the current boot

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

Bug is present in last 2 release and master, I have manually confirmed it. 

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

Increase BCM scache stable_size from 0x5500000 to 0x8000000 for Dell N3248TE and N3248PXE to fix ASIC initialization failure with SDK 6.5.34-SP1.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

