### PR TITLE
ci: fix golang security

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -117,10 +117,16 @@ RUN GO_ARCH=amd64 \
 
 ENV PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
 
-# Build grpcurl from source with patched Go (GO-2026-4337)
-RUN go install github.com/fullstorydev/grpcurl/cmd/grpcurl@v1.9.3 \
-    && mv "$(go env GOPATH)/bin/grpcurl" /usr/local/bin/grpcurl \
-    && chmod +x /usr/local/bin/grpcurl
+# Build grpcurl from source with patched Go and patched golang.org/x/net
+# to address GHSA-qxp5-gwg8-xv66.
+RUN GRPCURL_VERSION=v1.9.3 \
+    && X_NET_VERSION=v0.36.0 \
+    && git clone --depth 1 --branch "${GRPCURL_VERSION}" https://github.com/fullstorydev/grpcurl.git /tmp/grpcurl \
+    && cd /tmp/grpcurl \
+    && go get golang.org/x/net@${X_NET_VERSION} \
+    && go build -o /usr/local/bin/grpcurl ./cmd/grpcurl \
+    && chmod +x /usr/local/bin/grpcurl \
+    && rm -rf /tmp/grpcurl
 # Security fixes: upgrade all vulnerable system packages (S360 scan remediation)
 RUN apt-get update && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently there is a golang vulnerability golang.org/x/net (GHSA-qxp5-gwg8-xv66) which flagged since the x/net is 0.33.0 instead of 0.36.0. This could be a transitive module. 

To address this, we can build grpcurl from source instead. 
##### Work item tracking
- Microsoft ADO **(number only)**: 36979761

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

