### PR TITLE
Update sensors.conf for x86_64-arista_7280r4_32qf_32df

### DIFF
--- a/device/arista/x86_64-arista_7280r4_32qf_32df/sensors.conf
+++ b/device/arista/x86_64-arista_7280r4_32qf_32df/sensors.conf
@@ -1,3 +1,86 @@
+bus "i2c-16" "SCD 0000:04:00.0 SMBus master 1 bus 3"
+bus "i2c-19" "SCD 0000:06:00.0 SMBus master 0 bus 0"
+bus "i2c-22" "SCD 0000:06:00.0 SMBus master 0 bus 3"
+bus "i2c-23" "SCD 0000:06:00.0 SMBus master 0 bus 4"
+bus "i2c-24" "SCD 0000:06:00.0 SMBus master 0 bus 5"
+bus "i2c-25" "SCD 0000:06:00.0 SMBus master 0 bus 6"
+
+chip "k10temp-pci-00c3"
+    label temp1 "Cpu temp sensor"
+
+chip "tmp75-i2c-16-48"
+    label temp1 "Outlet"
+
+chip "tmp75-i2c-19-48"
+    label temp1 "Management Card"
+
+chip "amax31732-i2c-19-1c"
+    label temp1 "PCB Temp Near Q3D"
+    label temp2 "D0 Temp diode 0"
+    label temp3 "D0 Temp diode 1"
+    label temp4 "D1 Temp diode 0"
+    label temp5 "D1 Temp diode 1"
+
+chip "raa228228-i2c-24-45"
+    label temp1 "POS0V75_VDDC_D0"
+    label temp2 "POS3V3_OPTICS_A"
+    ignore temp3
+
+chip "isl68226-i2c-24-4c"
+    label temp1 "POS1V2_HBM_D0"
+    label temp2 "POS0V9_D0"
+    label temp3 "POS0V75_D0"
+    ignore temp4
+    ignore temp5
+    ignore temp6
+    ignore temp7
+
+chip "isl68226-i2c-24-4f"
+    label temp1 "POS1V2_VAA_PHY"
+    label temp2 "POS0V75_VDD_PHY1"
+    label temp3 "POS0V75_VDD_PHY2"
+    ignore temp4
+    ignore temp5
+    ignore temp6
+    ignore temp7
+
+chip "raa228228-i2c-25-45"
+    label temp1 "POS0V75_VDDC_D1"
+    label temp2 "POS3V3_OPTICS_B"
+    ignore temp3
+
+chip "isl68226-i2c-25-4c"
+    label temp1 "POS1V2_HBM_D1"
+    label temp2 "POS0V9_D1"
+    label temp3 "POS0V75_D1"
+    ignore temp4
+    ignore temp5
+    ignore temp6
+    ignore temp7
+
+chip "isl68223-i2c-25-47"
+    label temp1 "POS0V8_PBVDD"
+    ignore temp2
+    ignore temp3
+    ignore temp4
+    ignore temp5
+
+chip "dps800-i2c-22-58"
+    label temp1 "Power supply 1 inlet sensor"
+    label temp2 "Power supply 1 secondary hotspot sensor"
+    label temp3 "Power supply 1 primary hotspot sensor"
+
+    ignore fan3
+    ignore fan4
+
+chip "dps800-i2c-23-58"
+    label temp1 "Power supply 2 inlet sensor"
+    label temp2 "Power supply 2 secondary hotspot sensor"
+    label temp3 "Power supply 2 primary hotspot sensor"
+
+    ignore fan3
+    ignore fan4
+
 chip "nvme-pci-0500"
     ignore temp2
     ignore temp3


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fans 3 and 4 are not present.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Updated platform specific sensors.conf

#### How to verify it
Verified by running `sensors`

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202511

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Needed to suppress incorrect fan warnings 

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
<img width="598" height="900" alt="image" src="https://github.com/user-attachments/assets/40775f79-bbe3-4e87-b4be-76a3988e9b39" />
