### PR TITLE
Add t0 buffer settings for HWSKU NH-5010

### DIFF
--- a/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/BALANCED/buffers_defaults_t0.j2
+++ b/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/BALANCED/buffers_defaults_t0.j2
@@ -1,0 +1,53 @@
+{%- set default_cable = '300m' %}
+
+{%- include 'buffer_ports.j2' %}
+
+{%- set ports2cable = {
+        'torrouter_server'       : '300m',
+        'leafrouter_torrouter'   : '300m',
+        'spinerouter_leafrouter' : '2000m',
+        'upperspinerouter_spinerouter' : '50m',
+        'upperspinerouter_lowerspinerouter' : '50m',
+        'regionalhub_upperspinerouter': '120000m',
+        'aznghub_upperspinerouter'    : '120000m',
+        'regionalhub_spinerouter': '120000m',
+        'aznghub_spinerouter'    : '120000m'
+        }
+-%}
+
+{%- macro generate_qos_bypass_port_list(PORT_QOS_BYPASS) %}
+    {# Generate list of ports #}
+    {%- for port_idx in range(256, 261, 4) %}
+        {%- if PORT_QOS_BYPASS.append("Ethernet%d" % (port_idx)) %}{%- endif %}
+    {%- endfor %}
+{%- endmacro %}
+
+{%- macro generate_buffer_pool_and_profiles() %}
+    "BUFFER_POOL": {
+        "ingress_lossless_pool": {
+            "size": "25766440000",
+            "type": "both",
+            "mode": "dynamic",
+            "xoff": "5301600256"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_profile": {
+            "pool":"ingress_lossless_pool",
+            "size":"0",
+            "xon_offset": "0",
+            "dynamic_th":"0"
+        },
+        "egress_lossless_profile": {
+            "pool":"ingress_lossless_pool",
+            "size":"0",
+            "dynamic_th":"-1"
+        },
+        "egress_lossy_profile": {
+            "pool":"ingress_lossless_pool",
+            "size":"0",
+            "dynamic_th":"-6"
+        }
+    },
+{%- endmacro %}
+

--- a/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/buffers_defaults_t0.j2
+++ b/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/buffers_defaults_t0.j2
@@ -1,0 +1,53 @@
+{%- set default_cable = '300m' %}
+
+{%- include 'buffer_ports.j2' %}
+
+{%- set ports2cable = {
+        'torrouter_server'       : '300m',
+        'leafrouter_torrouter'   : '300m',
+        'spinerouter_leafrouter' : '2000m',
+        'upperspinerouter_spinerouter' : '50m',
+        'upperspinerouter_lowerspinerouter' : '50m',
+        'regionalhub_upperspinerouter': '120000m',
+        'aznghub_upperspinerouter'    : '120000m',
+        'regionalhub_spinerouter': '120000m',
+        'aznghub_spinerouter'    : '120000m'
+        }
+-%}
+
+{%- macro generate_qos_bypass_port_list(PORT_QOS_BYPASS) %}
+    {# Generate list of ports #}
+    {%- for port_idx in range(256, 261, 4) %}
+        {%- if PORT_QOS_BYPASS.append("Ethernet%d" % (port_idx)) %}{%- endif %}
+    {%- endfor %}
+{%- endmacro %}
+
+{%- macro generate_buffer_pool_and_profiles() %}
+    "BUFFER_POOL": {
+        "ingress_lossless_pool": {
+            "size": "25766440000",
+            "type": "both",
+            "mode": "dynamic",
+            "xoff": "5301600256"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_profile": {
+            "pool":"ingress_lossless_pool",
+            "size":"0",
+            "xon_offset": "0",
+            "dynamic_th":"0"
+        },
+        "egress_lossless_profile": {
+            "pool":"ingress_lossless_pool",
+            "size":"0",
+            "dynamic_th":"-1"
+        },
+        "egress_lossy_profile": {
+            "pool":"ingress_lossless_pool",
+            "size":"0",
+            "dynamic_th":"-6"
+        }
+    },
+{%- endmacro %}
+


### PR DESCRIPTION

#### Why I did it

config load_minigraph fails on NH-5010-F-O64 devices when the topology type resolves to t0 (e.g., dut_type: ToRRouter). The Jinja2 template rendering fails because buffers_defaults_t0.j2 is not present in any of the search paths.

Seeing this issue when deploying a minigraph for PTP topology to the device via sonic-mgmt. The PTP topology uses dut_type: ToRRouter, which maps to topology type t0.

So adding buffers_defaults for t0 topo in HWSKU NH-5010.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added buffers_default_t0.j2 in corresponding HWSKU directory.

#### How to verify it

For the topo type "torrouter", verify buffers_defaults_t0.j2 settings are applied.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

