### PR TITLE
Updating mgmt vrf table id for 4k vrf pool (#25504)

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -9,7 +9,7 @@
 {% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
 auto mgmt
 iface mgmt
-    vrf-table 5000
+    vrf-table 6000
 # The loopback network interface for mgmt VRF that is required for applications like NTP
     up ip link add lo-m type dummy
     up ip link set dev lo-m master mgmt
@@ -76,7 +76,7 @@ iface {{ name }} {{ 'inet' if prefix | ipv4 else 'inet6' }} static
     broadcast {{ prefix | broadcast }}
 {%     set vrf_table = 'default' %}
 {% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
-{%     set vrf_table = '5000' %}
+{%     set vrf_table = '6000' %}
     vrf mgmt
 {% endif %}
 {% set force_mgmt_route_priority = 32764 %}

--- a/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
@@ -5,7 +5,7 @@
 #
 auto mgmt
 iface mgmt
-    vrf-table 5000
+    vrf-table 6000
 # The loopback network interface for mgmt VRF that is required for applications like NTP
     up ip link add lo-m type dummy
     up ip link set dev lo-m master mgmt
@@ -31,19 +31,19 @@ iface eth0 inet static
     vrf mgmt
     ########## management network policy routing rules
     # management port up rules
-    up ip -4 route add default via 10.0.0.1 dev eth0 table 5000 metric 201
-    up ip -4 route add 10.0.0.0/24 dev eth0 table 5000
-    up ip -4 rule add pref 32765 from 10.0.0.100/32 table 5000
-    up ip -4 rule add pref 32764 to 11.11.11.11 table 5000
-    up ip -4 rule add pref 32764 to 22.22.22.0/23 table 5000
-    up ip rule add pref 32764 to 10.20.6.16/32 table 5000
+    up ip -4 route add default via 10.0.0.1 dev eth0 table 6000 metric 201
+    up ip -4 route add 10.0.0.0/24 dev eth0 table 6000
+    up ip -4 rule add pref 32765 from 10.0.0.100/32 table 6000
+    up ip -4 rule add pref 32764 to 11.11.11.11 table 6000
+    up ip -4 rule add pref 32764 to 22.22.22.0/23 table 6000
+    up ip rule add pref 32764 to 10.20.6.16/32 table 6000
     # management port down rules
-    pre-down ip -4 route delete default via 10.0.0.1 dev eth0 table 5000
-    pre-down ip -4 route delete 10.0.0.0/24 dev eth0 table 5000
-    pre-down ip -4 rule delete pref 32765 from 10.0.0.100/32 table 5000
-    pre-down ip -4 rule delete pref 32764 to 11.11.11.11 table 5000
-    pre-down ip -4 rule delete pref 32764 to 22.22.22.0/23 table 5000
-    down ip rule delete pref 32764 to 10.20.6.16/32 table 5000
+    pre-down ip -4 route delete default via 10.0.0.1 dev eth0 table 6000
+    pre-down ip -4 route delete 10.0.0.0/24 dev eth0 table 6000
+    pre-down ip -4 rule delete pref 32765 from 10.0.0.100/32 table 6000
+    pre-down ip -4 rule delete pref 32764 to 11.11.11.11 table 6000
+    pre-down ip -4 rule delete pref 32764 to 22.22.22.0/23 table 6000
+    down ip rule delete pref 32764 to 10.20.6.16/32 table 6000
 iface eth0 inet6 static
     address 2603:10e2:0:2902::8
     netmask 64
@@ -52,15 +52,15 @@ iface eth0 inet6 static
     vrf mgmt
     ########## management network policy routing rules
     # management port up rules
-    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table 5000 metric 201
-    up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table 5000
-    up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table 5000
-    up ip -6 rule add pref 32764 to 33:33:33::0/64 table 5000
+    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table 6000 metric 201
+    up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table 6000
+    up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table 6000
+    up ip -6 rule add pref 32764 to 33:33:33::0/64 table 6000
     # management port down rules
-    pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table 5000
-    pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table 5000
-    pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 table 5000
-    pre-down ip -6 rule delete pref 32764 to 33:33:33::0/64 table 5000
+    pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table 6000
+    pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table 6000
+    pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 table 6000
+    pre-down ip -6 rule delete pref 32764 to 33:33:33::0/64 table 6000
 #
 source /etc/network/interfaces.d/*
 #

--- a/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces_nomgmt
+++ b/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces_nomgmt
@@ -5,7 +5,7 @@
 #
 auto mgmt
 iface mgmt
-    vrf-table 5000
+    vrf-table 6000
 # The loopback network interface for mgmt VRF that is required for applications like NTP
     up ip link add lo-m type dummy
     up ip link set dev lo-m master mgmt

--- a/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
@@ -5,7 +5,7 @@
 #
 auto mgmt
 iface mgmt
-    vrf-table 5000
+    vrf-table 6000
 # The loopback network interface for mgmt VRF that is required for applications like NTP
     up ip link add lo-m type dummy
     up ip link set dev lo-m master mgmt
@@ -31,19 +31,19 @@ iface eth0 inet static
     vrf mgmt
     ########## management network policy routing rules
     # management port up rules
-    up ip -4 route add default via 10.0.0.1 dev eth0 table 5000 metric 201
-    up ip -4 route add 10.0.0.0/24 dev eth0 table 5000
-    up ip -4 rule add pref 32765 from 10.0.0.100/32 table 5000
-    up ip -4 rule add pref 32764 to 11.11.11.11 table 5000
-    up ip -4 rule add pref 32764 to 22.22.22.0/23 table 5000
-    up ip rule add pref 32764 to 10.20.6.16/32 table 5000
+    up ip -4 route add default via 10.0.0.1 dev eth0 table 6000 metric 201
+    up ip -4 route add 10.0.0.0/24 dev eth0 table 6000
+    up ip -4 rule add pref 32765 from 10.0.0.100/32 table 6000
+    up ip -4 rule add pref 32764 to 11.11.11.11 table 6000
+    up ip -4 rule add pref 32764 to 22.22.22.0/23 table 6000
+    up ip rule add pref 32764 to 10.20.6.16/32 table 6000
     # management port down rules
-    pre-down ip -4 route delete default via 10.0.0.1 dev eth0 table 5000
-    pre-down ip -4 route delete 10.0.0.0/24 dev eth0 table 5000
-    pre-down ip -4 rule delete pref 32765 from 10.0.0.100/32 table 5000
-    pre-down ip -4 rule delete pref 32764 to 11.11.11.11 table 5000
-    pre-down ip -4 rule delete pref 32764 to 22.22.22.0/23 table 5000
-    down ip rule delete pref 32764 to 10.20.6.16/32 table 5000
+    pre-down ip -4 route delete default via 10.0.0.1 dev eth0 table 6000
+    pre-down ip -4 route delete 10.0.0.0/24 dev eth0 table 6000
+    pre-down ip -4 rule delete pref 32765 from 10.0.0.100/32 table 6000
+    pre-down ip -4 rule delete pref 32764 to 11.11.11.11 table 6000
+    pre-down ip -4 rule delete pref 32764 to 22.22.22.0/23 table 6000
+    down ip rule delete pref 32764 to 10.20.6.16/32 table 6000
 iface eth0 inet6 static
     address 2603:10e2:0:2902::8
     netmask 64
@@ -52,15 +52,15 @@ iface eth0 inet6 static
     vrf mgmt
     ########## management network policy routing rules
     # management port up rules
-    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table 5000 metric 201
-    up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table 5000
-    up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table 5000
-    up ip -6 rule add pref 32764 to 33:33:33::0/64 table 5000
+    up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table 6000 metric 201
+    up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table 6000
+    up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table 6000
+    up ip -6 rule add pref 32764 to 33:33:33::0/64 table 6000
     # management port down rules
-    pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table 5000
-    pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table 5000
-    pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 table 5000
-    pre-down ip -6 rule delete pref 32764 to 33:33:33::0/64 table 5000
+    pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table 6000
+    pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table 6000
+    pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 table 6000
+    pre-down ip -6 rule delete pref 32764 to 33:33:33::0/64 table 6000
 #
 source /etc/network/interfaces.d/*
 #

--- a/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces_nomgmt
+++ b/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces_nomgmt
@@ -5,7 +5,7 @@
 #
 auto mgmt
 iface mgmt
-    vrf-table 5000
+    vrf-table 6000
 # The loopback network interface for mgmt VRF that is required for applications like NTP
     up ip link add lo-m type dummy
     up ip link set dev lo-m master mgmt


### PR DESCRIPTION
Why I did it
The Vrf Pool is being increased to 4096 by PR : sonic-net/sonic-swss#4168 Therefore the mgmt vrf tabled id is being moved to 6000.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

