### PR TITLE
Update kubeSonic managed systemctl to avoid using kubectl call

### DIFF
--- a/dockers/docker-telemetry-sidecar/cli-plugin-tests/test_systemd_stub.py
+++ b/dockers/docker-telemetry-sidecar/cli-plugin-tests/test_systemd_stub.py
@@ -193,6 +193,10 @@ def ss(tmp_path, monkeypatch):
     # Use "master" because it falls through to the default (non-branch-specific) path.
     monkeypatch.setattr(ss, "_get_branch_name", lambda: "master")
 
+    # Reset the one-shot cleanup flag so each test starts fresh
+    ss._stale_unit_cleaned = False
+    monkeypatch.setattr(ss, "_STALE_UNIT_CLEANUP_ENABLED", True)
+
     # Provide a default container_checker in both filesystems so the auto-appended
     # SyncItem from ensure_sync() is always satisfied and is a no-op.
     container_fs["/usr/share/sonic/systemd_scripts/container_checker"] = b"default-checker"
@@ -308,32 +312,111 @@ def test_env_controls_telemetry_src_default(monkeypatch):
     assert ss._TELEMETRY_SRC.endswith("telemetry.sh")
 
 
-def test_telemetry_service_syncs_to_host_when_different(ss):
-    ss, container_fs, host_fs, commands, config_db = ss
 
-    # Prepare container unit content and host old content
-    container_fs[ss.CONTAINER_TELEMETRY_SERVICE] = b"UNIT-NEW"
-    host_fs[ss.HOST_TELEMETRY_SERVICE] = b"UNIT-OLD"
+# ─────────────────────────── Tests for stale telemetry.service cleanup ───────────────────────────
 
-    # Only include the telemetry service item to make the assertion clear
-    ss.SYNC_ITEMS[:] = [
-        ss.SyncItem(ss.CONTAINER_TELEMETRY_SERVICE, ss.HOST_TELEMETRY_SERVICE, 0o644)
-    ]
+STALE_UNIT = b"""[Unit]
+Description=Telemetry container
 
-    # Add post actions for telemetry.service
-    ss.POST_COPY_ACTIONS[ss.HOST_TELEMETRY_SERVICE] = [
-        ["sudo", "systemctl", "daemon-reload"],
-        ["sudo", "systemctl", "restart", "telemetry"],
-    ]
+[Service]
+User=root
+ExecStartPre=/usr/local/bin/telemetry.sh start
+ExecStart=/usr/local/bin/telemetry.sh wait
+"""
 
-    ok = ss.ensure_sync()
-    assert ok is True
-    assert host_fs[ss.HOST_TELEMETRY_SERVICE] == b"UNIT-NEW"
+CLEAN_UNIT = b"""[Unit]
+Description=Telemetry container
 
-    # Verify systemctl actions were invoked
+[Service]
+User=admin
+ExecStartPre=/usr/local/bin/telemetry.sh start
+ExecStart=/usr/local/bin/telemetry.sh wait
+"""
+
+
+def test_cleanup_stale_unit_restores_from_packed_file(ss):
+    """When host telemetry.service has User=root, cleanup overwrites it with the packed clean file."""
+    ss_mod, container_fs, host_fs, commands, config_db = ss
+    host_fs[ss_mod._HOST_TELEMETRY_SERVICE] = STALE_UNIT
+    container_fs[ss_mod._CONTAINER_TELEMETRY_SERVICE] = CLEAN_UNIT
+
+    ss_mod._cleanup_stale_service_unit()
+
+    # Host file should now be the clean version
+    assert host_fs[ss_mod._HOST_TELEMETRY_SERVICE] == CLEAN_UNIT
+    # daemon-reload and restart should follow
     post_cmds = [args for _, args in commands if args and args[0] == "sudo"]
     assert ("sudo", "systemctl", "daemon-reload") in post_cmds
     assert ("sudo", "systemctl", "restart", "telemetry") in post_cmds
