### PR TITLE
[arp_update] Remove PID from arp_update logger output (#26137)

### DIFF
--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -11,7 +11,7 @@ ARP_UPDATE_VARS_FILE="/usr/share/sonic/templates/arp_update_vars.j2"
 
 # Overload `logger` command to include arp_update tag
 logger () {
-    command logger -i "$$" -t "arp_update" "$@"
+    command logger -t "arp_update" "$@"
 }
 
 while /bin/true; do
@@ -59,12 +59,8 @@ while /bin/true; do
                   fi
                   intf_up=$(ip link show $interface | grep "state UP")
                   if [[ -n "$intf_up" ]]; then
-                      pingcmd="timeout 0.2 $ping_prefix -I ${interface} -n -q -i 0 -c 1 -W 1 $nexthop >/dev/null"
-                      eval $pingcmd
-                      # STALE entries may appear more often, not logging to prevent periodic syslogs
-                      if [[ -z $(echo ${neigh_state} | grep 'STALE') ]]; then
-                          logger "static route nexthop not resolved ($neigh_state), pinging $nexthop on $interface"
-                      fi
+                      run_with_retry_cmd "static route ping to $nexthop on $interface" \
+                          timeout 0.2 $ping_prefix -I "$interface" -n -q -i 0 -c 1 -W 1 "$nexthop" >/dev/null 2>&1
                   fi
               fi
           done


### PR DESCRIPTION
Why I did it
arp_update logs for static routes showed entries like: 98 static route nexthop not resolved ...
which could be misinterpreted as 98 unreachable servers.

This change modifies the logger() function to remove PID argument.

Work item tracking
Microsoft ADO (number only):
How I did it
PID in arp_update logs is not needed.
Keeping only tag makes logs cleaner while preserving filterability (-t arp_update). How to verify it

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

