### PR TITLE
[202505][Arista] Moby: change thermal polling interval to 10 seconds

### DIFF
--- a/device/arista/x86_64-arista_7060x6_16pe_384c/pmon_daemon_control.json
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c/pmon_daemon_control.json
@@ -1,1 +1,9 @@
-../x86_64-arista_common/pmon_daemon_control.json
+{
+    "skip_fancontrol": true,
+    "enable_xcvrd_sff_mgr": true,
+    "thermalctld": {
+        "thermal_monitor_update_interval": 10,
+        "thermal_monitor_update_elapsed_threshold": 9
+    }
+}
+

--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/pmon_daemon_control.json
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/pmon_daemon_control.json
@@ -1,4 +1,9 @@
 {
     "skip_fancontrol": true,
-    "enable_xcvrd_sff_mgr": true
+    "enable_xcvrd_sff_mgr": true,
+    "thermalctld": {
+        "thermal_monitor_update_interval": 10,
+        "thermal_monitor_update_elapsed_threshold": 9
+    }
 }
+


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Reduce the thermal monitoring polling interval to improve diagnostics.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

