### PR TITLE
Changes to allowing setting per-platform DOM_INFO_UPDATE_PERIOD in xcvrd

### DIFF
--- a/device/nexthop/common/pmon_daemon_control.json
+++ b/device/nexthop/common/pmon_daemon_control.json
@@ -5,5 +5,8 @@
     "thermalctld": {
         "thermal_monitor_update_interval": 10,
         "thermal_monitor_update_elapsed_threshold": 9
+    },
+    "xcvrd": {
+        "dom_update_interval": 30
     }
 }

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -132,6 +132,10 @@ dependent_startup_wait_for=rsyslogd:running
     {%- set options = options + " --dom_temperature_poll_interval " + xcvrd.dom_temperature_poll_interval|string %}
 {% endif -%}
 
+{% if xcvrd and xcvrd.dom_update_interval %}
+    {%- set options = options + " --dom_update_interval " + xcvrd.dom_update_interval|string %}
+{% endif -%}
+
 {% if delay_xcvrd %}
     {%- set command = "bash -c \"sleep 30 && " ~ base_command ~ options ~ "\"" %}
 {% else %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

As described in https://github.com/sonic-net/sonic-platform-daemons/issues/774, DOM polling interval was made per-platform configurable by allowing platforms to pass in the value as a command line argument to xcvrd.

This change allows specifying the `dom_update_interval` value to use in `pmon_daemon_control.json`

This value is then passed to `xcvrd` when it is launched.

This PR requires https://github.com/sonic-net/sonic-platform-daemons/pull/775 to merge before it.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

