### PR TITLE
[202505] Add sysfs mount for pmon container (#24017)

### DIFF
--- a/rules/docker-platform-monitor.mk
+++ b/rules/docker-platform-monitor.mk
@@ -57,6 +57,8 @@ $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /host/reboot-cause:/host/reboot-cause:r
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /host/pmon/stormond:/usr/share/stormond:rw
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /var/run/platform_cache:/var/run/platform_cache:ro
 $(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /usr/share/sonic/device/pddf:/usr/share/sonic/device/pddf:ro
+# Add sysfs mounts for hardware access
+$(DOCKER_PLATFORM_MONITOR)_RUN_OPT += -v /sys/:/sys/:rw
 
 # Mount Arista python library on Aboot images to be used by plugins
 $(DOCKER_PLATFORM_MONITOR)_aboot_RUN_OPT += -v /usr/lib/libsfp-eeprom.so:/usr/lib/libsfp-eeprom.so:ro


### PR DESCRIPTION
Why I did it
For platform using sysfs, the current pmon is broken.

admin@sonic:~$ docker exec -it pmon bash
root@sonic:/# python3
Python 3.11.2 (main, Apr 28 2025, 14:11:48) [GCC 12.2.0] on linux Type "help", "copyright", "credits" or "license" for more information.
>>> open('/sys/class/i2c-adapter/i2c-71/71-0050/eeprom', mode='r+b', buffering=0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OSError: [Errno 30] Read-only file system: '/sys/class/i2c-adapter/i2c-71/71-0050/eeprom' After this fix

admin@sonic:~$ docker exec -it pmon bash
root@sonic:/# python3
Python 3.11.2 (main, Apr 28 2025, 14:11:48) [GCC 12.2.0] on linux Type "help", "copyright", "credits" or "license" for more information.
>>> open('/sys/class/i2c-adapter/i2c-71/71-0050/eeprom', mode='r+b', buffering=0)
<_io.FileIO name='/sys/class/i2c-adapter/i2c-71/71-0050/eeprom' mode='rb+' closefd=True>

This regression was introduced by #23457

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

