### PR TITLE
marvell-prestera: sai P7.0.0.1--1.17.1-2

### DIFF
--- a/platform/marvell-prestera/sai.mk
+++ b/platform/marvell-prestera/sai.mk
@@ -2,11 +2,11 @@
 
 BRANCH = master
 ifeq ($(CONFIGURED_ARCH),arm64)
-MRVL_SAI_VERSION = 1.17.1-1
+MRVL_SAI_VERSION = 1.17.1-2
 else ifeq ($(CONFIGURED_ARCH),armhf)
-MRVL_SAI_VERSION = 1.17.1-1
+MRVL_SAI_VERSION = 1.17.1-2
 else
-MRVL_SAI_VERSION = 1.17.1-1
+MRVL_SAI_VERSION = 1.17.1-2
 endif
 
 MRVL_SAI_URL_PREFIX = https://github.com/Marvell-switching/sonic-marvell-binaries/raw/master/$(CONFIGURED_ARCH)/sai-plugin/$(BRANCH)/


### PR DESCRIPTION
#### Why I did it
Update marvell-prestera SAI version from P7.0.0.0--1.17.1-1  onto P7.0.0.1--1.17.1-2

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Change version in platform/marvell-prestera/sai.mk

#### How to verify it
Build marvell-platform

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

#### Tested branch (Please provide the tested image version)

#### Description for the changelog

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