+
+
+def test_cleanup_skips_when_user_admin(ss):
+    """When host telemetry.service already has User=admin, cleanup is a no-op."""
+    ss_mod, container_fs, host_fs, commands, config_db = ss
+    host_fs[ss_mod._HOST_TELEMETRY_SERVICE] = CLEAN_UNIT
+
+    ss_mod._cleanup_stale_service_unit()
+
+    # No write should have occurred
+    write_cmds = [args for _, args in commands if args and args[0] == "/bin/sh"]
+    assert len(write_cmds) == 0
+
+
+def test_cleanup_skips_when_file_missing(ss):
+    """When host telemetry.service doesn't exist, cleanup is a no-op."""
+    ss_mod, container_fs, host_fs, commands, config_db = ss
+    # Don't put the file in host_fs
+
+    ss_mod._cleanup_stale_service_unit()
+
+    write_cmds = [args for _, args in commands if args and args[0] == "/bin/sh"]
+    assert len(write_cmds) == 0
+
+
+def test_cleanup_runs_only_once(ss):
+    """The cleanup is a one-shot; second call should be a no-op."""
+    ss_mod, container_fs, host_fs, commands, config_db = ss
+    host_fs[ss_mod._HOST_TELEMETRY_SERVICE] = STALE_UNIT
+    container_fs[ss_mod._CONTAINER_TELEMETRY_SERVICE] = CLEAN_UNIT
+
+    ss_mod._cleanup_stale_service_unit()
+    assert host_fs[ss_mod._HOST_TELEMETRY_SERVICE] == CLEAN_UNIT
+
+    # Revert host to stale to prove second call is a no-op
+    host_fs[ss_mod._HOST_TELEMETRY_SERVICE] = STALE_UNIT
+    ss_mod._cleanup_stale_service_unit()
+    # Should still be stale because the flag prevented re-run
+    assert host_fs[ss_mod._HOST_TELEMETRY_SERVICE] == STALE_UNIT
+
+def test_cleanup_retries_after_transient_read_failure(ss):
+    """When host_read_bytes fails transiently, cleanup retries on the next call."""
+    ss_mod, container_fs, host_fs, commands, config_db = ss
+    container_fs[ss_mod._CONTAINER_TELEMETRY_SERVICE] = CLEAN_UNIT
+    # First call: host file missing (transient failure)
+    # Don't put the file in host_fs
+
+    ss_mod._cleanup_stale_service_unit()
+    assert ss_mod._stale_unit_cleaned is False  # flag NOT set; will retry
+
+    # Second call: host file now present with stale content
+    host_fs[ss_mod._HOST_TELEMETRY_SERVICE] = STALE_UNIT
+    ss_mod._cleanup_stale_service_unit()
+    assert host_fs[ss_mod._HOST_TELEMETRY_SERVICE] == CLEAN_UNIT
+    assert ss_mod._stale_unit_cleaned is True
+
+
+def test_cleanup_disabled_by_env(ss, monkeypatch):
+    """When STALE_UNIT_CLEANUP_ENABLED=false, cleanup is skipped entirely."""
+    ss_mod, container_fs, host_fs, commands, config_db = ss
+    monkeypatch.setattr(ss_mod, "_STALE_UNIT_CLEANUP_ENABLED", False)
+    host_fs[ss_mod._HOST_TELEMETRY_SERVICE] = STALE_UNIT
+    container_fs[ss_mod._CONTAINER_TELEMETRY_SERVICE] = CLEAN_UNIT
+
+    ss_mod._cleanup_stale_service_unit()
+    # File should NOT be overwritten
+    assert host_fs[ss_mod._HOST_TELEMETRY_SERVICE] == STALE_UNIT
+    # Flag set so it won't retry
+    assert ss_mod._stale_unit_cleaned is True
 
 
 # ─────────────────────────── New tests for CONFIG_DB reconcile ───────────────────────────

--- a/dockers/docker-telemetry-sidecar/systemd_scripts/telemetry.service
+++ b/dockers/docker-telemetry-sidecar/systemd_scripts/telemetry.service
@@ -2,18 +2,15 @@
 Description=Telemetry container
 Requires=database.service
 After=database.service swss.service syncd.service
+Before=ntp-config.service
 BindsTo=sonic.target
 After=sonic.target
 StartLimitIntervalSec=1200
 StartLimitBurst=3
 
 [Service]
-Type=simple
-User=root
-ExecStartPre=/usr/local/bin/telemetry.sh start   # start: now returns in non-blocking (fire-and-forget pod deletion)
-ExecStart=/usr/local/bin/telemetry.sh wait       # wait: long-lived loop that observes pod status
-ExecStop=/usr/local/bin/telemetry.sh stop        # stop will not be working after kubesonic since pod will be auto-deployed via kubernetes
+User=admin
+ExecStartPre=/usr/local/bin/telemetry.sh start
+ExecStart=/usr/local/bin/telemetry.sh wait
+ExecStop=/usr/local/bin/telemetry.sh stop
 RestartSec=30
-TimeoutStartSec=30s
-TimeoutStopSec=30s
-Restart=always

--- a/dockers/docker-telemetry-sidecar/systemd_stub.py
+++ b/dockers/docker-telemetry-sidecar/systemd_stub.py
@@ -10,13 +10,10 @@ import argparse
 from typing import Dict, List
 
 from sonic_py_common.sidecar_common import (
-    get_bool_env_var, logger, SyncItem,
+    get_bool_env_var, logger, SyncItem, run_nsenter,
+    read_file_bytes_local, host_read_bytes, host_write_atomic,
     db_hget, db_hgetall, db_hset, db_del, sync_items, SYNC_INTERVAL_S
 )
-
-# ───────────── telemetry.service sync paths ─────────────
-CONTAINER_TELEMETRY_SERVICE = "/usr/share/sonic/systemd_scripts/telemetry.service"
-HOST_TELEMETRY_SERVICE = "/lib/systemd/system/telemetry.service"
 
 IS_V1_ENABLED = get_bool_env_var("IS_V1_ENABLED", default=False)
 
