### PR TITLE
Fix sidecar rollout issue

### DIFF
--- a/dockers/docker-restapi-sidecar/cli-plugin-tests/test_systemd_stub.py
+++ b/dockers/docker-restapi-sidecar/cli-plugin-tests/test_systemd_stub.py
@@ -212,7 +212,7 @@ def test_sync_no_change_fast_path(ss):
     # Put same files on host
     host_fs["/usr/bin/restapi.sh"] = b"same"
     host_fs["/bin/container_checker"] = b"same"
-    host_fs["/usr/share/sonic/scripts/k8s_pod_control.sh"] = b"same"
+    host_fs["/usr/share/sonic/scripts/docker-restapi-sidecar/k8s_pod_control.sh"] = b"same"
     host_fs["/lib/systemd/system/restapi.service"] = b"same"
 
     ok = ss.ensure_sync()
@@ -237,7 +237,7 @@ def test_sync_updates_and_post_actions(ss):
     # Put old files on host
     host_fs["/usr/bin/restapi.sh"] = b"OLD"
     host_fs["/bin/container_checker"] = b"OLD"
-    host_fs["/usr/share/sonic/scripts/k8s_pod_control.sh"] = b"OLD"
+    host_fs["/usr/share/sonic/scripts/docker-restapi-sidecar/k8s_pod_control.sh"] = b"OLD"
     host_fs["/lib/systemd/system/restapi.service"] = b"OLD"
 
     ss.POST_COPY_ACTIONS["/bin/container_checker"] = [
@@ -414,7 +414,7 @@ def test_post_copy_actions_match_sync_items(monkeypatch, tmp_path):
     expected_destinations = {
         "/usr/bin/restapi.sh",
         "/bin/container_checker",
-        "/usr/share/sonic/scripts/k8s_pod_control.sh",
+        "/usr/share/sonic/scripts/docker-restapi-sidecar/k8s_pod_control.sh",
         "/lib/systemd/system/restapi.service",
     }
     
@@ -595,7 +595,7 @@ def test_restapi_service_uses_per_branch_file(ss):
     host_fs[systemd_stub.HOST_RESTAPI_SERVICE] = b"UNIT-OLD"
     host_fs["/usr/bin/restapi.sh"] = b"DUMMY"
     host_fs["/bin/container_checker"] = b"DUMMY"
-    host_fs["/usr/share/sonic/scripts/k8s_pod_control.sh"] = b"DUMMY"
+    host_fs["/usr/share/sonic/scripts/docker-restapi-sidecar/k8s_pod_control.sh"] = b"DUMMY"
 
     # Add post actions for restapi.service
     systemd_stub.POST_COPY_ACTIONS[systemd_stub.HOST_RESTAPI_SERVICE] = [

--- a/dockers/docker-restapi-sidecar/systemd_scripts/restapi.sh
+++ b/dockers/docker-restapi-sidecar/systemd_scripts/restapi.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-# Thin wrapper for restapi pod control - uses shared k8s_pod_control.sh
-exec /usr/share/sonic/scripts/k8s_pod_control.sh restapi "$@"
+# Thin wrapper for restapi pod control - uses sidecar-specific k8s_pod_control.sh
+exec /usr/share/sonic/scripts/docker-restapi-sidecar/k8s_pod_control.sh restapi "$@"

--- a/dockers/docker-restapi-sidecar/systemd_stub.py
+++ b/dockers/docker-restapi-sidecar/systemd_stub.py
@@ -108,6 +108,10 @@ POST_COPY_ACTIONS = {
         ["sudo", "systemctl", "daemon-reload"],
         ["sudo", "systemctl", "restart", "monit"],
     ],
+    "/usr/share/sonic/scripts/docker-restapi-sidecar/k8s_pod_control.sh": [
+        ["sudo", "systemctl", "daemon-reload"],
+        ["sudo", "systemctl", "restart", "restapi"],
+    ],
 }
 
 
@@ -166,7 +170,7 @@ def ensure_sync() -> bool:
     sync_items_list: List[SyncItem] = [
         SyncItem(restapi_src, "/usr/bin/restapi.sh", mode=0o755),
         SyncItem(container_checker_src, "/bin/container_checker", mode=0o755),
-        SyncItem("/usr/share/sonic/scripts/k8s_pod_control.sh", "/usr/share/sonic/scripts/k8s_pod_control.sh", mode=0o755),
+        SyncItem("/usr/share/sonic/scripts/k8s_pod_control.sh", "/usr/share/sonic/scripts/docker-restapi-sidecar/k8s_pod_control.sh", mode=0o755),
         SyncItem(container_restapi_service, HOST_RESTAPI_SERVICE, mode=0o644),
     ]
     return sync_items(sync_items_list, POST_COPY_ACTIONS)

--- a/dockers/docker-telemetry-sidecar/systemd_scripts/telemetry.sh
+++ b/dockers/docker-telemetry-sidecar/systemd_scripts/telemetry.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-# Thin wrapper for telemetry pod control - uses shared k8s_pod_control.sh
-exec /usr/share/sonic/scripts/k8s_pod_control.sh telemetry "$@"
+# Thin wrapper for telemetry pod control - uses sidecar-specific k8s_pod_control.sh
+exec /usr/share/sonic/scripts/docker-telemetry-sidecar/k8s_pod_control.sh telemetry "$@"

--- a/dockers/docker-telemetry-sidecar/systemd_stub.py
+++ b/dockers/docker-telemetry-sidecar/systemd_stub.py
@@ -72,7 +72,7 @@ logger.log_notice(f"telemetry source set to {_TELEMETRY_SRC}")
 
 SYNC_ITEMS: List[SyncItem] = [
     SyncItem(_TELEMETRY_SRC, "/usr/local/bin/telemetry.sh"),
-    SyncItem("/usr/share/sonic/scripts/k8s_pod_control.sh", "/usr/share/sonic/scripts/k8s_pod_control.sh"),
+    SyncItem("/usr/share/sonic/scripts/k8s_pod_control.sh", "/usr/share/sonic/scripts/docker-telemetry-sidecar/k8s_pod_control.sh"),
     SyncItem(CONTAINER_TELEMETRY_SERVICE, HOST_TELEMETRY_SERVICE, mode=0o644),
 ]
 
@@ -165,6 +165,10 @@ POST_COPY_ACTIONS = {
     ],
     "/usr/local/lib/python3.11/dist-packages/health_checker/service_checker.py": [
         ["sudo", "systemctl", "restart", "system-health"],
+    ],
+    "/usr/share/sonic/scripts/docker-telemetry-sidecar/k8s_pod_control.sh": [
+        ["sudo", "systemctl", "daemon-reload"],
+        ["sudo", "systemctl", "restart", "telemetry"],
     ],
 }
 

