### PR TITLE
[minigraph] add minits to console device type

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -49,7 +49,7 @@ spine_chassis_frontend_role = 'SpineChassisFrontendRouter'
 chassis_backend_role = 'ChassisBackendRouter'
 
 backend_device_types = ['BackEndToRRouter', 'BackEndLeafRouter']
-console_device_types = ['MgmtTsToR']
+console_device_types = ['MgmtTsToR', 'MiniTs']
 dhcp_server_enabled_device_types = ['BmcMgmtToRRouter']
 mgmt_device_types = ['BmcMgmtToRRouter', 'MgmtToRRouter', 'MgmtTsToR']
 leafrouter_device_types = ['LeafRouter']
@@ -192,7 +192,7 @@ def normailize_port_map_for_chassis(asic_name, port_map):
         if asic_name.lower() in k.lower():
             k = k.split('-')[0]
         new_port_map.update({k:v})
-    
+
     return new_port_map
 
 ###############################################################################
@@ -249,7 +249,7 @@ def parse_chassis_metadata(root,hname, lcname):
 
 def parse_chassis_deviceinfo_intf_metadata(device_info, chassis_linecards_info, chassis_hwsku, num_voq, chassis_type, chassis_intf_map, voq_intf_attributes):
     """
-    This function iterates InterfaceMetadata for every port in the chassis and genetate the configuration for 
+    This function iterates InterfaceMetadata for every port in the chassis and genetate the configuration for
     systemport, chassis port alias and port default speeds.d.
 
     Args:
@@ -1003,7 +1003,7 @@ def parse_dpg(dpg, hname):
                         else:
                             prefix = prefix + "/32"
                     static_routes[prefix] = {'nexthop': ",".join(nexthop), 'ifname': ",".join(ifname), 'advertise': advertise}
-                    
+
             if port_nhipv4_map and port_nhipv6_map:
                 subnet_check_ip = list(port_nhipv4_map.values())[0]
                 for subnet_range in ip_intfs_map:
@@ -1639,9 +1639,9 @@ def parse_global_info(root):
             hostname = child.text
         if child.tag == str(docker_routing_config_mode_qn):
             docker_routing_config_mode = child.text
-            
+
     chassis_type, chassis_hostname  =  get_chassis_type_and_hostname(root, hostname)
-    return hwsku, hostname, docker_routing_config_mode, chassis_type, chassis_hostname 
+    return hwsku, hostname, docker_routing_config_mode, chassis_type, chassis_hostname
 
 def parse_asic_meta(meta, hname):
     sub_role = None
@@ -2121,14 +2121,14 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
                 linkmetas = parse_linkmeta(child, chassis_hostname)
 
     select_mmu_profiles(qos_profile, platform, hwsku)
-    
+
     # for chassis get the device type from chassis metadata not the asic or linecard type
     if chassis_hostname:
         device_type = devices.get(chassis_hostname, {}).get('type', None)
         card_type = [devices[key]['type'] for key in devices if key.lower() == hostname.lower()][0]
     else:
         device_type = [devices[key]['type'] for key in devices if key.lower() == hostname.lower()][0]
-        
+
     if asic_hostname is None:
         current_device = [devices[key] for key in devices if key.lower() == hostname.lower()][0]
     else:
@@ -2138,10 +2138,10 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
             current_device = {}
 
     # on single asic linecards, parse_dpg() will not get the mmanagement interface information
-    # check here and get the linecard managment interface information 
+    # check here and get the linecard managment interface information
     if chassis_hostname and not mgmt_intf:
         mgmt_intf = parse_linecard_mgmt_ip(root, hostname)
-        
+
     results = {}
     results['DEVICE_METADATA'] = {'localhost': {
         'region': region,
@@ -2160,7 +2160,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
 
     if chassis_hostname:
         results['DEVICE_METADATA']['localhost']['chassis_hostname'] = chassis_hostname
-        
+
     if deployment_id is not None:
         results['DEVICE_METADATA']['localhost']['deployment_id'] = deployment_id
 
@@ -2213,10 +2213,10 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
 
     if len(system_defaults) > 0:
         results['SYSTEM_DEFAULTS'] = system_defaults
-   
+
     if asic_name is not None:
         results['DEVICE_METADATA']['localhost']['asic_name'] =  asic_name
-    
+
     # for single asic Voq Linecards the asic_name needs to populated to "Asic0"
     if switch_type == "voq" or chassis_type in [CHASSIS_CARD_VOQ]:
         if not is_multi_asic():
@@ -2373,9 +2373,9 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
        results['SYSTEM_PORT'] = sys_ports
 
     if chassis_port_alias:
-        slot_index = get_linecard_slot_index(hostname, chassis_linecards_info) 
+        slot_index = get_linecard_slot_index(hostname, chassis_linecards_info)
         for port in ports.keys():
-            # Try first to get Chassis port alias based on port bandwidth/configured speed and if exception use port default speed. 
+            # Try first to get Chassis port alias based on port bandwidth/configured speed and if exception use port default speed.
             try:
                 ports[port]['alias'] = chassis_port_alias.get(slot_index, {})[(port, port_speed_png[port])]
             except KeyError:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add MiniTs to console_device_types so it is treated as one. Otherwise console feature will always be automatically turned off.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add MiniTs to console_device_types

#### How to verify it
Run test with it, and console feature stays on

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

