### PR TITLE
[Mellanox] Fix py import: sonic_platform/__init__.py in mellanox and nvidia-bluefield platforms

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/__init__.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/__init__.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2017-2021 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2017-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,4 +16,5 @@
 # limitations under the License.
 #
 __all__ = ["platform", "chassis"]
-from sonic_platform import *
+from . import platform
+from . import chassis

--- a/platform/nvidia-bluefield/platform-api/sonic_platform/__init__.py
+++ b/platform/nvidia-bluefield/platform-api/sonic_platform/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,4 +15,5 @@
 # limitations under the License.
 #
 __all__ = ["platform", "chassis"]
-from sonic_platform import *
+from . import platform
+from . import chassis


### PR DESCRIPTION
#### Why I did it

The mellanox and nvidia-bluefield platform python `sonic_platform/__init__.py` modules are self-referencing when importing, which sometimes races internally in the python runtime in specific situations and emits errors like the one below. This is a buggy implementation; the correct way to import submodules in `__init__.py` is to use relative imports.

This is a specific error message that is seen:

```
  AttributeError: partially initialized module 'sonic_platform' from '/usr/local/lib/python3.13/dist-packages/sonic_platform/__init__.py' has no attribute 'platform' (most likely due to a circular import)
```

For more context, this error log came from a pytest failure:

```
  =================================== FAILURES ===================================
  _____________________ Test_multiAsic_SFP.test_is_rj45_port _____________________

  self = <tests.sfp_test.Test_multiAsic_SFP object at 0x7f3c60a20b90>

      def test_is_rj45_port(self):
          import utilities_common.platform_sfputil_helper as platform_sfputil_helper
          platform_sfputil_helper.platform_chassis = None
          if 'sonic_platform' in sys.modules:
              sys.modules.pop('sonic_platform')
  >       assert platform_sfputil_helper.is_rj45_port("Ethernet0") == False

  tests/sfp_test.py:1233:
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  utilities_common/platform_sfputil_helper.py:312: in is_rj45_port
      import sonic_platform
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

      #
      # Copyright (c) 2017-2021 NVIDIA CORPORATION & AFFILIATES.
      # Apache-2.0
      #
      # Licensed under the Apache License, Version 2.0 (the "License");
      # you may not use this file except in compliance with the License.
      # You may obtain a copy of the License at
      #
      # http://www.apache.org/licenses/LICENSE-2.0
      #
      # Unless required by applicable law or agreed to in writing, software
      # distributed under the License is distributed on an "AS IS" BASIS,
      # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
      # See the License for the specific language governing permissions and
      # limitations under the License.
      #
      __all__ = ["platform", "chassis"]
  >   from sonic_platform import *
  E   AttributeError: partially initialized module 'sonic_platform' from '/usr/local/lib/python3.13/dist-packages/sonic_platform/__init__.py' has no attribute 'platform' (most likely due to a circular import)

  /usr/local/lib/python3.13/dist-packages/sonic_platform/__init__.py:18: AttributeError
```

After unrelated changes, python tests started failing. Specifically, tests.sfp_test.Test_multiAsic_SFP. I suspect the issues started occurring due to build timing changes affecting whether the sonic_platform module had been loaded into the module cache already, and perhaps newer versions of python are more sensitive to this issue than before.

#### How I did it

Replaced self-import, which relies on the `__all__` property of the same module, to relative imports, which is the documented correct way to import submodules in `__init__.py`.

#### How to verify it

I was not able to reproduce the python error on the master branch, but I do have my own where I was able to reproduce the error reliably and demonstrate that this change makes the error stop.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [x] master

#### Description for the changelog
Fix python self-import / circular import issue in `sonic_platform/__init__.py` for mellanox and nvidia-bluefield platforms.