--- a/files/scripts/k8s_pod_control.sh
+++ b/files/scripts/k8s_pod_control.sh
@@ -190,29 +190,9 @@ cmd_status() {
 }
 
 cmd_wait() {
-  local max_rounds="${WAIT_MAX_ROUNDS:-15}"
-  local round=0
-  log "Waiting on pods (ns=${NS}, selector=${POD_SELECTOR}) on node ${NODE_NAME} (max ${max_rounds} rounds)…"
-  while true; do
-    local out=""; out="$(pods_on_node)"
-    if [[ -z "$out" ]]; then
-      if (( ++round > max_rounds )); then
-        log "ERROR: timed out after ${max_rounds} rounds waiting for pods (ns=${NS}, selector=${POD_SELECTOR}) on ${NODE_NAME}"
-        exit 1
-      fi
-      sleep 20; continue
-    fi
-    if awk '$2=="Running"{found=1} END{exit found?0:1}' <<<"$out"; then
-      round=0
-      sleep 20
-    else
-      if (( ++round > max_rounds )); then
-        log "ERROR: timed out after ${max_rounds} rounds waiting for pods (ns=${NS}, selector=${POD_SELECTOR}) on ${NODE_NAME}"
-        exit 1
-      fi
-      sleep 20
-    fi
-  done
+  # No-op: just sleep forever so the systemd unit stays "active".
+  log "cmd_wait: sleeping indefinitely (ns=${NS}, selector=${POD_SELECTOR}) on ${NODE_NAME}"
+  while true; do sleep 300; done
 }
 
 case "${1:-}" in


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix sidecar rollout issue


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
1. Place each k8s_pod_control.sh to dedicated repo for each sidecar, to avoid potential overwrite issue when multiple sidecar co-exist.
2. Update cmd_wait with no-op but sleep, so that systemd service is still active but not triggering kubelet to get pod status.

#### How to verify it
Verified by telemetry service.

XXXXXX@XXXXXXXX:~ sudo ls /usr/share/sonic/scripts/docker-telemetry-sidecar/
k8s_pod_control.sh
XXXXXX@XXXXXXXX:~ sudo systemctl status telemetry.service 
● telemetry.service - Telemetry container
     Loaded: loaded (/lib/systemd/system/telemetry.service; static)
    Drop-In: /etc/systemd/system/telemetry.service.d
             └─auto_restart.conf
     Active: active (running) since Wed 2026-03-18 12:43:12 UTC; 23s ago
    Process: 4028247 ExecStartPre=/usr/local/bin/telemetry.sh start (code=exited, status=0/SUCCESS)
   Main PID: 4028267 (k8s_pod_control)
      Tasks: 2 (limit: 38299)
     Memory: ~2M
     CGroup: /system.slice/telemetry.service
             ├─4028267 /bin/bash /usr/share/sonic/scripts/docker-telemetry-sidecar/k8s_pod_control.sh telemetry wait
             └─4028xxx sleep 300

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

