### PR TITLE
[Mellanox] Fix get component versions script to fetch correct asic fw

### DIFF
--- a/platform/mellanox/get_component_versions/get_component_versions.j2
+++ b/platform/mellanox/get_component_versions/get_component_versions.j2
@@ -42,7 +42,7 @@ COMMANDS_FOR_ACTUAL = {
     "SDK": [["docker", "exec", "-it", "syncd", "bash", "-c", 'dpkg -l | grep sdk'], ".*1\\.mlnx\\.([0-9.]*)"],
     "SAI": [["docker", "exec", "-it", "syncd", "bash", "-c", 'dpkg -l | grep mlnx-sai'], ".*1\\.mlnx\\.([A-Za-z0-9.]*)"],
     "SAI_API_HEADERS": [["docker", "exec", "syncd", "dpkg", "-s", "mlnx-sai"], "X-Sai-Headers-Version: ([0-9.]+)"],
-    "FW": [["bash", "-c", "mlxfwmanager -d $(/usr/bin/asic_detect/asic_detect.sh -p) --query"], "FW * [0-9]{2}\\.([0-9.]*)"],
+    "FW": [["bash", "-c", "pci=$(/usr/bin/asic_detect/asic_detect.sh -p); if [ -n \"$pci\" ]; then mlxfwmanager -d \"$pci\" --query; else mlxfwmanager --query; fi"], "FW * [0-9]{2}\\.([0-9.]*)"],
     "KERNEL": [["uname", "-r"], "(.*)-[a-z0-9]+$"],
     "RSHIM": [["dpkg", "-l"], ["grep", "rshim "], "rshim *([0-9.-]*)"]
 }

--- a/platform/mellanox/get_component_versions/get_component_versions.j2
+++ b/platform/mellanox/get_component_versions/get_component_versions.j2
@@ -42,7 +42,7 @@ COMMANDS_FOR_ACTUAL = {
     "SDK": [["docker", "exec", "-it", "syncd", "bash", "-c", 'dpkg -l | grep sdk'], ".*1\\.mlnx\\.([0-9.]*)"],
     "SAI": [["docker", "exec", "-it", "syncd", "bash", "-c", 'dpkg -l | grep mlnx-sai'], ".*1\\.mlnx\\.([A-Za-z0-9.]*)"],
     "SAI_API_HEADERS": [["docker", "exec", "syncd", "dpkg", "-s", "mlnx-sai"], "X-Sai-Headers-Version: ([0-9.]+)"],
-    "FW": [["mlxfwmanager", "--query"], "FW * [0-9]{2}\\.([0-9.]*)"],
+    "FW": [["bash", "-c", "mlxfwmanager -d $(/usr/bin/asic_detect/asic_detect.sh -p) --query"], "FW * [0-9]{2}\\.([0-9.]*)"],
     "KERNEL": [["uname", "-r"], "(.*)-[a-z0-9]+$"],
     "RSHIM": [["dpkg", "-l"], ["grep", "rshim "], "rshim *([0-9.-]*)"]
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In systems with DPUs alongside a main Spectrum switch ASIC, running mlxfwmanager --query without specifying a device returns FW versions for all Mellanox devices. So we were inadvertently scraping the DPU firmware version instead of the main ASIC switch firmware because we always picked the first one in the output which could change. This PR ensures we always display the correct asic fw version.


#### How I did it
Updated get_component_versions.j2 to pass the correct Spectrum ASIC device ID using asic_detect.sh -p to mlxfwmanager -d.
#### How to verify it
Run /usr/bin/get_component_versions.py on a smartswitch and verify that the ACTUAL FW version accurately reflects the main Spectrum ASIC version instead of the DPU's FW version from one of the DPUs. 


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

