### PR TITLE
[SmartSwitch] [Mellanox] Ignore PCI sensors when DPU is power off

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn4280-r0/module_sensors_ignore_conf/ignore_sensors_DPU0.conf
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/module_sensors_ignore_conf/ignore_sensors_DPU0.conf
@@ -28,3 +28,6 @@ bus "i2c-18" "i2c-1-mux (chan_id 17)"
         ignore temp1 
         ignore temp2
         ignore curr6
+
+chip "mlx5-pci-0800"
+    ignore temp1

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/module_sensors_ignore_conf/ignore_sensors_DPU1.conf
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/module_sensors_ignore_conf/ignore_sensors_DPU1.conf
@@ -28,3 +28,6 @@ bus "i2c-19" "i2c-1-mux (chan_id 18)"
         ignore temp1 
         ignore temp2
         ignore curr6
+
+chip "mlx5-pci-0700"
+    ignore temp1

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/module_sensors_ignore_conf/ignore_sensors_DPU2.conf
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/module_sensors_ignore_conf/ignore_sensors_DPU2.conf
@@ -28,3 +28,6 @@ bus "i2c-20" "i2c-1-mux (chan_id 19)"
         ignore temp1 
         ignore temp2
         ignore curr6
+
+chip "mlx5-pci-0100"
+    ignore temp1

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/module_sensors_ignore_conf/ignore_sensors_DPU3.conf
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/module_sensors_ignore_conf/ignore_sensors_DPU3.conf
@@ -28,3 +28,6 @@ bus "i2c-21" "i2c-1-mux (chan_id 20)"
         ignore temp1 
         ignore temp2
         ignore curr6
+
+chip "mlx5-pci-0200"
+    ignore temp1


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

When DPU's are powered off and sensord restarts, we see the following error log. 



`
2026 Mar 17 18:24:42.400471 sonic ERR pmon#sensord: Error getting sensor data: mlx5/#0: Kernel interface error
`
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

This PCI Adapter sensor is not relevant after the DPU is powered off. Thus, add it to ignore list when it is powered off.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

When all DPU's are powered on:

```
mlx5-pci-0800
Adapter: PCI adapter
asic:
 temp1_input: 60.000
 temp1_crit: 91.000
 temp1_highest: 60.000

--
mlx5-pci-0100
Adapter: PCI adapter
asic:
 temp1_input: 68.000
 temp1_crit: 91.000
 temp1_highest: 68.000

--
mlx5-pci-0200
Adapter: PCI adapter
asic:
 temp1_input: 64.000
 temp1_crit: 91.000
 temp1_highest: 65.000

--
mlx5-pci-0700
Adapter: PCI adapter
asic:
 temp1_input: 71.000
 temp1_crit: 91.000
 temp1_highest: 73.000
```

Turn off the DPU's and no error log is seen

```
root@sonic:/home/admin# config chassis modules shutdown DPU3
Shutting down chassis module DPU3
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

