### PR TITLE
[sflow][XGS] install and load linux_bcmgenl kernel module

### DIFF
--- a/platform/broadcom/saibcm-modules/debian/opennsl-modules.init
+++ b/platform/broadcom/saibcm-modules/debian/opennsl-modules.init
@@ -49,6 +49,7 @@ function load_kernel_modules()
         modprobe linux_ngbde
         modprobe linux_ngknet rx_buffer_size=$rx_buffer_size
         modprobe linux_ngknetcb
+        modprobe linux_bcmgenl
     else
         modprobe linux-kernel-bde dmasize=$dmasize maxpayload=128 debug=4 dma_debug=1 usemsi=$usemsi
         modprobe linux-user-bde
@@ -63,6 +64,7 @@ function load_kernel_modules()
 function remove_kernel_modules()
 {
     if [[ $is_ltsw_chip -eq 1 ]]; then
+        rmmod linux_bcmgenl
         rmmod linux_ngknetcb
         rmmod linux_ngknet
         rmmod linux_ngbde

--- a/platform/broadcom/saibcm-modules/debian/opennsl-modules.install
+++ b/platform/broadcom/saibcm-modules/debian/opennsl-modules.install
@@ -6,3 +6,4 @@ systemd/opennsl-modules.service lib/systemd/system
 sdklt/build/bde/linux_ngbde.ko lib/modules/6.12.41+deb13-sonic-amd64/extra
 sdklt/build/knet/linux_ngknet.ko lib/modules/6.12.41+deb13-sonic-amd64/extra
 sdklt/build/knetcb/linux_ngknetcb.ko lib/modules/6.12.41+deb13-sonic-amd64/extra
+sdklt/build/bcmgenl/linux_bcmgenl.ko lib/modules/6.12.41+deb13-sonic-amd64/extra


### PR DESCRIPTION
#### Why I did it

`linux_bcmgenl` creates `/proc/bcm/genl/psample/rate`, which SAI uses to configure per-port sflow sampling rates on XGS (non-DNX) platforms. Without it, sflow is completely broken — the PTF receives 0 samples.

The module is built by the sdklt Makefile (`bcmgenl` is in `KMODS`) but was missing from the `.install` manifest and never loaded by the init script.

Closes #26363

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- `opennsl-modules.install`: added `sdklt/build/bcmgenl/linux_bcmgenl.ko` to the installed files
- `opennsl-modules.init`: added `modprobe linux_bcmgenl` after `linux_ngknetcb` in the load path, and `rmmod linux_bcmgenl` before `linux_ngknetcb` in the unload path

#### How to verify it

Build an XGS image and run `tests/sflow/test_sflow.py`. Confirm `/proc/bcm/genl/psample/rate` exists after boot and sflow samples are received.

#### Which release branch to backport (provide reason below if selected)

The `bcmgenl` sdklt module does not exist in 202505 or 202511 — backport not applicable.

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version 1 -->

#### Description for the changelog

[sflow][XGS] install and load linux_bcmgenl kernel module so that per-port sflow sampling rates can be configured via SAI.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

```
    /\_____/\
   /  o   o  \
  ( ==  ^  == )
   )         (
  (           )
 ( (  )   (  ) )
(__(__)___(__)__)
```