### PR TITLE
[yang-models]: Add NetworkBmc device type to DEVICE_METADATA YANG model

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -99,6 +99,9 @@
     "DEVICE_METADATA_TYPE_FILTER_LEAF_PATTERN": {
         "desc": "DEVICE_METADATA value as FilterLeaf for Type field"
     },
+    "DEVICE_METADATA_TYPE_NETWORK_BMC_PATTERN": {
+        "desc": "DEVICE_METADATA value as NetworkBmc for Type field"
+    },
     "DEVICE_METADATA_TYPE_NOT_PROVISIONED_PATTERN": {
         "desc": "DEVICE_METADATA value as not-provisioned for Type field"
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
@@ -282,6 +282,16 @@
             }
         }
     },
+    "DEVICE_METADATA_TYPE_NETWORK_BMC_PATTERN": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "bgp_asn": "65002",
+                    "type": "NetworkBmc"
+                }
+            }
+        }
+    },
     "DEVICE_METADATA_TYPE_NOT_PROVISIONED_PATTERN": {
         "sonic-device_metadata:sonic-device_metadata": {
             "sonic-device_metadata:DEVICE_METADATA": {

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -100,7 +100,7 @@ module sonic-device_metadata {
                 leaf type {
                     type string {
                         length 1..255;
-                        pattern "ToRRouter|LeafRouter|SpineChassisFrontendRouter|ChassisBackendRouter|ASIC|MgmtToRRouter|MgmtLeafRouter|MgmtSpineRouter|MgmtAccessRouter|LowerMgmtAggregator|UpperMgmtAggregator|SpineRouter|UpperSpineRouter|FabricSpineRouter|LowerSpineRouter|BackEndToRRouter|BackEndLeafRouter|EPMS|MgmtTsToR|BmcMgmtToRRouter|MiniTs|LeafTs|SpineTs|CoreTs|ConsoleServer|TerminalServer|SonicHost|SmartSwitchDPU|FilterLeaf|not-provisioned";
+                        pattern "ToRRouter|LeafRouter|SpineChassisFrontendRouter|ChassisBackendRouter|ASIC|MgmtToRRouter|MgmtLeafRouter|MgmtSpineRouter|MgmtAccessRouter|LowerMgmtAggregator|UpperMgmtAggregator|SpineRouter|UpperSpineRouter|FabricSpineRouter|LowerSpineRouter|BackEndToRRouter|BackEndLeafRouter|EPMS|MgmtTsToR|BmcMgmtToRRouter|MiniTs|LeafTs|SpineTs|CoreTs|ConsoleServer|TerminalServer|SonicHost|SmartSwitchDPU|FilterLeaf|NetworkBmc|not-provisioned";
                     }
                 }
 


### PR DESCRIPTION
#### Why I did it

Add **NetworkBmc** as a new valid device type in the SONiC YANG model. NetworkBmc is a new device role for BMC (Baseboard Management Controller) network devices that need to be recognized in SONiC device metadata configuration.

##### Work item tracking
- Microsoft ADO:

#### How I did it

- Added `NetworkBmc` to the `type` leaf pattern in `sonic-device_metadata.yang`
- Added YANG model unit test definition (`DEVICE_METADATA_TYPE_NETWORK_BMC_PATTERN`) in `tests/device_metadata.json`
- Added test configuration data for `NetworkBmc` type pattern validation in `tests_config/device_metadata.json`

#### How to verify it

YANG model unit tests validate that `NetworkBmc` is accepted as a valid device type pattern:
```bash
cd src/sonic-yang-models
python -m pytest tests/yang_model_tests/test_yang_model.py -k device_metadata
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

Add NetworkBmc as a supported device type in DEVICE_METADATA YANG model.

#### Link to config_db schema for YANG module changes

https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#device-metadata

#### A picture of a cute animal (not mandatory but encouraged)
