### PR TITLE
Deleting chassisdb and disaggregated_chassis=1 flag in Arista 7280R4[K] SKUs

### DIFF
--- a/device/arista/x86_64-arista_7280r4_32qf_32df/chassisdb.conf
+++ b/device/arista/x86_64-arista_7280r4_32qf_32df/chassisdb.conf
@@ -1,4 +1,0 @@
-start_chassis_db=1
-chassis_db_address=240.127.1.1
-lag_id_start=1
-lag_id_end=1023

--- a/device/arista/x86_64-arista_7280r4_32qf_32df/platform_env.conf
+++ b/device/arista/x86_64-arista_7280r4_32qf_32df/platform_env.conf
@@ -1,4 +1,3 @@
 SYNCD_SHM_SIZE=1gb
 dmasize=64M
 usemsi=1
-disaggregated_chassis=1

--- a/device/arista/x86_64-arista_7280r4k_32qf_32df/chassisdb.conf
+++ b/device/arista/x86_64-arista_7280r4k_32qf_32df/chassisdb.conf
@@ -1,1 +1,0 @@
-../x86_64-arista_7280r4_32qf_32df/chassisdb.conf

--- a/device/arista/x86_64-arista_7280r4k_32qf_32df/platform_env.conf
+++ b/device/arista/x86_64-arista_7280r4k_32qf_32df/platform_env.conf
@@ -1,5 +1,4 @@
 SYNCD_SHM_SIZE=1gb
 dmasize=64M
 usemsi=1
-disaggregated_chassis=1
 macsec_enabled=1


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This is a single-asic fixed box system and does not require chassis DB.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Removed chassis_db configs from Arista platform files.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202511

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

<img width="2121" height="1414" alt="image" src="https://github.com/user-attachments/assets/1fdc648b-2ce1-4a7c-a4c3-302cd1847baf" />
