### PR TITLE
[build][202511] use locally built libnetsnmptrapd40 and libsnmp-dev

### DIFF
--- a/build_debug_docker_j2.sh
+++ b/build_debug_docker_j2.sh
@@ -18,10 +18,12 @@ debs/{{ deb }}{{' '}}
 {%- endfor -%}
 debs/
 
+RUN apt-get update
+
 RUN dpkg -i \
 {% for deb in $2.split(' ') -%}
 debs/{{ deb }}{{' '}}
-{%- endfor %}
+{%- endfor %} || apt-get -y install -f --no-remove
 
 {% endif %}
 {% endif %}

--- a/rules/snmpd.mk
+++ b/rules/snmpd.mk
@@ -41,9 +41,11 @@ $(SNMPD)_RDEPENDS += $(LIBSNMP)
 $(eval $(call add_derived_package,$(LIBSNMP_BASE),$(SNMPD)))
 
 SNMP_DBG = snmp-dbgsym_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb
+$(SNMP_DBG)_RDEPENDS += $(SNMP)
 $(eval $(call add_derived_package,$(LIBSNMP_BASE),$(SNMP_DBG)))
 
 SNMPD_DBG = snmpd-dbgsym_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb
+$(SNMPD_DBG)_RDEPENDS += $(SNMPD)
 $(eval $(call add_derived_package,$(LIBSNMP_BASE),$(SNMPD_DBG)))
 
 ifeq ($(BLDENV),trixie)
@@ -63,8 +65,17 @@ $(LIBSNMP_DBG)_DEPENDS += $(LIBSNMP)
 $(LIBSNMP_DBG)_RDEPENDS += $(LIBSNMP)
 $(eval $(call add_derived_package,$(LIBSNMP_BASE),$(LIBSNMP_DBG)))
 
+ifeq ($(BLDENV),trixie)
+LIBNETSNMPTRAPD40 = libnetsnmptrapd40t64_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb
+else
+LIBNETSNMPTRAPD40 = libnetsnmptrapd40_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb
+endif
+$(LIBNETSNMPTRAPD40)_DEPENDS += $(LIBSNMP)
+$(LIBNETSNMPTRAPD40)_RDEPENDS += $(LIBSNMP) $(LIBSNMP_BASE)
+$(eval $(call add_derived_package,$(LIBSNMP_BASE),$(LIBNETSNMPTRAPD40)))
+
 LIBSNMP_DEV = libsnmp-dev_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb
-$(LIBSNMP_DEV)_DEPENDS += $(LIBSNMP)
+$(LIBSNMP_DEV)_DEPENDS += $(LIBSNMP) $(LIBNETSNMPTRAPD40)
 $(eval $(call add_derived_package,$(LIBSNMP_BASE),$(LIBSNMP_DEV)))
 
 LIBSNMP_PERL = libsnmp-perl_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb

--- a/sonic-slave-bookworm/Dockerfile.j2
+++ b/sonic-slave-bookworm/Dockerfile.j2
@@ -141,7 +141,6 @@ RUN apt-get update && apt-get install -y eatmydata && eatmydata apt-get install 
         chrpath \
 # For frr build
         libc-ares-dev \
-        libsnmp-dev \
         libjson-c-dev \
         libsystemd-dev \
         libcmocka-dev \
@@ -445,7 +444,6 @@ RUN apt-get update && apt-get install -y eatmydata && eatmydata apt-get install 
         pciutils \
         dh-dkms \
         rpm2cpio \
-        libsnmp-dev \
         libpopt-dev \
         libfuse-dev \
 {%- if CONFIGURED_ARCH == "arm64" %}

--- a/src/snmpd/Makefile
+++ b/src/snmpd/Makefile
@@ -12,6 +12,7 @@ DERIVED_TARGETS = snmptrapd_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  snmpd-dbgsym_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  libsnmp40_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  libsnmp40-dbgsym_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
+		  libnetsnmptrapd40_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  libsnmp-dev_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  libsnmp-perl_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \
 		  libsnmp-perl-dbgsym_$(SNMPD_VERSION_FULL)_$(CONFIGURED_ARCH).deb \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
cherry pick https://github.com/sonic-net/sonic-buildimage/commit/4c84167cc7296e80369b379750f3343616c82cf9 into 202511
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