@@ -73,7 +70,6 @@ logger.log_notice(f"telemetry source set to {_TELEMETRY_SRC}")
 SYNC_ITEMS: List[SyncItem] = [
     SyncItem(_TELEMETRY_SRC, "/usr/local/bin/telemetry.sh"),
     SyncItem("/usr/share/sonic/scripts/k8s_pod_control.sh", "/usr/share/sonic/scripts/docker-telemetry-sidecar/k8s_pod_control.sh"),
-    SyncItem(CONTAINER_TELEMETRY_SERVICE, HOST_TELEMETRY_SERVICE, mode=0o644),
 ]
 
 # Compile regex patterns once at module level to avoid repeated compilation
@@ -149,10 +145,6 @@ def _get_branch_name() -> str:
 
 
 POST_COPY_ACTIONS = {
-    "/lib/systemd/system/telemetry.service": [
-        ["sudo", "systemctl", "daemon-reload"],
-        ["sudo", "systemctl", "restart", "telemetry"],
-    ],
     "/usr/local/bin/telemetry.sh": [
         ["sudo", "docker", "stop", "telemetry"],
         ["sudo", "docker", "rm", "telemetry"],
@@ -219,8 +211,58 @@ def reconcile_config_db_once() -> None:
 # Host destination for service_checker.py
 HOST_SERVICE_CHECKER = "/usr/local/lib/python3.11/dist-packages/health_checker/service_checker.py"
 
+# TO-be-deleted in next rounds releases, as long as telemetry.service rollouted have been restored.
+# Previous sidecar versions overwrote /lib/systemd/system/telemetry.service
+# with a variant containing "User=root" (needed for kubectl).  Now that kubectl
+# is gone we no longer sync that file, but hosts upgraded from the old sidecar
+# still carry the stale unit.  This one-shot cleanup restores the original
+# build-template version (User=admin) packed inside this container.
+_CONTAINER_TELEMETRY_SERVICE = "/usr/share/sonic/systemd_scripts/telemetry.service"
+_HOST_TELEMETRY_SERVICE = "/lib/systemd/system/telemetry.service"
+_STALE_UNIT_CLEANUP_ENABLED = get_bool_env_var("STALE_UNIT_CLEANUP_ENABLED", default=True)
+_stale_unit_cleaned = False
+
+def _cleanup_stale_service_unit() -> None:
+    """If the host telemetry.service still has User=root from a prior sidecar, restore it."""
+    global _stale_unit_cleaned
+    if _stale_unit_cleaned:
+        return
+    if not _STALE_UNIT_CLEANUP_ENABLED:
+        _stale_unit_cleaned = True
+        return
+
+    host_bytes = host_read_bytes(_HOST_TELEMETRY_SERVICE)
+    if host_bytes is None:
+        return  # transient failure or file missing; retry next cycle
+
+    host_content = host_bytes.decode("utf-8", errors="ignore")
+    if "\nUser=root\n" not in f"\n{host_content}\n":
+        _stale_unit_cleaned = True  # unit is clean; no further retries needed
+        return
+
+    clean_bytes = read_file_bytes_local(_CONTAINER_TELEMETRY_SERVICE)
+    if clean_bytes is None:
+        logger.log_error(f"Cannot read restore file {_CONTAINER_TELEMETRY_SERVICE}")
+        return  # container file missing; retry next cycle
+
+    logger.log_notice("Stale sidecar telemetry.service detected (User=root); restoring from packed file")
+    if not host_write_atomic(_HOST_TELEMETRY_SERVICE, clean_bytes, 0o644):
+        logger.log_error("Failed to restore telemetry.service")
+        return  # write failed; retry next cycle
+    rc, _, err = run_nsenter(["sudo", "systemctl", "daemon-reload"])
+    if rc != 0:
+        logger.log_error(f"daemon-reload failed after telemetry.service restore: {err}")
+        return  # retry next cycle
+    rc, _, err = run_nsenter(["sudo", "systemctl", "restart", "telemetry"])
+    if rc != 0:
+        logger.log_error(f"telemetry restart failed after telemetry.service restore: {err}")
+        return  # retry next cycle
+    _stale_unit_cleaned = True
+    logger.log_notice("Restored telemetry.service and restarted")
+
 
 def ensure_sync() -> bool:
+    _cleanup_stale_service_unit()
     branch_name = _get_branch_name()
 
     if branch_name in ("202411", "202412", "202505"):

--- a/files/scripts/k8s_pod_control.sh
+++ b/files/scripts/k8s_pod_control.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 # Shared Kubernetes pod control script for SONiC sidecar services
-# 1. Runs as root via systemd service, so direct access to kubelet.conf is available; sudo is not required
-# 2. Pod listing queries the local kubelet API (localhost:10250)
-# 3. start/restart complete quickly (kubectl --wait=false); stop is a no-op
-# 4. Only target pods matching POD_SELECTOR (default: raw_container_name=<SERVICE_NAME>)
+# 1. Discovers K8s-managed containers via 'docker ps' name filtering
+# 2. Uses 'docker restart' to restart the target container
+# 3. K8s container names follow the pattern k8s_<container>_<pod>_<ns>_<uid>
 #
 # Usage: SERVICE_NAME=telemetry k8s_pod_control.sh start
 #        Or source this script after setting SERVICE_NAME
@@ -23,166 +22,80 @@ if [[ -z "${SERVICE_NAME:-}" ]]; then
 fi
 
 NS="sonic"
-KUBECTL_BIN="/usr/bin/kubectl"
-KCF=(--kubeconfig=/etc/kubernetes/kubelet.conf)
-REQ_TIMEOUT="5s"
-MAX_ATTEMPTS=10
-BACKOFF_START=1
-BACKOFF_MAX=8
-
-# Kubelet local API – queries stay on-node; avoids API server load
-# Note: -k (skip server cert verification) is used because the kubelet's
-# serving cert is self-signed and not signed by the cluster CA.  This is
-# safe because the connection is to localhost only (loopback); there is no
-# network path for MITM.  Client authentication is still performed via certs.
-KUBELET_URL="https://localhost:10250"
-KUBELET_CERT="/var/lib/kubelet/pki/kubelet-client-current.pem"
-KUBELET_KEY="/var/lib/kubelet/pki/kubelet-client-current.pem"
-
-# Label selector for pods; can be overridden via env
-# Example override: POD_SELECTOR="app=telemetry" telemetry.sh start
-POD_SELECTOR="${POD_SELECTOR:-raw_container_name=${SERVICE_NAME}}"
 
 NODE_NAME="$(hostname | tr '[:upper:]' '[:lower:]')"
 log() { /usr/bin/logger -t "k8s-podctl#system" "$*"; }
 
-kubectl_retry() {
-  local attempt=1 backoff=${BACKOFF_START} out rc
-  while true; do
-    out="$("${KUBECTL_BIN}" "${KCF[@]}" --request-timeout="${REQ_TIMEOUT}" "$@" 2>&1)"; rc=$?
-    if (( rc == 0 )); then
-      printf '%s' "$out"
-      return 0
-    fi
-    if (( attempt >= MAX_ATTEMPTS )); then
-      echo "$out" >&2
-      return "$rc"
-    fi
-    log "kubectl retry ${attempt}/${MAX_ATTEMPTS} for: $*"
-    sleep "${backoff}"
-    (( backoff = backoff < BACKOFF_MAX ? backoff*2 : BACKOFF_MAX ))
-    (( attempt++ ))
-  done
-}
+# Docker filter for K8s-managed containers of this service.
+# K8s container names follow: k8s_<container>_<pod>_<ns>_<uid>
+DOCKER_FILTER="name=k8s_${SERVICE_NAME}_"
 
-kubelet_get_pods() {
-  local attempt=1 backoff=${BACKOFF_START} out rc http_code body err_msg
-  while true; do
-    # -w appends the 3-digit HTTP status code after the response body
-    out=$(curl -sk --cert "${KUBELET_CERT}" --key "${KUBELET_KEY}" \
-      --max-time 5 -w '%{http_code}' "${KUBELET_URL}/pods" 2>&1); rc=$?
-
-    http_code="" body="" err_msg="$out"
-    if (( rc == 0 )) && (( ${#out} >= 3 )); then
-      http_code="${out: -3}"
-      body="${out:0:${#out}-3}"
-      if [[ "$http_code" =~ ^2[0-9][0-9]$ ]]; then
-        printf '%s' "$body"
-        return 0
-      fi
-      # Non-2xx: build a descriptive message and fall through to retry
-      if [[ "$http_code" == "401" || "$http_code" == "403" ]]; then
-        err_msg="HTTP ${http_code} from kubelet (authn/authz failure)"
-      else
-        err_msg="HTTP ${http_code} from kubelet"
-      fi
-      rc=1
-    fi
-
-    if (( attempt >= MAX_ATTEMPTS )); then
-      echo "$err_msg" >&2
-      return "${rc:-1}"
-    fi
-    log "kubelet curl retry ${attempt}/${MAX_ATTEMPTS}: ${err_msg}"
-    sleep "${backoff}"
-    (( backoff = backoff < BACKOFF_MAX ? backoff*2 : BACKOFF_MAX ))
-    (( attempt++ ))
-  done
+container_ids_on_node() {
+  docker ps -q --filter "${DOCKER_FILTER}" 2>/dev/null || true
 }
 
 pods_on_node() {
-  local key="${POD_SELECTOR%%=*}"
-  local val="${POD_SELECTOR#*=}"
-  kubelet_get_pods | jq -r \
-    --arg ns "${NS}" --arg key "$key" --arg val "$val" \
-    '.items[] | select(.metadata.namespace == $ns) |
-     select(.metadata.labels[$key] == $val) |
-     "\(.metadata.name) \(.status.phase)"' || true
+  docker ps -a --filter "${DOCKER_FILTER}" \
+    --format '{{index .Labels "io.kubernetes.pod.name"}} {{.State}}' \
+    2>/dev/null || true
 }
 
 pod_names_on_node() {
-  local key="${POD_SELECTOR%%=*}"
-  local val="${POD_SELECTOR#*=}"
-  kubelet_get_pods | jq -r \
-    --arg ns "${NS}" --arg key "$key" --arg val "$val" \
-    '.items[] | select(.metadata.namespace == $ns) |
-     select(.metadata.labels[$key] == $val) |
-     .metadata.name' || true
+  docker ps -a --filter "${DOCKER_FILTER}" \
+    --format '{{index .Labels "io.kubernetes.pod.name"}}' \
+    2>/dev/null || true
 }
 
-delete_pod_with_retry() {
-  local name="$1"
-  local out rc
-  out=$(kubectl_retry -n "${NS}" delete pod "${name}" --force --grace-period=0 --wait=false 2>&1)
-  rc=$?
-  if (( rc != 0 )); then
-    log "ERROR delete pod '${name}' failed rc=${rc}: ${out}"
-  else
-    log "Deleted pod '${name}'"
-  fi
-  return "$rc"
-}
-
-kill_pods() {
-  mapfile -t names < <(pod_names_on_node)
-  if (( ${#names[@]} == 0 )); then
-    log "No pods found on ${NODE_NAME} (ns=${NS}, selector=${POD_SELECTOR})."
+restart_containers() {
+  mapfile -t cids < <(container_ids_on_node)
+  if (( ${#cids[@]} == 0 )); then
+    log "No containers found for '${SERVICE_NAME}' on ${NODE_NAME} (ns=${NS})."
     return 0
   fi
 
-  log "Deleting pods on ${NODE_NAME} (ns=${NS}, selector=${POD_SELECTOR}): ${names[*]}"
+  log "Restarting containers for '${SERVICE_NAME}' on ${NODE_NAME}: ${cids[*]}"
 
   local rc_any=0
-  for p in "${names[@]}"; do
-    [[ -z "$p" ]] && continue
-    if ! delete_pod_with_retry "$p"; then
+  for cid in "${cids[@]}"; do
+    [[ -z "$cid" ]] && continue
+    if docker restart "$cid" >/dev/null 2>&1; then
+      log "Restarted container ${cid} (${SERVICE_NAME})"
+    else
+      log "ERROR: failed to restart container ${cid} (${SERVICE_NAME})"
       rc_any=1
     fi
   done
 
   if (( rc_any != 0 )); then
-    log "ERROR one or more pod deletions failed on ${NODE_NAME} (selector=${POD_SELECTOR})"
+    log "ERROR one or more container restarts failed for '${SERVICE_NAME}' on ${NODE_NAME}"
   else
-    log "All targeted pods deleted on ${NODE_NAME} (selector=${POD_SELECTOR})"
+    log "All containers restarted for '${SERVICE_NAME}' on ${NODE_NAME}"
   fi
   return "$rc_any"
 }
 
 cmd_start() {
   # Re-invoke ourselves with the "restart" action under a hard 20s cap.
-  # On a healthy node this finishes in 1-2s (kubectl --wait=false).
-  # If the API server is unreachable, timeout(1) kills the child so we
-  # stay well within the service's TimeoutStartSec (30s).
+  # On a healthy node this finishes in 1-2s; the timeout guards against
+  # a hung 'docker restart' so we stay within TimeoutStartSec (30s).
   timeout 20 "${BASH_SOURCE[0]}" "${SERVICE_NAME}" restart 2>&1 \
     | logger -t "${SERVICE_NAME}-start" || true
 }
 
-# stop is a no-op: K8s controls the pod lifecycle; deleting the pod here
-# would just cause the controller to recreate it immediately.
-cmd_stop()    { kill_pods; }
-cmd_restart() { kill_pods; }
+cmd_stop()    { restart_containers; }
+cmd_restart() { restart_containers; }
 
 cmd_status() {
   local out=""; out="$(pods_on_node)"
   if [[ -z "$out" ]]; then
-    echo "NOT RUNNING (no pod on node ${NODE_NAME} with selector '${POD_SELECTOR}')"
+    echo "NOT RUNNING (no container on node ${NODE_NAME} for '${SERVICE_NAME}')"
     exit 3
   fi
-  while read -r name phase; do
+  while read -r name state; do
     [[ -z "$name" ]] && continue
-    echo "pod ${name}: ${phase}"
+    echo "pod ${name}: ${state}"
   done <<<"$out"
-  if awk '$2=="Running"{found=1} END{exit found?0:1}' <<<"$out"; then
+  if awk '$2=="running"{found=1} END{exit found?0:1}' <<<"$out"; then
     exit 0
   else
     exit 1
@@ -191,7 +104,7 @@ cmd_status() {
 
 cmd_wait() {
   # No-op: just sleep forever so the systemd unit stays "active".
-  log "cmd_wait: sleeping indefinitely (ns=${NS}, selector=${POD_SELECTOR}) on ${NODE_NAME}"
+  log "cmd_wait: sleeping indefinitely for '${SERVICE_NAME}' on ${NODE_NAME}"
   while true; do sleep 300; done
 }
 

--- a/files/scripts/tests/test_k8s_pod_control.sh
+++ b/files/scripts/tests/test_k8s_pod_control.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Unit tests for k8s_pod_control.sh
-# Validates jq filtering logic by mocking kubelet /pods JSON responses.
+# Uses a mock docker command to test container discovery and restart logic.
 #
 # Usage: bash files/scripts/tests/test_k8s_pod_control.sh
 
@@ -8,7 +8,8 @@ set -euo pipefail
 
 PASS=0
 FAIL=0
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="${SCRIPT_DIR}/k8s_pod_control.sh"
 
 # ── helpers ──────────────────────────────────────────────────────────
 red()   { printf '\033[31m%s\033[0m' "$*"; }
@@ -27,218 +28,174 @@ assert_eq() {
   fi
 }
 
-# ── sample kubelet /pods JSON ─────────────────────────────────────────
-# Mimics the structure returned by https://localhost:10250/pods
-MOCK_PODS_JSON='{
-  "kind": "PodList",
-  "apiVersion": "v1",
-  "items": [
-    {
-      "metadata": {
-        "name": "ds-leafrouter-ussouth-az01-4vvnd",
-        "namespace": "sonic",
-        "labels": {
-          "controller-revision-hash": "5796d79c5f",
-          "name": "ds-leafrouter",
-          "pod-template-generation": "1743567"
-        }
-      },
-      "status": { "phase": "Running" }
-    },
-    {
-      "metadata": {
-        "name": "ds-leafrouter-telemetry-zgmsl",
-        "namespace": "sonic",
-        "labels": {
-          "controller-revision-hash": "fb47dd8b7",
-          "name": "ds-leafrouter-telemetry",
-          "pod-template-generation": "9",
-          "raw_container_name": "telemetry"
-        }
-      },
-      "status": { "phase": "Running" }
-    },
-    {
-      "metadata": {
-        "name": "ds-leafrouter-restapi-abc12",
-        "namespace": "sonic",
-        "labels": {
-          "raw_container_name": "restapi"
-        }
-      },
-      "status": { "phase": "Pending" }
-    },
-    {
-      "metadata": {
-        "name": "other-ns-pod",
-        "namespace": "kube-system",
-        "labels": {
-          "raw_container_name": "telemetry"
-        }
-      },
-      "status": { "phase": "Running" }
-    }
-  ]
-}'
+# ── Mock environment ──────────────────────────────────────────────────
+MOCK_DIR="$(mktemp -d)"
+trap 'rm -rf "${MOCK_DIR}"' EXIT
 
-# Empty pod list
-MOCK_EMPTY_JSON='{
-  "kind": "PodList",
-  "apiVersion": "v1",
-  "items": []
-}'
+# Mock docker: handles ps and restart subcommands
+cat > "${MOCK_DIR}/docker" <<'MOCK_DOCKER'
+#!/bin/bash
+subcmd="$1"; shift
+case "$subcmd" in
+  ps)
+    quiet=false; all=false; filter=""; format=""
+    while (( $# > 0 )); do
+      case "$1" in
+        -q) quiet=true; shift ;;
+        -a) all=true; shift ;;
+        --filter) filter="$2"; shift 2 ;;
+        --format) format="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    case "$filter" in
+      "name=k8s_telemetry_")
+        if $quiet; then
+          echo "abc123def456"
+        elif [[ "$format" == *".State"* ]]; then
+          echo "ds-leafrouter-telemetry-zgmsl running"
+        else
+          echo "ds-leafrouter-telemetry-zgmsl"
+        fi
+        ;;
+      "name=k8s_multi_")
+        if $quiet; then
+          printf '%s\n' "aaa111" "bbb222"
+        elif [[ "$format" == *".State"* ]]; then
+          printf '%s\n' "pod-multi-1 running" "pod-multi-2 exited"
+        else
+          printf '%s\n' "pod-multi-1" "pod-multi-2"
+        fi
+        ;;
+      "name=k8s_nonexistent_")
+        ;;  # no output
+    esac
+    ;;
+  restart)
+    cid="$1"
+    case "$cid" in
+      "abc123def456"|"aaa111"|"bbb222") ;;
+      *) exit 1 ;;
+    esac
+    ;;
+esac
+MOCK_DOCKER
+chmod +x "${MOCK_DIR}/docker"
 
-# Pod with no labels
-MOCK_NO_LABELS_JSON='{
-  "kind": "PodList",
-  "apiVersion": "v1",
-  "items": [
-    {
-      "metadata": {
-        "name": "no-labels-pod",
-        "namespace": "sonic"
-      },
-      "status": { "phase": "Running" }
-    }
-  ]
-}'
+# Mock logger (absorb all log output)
+cat > "${MOCK_DIR}/logger" <<'MOCK_LOGGER'
+#!/bin/bash
+exit 0
+MOCK_LOGGER
+chmod +x "${MOCK_DIR}/logger"
 
-# ── extract jq filters from the script to test them directly ─────────
-# We test the exact same jq expressions used in pods_on_node / pod_names_on_node
+export PATH="${MOCK_DIR}:${PATH}"
 
-jq_pods_on_node() {
-  local ns="$1" key="$2" val="$3" json="$4"
-  printf '%s' "$json" | jq -r \
-    --arg ns "$ns" --arg key "$key" --arg val "$val" \
-    '.items[] | select(.metadata.namespace == $ns) |
-     select(.metadata.labels[$key] == $val) |
-     "\(.metadata.name) \(.status.phase)"' || true
-}
+# Create a sourceable version of the script:
+# - replace /usr/bin/logger with plain logger (so our PATH mock is used)
+# - strip the case dispatch block at the bottom
+SOURCE_SCRIPT="${MOCK_DIR}/k8s_pod_control_funcs.sh"
+sed -e 's|/usr/bin/logger|logger|g' \
+    -e '/^case "\${1:-}" in$/,/^esac$/d' \
+    "$SCRIPT" > "$SOURCE_SCRIPT"
 
-jq_pod_names_on_node() {
-  local ns="$1" key="$2" val="$3" json="$4"
-  printf '%s' "$json" | jq -r \
-    --arg ns "$ns" --arg key "$key" --arg val "$val" \
-    '.items[] | select(.metadata.namespace == $ns) |
-     select(.metadata.labels[$key] == $val) |
-     .metadata.name' || true
-}
+# Source functions with SERVICE_NAME pre-set
+export SERVICE_NAME="telemetry"
+source "$SOURCE_SCRIPT"
 
 # ── Test suite ────────────────────────────────────────────────────────
-echo "=== pods_on_node jq filter ==="
+echo "=== DOCKER_FILTER ==="
 
-# Test 1: Match telemetry pod in sonic namespace
-result="$(jq_pods_on_node "sonic" "raw_container_name" "telemetry" "$MOCK_PODS_JSON")"
-assert_eq "match telemetry pod" \
-  "ds-leafrouter-telemetry-zgmsl Running" \
-  "$result"
-
-# Test 2: Match restapi pod (Pending phase)
-result="$(jq_pods_on_node "sonic" "raw_container_name" "restapi" "$MOCK_PODS_JSON")"
-assert_eq "match restapi pod (Pending)" \
-  "ds-leafrouter-restapi-abc12 Pending" \
-  "$result"
-
-# Test 3: Should NOT match pods in other namespaces
-result="$(jq_pods_on_node "sonic" "raw_container_name" "telemetry" "$MOCK_PODS_JSON")"
-# Should only return the sonic-namespace pod, not the kube-system one
-line_count=$(echo "$result" | wc -l)
-assert_eq "excludes other namespaces (single result)" "1" "$line_count"
-
-# Test 4: No match when label value differs
-result="$(jq_pods_on_node "sonic" "raw_container_name" "nonexistent" "$MOCK_PODS_JSON")"
-assert_eq "no match for unknown service" "" "$result"
-
-# Test 5: No match when label key differs
-result="$(jq_pods_on_node "sonic" "app" "telemetry" "$MOCK_PODS_JSON")"
-assert_eq "no match for wrong label key" "" "$result"
-
-# Test 6: Empty pod list
-result="$(jq_pods_on_node "sonic" "raw_container_name" "telemetry" "$MOCK_EMPTY_JSON")"
-assert_eq "empty pod list returns empty" "" "$result"
-
-# Test 7: Pod with no labels (should not error, just no match)
-result="$(jq_pods_on_node "sonic" "raw_container_name" "telemetry" "$MOCK_NO_LABELS_JSON")"
-assert_eq "pod with no labels returns empty" "" "$result"
+assert_eq "DOCKER_FILTER for telemetry" \
+  "name=k8s_telemetry_" "$DOCKER_FILTER"
 
 echo ""
-echo "=== pod_names_on_node jq filter ==="
+echo "=== container_ids_on_node ==="
 
-# Test 8: Match telemetry pod name only
-result="$(jq_pod_names_on_node "sonic" "raw_container_name" "telemetry" "$MOCK_PODS_JSON")"
-assert_eq "match telemetry pod name" \
-  "ds-leafrouter-telemetry-zgmsl" \
-  "$result"
+result="$(container_ids_on_node)"
+assert_eq "returns container ID for telemetry" "abc123def456" "$result"
 
-# Test 9: Match restapi pod name
-result="$(jq_pod_names_on_node "sonic" "raw_container_name" "restapi" "$MOCK_PODS_JSON")"
-assert_eq "match restapi pod name" \
-  "ds-leafrouter-restapi-abc12" \
-  "$result"
+# Switch to multi-container service
+DOCKER_FILTER="name=k8s_multi_"
+result="$(container_ids_on_node)"
+line_count=$(printf '%s\n' "$result" | grep -c .)
+assert_eq "returns multiple container IDs" "2" "$line_count"
 
-# Test 10: No match
-result="$(jq_pod_names_on_node "sonic" "raw_container_name" "nonexistent" "$MOCK_PODS_JSON")"
+# No match
+DOCKER_FILTER="name=k8s_nonexistent_"
+result="$(container_ids_on_node)"
 assert_eq "no match returns empty" "" "$result"
 
-# Test 11: Empty list
-result="$(jq_pod_names_on_node "sonic" "raw_container_name" "telemetry" "$MOCK_EMPTY_JSON")"
-assert_eq "empty list returns empty" "" "$result"
+echo ""
+echo "=== pods_on_node ==="
+
+DOCKER_FILTER="name=k8s_telemetry_"
+result="$(pods_on_node)"
+assert_eq "returns pod name and state" \
+  "ds-leafrouter-telemetry-zgmsl running" "$result"
+
+DOCKER_FILTER="name=k8s_multi_"
+result="$(pods_on_node)"
+line_count=$(printf '%s\n' "$result" | grep -c .)
+assert_eq "returns multiple pods" "2" "$line_count"
+
+DOCKER_FILTER="name=k8s_nonexistent_"
+result="$(pods_on_node)"
+assert_eq "no match returns empty" "" "$result"
 
 echo ""
-echo "=== POD_SELECTOR parsing ==="
+echo "=== pod_names_on_node ==="
 
-# Test 12-13: Verify the bash parameter expansion used to split key=value
-selector="raw_container_name=telemetry"
-key="${selector%%=*}"
-val="${selector#*=}"
-assert_eq "selector key parsing" "raw_container_name" "$key"
-assert_eq "selector val parsing" "telemetry" "$val"
+DOCKER_FILTER="name=k8s_telemetry_"
+result="$(pod_names_on_node)"
+assert_eq "returns pod name only" \
+  "ds-leafrouter-telemetry-zgmsl" "$result"
 
-# Test 14-15: Custom selector
-selector="app=my-service"
-key="${selector%%=*}"
-val="${selector#*=}"
-assert_eq "custom selector key" "app" "$key"
-assert_eq "custom selector val" "my-service" "$val"
+DOCKER_FILTER="name=k8s_multi_"
+result="$(pod_names_on_node)"
+line_count=$(printf '%s\n' "$result" | grep -c .)
+assert_eq "returns multiple pod names" "2" "$line_count"
+
+DOCKER_FILTER="name=k8s_nonexistent_"
+result="$(pod_names_on_node)"
+assert_eq "no match returns empty" "" "$result"
 
 echo ""
-echo "=== HTTP status code parsing ==="
+echo "=== restart_containers ==="
 
-# Test 16-19: Simulate the -w '%{http_code}' output parsing from kubelet_get_pods
-parse_http_response() {
-  local out="$1" http_code="" body=""
-  if (( ${#out} >= 3 )); then
-    http_code="${out: -3}"
-    body="${out:0:${#out}-3}"
-  fi
-  echo "${http_code}|${body}"
-}
+DOCKER_FILTER="name=k8s_telemetry_"
+SERVICE_NAME="telemetry"
+restart_containers; rc=$?
+assert_eq "restart single container succeeds" "0" "$rc"
 
-result="$(parse_http_response '{"items":[]}200')"
-assert_eq "parse 200 response code" '200|{"items":[]}' "$result"
+DOCKER_FILTER="name=k8s_multi_"
+SERVICE_NAME="multi"
+restart_containers; rc=$?
+assert_eq "restart multiple containers succeeds" "0" "$rc"
 
-result="$(parse_http_response '401')"
-assert_eq "parse 401 with empty body" '401|' "$result"
-
-result="$(parse_http_response 'Unauthorized403')"
-assert_eq "parse 403 with error body" '403|Unauthorized' "$result"
-
-result="$(parse_http_response '{"items":[{"metadata":{"name":"pod1"}}]}200')"
-assert_eq "parse 200 with pod data" '200|{"items":[{"metadata":{"name":"pod1"}}]}' "$result"
+DOCKER_FILTER="name=k8s_nonexistent_"
+SERVICE_NAME="nonexistent"
+restart_containers; rc=$?
+assert_eq "restart with no containers is no-op" "0" "$rc"
 
 echo ""
 echo "=== cmd_status awk filter ==="
 
-# Test 20-21: Verify the awk expression used in cmd_status/cmd_wait
 has_running() {
-  awk '$2=="Running"{found=1} END{exit found?0:1}' <<<"$1" && echo "yes" || echo "no"
+  awk '$2=="running"{found=1} END{exit found?0:1}' <<<"$1" && echo "yes" || echo "no"
 }
 
-result="$(has_running "ds-leafrouter-telemetry-zgmsl Running")"
-assert_eq "awk detects Running" "yes" "$result"
+result="$(has_running "ds-leafrouter-telemetry-zgmsl running")"
+assert_eq "awk detects running" "yes" "$result"
 
-result="$(has_running "ds-leafrouter-restapi-abc12 Pending")"
-assert_eq "awk detects non-Running" "no" "$result"
+result="$(has_running "ds-leafrouter-restapi-abc12 exited")"
+assert_eq "awk detects exited" "no" "$result"
+
+result="$(has_running $'pod1 running\npod2 exited')"
+assert_eq "awk mixed (has running)" "yes" "$result"
+
+result="$(has_running $'pod1 exited\npod2 exited')"
+assert_eq "awk all exited" "no" "$result"
 
 # ── Summary ───────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In order to use kubelet/kubectl, we update systemctl service user from admin into root, but there's some systemctl generator which will ingest data into systemctl service unit file, that will result in endless overwrite from sidecar container.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Switch back to admin user for systemctl unit file, and use docker command instead of kubelet for systemctl service restart

#### How to verify it
<img width="1613" height="614" alt="image" src="https://github.com/user-attachments/assets/b162a62b-e0cb-4d4d-adf1-aa488c5a6a90" />

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

