### PR TITLE
mgmt interface: Fix incorrect management route addition order

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -92,8 +92,8 @@ iface {{ name }} {{ 'inet' if prefix | ipv4 else 'inet6' }} static
 {% set force_mgmt_route_priority = 32764 %}
     ########## management network policy routing rules
     # management port up rules
-    up ip {{ '-4' if prefix | ipv4 else '-6' }} route add default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev {{ name }} table {{ vrf_table }} metric 201
     up ip {{ '-4' if prefix | ipv4 else '-6' }} route add {{ prefix | network }}/{{ prefix | prefixlen }} dev {{ name }} table {{ vrf_table }}
+    up ip {{ '-4' if prefix | ipv4 else '-6' }} route add default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev {{ name }} table {{ vrf_table }} metric 201
     up ip {{ '-4' if prefix | ipv4 else '-6' }} rule add pref {{ force_mgmt_route_priority + 1 }} from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }}
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
     up ip {{ '-4' if prefix | ipv4 else '-6' }} rule add pref {{ force_mgmt_route_priority }} to {{ route }} table {{ vrf_table }}

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces
@@ -21,8 +21,8 @@ iface eth0 inet static
     broadcast 10.0.0.255
     ########## management network policy routing rules
     # management port up rules
-    up ip -4 route add default via 10.0.0.1 dev eth0 table default metric 201
     up ip -4 route add 10.0.0.0/24 dev eth0 table default
+    up ip -4 route add default via 10.0.0.1 dev eth0 table default metric 201
     up ip -4 rule add pref 32765 from 10.0.0.100/32 table default
     up ip rule add pref 32764 to 10.20.6.16/32 table default
     # management port down rules
@@ -37,8 +37,8 @@ iface eth0 inet6 static
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
     ########## management network policy routing rules
     # management port up rules
-    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default
+    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201
     up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table default
     # IPV6 default table not add to lookup by default, management server need this to access IPV6 address when BGP shutdown
     up ip -6 rule add pref 32767 lookup default

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_mgmt31
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_mgmt31
@@ -20,8 +20,8 @@ iface eth0 inet static
     network 10.10.4.12
     ########## management network policy routing rules
     # management port up rules
-    up ip -4 route add default via 10.10.4.12 dev eth0 table default metric 201
     up ip -4 route add 10.10.4.12/31 dev eth0 table default
+    up ip -4 route add default via 10.10.4.12 dev eth0 table default metric 201
     up ip -4 rule add pref 32765 from 10.10.4.13/32 table default
     up ip rule add pref 32764 to 10.20.6.16/32 table default
     # management port down rules
@@ -36,8 +36,8 @@ iface eth0 inet6 static
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
     ########## management network policy routing rules
     # management port up rules
-    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default
+    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201
     up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table default
     # IPV6 default table not add to lookup by default, management server need this to access IPV6 address when BGP shutdown
     up ip -6 rule add pref 32767 lookup default

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_syslog
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_syslog
@@ -21,8 +21,8 @@ iface eth0 inet static
     broadcast 10.0.0.255
     ########## management network policy routing rules
     # management port up rules
-    up ip -4 route add default via 10.0.0.1 dev eth0 table default metric 201
     up ip -4 route add 10.0.0.0/24 dev eth0 table default
+    up ip -4 route add default via 10.0.0.1 dev eth0 table default metric 201
     up ip -4 rule add pref 32765 from 10.0.0.100/32 table default
     up ip rule add pref 32764 to 10.3.145.8/32 table default
     up ip rule add pref 32764 to 100.127.20.21/32 table default
@@ -39,8 +39,8 @@ iface eth0 inet6 static
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
     ########## management network policy routing rules
     # management port up rules
-    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default
+    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201
     up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table default
     # IPV6 default table not add to lookup by default, management server need this to access IPV6 address when BGP shutdown
     up ip -6 rule add pref 32767 lookup default

--- a/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
@@ -31,8 +31,8 @@ iface eth0 inet static
     vrf mgmt
     ########## management network policy routing rules
     # management port up rules
-    up ip -4 route add default via 10.0.0.1 dev eth0 table 6000 metric 201
     up ip -4 route add 10.0.0.0/24 dev eth0 table 6000
+    up ip -4 route add default via 10.0.0.1 dev eth0 table 6000 metric 201
     up ip -4 rule add pref 32765 from 10.0.0.100/32 table 6000
     up ip -4 rule add pref 32764 to 11.11.11.11 table 6000
     up ip -4 rule add pref 32764 to 22.22.22.0/23 table 6000
@@ -52,8 +52,8 @@ iface eth0 inet6 static
     vrf mgmt
     ########## management network policy routing rules
     # management port up rules
