### PR TITLE
[SmartSwitch] Stop systemd from deleting unrelated zebra nexthop groups

### DIFF
--- a/files/image_config/midplane-network/midplane-network-npu.network
+++ b/files/image_config/midplane-network/midplane-network-npu.network
@@ -3,3 +3,4 @@ Name=dpu*
 
 [Network]
 Bridge=bridge-midplane
+KeepConfiguration=static


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Here's the timeline and RCA analysis for this bug that spans issues across systemd and frr community:

The original fix made by systemd community using the PR: "network: introduce ManageForeignNextHops= :" systemd/systemd/pull/30433 that fixes "systemd-networkd removes zebra nexthops" : systemd/systemd/issues/29034 has a catch. 

I see that foreign nexthops are not deleted after adding the ManageForeignNextHops=no configuration as expected. But the foreign nexthop groups are still deleted.

Nexthop groups have ifindex = 0 because they are not bound to any specific device and they are nor skipped for deletion again
https://github.com/systemd/systemd/blob/70b5d110be7702afc4dbce012f60d49506d513da/src/network/networkd-nexthop.c#L926

```
/* Ignore nexthops bound to other links. */
if (nexthop->ifindex > 0 && nexthop->ifindex != link->ifindex)
        continue;
```

```
Before dpu interface configuration

root@sonic:/home/admin# ip route list exact 0.0.0.0/0
default nhid 516 proto bgp src 10.1.0.32 metric 20
        nexthop via 10.0.0.9 dev PortChannel108 weight 1
        nexthop via 10.0.0.1 dev PortChannel102 weight 1
        nexthop via 10.0.0.5 dev PortChannel105 weight 1
        nexthop via 10.0.0.13 dev PortChannel111 weight 1
root@sonic:/home/admin# show ip route 0.0.0.0/0
Routing entry for 0.0.0.0/0
  Known via "bgp", distance 20, metric 0, best
  Last update 00:03:42 ago
  * 10.0.0.1, via PortChannel102
  * 10.0.0.5, via PortChannel105
  * 10.0.0.9, via PortChannel108
  * 10.0.0.13, via PortChannel111



Dpu reboot which causes dpu interfaces to go down and come up

root@sonic:/home/admin# reboot -d dpu0

systemd-networkd configures the interface
20:58:47 systemd-networkd: eth1: Interface name change detected, renamed to dpu0.
20:58:47 systemd-networkd: dpu0: Configuring with /usr/lib/systemd/network/midplane-network-npu.network.


root@sonic:/home/admin# ip monitor nexthop
Deleted id 516 group 486/491/501/515 proto zebra
Deleted id 253 group 177/252 proto zebra
Deleted id 367 group 261/368 proto zebra
Deleted id 363 group 246/364 proto zebra
Deleted id 427 group 322/428 proto zebra
Deleted id 552 group 518/525/533/551 proto zebra
id 516 group 486/491/501/515 proto zebra
id 253 group 177/252 proto zebra
id 367 group 261/368 proto zebra
id 363 group 246/364 proto zebra
id 427 group 322/428 proto zebra
id 552 group 518/525/533/551 proto zebra


We can see that because of the systemd fix no zebra nexthop IDs are deleted but zebra nexthop groups are deleted. But since default route is pointing towards the nexthop group 516 even though the nexthop group was added back by zebra the kernel route is still deleted and lost


root@sonic:/home/admin# vtysh -c "show ip route 0.0.0.0/0 nexthop"
Routing entry for 0.0.0.0/0
  Known via "bgp", distance 20, metric 0, best
  Last update 00:06:49 ago
  Nexthop Group ID: 516
  Received Nexthop Group ID: 516
  * 10.0.0.1, via PortChannel102, rmapsrc 10.1.0.32, weight 1
  * 10.0.0.5, via PortChannel105, rmapsrc 10.1.0.32, weight 1
  * 10.0.0.9, via PortChannel108, rmapsrc 10.1.0.32, weight 1
  * 10.0.0.13, via PortChannel111, rmapsrc 10.1.0.32, weight 1

root@sonic:/home/admin# ip route list exact 0.0.0.0/0
root@sonic:/home/admin#
```


#### How I did it
Added KeepConfiguration=static to midplane-network-npu.network. This prevents systemd-networkd from deleting foreign kernel nexthop groups when configuring dpu* interfaces.

systemd v257 introduces a new configuration to workaround this issue by using KeepConfiguration= parameter here: https://www.freedesktop.org/software/systemd/man/latest/systemd.network.html?__goaway_challenge=meta-refresh&__goaway_id=d79c35043f9ed2bb302282db2d46b793#KeepConfiguration=

#### How to verify it
Verify similar to above and the default routes shouldn't be deleted.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

