### PR TITLE
[agent][orchagent] Fix missing backslash continuation in docker-init.j2

### DIFF
--- a/dockers/docker-orchagent/docker-init.j2
+++ b/dockers/docker-orchagent/docker-init.j2
@@ -21,7 +21,7 @@ CFGGEN_PARAMS=" \
     -t /usr/share/sonic/templates/ndppd.conf.j2,/etc/ndppd.conf \
     -t /usr/share/sonic/templates/critical_processes.j2,/etc/supervisor/critical_processes \
     -t /usr/share/sonic/templates/watchdog_processes.j2,/etc/supervisor/watchdog_processes \
-    -t /usr/share/sonic/templates/supervisord.conf.j2,/etc/supervisor/conf.d/supervisord.conf
+    -t /usr/share/sonic/templates/supervisord.conf.j2,/etc/supervisor/conf.d/supervisord.conf \
     -t /usr/share/sonic/templates/wait_for_link.sh.j2,/usr/bin/wait_for_link.sh \
 "
 VLAN=$(sonic-cfggen $CFGGEN_PARAMS)


### PR DESCRIPTION
#### What I did
Add missing trailing `\` on the supervisord.conf.j2 line in the docker-orchagent docker-init.j2 template.

#### How I did it
Added `\` at the end of line 24 so the `wait_for_link.sh.j2` template argument is included in the `sonic-cfggen` invocation.

#### How to verify it
Inspect the generated docker-init.sh inside docker-orchagent — `wait_for_link.sh` should now be rendered from its template.

#### Which release branch to backport
master

#### Description for the changelog
Fix missing backslash in orchagent docker-init.j2 that prevented wait_for_link.sh template rendering.

Fixes: #26402