### PR TITLE
ci: fix debian security docker-ptf

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -121,10 +121,8 @@ ENV PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
 RUN go install github.com/fullstorydev/grpcurl/cmd/grpcurl@v1.9.3 \
     && mv "$(go env GOPATH)/bin/grpcurl" /usr/local/bin/grpcurl \
     && chmod +x /usr/local/bin/grpcurl
-# Security fixes: upgrade vulnerable system packages (S360 scan remediation)
-RUN apt-get update && apt-get install -y --only-upgrade \
-        telnet               \
-        inetutils-telnet     \
+# Security fixes: upgrade all vulnerable system packages (S360 scan remediation)
+RUN apt-get update && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/*
 {% if PTF_ENV_PY_VER == "py3" %}
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \
@@ -321,6 +319,9 @@ RUN set -e; \
 # Install locally-built Python wheel dependencies
 {{ install_python_wheels(docker_ptf_whls.split(' ')) }}
 {% endif %}
+
+# Ensure setuptools >= 70.0.0 to address GHSA-cx63-2mw6-8hw5
+RUN pip3 install "setuptools>=70.0.0"
 
 ## Adjust sshd settings
 RUN mkdir /var/run/sshd \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Upgrading individual packages will get us keep getting flagged for new security issues. We should upgrade all what we could.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

