### PR TITLE
fix: golang security

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -117,13 +117,14 @@ RUN GO_ARCH=amd64 \
 
 ENV PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
 
-# Build grpcurl from source with patched Go and patched golang.org/x/net
-# to address GHSA-qxp5-gwg8-xv66.
+# Build grpcurl from source with patched Go and golang.org/x/* deps
+# upgraded to latest to address current and future golang.org/x/* CVEs.
 RUN GRPCURL_VERSION=v1.9.3 \
-    && X_NET_VERSION=v0.36.0 \
     && git clone --depth 1 --branch "${GRPCURL_VERSION}" https://github.com/fullstorydev/grpcurl.git /tmp/grpcurl \
     && cd /tmp/grpcurl \
-    && go get golang.org/x/net@${X_NET_VERSION} \
+    && go get google.golang.org/grpc@v1.79.3 \
+    && go get golang.org/x/crypto@latest golang.org/x/net@latest golang.org/x/text@latest golang.org/x/sys@latest golang.org/x/oauth2@latest \
+    && go mod tidy \
     && go build -o /usr/local/bin/grpcurl ./cmd/grpcurl \
     && chmod +x /usr/local/bin/grpcurl \
     && rm -rf /tmp/grpcurl
@@ -378,27 +379,35 @@ RUN cd gnxi \
 # Deactivating a virtualenv.
 # ENV PATH="$BACKUP_OF_PATH"
 
-# Build gnoic from source with patched Go (GO-2026-4337)
+# Build gnoic from source with patched Go and golang.org/x/* deps
+# upgraded to latest to address current and future golang.org/x/* CVEs.
 RUN git clone https://github.com/karimra/gnoic.git \
     && cd gnoic \
     && git checkout 27bc5a6 \
+    && go get google.golang.org/grpc@v1.79.3 \
+    && go get github.com/go-viper/mapstructure/v2@v2.4.0 \
+    && go get golang.org/x/crypto@latest golang.org/x/net@latest golang.org/x/text@latest golang.org/x/sys@latest golang.org/x/oauth2@latest \
+    && go mod tidy \
     && go build -o /usr/local/bin/gnoic . \
     && cd .. \
     && rm -rf gnoic
 
-# Install gnmic tool
-{% if CONFIGURED_ARCH == "armhf" %}
-RUN GNMIC_ARCH=armv7 \
-{% elif CONFIGURED_ARCH == "arm64" %}
-RUN GNMIC_ARCH=aarch64 \
-{% else %}
-RUN GNMIC_ARCH=x86_64 \
-{% endif %}
-    && GNMIC_VERSION=0.43.0 \
-    && curl -sL "https://github.com/openconfig/gnmic/releases/download/v${GNMIC_VERSION}/gnmic_${GNMIC_VERSION}_Linux_${GNMIC_ARCH}.deb" \
-      -o /tmp/gnmic.deb \
-    && dpkg -i /tmp/gnmic.deb \
-    && rm -f /tmp/gnmic.deb
+# Build gnmic from source with patched Go and upgraded deps
+# to address CVE-2026-33186 (grpc), CVE-2025-8556/CVE-2026-1229 (circl),
+# CVE-2026-25934 (go-git), CVE-2026-27571 (nats-server), CVE-2026-24051 (otel)
+RUN GNMIC_VERSION=v0.43.0 \
+    && git clone --depth 1 --branch "${GNMIC_VERSION}" https://github.com/openconfig/gnmic.git /tmp/gnmic \
+    && cd /tmp/gnmic \
+    && go get google.golang.org/grpc@v1.79.3 \
+    && go get github.com/cloudflare/circl@v1.6.3 \
+    && go get github.com/go-git/go-git/v5@v5.16.5 \
+    && go get github.com/nats-io/nats-server/v2@v2.11.12 \
+    && go get go.opentelemetry.io/otel/sdk@v1.40.0 \
+    && go get golang.org/x/crypto@latest golang.org/x/net@latest golang.org/x/text@latest golang.org/x/sys@latest golang.org/x/oauth2@latest \
+    && go mod tidy \
+    && go build -o /usr/local/bin/gnmic . \
+    && chmod +x /usr/local/bin/gnmic \
+    && rm -rf /tmp/gnmic
 
 # Remove Go toolchain to reduce image size
 RUN rm -rf /usr/local/go "$(go env GOPATH 2>/dev/null || echo $HOME/go)"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Golang security fix for docker-ptf:latest

Currently, we're flagged for (GHSA-vvgc-356p-c3xw) and (GHSA-j5w8-q4qc-rx2x).

Instead of pinning the versioning. We should just upgrade them to latest.

##### Work item tracking
- Microsoft ADO **(number only)**: 36979761

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

