### PR TITLE
Backport fix for passing PTF_MODIFIED

### DIFF
--- a/.azure-pipelines/azure-pipelines-image-template.yml
+++ b/.azure-pipelines/azure-pipelines-image-template.yml
@@ -85,6 +85,29 @@ jobs:
           BUILD_REASON=$(Build.Reason)
           echo "Build.Reason = $BUILD_REASON"
           echo "Build.DefinitionName = $BUILD_DEFINITIONNAME"
+
+          if [[ "$BUILD_REASON" == "PullRequest" ]]; then
+            echo "Checking for changes to dockers/docker-ptf/Dockerfile.j2 in PR..."
+            # Get the target branch and check for changes
+            TARGET_BRANCH="origin/$(System.PullRequest.TargetBranch)"
+            echo "Comparing against target branch: $TARGET_BRANCH"
+            # Fetch target branch to ensure we have the latest
+            git fetch origin $(System.PullRequest.TargetBranch)
+            # Check if docker-ptf Dockerfile.j2 has changes
+            # NOTE: The PTF_MODIFIED template parameter is of type string
+            # Ensure to set it to "True" or "False" (not boolean true/false)
+            if git diff --name-only $TARGET_BRANCH...HEAD | grep -q "dockers/docker-ptf/Dockerfile.j2"; then
+              echo "docker-ptf/Dockerfile.j2 has been modified in this PR"
+              echo "##vso[task.setvariable variable=PTF_MODIFIED;isOutput=true]True"
+            else
+              echo "docker-ptf/Dockerfile.j2 has not been modified in this PR"
+              echo "##vso[task.setvariable variable=PTF_MODIFIED;isOutput=true]False"
+            fi
+          else
+            echo "Not a PR build, setting PTF_MODIFIED to false"
+            echo "##vso[task.setvariable variable=PTF_MODIFIED;isOutput=true]False"
+          fi
+
           if [[ "$BUILD_REASON" != "PullRequest" && "$BUILD_DEFINITIONNAME" == "Azure.sonic-buildimage.official.vs" ]]
           then
             PORT=443
