### PR TITLE
Disable routeCheck, dualtorNeighborCheck and vnetRouteCheck in monit config on DPU platforms

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -374,6 +374,12 @@ sudo cp $IMAGE_CONFIGS/monit/monitrc $FILESYSTEM_ROOT/etc/monit/
 sudo chmod 600 $FILESYSTEM_ROOT/etc/monit/monitrc
 sudo cp $IMAGE_CONFIGS/monit/conf.d/* $FILESYSTEM_ROOT/etc/monit/conf.d/
 sudo chmod 600 $FILESYSTEM_ROOT/etc/monit/conf.d/*
+# Remove inapplicable monit checks on DPU platforms
+if [[ $CONFIGURED_PLATFORM == pensando ]] || [[ $CONFIGURED_PLATFORM == nvidia-bluefield ]]; then
+    sudo sed -i '/^# route_check\.py/,/^$/d' $FILESYSTEM_ROOT/etc/monit/conf.d/sonic-host
+    sudo sed -i '/^# dualtor_neighbor_check\.py/,/^$/d' $FILESYSTEM_ROOT/etc/monit/conf.d/sonic-host
+    sudo sed -i '/^# vnet_route_check\.py/,/^$/d' $FILESYSTEM_ROOT/etc/monit/conf.d/sonic-host
+fi
 sudo cp $IMAGE_CONFIGS/monit/container_checker $FILESYSTEM_ROOT/usr/bin/
 sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/container_checker
 sudo cp $IMAGE_CONFIGS/monit/memory_checker $FILESYSTEM_ROOT/usr/bin/


### PR DESCRIPTION
#### Why I did it

routeCheck, dualtorNeighborCheck and vnetRouteCheck monit checks are not applicable on DPU hosts:
- **routeCheck** verifies routes between APPL-DB and ASIC-DB, which are not relevant on DPUs.
- **dualtorNeighborCheck** verifies neighbor/tunnel route entries for dualtor configurations, which don't exist on DPUs.
- **vnetRouteCheck** verifies VNET routes consistency between SONiC and vendor SDK DBs, which is not applicable on DPUs.

When monit runs these checks on DPU hosts, they report failures that cause post-test DPU health checks to fail with errors like:
```
ERROR root:device_utils_dpu.py:499 'dualtorNeighborCheck' has failed in DPU0
ERROR root:device_utils_dpu.py:499 'routeCheck' has failed in DPU0
```

Fixes https://github.com/sonic-net/sonic-buildimage/issues/26225

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Remove `routeCheck`, `dualtorNeighborCheck` and `vnetRouteCheck` entries from the monit `sonic-host` config during image build for DPU platforms (pensando, nvidia-bluefield) using sed in `sonic_debian_extension.j2`.

Each sed command matches the comment line (e.g. `# route_check.py`) through the next blank/whitespace-only line, deleting the entire monit check block. The sed range terminator uses `^[[:space:]]*$` instead of `^$` for robustness against trailing whitespace.

**Companion PR:** https://github.com/sonic-net/sonic-utilities/pull/4405 — guards `monit unmonitor/monitor routeCheck` calls in `config reload` so they don't fail on DPU platforms where routeCheck is removed.

#### How to verify it

1. Build a SONiC image for a DPU platform:
   ```bash
   make configure PLATFORM=nvidia-bluefield
   make target/sonic-nvidia-bluefield.bin
   ```
2. On the built image, verify the monit config no longer contains the removed checks:
   ```bash
   grep -E "route_check|dualtor_neighbor_check|vnet_route_check" /etc/monit/conf.d/sonic-host
   ```
   Should return no output.
3. Verify monit runs without errors:
   ```bash
   sudo monit summary
   ```
4. Verify non-DPU platforms are unaffected (e.g. `PLATFORM=broadcom` image still has all three checks).

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version -->

#### Description for the changelog

Disable routeCheck, dualtorNeighborCheck and vnetRouteCheck monit checks on DPU platforms (pensando, nvidia-bluefield).

#### Link to config_db schema for YANG module changes

N/A — no YANG model changes.

#### A picture of a cute animal (not mandatory but encouraged)

