### PR TITLE
[202511][FRR]: Fix crash on SRv6 locator deletion

### DIFF
--- a/src/sonic-frr/patch/0102-staticd-Fix-SRv6-SID-use-after-free-on-locator-deletion.patch
+++ b/src/sonic-frr/patch/0102-staticd-Fix-SRv6-SID-use-after-free-on-locator-deletion.patch
@@ -1,0 +1,44 @@
+From 3fd5c01f6e71de1ca05c1983f8762a7713ead7b2 Mon Sep 17 00:00:00 2001
+From: Carmine Scarpitta <cscarpit@cisco.com>
+Date: Mon, 2 Feb 2026 20:17:27 +0000
+Subject: [PATCH] staticd: Unset SID validity flag when locator is deleted
+
+When a locator is removed, we iterate over the list of SIDs and
+uninstall them from the data plane. However, the validity flag of
+the SID remains set, and the locator pointer still points to the
+freed locator memory.
+
+This causes issues in other parts of the code where we check the
+SID validity flag. Since the flag is still set, we assume the SID
+is valid and attempt to access the locator pointer, resulting in
+use-after-free crashes.
+
+Fix this by:
+- Unsetting the STATIC_FLAG_SRV6_SID_VALID flag to mark the SID
+  as invalid when its locator is deleted
+- Setting the locator pointer to NULL to indicate that the SID
+  no longer has a locator associated with it
+
+This ensures that when the locator is removed, associated SIDs are
+properly marked as invalid and cannot accidentally reference freed
+memory.
+
+Signed-off-by: Carmine Scarpitta <cscarpit@cisco.com>
+---
+ staticd/static_zebra.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/staticd/static_zebra.c b/staticd/static_zebra.c
+index b6757ed5b1b0..ceb60bfbc00b 100644
+--- a/staticd/static_zebra.c
++++ b/staticd/static_zebra.c
+@@ -1259,6 +1259,9 @@ static int static_zebra_process_srv6_locator_delete(ZAPI_CALLBACK_ARGS)
+ 			static_zebra_srv6_sid_uninstall(sid);
+ 			UNSET_FLAG(sid->flags, STATIC_FLAG_SRV6_SID_SENT_TO_ZEBRA);
+ 		}
++
++		sid->locator = NULL;
++		UNSET_FLAG(sid->flags, STATIC_FLAG_SRV6_SID_VALID);
+ 	}
+ 
+ 	listnode_delete(srv6_locators, locator);

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -60,3 +60,4 @@
 0098-SRv6-Add-support-for-multiple-SRv6-locators.patch
 0099-zebra-Fix-SRv6-explicit-SID-allocation-to-use-the-provided-locator.patch
 0100-bgpd-Allow-proper-shutdown-of-bgp-dynamic-peers.patch
+0102-staticd-Fix-SRv6-SID-use-after-free-on-locator-deletion.patch


### PR DESCRIPTION
Manual cherry-pick of https://github.com/sonic-net/sonic-buildimage/pull/25358

#### Why I did it

Fix issue https://github.com/sonic-net/sonic-buildimage/issues/22690 "staticd crashes on SRv6 configuration removal"

#### How I did it

Port upstream FRR fix into SONiC:
* https://github.com/FRRouting/frr/pull/20660

#### How to verify it

Verified that the fix solves the problem.

#### Which release branch to backport (provide reason below if selected)


- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

