### PR TITLE
[202511 cherry-pick] Update thermal sensors after adding TH5 diodes in platform driver (#2…

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe/platform.json
+++ b/device/arista/x86_64-arista_7060x6_64pe/platform.json
@@ -110,6 +110,14 @@
             {
                 "name": "Management Card Inlet",
                 "controllable": false
+            },
+            {
+                "name": "TH5 Diode 1",
+                "controllable": false
+            },
+            {
+                "name": "TH5 Diode 2",
+                "controllable": false
             }
         ],
         "sfps": [

--- a/device/arista/x86_64-arista_7060x6_64pe/sensors.conf
+++ b/device/arista/x86_64-arista_7060x6_64pe/sensors.conf
@@ -5,8 +5,6 @@ bus "i2c-29" "SCD 0000:03:00.0 SMBus master 1 bus 4"
 chip "max6581-i2c-25-4d"
     ignore temp5
     ignore temp6
-    ignore temp7
-    ignore temp8
 
 chip "nvme-pci-0400"
     # TODO: sensors complaining about tempX_min and tempX_max

--- a/device/arista/x86_64-arista_7060x6_64pe_b/platform.json
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/platform.json
@@ -118,6 +118,14 @@
             {
                 "name": "Management Card Inlet",
                 "controllable": false
+            },
+            {
+                "name": "TH5 Diode 1",
+                "controllable": false
+            },
+            {
+                "name": "TH5 Diode 2",
+                "controllable": false
             }
         ],
         "sfps": [

--- a/device/arista/x86_64-arista_7060x6_64pe_b/sensors.conf
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/sensors.conf
@@ -5,8 +5,6 @@ bus "i2c-31" "SCD 0000:05:00.0 SMBus master 1 bus 4"
 chip "max6581-i2c-27-4d"
     ignore temp5
     ignore temp6
-    ignore temp7
-    ignore temp8
 
 chip "nvme-pci-0400"
     # TODO: sensors complaining about tempX_min and tempX_max


### PR DESCRIPTION
Manual cherry-pick: https://github.com/sonic-net/sonic-buildimage/pull/25337, CI Issue in automatic: https://github.com/sonic-net/sonic-buildimage/pull/25714

…5337)

Update thermal sensors after adding TH5 diodes in platform driver

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

