### PR TITLE
[platform/Micas]: fix show ssdhealth for micas

### DIFF
--- a/device/micas/x86_64-micas_m2-w6510-48gt4v-r0/plugins/ssd_util.py
+++ b/device/micas/x86_64-micas_m2-w6510-48gt4v-r0/plugins/ssd_util.py
@@ -9,7 +9,7 @@
 
 try:
     import subprocess
-    from sonic_platform_base.sonic_ssd.ssd_base import SsdBase
+    from sonic_platform_base.sonic_storage.storage_base import StorageBase
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
@@ -18,7 +18,7 @@ SERIAL_CMD = "cat /sys/bus/mmc/devices/mmc0\\:0001/serial"
 FIRMWARE_CMD = "cat /sys/kernel/debug/mmc0/mmc0:0001/ext_csd | cut -c 509-522"
 NOT_AVAILABLE = "N/A"
 
-class SsdUtil(SsdBase):
+class SsdUtil(StorageBase):
     """
     Generic implementation of the SSD health API
     """

--- a/device/micas/x86_64-micas_m2-w6510-48v8c-r0/plugins/ssd_util.py
+++ b/device/micas/x86_64-micas_m2-w6510-48v8c-r0/plugins/ssd_util.py
@@ -11,7 +11,7 @@ try:
     import re
     import os
     import subprocess
-    from sonic_platform_base.sonic_ssd.ssd_base import SsdBase
+    from sonic_platform_base.sonic_storage.storage_base import StorageBase
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
@@ -30,7 +30,7 @@ FAIL_PERCENT = 95
 INNODISK_HEALTH_ID = 169
 INNODISK_TEMPERATURE_ID = 194
 
-class SsdUtil(SsdBase):
+class SsdUtil(StorageBase):
     """
     Generic implementation of the SSD health API
     """


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In order to adapt to the changes brought by this PR：https://github.com/sonic-net/SONiC/pull/1481
The equipment involved includes：micas_m2-w6510-48gt4v and micas_m2-w6510-48v8c
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Change the import path “sonic_platform_base.sonic_ssd.ssd_base” to “sonic_platform_base.sonic_storage.storage_base”
#### How to verify it
You can use the "show platform ssdhealth" command to query information.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [x] 202405
- [x] 202411
- [x] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

