### PR TITLE
Added MUX cable failover_mode config

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -1766,7 +1766,7 @@ instead of data network.
 ```
 ### MUX_CABLE
 
-The **MUX_CABLE** table is used for dualtor interface configuration. The `cable_type`, `soc_ipv4` and `neighbor_mode` objects are optional.
+The **MUX_CABLE** table is used for dualtor interface configuration. The `cable_type`, `soc_ipv4`, `neighbor_mode` and `failover_mode` objects are optional.
 
 ```
 {
@@ -1774,6 +1774,7 @@ The **MUX_CABLE** table is used for dualtor interface configuration. The `cable_
         "Ethernet4": {
             "cable_type": "active-active",
             "neighbor_mode": "prefix-route",
+            "failover_mode": "hardware",
             "server_ipv4": "192.168.0.2/32",
             "server_ipv6": "fc02:1000::30/128",
             "soc_ipv4": "192.168.0.3/32",

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2600,6 +2600,7 @@
                 "cable_type": "active-active",
                 "prober_type": "software",
                 "neighbor_mode": "prefix-route",
+                "failover_mode": "hardware",
                 "server_ipv4": "192.168.0.2/32",
                 "server_ipv6": "fc02:1000::30/128",
                 "soc_ipv4": "192.168.0.3/32",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/mux_cable.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/mux_cable.json
@@ -56,6 +56,7 @@
                         "cable_type": "active-active",
                         "prober_type": "software",
                         "neighbor_mode": "prefix-route",
+                        "failover_mode": "hardware",
                         "server_ipv4": "192.168.0.2/32",
                         "server_ipv6": "fc02:1000::30/128",
                         "soc_ipv4": "192.168.0.3/32",

--- a/src/sonic-yang-models/yang-models/sonic-mux-cable.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mux-cable.yang
@@ -68,6 +68,15 @@ module sonic-mux-cable {
                     description "DualToR MUX neighbor mode.";
                 }
 
+                leaf failover_mode {
+                    type enumeration {
+                        enum hardware;
+                        enum software;
+                    }
+                    default software;
+                    description "DualToR MUX failover mode.";
+                }
+
                 leaf server_ipv4 {
                     type inet:ipv4-prefix;
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Adding support for MUX switching_mode to support hardware based protection switching of mux neighbors and routes
SONiC HLD: https://github.com/sonic-net/SONiC/pull/2251

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