-    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table 6000 metric 201
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table 6000
+    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table 6000 metric 201
     up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table 6000
     up ip -6 rule add pref 32764 to 33:33:33::0/64 table 6000
     # management port down rules

--- a/src/sonic-config-engine/tests/sample_output/py2/two_mgmt_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/two_mgmt_interfaces
@@ -22,8 +22,8 @@ iface eth1 inet static
     broadcast 10.0.10.255
     ########## management network policy routing rules
     # management port up rules
-    up ip -4 route add default via 10.0.10.1 dev eth1 table default metric 201
     up ip -4 route add 10.0.10.0/24 dev eth1 table default
+    up ip -4 route add default via 10.0.10.1 dev eth1 table default metric 201
     up ip -4 rule add pref 32765 from 10.0.10.100/32 table default
     up ip rule add pref 32764 to 10.20.6.16/32 table default
     # management port down rules
@@ -38,8 +38,8 @@ iface eth0 inet static
     broadcast 10.0.0.255
     ########## management network policy routing rules
     # management port up rules
-    up ip -4 route add default via 10.0.0.1 dev eth0 table default metric 201
     up ip -4 route add 10.0.0.0/24 dev eth0 table default
+    up ip -4 route add default via 10.0.0.1 dev eth0 table default metric 201
     up ip -4 rule add pref 32765 from 10.0.0.100/32 table default
     up ip rule add pref 32764 to 10.20.6.16/32 table default
     # management port down rules
@@ -54,8 +54,8 @@ iface eth1 inet6 static
     broadcast 2603:10e2:0:abcd:ffff:ffff:ffff:ffff
     ########## management network policy routing rules
     # management port up rules
-    up ip -6 route add default via 2603:10e2:0:abcd::1 dev eth1 table default metric 201
     up ip -6 route add 2603:10e2:0:abcd::/64 dev eth1 table default
+    up ip -6 route add default via 2603:10e2:0:abcd::1 dev eth1 table default metric 201
     up ip -6 rule add pref 32765 from 2603:10e2:0:abcd::8/128 table default
     # IPV6 default table not add to lookup by default, management server need this to access IPV6 address when BGP shutdown
     up ip -6 rule add pref 32767 lookup default
@@ -71,8 +71,8 @@ iface eth0 inet6 static
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
     ########## management network policy routing rules
     # management port up rules
-    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default
+    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201
     up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table default
     # IPV6 default table not add to lookup by default, management server need this to access IPV6 address when BGP shutdown
     up ip -6 rule add pref 32767 lookup default

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces
@@ -21,8 +21,8 @@ iface eth0 inet static
     broadcast 10.0.0.255
     ########## management network policy routing rules
     # management port up rules
-    up ip -4 route add default via 10.0.0.1 dev eth0 table default metric 201
     up ip -4 route add 10.0.0.0/24 dev eth0 table default
+    up ip -4 route add default via 10.0.0.1 dev eth0 table default metric 201
     up ip -4 rule add pref 32765 from 10.0.0.100/32 table default
     up ip rule add pref 32764 to 10.20.6.16/32 table default
     # management port down rules
@@ -37,8 +37,8 @@ iface eth0 inet6 static
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
     ########## management network policy routing rules
     # management port up rules
-    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default
+    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201
     up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table default
     # IPV6 default table not add to lookup by default, management server need this to access IPV6 address when BGP shutdown
     up ip -6 rule add pref 32767 lookup default

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_mgmt31
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_mgmt31
@@ -20,8 +20,8 @@ iface eth0 inet static
     network 10.10.4.12
     ########## management network policy routing rules
     # management port up rules
-    up ip -4 route add default via 10.10.4.12 dev eth0 table default metric 201
     up ip -4 route add 10.10.4.12/31 dev eth0 table default
+    up ip -4 route add default via 10.10.4.12 dev eth0 table default metric 201
     up ip -4 rule add pref 32765 from 10.10.4.13/32 table default
     up ip rule add pref 32764 to 10.20.6.16/32 table default
     # management port down rules
@@ -36,8 +36,8 @@ iface eth0 inet6 static
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
     ########## management network policy routing rules
     # management port up rules
-    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default
+    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201
     up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table default
     # IPV6 default table not add to lookup by default, management server need this to access IPV6 address when BGP shutdown
     up ip -6 rule add pref 32767 lookup default

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_syslog
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_syslog
@@ -21,8 +21,8 @@ iface eth0 inet static
     broadcast 10.0.0.255
     ########## management network policy routing rules
     # management port up rules
-    up ip -4 route add default via 10.0.0.1 dev eth0 table default metric 201
     up ip -4 route add 10.0.0.0/24 dev eth0 table default
