### PR TITLE
Fixes test_dns_resolv_conf.py failures due to stale DNS config in some of the containers

### DIFF
--- a/files/image_config/resolv-config/update-containers
+++ b/files/image_config/resolv-config/update-containers
@@ -87,13 +87,6 @@ if [[ $# -gt 0 ]]; then
     exit $?
 fi
 
-# Check if networking service is active (only for bulk updates)
-networking_status=$(systemctl is-active networking.service 2>/dev/null)
-if [[ $networking_status != "active" ]]; then
-    log_message "info" "Networking service is not active, skipping container updates"
-    exit 0
-fi
-
 # If no container name provided, update only running containers
 log_message "info" "Starting resolv.conf update for running containers"
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
test_dns_resolv_conf.py removes DNS config and checks if /etc/resolv.conf is updated in all containers. Test fails as some of teh containers like pmon/restapi still had stale DNS config on their /etc/resolv.conf

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
When DNS config is removed,

All containers are restarted
config load minigraph is called with empty nameserver which results in all containers getting restarted.
Updating host /etc/resolv.conf
2a. Hostcfd (sonic-host-services/scripts/hostcfgd) detects changes to restarts resolv.config service
2b. /usr/bin/resolv-config.sh updates /etc/resolv.conf
Networking service restarts
(3a) config load minigraph restarts sonic target which results in triggerig interfaces-config.service to call interfaces-config.sh
(3b) interfaces-config.sh calls "systemctl restart networking" to restart the networking service
Per container /etc/resolv.conf update
When containers come up, update containers get called with container name as their arg. Pls see files/build_templates/docker_image_ctl.j2. Update-containers when called with container name, reads updates /etc/resolv.conf in the container based on the contents of host /etc/resolv.conf.
(4a). If containers come up after the host /etc/resolv.conf is updated - NO ISSUES
(4b) Containers that came up before the host /etc/resolv.conf update will have stale config in them
Bulk update to containers -
Any changes to /etc/resolv.conf willl result in running all teh scripts under /etc/resolvconf/update-libc.d/ path. As a result udpate-containers should get called without the container name (to update all containers).
During bulk update, udate containers goes through all active containers and call update_container_resolv for each container which updates /etc/resolv.conf inside container based on values read from host etc/resolv.conf.
update-containers exits early in case if networking service is not up. This came in as part of - 
https://github.com/sonic-net/sonic-buildimage/commit/3a143adda210e015a47e2374d812355f6b8bcc3f
Optimization to skip updates during warm reboot

Sequence that lands in problem state:

All containers restarted along with networking service
pmon/restapi came early with stale DNS config. All other containers came in after the update to host /etc/resolv.conf.
update_containers is called for bulk update. Exits early becos networking service is down
networking service comes back up
pmon/restapi still continues to have stale config
Fix here removes the networking check in update containers.

#### How to verify it
Ran the test multiple times on different products and ensured that the test passes consistently.


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

