### PR TITLE
[agent][build] Fix Makefile bullseye target using wrong guard variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ endif
 
 bullseye:
 	@echo "+++ Making $@ +++"
-ifeq ($(NOBUSTER), 0)
+ifeq ($(NOBULLSEYE), 0)
 	$(MAKE) -f Makefile.work bullseye
 endif
 


### PR DESCRIPTION
#### What I did
Fix the bullseye target guard from `$(NOBUSTER)` to `$(NOBULLSEYE)`.

#### How I did it
One-line change in `Makefile:91`. Compare with the correct trixie target which uses `$(NOTRIXIE)`.

#### How to verify it
`NOBULLSEYE=1 make bullseye` should now skip the bullseye build.

#### Which release branch to backport
master

#### Description for the changelog
Fix Makefile bullseye target incorrectly gated on NOBUSTER instead of NOBULLSEYE.

Fixes: #26403