+    up ip -4 route add default via 10.0.0.1 dev eth0 table default metric 201
     up ip -4 rule add pref 32765 from 10.0.0.100/32 table default
     up ip rule add pref 32764 to 10.3.145.8/32 table default
     up ip rule add pref 32764 to 100.127.20.21/32 table default
@@ -39,8 +39,8 @@ iface eth0 inet6 static
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
     ########## management network policy routing rules
     # management port up rules
-    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default
+    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201
     up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table default
     # IPV6 default table not add to lookup by default, management server need this to access IPV6 address when BGP shutdown
     up ip -6 rule add pref 32767 lookup default

--- a/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
@@ -31,8 +31,8 @@ iface eth0 inet static
     vrf mgmt
     ########## management network policy routing rules
     # management port up rules
-    up ip -4 route add default via 10.0.0.1 dev eth0 table 6000 metric 201
     up ip -4 route add 10.0.0.0/24 dev eth0 table 6000
+    up ip -4 route add default via 10.0.0.1 dev eth0 table 6000 metric 201
     up ip -4 rule add pref 32765 from 10.0.0.100/32 table 6000
     up ip -4 rule add pref 32764 to 11.11.11.11 table 6000
     up ip -4 rule add pref 32764 to 22.22.22.0/23 table 6000
@@ -52,8 +52,8 @@ iface eth0 inet6 static
     vrf mgmt
     ########## management network policy routing rules
     # management port up rules
-    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table 6000 metric 201
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table 6000
+    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table 6000 metric 201
     up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table 6000
     up ip -6 rule add pref 32764 to 33:33:33::0/64 table 6000
     # management port down rules

--- a/src/sonic-config-engine/tests/sample_output/py3/two_mgmt_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/two_mgmt_interfaces
@@ -22,8 +22,8 @@ iface eth0 inet static
     broadcast 10.0.0.255
     ########## management network policy routing rules
     # management port up rules
-    up ip -4 route add default via 10.0.0.1 dev eth0 table default metric 201
     up ip -4 route add 10.0.0.0/24 dev eth0 table default
+    up ip -4 route add default via 10.0.0.1 dev eth0 table default metric 201
     up ip -4 rule add pref 32765 from 10.0.0.100/32 table default
     up ip rule add pref 32764 to 10.20.6.16/32 table default
     # management port down rules
@@ -38,8 +38,8 @@ iface eth0 inet6 static
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
     ########## management network policy routing rules
     # management port up rules
-    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default
+    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table default metric 201
     up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table default
     # IPV6 default table not add to lookup by default, management server need this to access IPV6 address when BGP shutdown
     up ip -6 rule add pref 32767 lookup default
@@ -55,8 +55,8 @@ iface eth1 inet static
     broadcast 10.0.10.255
     ########## management network policy routing rules
     # management port up rules
-    up ip -4 route add default via 10.0.10.1 dev eth1 table default metric 201
     up ip -4 route add 10.0.10.0/24 dev eth1 table default
+    up ip -4 route add default via 10.0.10.1 dev eth1 table default metric 201
     up ip -4 rule add pref 32765 from 10.0.10.100/32 table default
     up ip rule add pref 32764 to 10.20.6.16/32 table default
     # management port down rules
@@ -71,8 +71,8 @@ iface eth1 inet6 static
     broadcast 2603:10e2:0:abcd:ffff:ffff:ffff:ffff
     ########## management network policy routing rules
     # management port up rules
-    up ip -6 route add default via 2603:10e2:0:abcd::1 dev eth1 table default metric 201
     up ip -6 route add 2603:10e2:0:abcd::/64 dev eth1 table default
+    up ip -6 route add default via 2603:10e2:0:abcd::1 dev eth1 table default metric 201
     up ip -6 rule add pref 32765 from 2603:10e2:0:abcd::8/128 table default
     # IPV6 default table not add to lookup by default, management server need this to access IPV6 address when BGP shutdown
     up ip -6 rule add pref 32767 lookup default


### PR DESCRIPTION
#### Why I did it
The connected (subnet) route must be added before the default gateway route. Without the connected route in the routing table, the gateway route addition intermittently fails with:

```bash
networking[632]: warning: eth0: up cmd 'ip -6 route add default via 2004::1 dev eth0 table default metric 201' failed: returned 2 (RTNETLINK answers: No route to host)
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
swap the order of the two 'up' route commands in interfaces.j2 so the connected route is installed first, then the default gateway.

#### How to verify it
Sonic-mgmt:
1. deploy-mg and verify default route exists
2. Test cases - ip/test_mgmt_ipv6_only.py::test_syslog_ipv6_only and syslog/test_syslog.py::test_syslog


#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [X] 202511

#### Description for the changelog
[interfaces-config]: Fix incorrect management route addition order

Signed-off-by: Ravi Minnikanti <rminnikanti@marvell.com>