### PR TITLE
fix(bgpcfgd): handle list-wrapped IP addresses in BGP_NEIGHBOR (#25881)

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
@@ -154,6 +154,18 @@ class BGPPeerMgrBase(Manager):
         self.peer_group_mgr = BGPPeerGroupMgr(self.common_objs, base_template)
         return
 
+    @staticmethod
+    def normalize_ip_str(ip_str):
+        """
+        Normalize an IP address string that may be wrapped in Python list notation.
+        On chassis linecards, CONFIG_DB may store IPs as "['fc00::15']" instead of "fc00::15".
+        :param ip_str: IP address string, possibly list-wrapped
+        :return: cleaned IP address string
+        """
+        if isinstance(ip_str, str) and ip_str.startswith("["):
+            ip_str = ip_str.strip("[]'\" ")
+        return ip_str
+
     def set_handler(self, key, data):
         """
          It runs on 'SET' command
@@ -161,6 +173,9 @@ class BGPPeerMgrBase(Manager):
         :param data: the data associated with the change
         """
         vrf, nbr = self.split_key(key)
+        nbr = self.normalize_ip_str(nbr)
+        if "local_addr" in data:
+            data["local_addr"] = self.normalize_ip_str(data["local_addr"])
         peer_key = (vrf, nbr)
         if peer_key not in self.peers:
             return self.add_peer(vrf, nbr, data)
@@ -422,6 +437,7 @@ class BGPPeerMgrBase(Manager):
         :param key: key of the neighbor
         """
         vrf, nbr = self.split_key(key)
+        nbr = self.normalize_ip_str(nbr)
         peer_key = (vrf, nbr)
         if peer_key not in self.peers:
             log_warn("Peer '(%s|%s)' has not been found" % (vrf, nbr))

--- a/src/sonic-bgpcfgd/tests/test_bgp.py
+++ b/src/sonic-bgpcfgd/tests/test_bgp.py
@@ -263,6 +263,50 @@ def test_del_handler_nonexist_peer(mocked_log_warn):
         m.del_handler("40.40.40.1")
         mocked_log_warn.assert_called_with("Peer '(default|40.40.40.1)' has not been found")
 
+
+# Tests for normalize_ip_str and list-wrapped IP handling (issue #25881)
+
+def test_normalize_ip_str_plain_ipv4():
+    result = bgpcfgd.managers_bgp.BGPPeerMgrBase.normalize_ip_str("10.0.0.1")
+    assert result == "10.0.0.1"
+
+def test_normalize_ip_str_plain_ipv6():
+    result = bgpcfgd.managers_bgp.BGPPeerMgrBase.normalize_ip_str("fc00::15")
+    assert result == "fc00::15"
+
+def test_normalize_ip_str_list_wrapped_ipv4():
+    result = bgpcfgd.managers_bgp.BGPPeerMgrBase.normalize_ip_str("['10.0.0.1']")
+    assert result == "10.0.0.1"
+
+def test_normalize_ip_str_list_wrapped_ipv6():
+    result = bgpcfgd.managers_bgp.BGPPeerMgrBase.normalize_ip_str("['fc00::15']")
+    assert result == "fc00::15"
+
+def test_normalize_ip_str_non_string():
+    result = bgpcfgd.managers_bgp.BGPPeerMgrBase.normalize_ip_str(12345)
+    assert result == 12345
+
+def test_add_peer_list_wrapped_ipv4():
+    """Test that list-wrapped IPv4 addresses are handled correctly in add_peer"""
+    for constant in load_constant_files():
+        m = constructor(constant)
+        res = m.set_handler("['30.30.30.1']", {'asn': '65200', 'holdtime': '180', 'keepalive': '60', 'local_addr': "['30.30.30.30']", 'name': 'TOR', 'nhopself': '0', 'rrclient': '0'})
+        assert res, "Expect True return value for list-wrapped IPv4 peer"
+
+def test_add_peer_list_wrapped_ipv6():
+    """Test that list-wrapped IPv6 addresses are handled correctly in add_peer"""
+    for constant in load_constant_files():
+        m = constructor(constant)
+        res = m.set_handler("['fc00:20::1']", {'asn': '65200', 'holdtime': '180', 'keepalive': '60', 'local_addr': "['fc00:20::20']", 'name': 'TOR', 'nhopself': '0', 'rrclient': '0'})
+        assert res, "Expect True return value for list-wrapped IPv6 peer"
+
+def test_add_peer_list_wrapped_local_addr_only():
+    """Test that list-wrapped local_addr is handled even when key is clean"""
+    for constant in load_constant_files():
+        m = constructor(constant)
+        res = m.set_handler("30.30.30.1", {'asn': '65200', 'holdtime': '180', 'keepalive': '60', 'local_addr': "['30.30.30.30']", 'name': 'TOR', 'nhopself': '0', 'rrclient': '0'})
+        assert res, "Expect True return value for list-wrapped local_addr"
+
 @patch('bgpcfgd.managers_bgp.log_info')
 @patch('bgpcfgd.managers_bgp.log_warn')
 def test_del_handler_dynamic_nonexist_peer_template_exists(mocked_log_warn, mocked_log_info):


### PR DESCRIPTION
## Description

On chassis linecards, `BGP_NEIGHBOR` keys and `local_addr` values in CONFIG_DB
are stored as Python list strings (e.g., `"['fc00::15']"`) instead of plain IP
strings (`"fc00::15"`). This causes `bgpcfgd` to crash with
`netaddr.core.AddrFormatError` when it tries to parse the address via
`netaddr.IPNetwork()`.

## Root Cause

The chassis supervisor's config sync mechanism writes BGP neighbor entries with
IP addresses wrapped in Python list notation to the linecard's CONFIG_DB.

## Fix

Added `normalize_ip_str()` static method to `BGPPeerMgrBase` that strips
Python list notation (`['...'] → ...`) before IP address parsing. Applied in:
- `set_handler()`: normalizes both the neighbor key and `local_addr`
- `del_handler()`: normalizes the neighbor key

This is a defensive fix at the crash site. The upstream root cause (why IPs are
list-wrapped) should also be investigated separately.

## Tests

Added 8 unit tests covering:
- Plain IPv4/IPv6 passthrough (existing behavior preserved)
- List-wrapped IPv4/IPv6 normalization
- Non-string input passthrough
- Integration tests with `set_handler()` for list-wrapped addresses

## Fixes

Fixes #25881