### PR TITLE
sonic-py-common: remove unused variables in fabric config lookups

### DIFF
--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -347,9 +347,6 @@ def get_path_to_fabric_monitor_config_file(hwsku=None, asic=None):
 
     fabric_monitor_config_candidates = []
 
-    # Check for 'hwsku.json' file presence first
-    hwsku_json_file = os.path.join(hwsku_path, HWSKU_JSON_FILE)
-
     # Check for 'fabric_monitor_config.json' file presence
     fabric_monitor_config_candidates.append(os.path.join(hwsku_path, FABRIC_MONITOR_CONFIG_FILE))
 
@@ -395,12 +392,6 @@ def get_path_to_fabric_port_config_file(hwsku=None, asic=None):
         (platform_path, hwsku_path) = get_paths_to_platform_and_hwsku_dirs()
 
     fabric_port_config_candidates = []
-
-    # Check for 'hwsku.json' file presence first
-    hwsku_json_file = os.path.join(hwsku_path, HWSKU_JSON_FILE)
-
-    # if 'hwsku.json' file is available, Check for 'platform.json' file presence,
-    # if 'platform.json' is available, APPEND it. Otherwise, SKIP it.
 
     # Check for 'fabric_port_config.ini' file presence in a few locations
     if asic:


### PR DESCRIPTION
Remove unused hwsku_json_file assignments in get_path_to_fabric_monitor_config_file() and get_path_to_fabric_port_config_file(). The variables were computed but never referenced.



#### A picture of a cute animal (not mandatory but encouraged)


