### PR TITLE
kdump-tools: Generate kdump initrd on build time

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -346,6 +346,7 @@ if [[ $CONFIGURED_ARCH == amd64 || $CONFIGURED_ARCH == arm64 ]]; then
 for kernel_release in $(ls $FILESYSTEM_ROOT/lib/modules/); do
 	sudo LANG=C chroot $FILESYSTEM_ROOT /etc/kernel/postinst.d/kdump-tools $kernel_release > /dev/null 2>&1
 	sudo LANG=C chroot $FILESYSTEM_ROOT kdump-config symlinks $kernel_release
+	sudo LANG=C chroot $FILESYSTEM_ROOT cp /etc/kdump/sysctl.conf /var/lib/kdump/latest_sysctls-$kernel_release
 done
 fi
 

--- a/src/kdump-tools/patch/0005-Generate-initrd-for-kdump-on-build-time.patch
+++ b/src/kdump-tools/patch/0005-Generate-initrd-for-kdump-on-build-time.patch
@@ -1,0 +1,30 @@
+From fb8a5829fba4b89cff85f43eb70e13161f427194 Mon Sep 17 00:00:00 2001
+From: Boyang Yu <byu@arista.com>
+Date: Wed, 11 Mar 2026 22:43:17 +0000
+Subject: [PATCH] Generate initrd for kdump on build time
+
+---
+ debian/kernel-postinst-generate-initrd | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/debian/kernel-postinst-generate-initrd b/debian/kernel-postinst-generate-initrd
+index 809edb7..182cdc6 100755
+--- a/debian/kernel-postinst-generate-initrd
++++ b/debian/kernel-postinst-generate-initrd
+@@ -21,13 +21,6 @@ if [ "${INITRD-}" = 'No' ]; then
+ 	exit 0
+ fi
+ 
+-# initramfs generation may fail, or include an inappropriate set of kernel
+-# modules in a chroot. Leave it to the target system to handle on reboot
+-if [ -x "$(command -v ischroot)" ] && ischroot; then
+-	echo "W: kdump-tools: Executing in a chroot, skipping initramfs generation." >&2
+-	exit 0;
+-fi
+-
+ # avoid running multiple times
+ if [ -n "${DEB_MAINT_PARAMS-}" ]; then
+ 	eval set -- "$DEB_MAINT_PARAMS"
+-- 
+2.47.0
+

--- a/src/kdump-tools/patch/0005-Generate-initrd-for-kdump-on-build-time.patch
+++ b/src/kdump-tools/patch/0005-Generate-initrd-for-kdump-on-build-time.patch
@@ -1,8 +1,25 @@
-From fb8a5829fba4b89cff85f43eb70e13161f427194 Mon Sep 17 00:00:00 2001
+From b625c34307f243c8ea0b61a84916574b268148a6 Mon Sep 17 00:00:00 2001
 From: Boyang Yu <byu@arista.com>
 Date: Wed, 11 Mar 2026 22:43:17 +0000
 Subject: [PATCH] Generate initrd for kdump on build time
 
+Before the change, kdump-tools generates initrd in the first time
+of booting, which affects the down time of warm upgrade. It takes
+23 seconds in the example below:
+systemctl status kdump-tools
+Mar 10 21:52:32 sonic kdump-tools[922]: kdump-tools: Generating
+/var/lib/kdump/initrd.img-6.12.41+deb13-sonic-amd64
+Mar 10 21:52:55 sonic kdump-tools[906]: Creating symlink
+/var/lib/kdump/initrd.img.
+
+MODULES=dep was the main cause for generating the initrd in
+booting, but MODULES=dep is not used by SONiC.
+
+Make changes for generating initrd at build time
+ - Remove the existing code for "Executing in a chroot, skipping
+   initramfs generation"
+ - Copy latest_sysctls-$kernel_release to the image; it is used to
+   determine if initrd needs to be re-generated at booting
 ---
  debian/kernel-postinst-generate-initrd | 7 -------
  1 file changed, 7 deletions(-)
@@ -26,5 +43,5 @@ index 809edb7..182cdc6 100755
  if [ -n "${DEB_MAINT_PARAMS-}" ]; then
  	eval set -- "$DEB_MAINT_PARAMS"
 -- 
-2.47.0
+2.51.0
 

--- a/src/kdump-tools/patch/series
+++ b/src/kdump-tools/patch/series
@@ -1,3 +1,4 @@
 0002-core-file-prefixed-by-kdump.patch
 0003-Revert-the-MODULES-dep-optimization.patch
 0004-disable-kdump-load-check.patch
+0005-Generate-initrd-for-kdump-on-build-time.patch


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
kdump-tools would need to generate initrd in the first time of booting, which affects the down time of warm upgrade.
It takes 23 seconds in the example below
```
sudo systemctl status kdump-tools 
....
Mar 10 21:52:32 sonic kdump-tools[922]: kdump-tools: Generating /var/lib/kdump/initrd.img-6.12.41+deb13-sonic-amd64
Mar 10 21:52:55 sonic kdump-tools[906]: Creating symlink /var/lib/kdump/initrd.img.
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Make changes to allow generating initrd for kdump at build time
 - Remove the existing code for "Executing in a chroot, skipping initramfs generation"
 - Copy latest_sysctls-$kernel_release to the image; it is used to determine if initrd needs to be re-generated at booting

#### How to verify it
Checked that the kdump-tools running time is reduced to less than 1 second
Checked that the kernel crash triggered by "echo c > /proc/sysrq-trigger" still have kdump generated under /var/crash

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

