### PR TITLE
[.github]: Add PR template reference to copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -79,7 +79,7 @@ make target/debs/bookworm/swss_1.0.0_amd64.deb
 - **Single logical change per PR**: Isolate each commit to one component/bugfix/feature
 - **Submodule updates**: When updating a submodule, reference the PR in the submodule repo
 - **PR description**: Include what changed, why, and how to test
-- **PR description template**: Fill out all sections of the [PR template](.github/pull_request_template.md) when submitting a pull request:
+- **PR description template**: Fill out all sections of the [PR template](pull_request_template.md) when submitting a pull request:
   - **Why I did it**: Explain motivation and context for the change
   - **Work item tracking**: Microsoft ADO number if applicable
   - **How I did it**: Describe the implementation approach


### PR DESCRIPTION
#### Why I did it

The `copilot-instructions.md` file in sonic-buildimage did not reference the PR description template. When Copilot assists with creating PRs, it needs to know about the required PR template sections to produce properly formatted PR descriptions.

#### How I did it

Added a **PR description template** bullet to the `## PR Guidelines` section of `.github/copilot-instructions.md`, listing all key sections from the [PR template](.github/pull_request_template.md):
- Why I did it
- How I did it
- How to verify it
- Which release branch to backport
- Description for the changelog
- Link to config_db schema for YANG module changes

#### How to verify it

1. Open `.github/copilot-instructions.md` and verify the PR Guidelines section now includes the PR template reference with all subsections listed.
2. When using Copilot to create a PR in sonic-buildimage, it should now fill out all the required PR template sections.

#### Description for the changelog

Add PR description template reference to copilot-instructions.md so Copilot fills out all required PR sections.
