### PR TITLE
Fix system-health crash on VS platform due to missing metadata file

### DIFF
--- a/platform/vs/sonic-platform-modules-vs/sonic_platform/chassis.py
+++ b/platform/vs/sonic-platform-modules-vs/sonic_platform/chassis.py
@@ -30,8 +30,6 @@ class Chassis(ChassisBase):
         if os.path.exists(self.metadata_file):
             with open(self.metadata_file, 'r') as f:
                 metadata = json.load(f)
-        else:
-            raise FileNotFoundError("Metadata file {} not found".format(self.metadata_file))
         return metadata
 
     def get_supervisor_slot(self):


### PR DESCRIPTION
## Description

The VS chassis platform module (`sonic_platform/chassis.py`) raises `FileNotFoundError` when `/etc/sonic/vs_chassis_metadata.json` does not exist. This file is only present on VS chassis (T2-VOQ) setups introduced in #18512, not on standalone VS platforms (e.g., ToR used in KVM testbeds).

## Impact

The crash prevents `system-health.service` from running, which means `SYSTEM_READY|SYSTEM_STATE` is never set in STATE_DB. This blocks any daemon that waits for system-ready — specifically `hsflowd` in the sflow container, which loops in `waitConfig`/`getSystemReady()` forever, never reads CONFIG_DB, and never generates `/etc/hsflowd.auto`.

This causes all sflow KVM tests to fail on trixie images with:
```
Failed: hsflowd failed to initialize collector(s) ['20.1.1.2'] within 240 seconds
```

The issue is currently masked in CI because sflow tests are blanket-skipped via `tests_mark_conditions.yaml` (sonic-mgmt#21701).

## Fix

Return an empty metadata dict when the file doesn't exist instead of raising an exception. The chassis methods that consume metadata (`get_supervisor_slot`, `get_linecard_slot`, `get_my_slot`) already raise `KeyError`/`ValueError` for missing fields, so the behavior is correct for chassis setups.

## Testing

- Verified on KVM testbed: after manually setting `SYSTEM_READY` (the workaround), hsflowd initializes correctly and sflow tests pass
- The fix ensures `system-health.service` starts successfully on standalone VS, which sets `SYSTEM_READY` automatically

Fixes #26429