### PR TITLE
[Mellanox][SmartSwitch]Remove rescan capability for DPUs

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py
@@ -279,8 +279,10 @@ class DpuCtlPlat():
     def dpu_pci_scan(self):
         """PCI Scan API"""
         try:
-            pci_scan_path = "/sys/bus/pci/rescan"
-            self.write_file(pci_scan_path, OperationType.SET.value)
+            for pci_dev_path in self.get_pci_dev_path():
+                if not os.path.exists(pci_dev_path):
+                    #Only log error if the device is not found, don't perform explicit ``
+                    self.log_warning(f"PCI device {pci_dev_path} not found")
             return True
         except Exception as e:
             self.log_error(f"Failed to rescan with error {e}")

--- a/platform/mellanox/mlnx-platform-api/tests/test_dpuctlplat.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_dpuctlplat.py
@@ -125,12 +125,11 @@ class TestDpuCtlPlatPCI:
             assert written_data[1]["file"] == TEST_RSHIM_PCI_REMOVE_PATH
             assert written_data[1]["data"] == "1"
 
-        # Test PCI scan - should scan devices
+        # Test PCI scan - only checks device paths exist, no write_file calls
         written_data.clear()
-        with patch.object(dpuctl_obj, 'write_file', wraps=mock_write_file):
+        with patch('os.path.exists', return_value=True):
             assert dpuctl_obj.dpu_pci_scan()
-            assert written_data[0]["file"].endswith("rescan")
-            assert written_data[0]["data"] == "1"
+            assert len(written_data) == 0  # dpu_pci_scan no longer writes to rescan
 
 class TestDpuCtlPlatPower:
     """Tests for power management functionality"""
@@ -205,13 +204,11 @@ class TestDpuCtlPlatPower:
              patch.object(dpuctl_obj, 'read_boot_prog', return_value=BootProgEnum.RST.value), \
              patch.object(dpuctl_obj, 'read_force_power_path', return_value=1):
             assert dpuctl_obj.dpu_power_on(True)
-            assert len(written_data) == 3  # pwr_force + rst + rescan
+            assert len(written_data) == 2  # pwr_force + rst (dpu_pci_scan no longer writes)
             assert written_data[0]["file"].endswith("_pwr_force")
             assert written_data[0]["data"] == "1"
             assert written_data[1]["file"].endswith("_rst")
             assert written_data[1]["data"] == "1"
-            assert written_data[2]["file"].endswith("rescan")
-            assert written_data[2]["data"] == "1"
 
         # Test normal power on
         written_data.clear()
@@ -219,10 +216,9 @@ class TestDpuCtlPlatPower:
              patch.object(dpuctl_obj, 'read_boot_prog', return_value=BootProgEnum.RST.value), \
              patch.object(dpuctl_obj, 'read_force_power_path', return_value=1):
             assert dpuctl_obj.dpu_power_on(False)
-            assert len(written_data) == 3  # pwr + rst + rescan
+            assert len(written_data) == 2  # pwr + rst (dpu_pci_scan no longer writes)
             assert written_data[0]["file"].endswith("_pwr")
             assert written_data[1]["file"].endswith("_rst")
-            assert written_data[2]["file"].endswith("rescan")
 
         # Test power on with skip_pre_post=True
         written_data.clear()
@@ -255,26 +251,24 @@ class TestDpuCtlPlatReboot:
         with patch.object(dpuctl_obj, 'write_file', wraps=mock_write_file), \
              patch.object(dpuctl_obj, 'read_boot_prog', return_value=BootProgEnum.OS_RUN.value):
             assert dpuctl_obj.dpu_reboot(False)
-            assert len(written_data) == 5  # Both PCI removals + rst + rst + rescan
+            assert len(written_data) == 4  # Both PCI removals + rst + rst (dpu_pci_scan no longer writes)
             assert written_data[0]["file"] == TEST_PCI_REMOVE_PATH
             assert written_data[1]["file"] == TEST_RSHIM_PCI_REMOVE_PATH
             assert written_data[2]["file"].endswith("_rst")
             assert written_data[3]["file"].endswith("_rst")
-            assert written_data[4]["file"].endswith("rescan")
 
         # Test force reboot
         written_data.clear()
         with patch.object(dpuctl_obj, 'write_file', wraps=mock_write_file), \
              patch.object(dpuctl_obj, 'read_boot_prog', return_value=BootProgEnum.OS_RUN.value):
             assert dpuctl_obj.dpu_reboot(True)
-            assert len(written_data) == 7  # Both PCI removals + rst + pwr_force + pwr_force + rst + rescan
+            assert len(written_data) == 6  # Both PCI removals + rst + pwr_force + pwr_force + rst (dpu_pci_scan no longer writes)
             assert written_data[0]["file"] == TEST_PCI_REMOVE_PATH
             assert written_data[1]["file"] == TEST_RSHIM_PCI_REMOVE_PATH
             assert written_data[2]["file"].endswith("_rst")
             assert written_data[3]["file"].endswith("_pwr_force")
             assert written_data[4]["file"].endswith("_pwr_force")
             assert written_data[5]["file"].endswith("_rst")
-            assert written_data[6]["file"].endswith("rescan")
 
         # Test no-wait reboot
         written_data.clear()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

We do not need explicit PCI global rescan. The hotplug capability of the switch and DPUs will confirm that the DPUs are added, so writing to `/sys/bus/pci/rescan` is unnecessary. This change removes the global rescan and instead only validates that the expected PCI device paths exist after startup/reboot, logging an warning if a device is not found.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- **`platform/mellanox/mlnx-platform-api/sonic_platform/dpuctlplat.py`**: Updated `dpu_pci_scan()` to stop writing to `/sys/bus/pci/rescan`. It now iterates over the PCI device paths from `get_pci_dev_path()` (DPU and RSHIM PCI devices), checks that each path exists via `os.path.exists()`, and logs a warning only when a device path is missing. No explicit rescan is performed.
- **`platform/mellanox/mlnx-platform-api/tests/test_dpuctlplat.py`**: Adjusted unit tests to match the new behavior: removed all expectations of a write to "rescan", reduced expected write counts for power-on and reboot flows (since post-startup no longer performs rescan), and updated the PCI scan test to assert that `dpu_pci_scan()` returns success without calling `write_file`.

#### How to verify it

- Run the mlnx-platform-api unit tests:  
  `cd platform/mellanox/mlnx-platform-api && python -m pytest tests/test_dpuctlplat.py -v`
- On a Mellanox switch with DPU(s), verify DPU power-on and reboot still work and that the DPU(s) are detected after startup (relying on hotplug rather than explicit rescan).

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Remove explicit PCI global rescan in DPU platform API; rely on switch/DPU hotplug for device detection.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

N/A – no YANG/config_db changes.

#### A picture of a cute animal (not mandatory but encouraged)

