### PR TITLE
[202505] ci: fix debian security docker-ptf cherry-pick 26242

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -116,10 +116,8 @@ ENV PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
 RUN go install github.com/fullstorydev/grpcurl/cmd/grpcurl@v1.9.3 \
     && mv "$(go env GOPATH)/bin/grpcurl" /usr/local/bin/grpcurl \
     && chmod +x /usr/local/bin/grpcurl
-# Security fixes: upgrade vulnerable system packages (S360 scan remediation)
-RUN apt-get update && apt-get install -y --only-upgrade \
-        telnet               \
-        inetutils-telnet     \
+# Security fixes: upgrade all vulnerable system packages (S360 scan remediation)
+RUN apt-get update && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/*
 {% if PTF_ENV_PY_VER == "py3" %}
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \
@@ -283,15 +281,8 @@ RUN pip3 install Flask \
     && pip3 install retrying \
     && pip3 install jinja2
 
-# gnxi/gnmi_cli_py ships pre-generated _pb2.py stubs; they are
-# Pin to 6.33.5 to match grpcio-tools keep a known-good version.
-RUN set -e; \
-    . /etc/os-release; \
-    if [ "$VERSION_CODENAME" = "bookworm" ]; then \
-        pip3 install protobuf==6.33.5; \
-    else \
-        pip3 install protobuf; \
-    fi
+# Keep protobuf aligned with generated gNMI stubs.
+RUN pip3 install protobuf==6.33.5
 
 {% if docker_ptf_whls.strip() -%}
 # Copy locally-built Python wheel dependencies
@@ -305,6 +296,10 @@ RUN set -e; \
 # Deactivating a virtualenv.
 ENV PATH="$BACKUP_OF_PATH"
 {% endif %}
+
+# Ensure setuptools stays in a secure range while retaining pkg_resources
+# required by grpc_tools.protoc.
+RUN pip3 install "setuptools>=70.0.0,<78.0"
 
 ## Adjust sshd settings
 RUN mkdir /var/run/sshd \
@@ -339,14 +334,17 @@ RUN cd gnxi \
     && pip install -r requirements.txt \
     && pip3 install protobuf==6.33.5 --no-binary=protobuf
 {% else %}
+    && pip3 install "setuptools>=70.0.0,<78.0" "grpcio==1.74.0" "grpcio-tools==1.74.0" "protobuf==6.33.5" \
+    && rm -f gnmi_pb2.py gnmi_ext_pb2.py gnmi_pb2_grpc.py \
     && wget -q -O gnmi_ext.proto https://raw.githubusercontent.com/openconfig/gnmi/master/proto/gnmi_ext/gnmi_ext.proto \
     && wget -q -O gnmi.proto https://raw.githubusercontent.com/openconfig/gnmi/master/proto/gnmi/gnmi.proto \
     && sed -i 's|github.com/openconfig/gnmi/proto/gnmi_ext/gnmi_ext.proto|gnmi_ext.proto|' gnmi.proto \
-    && python -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. gnmi_ext.proto gnmi.proto \
+    && python3 -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. gnmi_ext.proto gnmi.proto \
+    && if grep -q _internal_create_key gnmi_ext_pb2.py; then echo "ERROR: gnmi stubs generated with incompatible protoc"; exit 1; fi \
     && rm -f gnmi.proto gnmi_ext.proto \
-    && pip3 install setuptools==51.0.0 \
-    && cat requirements.txt | grep -v futures > /tmp/requirements.txt \
-    && pip3 install -r /tmp/requirements.txt
+    && cat requirements.txt | grep -Ev '^(futures|grpcio==|grpcio-tools==|protobuf==)' > /tmp/requirements.txt \
+    && pip3 install -r /tmp/requirements.txt \
+    && pip3 install "setuptools>=70.0.0,<78.0" "grpcio==1.74.0" "grpcio-tools==1.74.0" "protobuf==6.33.5"
 {% endif %}
 
 # Install gnoic tool


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Cherry-pick https://github.com/sonic-net/sonic-buildimage/pull/26242 to fix docker-ptf vulnerability 


Custom test since our docker-ptf is blocked and only load from upstream:
https://elastictest.org/scheduler/testplan/69c20ef5038e650c6d65ff36

This will pass the test/telemetry problem

##### Work item tracking
- Microsoft ADO **(number only)**: 36979761

#### How I did it
Cherry-pick some changes to solve vulnerability from 202505

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

