### PR TITLE
[Nokia-vs] Add fpga temp and fix error

### DIFF
--- a/platform/nokia-vs/sonic-platform-nokia/7215-c1/modules/Makefile
+++ b/platform/nokia-vs/sonic-platform-nokia/7215-c1/modules/Makefile
@@ -1,1 +1,4 @@
-obj-m:= nokia_7215_ixs_c1_cpld.o cn9130_cpu_thermal_sensor.o cn9130_led.o
+MULE = mule
+$(MULE)-objs := mule_uart.o
+obj-m:= nokia_7215_ixs_c1_cpld.o cn9130_cpu_thermal_sensor.o cn9130_led.o \
+  $(MULE).o

--- a/platform/nokia-vs/sonic-platform-nokia/7215-c1/scripts/nokia-7215-init.sh
+++ b/platform/nokia-vs/sonic-platform-nokia/7215-c1/scripts/nokia-7215-init.sh
@@ -190,7 +190,7 @@ load_kernel_drivers() {
     sudo insmod /lib/modules/${KVER}/kernel/extra/nokia_7215_ixs_c1_cpld.ko
     fi
     sudo insmod /lib/modules/${KVER}/kernel/extra/cn9130_cpu_thermal_sensor.ko
-    sudo insmod /lib/modules/${KVER}/kernel/extra/nokia_console_fpga.ko
+    sudo insmod /lib/modules/${KVER}/kernel/extra/mule.ko
     sudo insmod /lib/modules/${KVER}/kernel/extra/cn9130_led.ko
 }
 

--- a/platform/nokia-vs/sonic-platform-nokia/7215-c1/sonic_platform/thermal.py
+++ b/platform/nokia-vs/sonic-platform-nokia/7215-c1/sonic_platform/thermal.py
@@ -15,7 +15,7 @@ except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
 sonic_logger = logger.Logger('thermal')
-
+FPGA_DIR = "/sys/bus/pci/devices/0000:01:00.0/"
 class Thermal(ThermalBase):
     """Nokia platform-specific Thermal class"""
 
@@ -25,7 +25,7 @@ class Thermal(ThermalBase):
                        ['0-004a/hwmon/', 1])
 
     CN9130_THERMAL_DIR = "/sys/class/hwmon/hwmon1/"
-    FPGA_TEMP_INFO = "FPGA_TEMPERATURE_INFO"
+
 
     THERMAL_NAME = ("PCB BACK", "PCB FRONT", "PCB MID", "FPGA", "CPU CORE")
 
@@ -157,8 +157,11 @@ class Thermal(ThermalBase):
         """
 
         if self.index == 4:
-            #TODO: add FPGA temperature sensor
-            thermal_temperature = 1
+            thermal_temperature = self._read_sysfs_file(FPGA_DIR + "temp_cur")
+            if (thermal_temperature != 'ERR'):
+                thermal_temperature = float(thermal_temperature)
+            else:
+                thermal_temperature = 0
         else:
             thermal_temperature = self._read_sysfs_file(self.thermal_temperature_file)
             if (thermal_temperature != 'ERR'):


### PR DESCRIPTION
1) Add support for fpga temperature
2) Fix error of incorrect driver load

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

