### PR TITLE
sonic-py-common: remove deprecated imp module usage

### DIFF
--- a/src/sonic-py-common/sonic_py_common/general.py
+++ b/src/sonic-py-common/sonic_py_common/general.py
@@ -1,6 +1,4 @@
 import sys
-import importlib.machinery
-import importlib.util
 from subprocess import Popen, STDOUT, PIPE, CalledProcessError, check_output
 
 
@@ -9,6 +7,8 @@ def load_module_from_source(module_name, file_path):
     This function will load the Python source file specified by <file_path>
     as a module named <module_name> and return an instance of the module
     """
+    import importlib.machinery
+    import importlib.util
     loader = importlib.machinery.SourceFileLoader(module_name, file_path)
     spec = importlib.util.spec_from_loader(loader.name, loader)
     module = importlib.util.module_from_spec(spec)


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The imp module was deprecated in Python 3.4 and removed in Python 3.12. Replace the version-guarded imp.load_source() fallback with direct use of importlib, which has been available since Python 3.1. Move importlib imports to the top of the file.



<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->


<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->




<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of cute animal (not mandatory but encouraged)

![IMG-20260322-WA0001](https://github.com/user-attachments/assets/06672637-d337-4810-8473-db82e8d85713)


