### PR TITLE
sonic-py-common: use yaml.safe_load unconditionally in get_sonic_version_info

### DIFF
--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -515,10 +515,7 @@ def get_sonic_version_info():
         return sonic_ver_info
 
     with open(SONIC_VERSION_YAML_PATH) as stream:
-        if yaml.__version__ >= "5.1":
-            sonic_ver_info = yaml.full_load(stream)
-        else:
-            sonic_ver_info = yaml.safe_load(stream)
+        sonic_ver_info = yaml.safe_load(stream)
 
     return sonic_ver_info
 


### PR DESCRIPTION
#### How I did it:

Replaced the if/else version check with a single yaml.safe_load() call.

#### How to verify it:

The existing test_get_sonic_version in device_info_test.py
covers this function. yaml.safe_load() correctly parses the simple key-value format of sonic_version.yml.