### PR TITLE
Fix port alias collision in minigraph parser

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -643,14 +643,14 @@ def parse_png(png, hname, dpg_ecmp_content = None):
                 bandwidth_node = link.find(str(QName(ns, "Bandwidth")))
                 bandwidth = bandwidth_node.text if bandwidth_node is not None else None
                 if enddevice.lower() == hname.lower():
-                    if endport in port_alias_map:
+                    if endport in port_alias_map and endport not in port_names_map:
                         endport = port_alias_map[endport]
                     if linktype != "DeviceMgmtLink":
                         neighbors[endport] = {'name': startdevice, 'port': startport}
                     if bandwidth:
                         port_speeds[endport] = bandwidth
                 elif startdevice.lower() == hname.lower():
-                    if startport in port_alias_map:
+                    if startport in port_alias_map and startport not in port_names_map:
                         startport = port_alias_map[startport]
                     if linktype != "DeviceMgmtLink":
                         neighbors[startport] = {'name': enddevice, 'port': endport}
@@ -707,7 +707,7 @@ def parse_png(png, hname, dpg_ecmp_content = None):
                 if link.find(str(QName(ns, "ElementType"))).text == "LogicalLink":
                     intf_name = link.find(str(QName(ns, "EndPort"))).text
                     start_device = link.find(str(QName(ns, "StartDevice"))).text
-                    if intf_name in port_alias_map:
+                    if intf_name in port_alias_map and intf_name not in port_names_map:
                         intf_name = port_alias_map[intf_name]
 
                     mux_cable_ports[intf_name] = start_device
@@ -761,14 +761,14 @@ def parse_asic_internal_link(link, asic_name, hostname):
     bandwidth = bandwidth_node.text if bandwidth_node is not None else None
     if ((enddevice.lower() == asic_name.lower()) and
             (startdevice.lower() != hostname.lower())):
-        if endport in port_alias_map:
+        if endport in port_alias_map and endport not in port_names_map:
             endport = port_alias_map[endport]
             neighbors[endport] = {'name': startdevice, 'port': startport}
             if bandwidth:
                 port_speeds[endport] = bandwidth
     elif ((startdevice.lower() == asic_name.lower()) and
             (enddevice.lower() != hostname.lower())):
-        if startport in port_alias_map:
+        if startport in port_alias_map and startport not in port_names_map:
             startport = port_alias_map[startport]
             neighbors[startport] = {'name': enddevice, 'port': endport}
             if bandwidth:
@@ -910,7 +910,7 @@ def parse_dpg(dpg, hname):
                 voq_inband_intfs["%s|%s" % (intfalias, ipprefix)] = {}
 
                 continue
-            intfname = port_alias_map.get(intfalias, intfalias)
+            intfname = intfalias if intfalias in port_names_map else port_alias_map.get(intfalias, intfalias)
             intfs[(intfname, ipprefix)] = {}
             ip_intfs_map[ipprefix] = intfalias
         lo_intfs = parse_loopback_intf(child)
@@ -919,7 +919,7 @@ def parse_dpg(dpg, hname):
         if subintfs is not None:
             for subintf in subintfs.findall(str(QName(ns, "SubInterface"))):
                 intfalias = subintf.find(str(QName(ns, "AttachTo"))).text
-                intfname = port_alias_map.get(intfalias, intfalias)
+                intfname = intfalias if intfalias in port_names_map else port_alias_map.get(intfalias, intfalias)
                 ipprefix = subintf.find(str(QName(ns, "Prefix"))).text
                 subintfvlan = subintf.find(str(QName(ns, "Vlan"))).text
                 subintfname = intfname + VLAN_SUB_INTERFACE_SEPARATOR + subintfvlan


### PR DESCRIPTION
#### Why I did it
On platforms where a port alias matches a different interface's name (e.g., Arista-7050CX3-32C-S128 where Ethernet128 has alias `Ethernet33`), the minigraph parser incorrectly resolves port names via alias lookup even when the port string is already a valid interface name. This causes double resolution and incorrect port-to-IP mapping.

For example, `Ethernet9/2` (alias of Ethernet33) gets resolved to `Ethernet33` (correct), but then `Ethernet33` is looked up again in `port_alias_map` and becomes `Ethernet128` (wrong, because `Ethernet33` is also the alias of Ethernet128).

#### How I did it
At all locations where `port_alias_map` is used to resolve port names, added a guard: if the port string is already a valid interface name (exists in `port_names_map`), use it directly instead of looking up in `port_alias_map`.

Affected locations in `minigraph.py`:
- `parse_png()`: DeviceInterfaceLink startport/endport resolution
- `parse_png()`: mux_cable_ports intf_name resolution
- `parse_png()`: interface IP assignment (intfname from InterfaceName)
- `parse_asic_internal_link()`: startport/endport resolution

#### How to verify it
Tested on Arista-7050CX3-32C-S128:
- Before fix: ARISTA29M0 IP assigned to Ethernet128 (wrong port, oper down)
- After fix: ARISTA29M0 IP assigned to Ethernet33 (correct port, oper up, BGP established)

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505
- [x] 202511

Backport reason: Latent bug affecting any platform with port alias/name collision. Arista-7050CX3-32C-S128 is actively used in test labs.

#### Description for the changelog
Fix minigraph parser to prioritize interface name over alias when resolving ports, preventing incorrect port mapping on platforms with alias-name collisions.