@@ -103,6 +126,7 @@ jobs:
           mv target/* $(Build.ArtifactStagingDirectory)/target/
         env:
           REGISTRY_PASSWD: $(REGISTRY_PASSWD)
+        name: PublishAndSetPtfTag
         displayName: Publish to Docker Registry and Copy Artifacts
         condition: always()
       - publish:  $(Build.ArtifactStagingDirectory)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,12 +105,29 @@ stages:
     value: veos_vtb
   - name: testbed_file
     value: vtestbed.csv
+  - name: PTF_MODIFIED
+    value: $[ coalesce(stageDependencies.BuildVS.vs.outputs['PublishAndSetPtfTag.PTF_MODIFIED'], stageDependencies.BuildVS.vs.outputs['script.PTF_MODIFIED'], stageDependencies.BuildVS.vs.outputs['script1.PTF_MODIFIED'], 'False') ]
 
 # For every test job:
 # continueOnError: false means it's a required test job and will block merge if it fails
 # continueOnError: true means it's an optional test job and will not block merge even though it fails(unless a required test job depends on its result)
 
   jobs:
+  - job: debug_variables
+    pool: sonictest
+    displayName: "Debug PTF_MODIFIED Variable"
+    steps:
+    - script: |
+        echo "PTF_MODIFIED variable value: $(PTF_MODIFIED)"
+        echo "Debug: Checking if PTF_MODIFIED is being passed correctly from BuildVS stage"
+        if [ "$(PTF_MODIFIED)" = "True" ]; then
+          echo "SUCCESS: PTF_MODIFIED is True"
+        elif [ "$(PTF_MODIFIED)" = "False" ]; then
+          echo "INFO: PTF_MODIFIED is False"
+        else
+          echo "ERROR: PTF_MODIFIED has unexpected value: $(PTF_MODIFIED)"
+        fi
+      displayName: "Debug PTF_MODIFIED Variable"
   - job:
     pool: sonictest
     displayName: "vstest"
@@ -206,6 +223,7 @@ stages:
           MAX_WORKER: $(INSTANCE_NUMBER)
           KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
           MGMT_BRANCH: $(BUILD_BRANCH)
+          PTF_MODIFIED: ${{ eq(variables['PTF_MODIFIED'], 'true') }}
 
   - job: impacted_area_t0_2vlans_elastictest
     displayName: "impacted-area-kvmtest-t0-2vlans by Elastictest"
@@ -233,6 +251,7 @@ stages:
           DEPLOY_MG_EXTRA_PARAMS: "-e vlan_config=two_vlan_a"
           KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
           MGMT_BRANCH: $(BUILD_BRANCH)
+          PTF_MODIFIED: ${{ eq(variables['PTF_MODIFIED'], 'true') }}
 
   - job: impacted_area_t1_lag_elastictest
     displayName: "impacted-area-kvmtest-t1-lag by Elastictest"
@@ -261,6 +280,7 @@ stages:
           MAX_WORKER: $(INSTANCE_NUMBER)
           KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
           MGMT_BRANCH: $(BUILD_BRANCH)
+          PTF_MODIFIED: ${{ eq(variables['PTF_MODIFIED'], 'true') }}
 
   - job: impacted_area_dualtor_elastictest
     displayName: "impacted-area-kvmtest-dualtor by Elastictest"
@@ -290,6 +310,7 @@ stages:
           COMMON_EXTRA_PARAMS: "--disable_loganalyzer "
           KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
           MGMT_BRANCH: $(BUILD_BRANCH)
+          PTF_MODIFIED: ${{ eq(variables['PTF_MODIFIED'], 'true') }}
 
   - job: impacted_area_multi_asic_elastictest
     displayName: "impacted-area-kvmtest-multi-asic-t1 by Elastictest"
@@ -317,6 +338,7 @@ stages:
           NUM_ASIC: 4
           KVM_IMAGE_BRANCH: $(BUILD_BRANCH)
           MGMT_BRANCH: $(BUILD_BRANCH)
+          PTF_MODIFIED: ${{ eq(variables['PTF_MODIFIED'], 'true') }}
 
   - job: impacted_area_t0_sonic_elastictest
     displayName: "impacted-area-kvmtest-t0-sonic by Elastictest"
@@ -350,6 +372,7 @@ stages:
             {"name": "bgp/test_bgp_fact.py", "param": "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"},
             {"name": "macsec", "param": "--neighbor_type=sonic --enable_macsec --macsec_profile=128_SCI,256_XPN_SCI"}
             ]'
+          PTF_MODIFIED: ${{ eq(variables['PTF_MODIFIED'], 'true') }}
 
   - job: impacted_area_dpu_elastictest
     displayName: "impacted-area-kvmtest-dpu by Elastictest"
@@ -379,3 +402,4 @@ stages:
           SPECIFIC_PARAM: '[
             {"name": "dash/test_dash_vnet.py", "param": "--skip_dataplane_checking"}
             ]'
+          PTF_MODIFIED: ${{ eq(variables['PTF_MODIFIED'], 'true') }}


### PR DESCRIPTION
#### Why I did it

Required to test docker-ptf changes on release branch. Backport from https://github.com/sonic-net/sonic-buildimage/pull/23869 and https://github.com/sonic-net/sonic-buildimage/pull/24323

Detect changes in PR for `dockers/docker-ptf/Dockerfile.j2` and pass flag to sonic-mgmt tests.  This change will be used in sonic-mgmt tests to download the PR built `docker-ptf.gz` image instead of testing against the `latest` tag which was published from `master` branch builds.

##### Work item tracking
- Microsoft ADO **(number only)**:  34093272

#### How I did it

Added code to detect change and pass PTF_MODIFIED flag.

#### How to verify it

Can be tested after PR merges in sonic-mgmt and elastic test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

NA

#### Description for the changelog

[docker-ptf] Detect if PR modifies docker-ptf Dockerfile.

- Pass flag to sonic-mgmt test stage in pipeline if PR modifies docker-ptf Dockerfile. 

#### Link to config_db schema for YANG module changes

NA

#### A picture of a cute animal (not mandatory but encouraged)

NA