### PR TITLE
[202511] BROADCOM_LEGACY_SAI_COMPAT: Fix sai_query_stats_st_capability crash on Tomahawk-1 (BCM56960)

### DIFF
--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/sai.profile
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/sai.profile
@@ -1,2 +1,5 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th-a7060-cx32s-32x100G-t1.config.bcm
 SAI_NUM_ECMP_MEMBERS=64
+# BROADCOM_LEGACY_SAI_COMPAT: TH1 (BCM56960) has no streaming telemetry platform driver;
+# sai_query_stats_st_capability crashes in brcm_sai_st_pd_ctr_cap_list_get.
+SAI_STATS_ST_CAPABILITY_SUPPORTED=0

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-D48C8/sai.profile
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-D48C8/sai.profile
@@ -1,2 +1,5 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th-a7060-cx32s-8x100G+48x50G.config.bcm
 SAI_NUM_ECMP_MEMBERS=64
+# BROADCOM_LEGACY_SAI_COMPAT: TH1 (BCM56960) has no streaming telemetry platform driver;
+# sai_query_stats_st_capability crashes in brcm_sai_st_pd_ctr_cap_list_get.
+SAI_STATS_ST_CAPABILITY_SUPPORTED=0

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q24C8/sai.profile
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q24C8/sai.profile
@@ -1,2 +1,5 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th-a7060-cx32s-8x100G+24x40G.config.bcm
 SAI_NUM_ECMP_MEMBERS=64
+# BROADCOM_LEGACY_SAI_COMPAT: TH1 (BCM56960) has no streaming telemetry platform driver;
+# sai_query_stats_st_capability crashes in brcm_sai_st_pd_ctr_cap_list_get.
+SAI_STATS_ST_CAPABILITY_SUPPORTED=0

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-T96C8/sai.profile
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-T96C8/sai.profile
@@ -1,2 +1,5 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th-a7060-cx32s-8x100G+96x25G.config.bcm
 SAI_NUM_ECMP_MEMBERS=64
+# BROADCOM_LEGACY_SAI_COMPAT: TH1 (BCM56960) has no streaming telemetry platform driver;
+# sai_query_stats_st_capability crashes in brcm_sai_st_pd_ctr_cap_list_get.
+SAI_STATS_ST_CAPABILITY_SUPPORTED=0

--- a/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S/sai.profile
+++ b/device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S/sai.profile
@@ -1,1 +1,4 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/platform/th-a7060-cx32s-flex-all.config.bcm
+# BROADCOM_LEGACY_SAI_COMPAT: TH1 (BCM56960) has no streaming telemetry platform driver;
+# sai_query_stats_st_capability crashes in brcm_sai_st_pd_ctr_cap_list_get.
+SAI_STATS_ST_CAPABILITY_SUPPORTED=0


### PR DESCRIPTION
#### Why I did it

On Arista 7060cx (BCM56960_B1 / Tomahawk-1, `broadcom-legacy` platform), syncd crashes at startup with a SIGSEGV inside `brcm_sai_st_pd_ctr_cap_list_get+0x10` when running SONiC 202511 images.

**Root cause:** sairedis commit `4f1d7d99` (PR #1700) restored `sai_query_stats_st_capability` to `AC_CHECK_FUNCS` in `configure.ac`. Because all Broadcom builds share XGS SAI headers ([buildimage issue #23387](https://github.com/sonic-net/sonic-buildimage/issues/23387)), `HAVE_SAI_QUERY_STATS_ST_CAPABILITY=1` is defined for all Broadcom platforms including broadcom-legacy. On TH1, the SAI library initializes `p_pdapi_st=NULL` (no streaming telemetry hardware on TH1), but `brcm_sai_st_pd_ctr_cap_list_get` dereferences it without a null check — SIGSEGV.

This is a 202511 backport of the fix already merged into master via sonic-sairedis PR #1788 + sonic-buildimage [master PR #26013](https://github.com/sonic-net/sonic-buildimage/pull/26013).

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Add `SAI_STATS_ST_CAPABILITY_SUPPORTED=0` to `sai.profile` for all 5 Arista 7060cx HWSKU variants (BCM56960/Tomahawk-1). The runtime guard in syncd (sairedis PR #1788, now in 202511 via PR #1790) reads this key during `apiInitialize()` and nulls the `query_stats_st_capability` function pointer, causing `VendorSai::queryStatsStCapability()` to return `SAI_STATUS_NOT_IMPLEMENTED` — same behavior as before the regression.

Files changed (5):
- `device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S/sai.profile`
- `device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-C32/sai.profile`
- `device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-D48C8/sai.profile`
- `device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-Q24C8/sai.profile`
- `device/arista/x86_64-arista_7060_cx32s/Arista-7060CX-32S-T96C8/sai.profile`

Each file gets:
```ini
# BROADCOM_LEGACY_SAI_COMPAT: TH1 (BCM56960) has no streaming telemetry platform driver;
# sai_query_stats_st_capability crashes in brcm_sai_st_pd_ctr_cap_list_get.
SAI_STATS_ST_CAPABILITY_SUPPORTED=0
```

#### How to verify it

1. Build `broadcom-legacy` SONiC image for 202511 with this PR + sairedis 202511 PR #1790
2. Boot on Arista 7060cx (BCM56960_B1)
3. Confirm syncd starts without crash: `show logging | grep -i sigsegv` → no output
4. Confirm key is read: `show logging | grep SAI_STATS_ST_CAPABILITY_SUPPORTED` → `disabling query_stats_st_capability for this platform`
5. Confirm counters work normally

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version -->

#### Description for the changelog

Add SAI_STATS_ST_CAPABILITY_SUPPORTED=0 to sai.profile for Arista 7060cx (BCM56960/Tomahawk-1) to prevent syncd SIGSEGV crash at startup on broadcom-legacy 202511 images.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

🐧