### PR TITLE
[SONiC-only] bgpd: reduce suppress-fib advertisement delay from 1s to 50ms

### DIFF
--- a/src/sonic-frr/patch/0065-SONiC-ONLY-bgpd-reduce-suppress-fib-advertisement-delay-to-50ms.patch
+++ b/src/sonic-frr/patch/0065-SONiC-ONLY-bgpd-reduce-suppress-fib-advertisement-delay-to-50ms.patch
@@ -1,0 +1,60 @@
+From 711020251cd0f6ab069a57cfeca91a376f899751 Mon Sep 17 00:00:00 2001
+From: Deepak Singhal <deepsinghal@microsoft.com>
+Date: Mon, 30 Mar 2026 06:39:34 +0000
+Subject: [PATCH] SONiC-ONLY: bgpd: reduce suppress-fib advertisement delay
+ to 50ms
+
+When bgp suppress-fib-pending is enabled, BGP_UPDATE_GROUP_TIMER_ON adds
+a batching delay after FIB confirmation before advertising routes. The
+default value of BGP_DEFAULT_UPDATE_ADVERTISEMENT_TIME (1 second) causes
+an additional 1-second delay on every route relay.
+
+This is a SONiC-only interim patch. The upstream FRR PR
+(FRRouting/frr#21384) adds a configurable knob. Once that lands in
+the FRR version used by SONiC (target: 202611), this patch should be
+removed and replaced with the upstream knob.
+
+Replace BGP_DEFAULT_UPDATE_ADVERTISEMENT_TIME with a new constant
+BGP_SUPPRESS_FIB_ADV_DELAY_MSEC (50ms) and reference it in the
+BGP_UPDATE_GROUP_TIMER_ON macro. Remove the now-unused
+BGP_DEFAULT_UPDATE_ADVERTISEMENT_TIME define.
+
+Ticket: sonic-net/sonic-buildimage#26345
+Ticket: FRRouting/frr#21298
+Signed-off-by: Deepak Singhal <deepsinghal@microsoft.com>
+---
+ bgpd/bgp_fsm.h | 3 +--
+ bgpd/bgpd.h    | 3 ++-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/bgpd/bgp_fsm.h b/bgpd/bgp_fsm.h
+index fcc0bfe2a..e39d0f28a 100644
+--- a/bgpd/bgp_fsm.h
++++ b/bgpd/bgp_fsm.h
+@@ -33,8 +33,7 @@ enum bgp_fsm_state_progress {
+ 		if (BGP_SUPPRESS_FIB_ENABLED(peer->bgp) &&                            \
+ 		    PEER_ROUTE_ADV_DELAY(peer))                                       \
+ 			event_add_timer_msec(bm->master, (F), connection,             \
+-					     (BGP_DEFAULT_UPDATE_ADVERTISEMENT_TIME * \
+-					      1000),                                  \
++					     BGP_SUPPRESS_FIB_ADV_DELAY_MSEC,         \
+ 					     (T));                                    \
+ 		else                                                                  \
+ 			event_add_timer_msec(bm->master, (F), connection, 0,          \
+diff --git a/bgpd/bgpd.h b/bgpd/bgpd.h
+index c863ed2ee..5ebb28aff 100644
+--- a/bgpd/bgpd.h
++++ b/bgpd/bgpd.h
+@@ -2341,7 +2341,8 @@ struct bgp_nlri {
+ #define BGP_DEFAULT_STALEPATH_TIME             360
+ #define BGP_DEFAULT_SELECT_DEFERRAL_TIME       240
+ #define BGP_DEFAULT_RIB_STALE_TIME             500
+-#define BGP_DEFAULT_UPDATE_ADVERTISEMENT_TIME  1
++/* Post-FIB-confirmation batching delay for suppress-fib advertisement (ms) */
++#define BGP_SUPPRESS_FIB_ADV_DELAY_MSEC       50
+ 
+ /* BGP Long-lived Graceful Restart */
+ #define BGP_DEFAULT_LLGR_STALE_TIME 0
+-- 
+2.34.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -19,3 +19,4 @@
 0026-SONiC-ONLY-Translate-tableid-for-dplane-route-notify.patch
 0027-Dont-skip-kernel-routes-uninstall.patch
 0064-bgpd-Prevent-unnecessary-re-install-of-routes.patch
+0065-SONiC-ONLY-bgpd-reduce-suppress-fib-advertisement-delay-to-50ms.patch


### PR DESCRIPTION
> **Note:** This is a SONiC-only interim patch. The upstream FRR PR ([FRRouting/frr#21384](https://github.com/FRRouting/frr/pull/21384)) adds a configurable `bgp suppress-fib-pending [(0-1000)]` knob. Once that lands in the FRR version used by SONiC (target: 202611), this patch should be removed and replaced with the upstream knob configured via bgpcfgd/config_db.

#### Why I did it

When `bgp suppress-fib-pending` is enabled in FRR (unconditionally configured by bgpcfgd since 202411 via `apply_op()`), the `BGP_UPDATE_GROUP_TIMER_ON` macro in `bgp_fsm.h` adds an **additional 1-second batching delay** to BGP UPDATE advertisement after FIB confirmation. This additional delay is always active — even when real FIB suppression is not occurring (fpmsyncd auto-offloads when ConfigDB `suppress-fib-pending` is NOT set).

Fixes #26345

##### Work item tracking
- Microsoft ADO: 37212783

#### How I did it

Added FRR patch `0065-bgpd-reduce-suppress-fib-advertisement-delay-to-50ms.patch` that:
1. Introduces `BGP_SUPPRESS_FIB_ADV_DELAY_MSEC` (50ms) as a named constant in `bgpd/bgpd.h`
2. Changes `BGP_UPDATE_GROUP_TIMER_ON` macro in `bgpd/bgp_fsm.h` to use the new constant instead of `BGP_DEFAULT_UPDATE_ADVERTISEMENT_TIME * 1000` (was 1000ms)
3. Removes the `BGP_DEFAULT_UPDATE_ADVERTISEMENT_TIME` define in `bgpd/bgpd.h` (no longer needed — replaced by the new constant)

The suppress-fib mechanism remains fully intact — routes still wait for FIB confirmation before advertising. This only reduces the post-confirmation batching window from 1s to 50ms, which still allows zebra batch processing to coalesce routes during bulk convergence.

**Why not remove `bgp suppress-fib-pending` from bgpcfgd?**
Per PR #24883 revert rationale, the unconditional `bgp suppress-fib-pending` in `apply_op()` is intentional by design. The feature has been enabled/reverted 5 times (#17072, #17578, #19027, #19836, #23187, #24883), and the current design deliberately keeps FRR config static while controlling behavior via fpmsyncd.

**New integration test to catch regressions:**
A companion sonic-mgmt test ([sonic-net/sonic-mgmt#23390](https://github.com/sonic-net/sonic-mgmt/pull/23390)) is being added to continuously validate BGP UPDATE relay latency. The test injects a route from a downstream peer, captures BGP traffic via tcpdump, and measures the time between inbound UPDATE and outbound UPDATE relay using scapy pcap analysis. It covers both `fib_suppress_off` (default) and `fib_suppress_on` scenarios and asserts relay latency stays below 500ms, ensuring any future regression that reintroduces the additional 1-second delay will be caught automatically.

#### How to verify it

**Test setup:** VS image on cSONiC KVM testbed (t0 topology, 4 BGP peers)

**Relay latency measurement (tcpdump + scapy pcap analysis):**
- Injected `99.99.99.0/24` from downstream peer via vtysh
- Captured BGP traffic on DUT
- **Result: 113ms relay latency** (inbound UPDATE at T+0, outbound UPDATE at T+113ms)
- **Without this fix:** the additional 1-second batching delay would push relay latency above 1 second

**BGP health check:** All 4 IPv4 BGP sessions remain Established after fix.

```
Neighbhor      V     AS    MsgRcvd    MsgSent    TblVer    InQ    OutQ  Up/Down      State/PfxRcd
10.0.0.57      4  64600         33         34         2      0       0  00:01:27                1
10.0.0.59      4  64600         33         34         2      0       0  00:01:27                1
10.0.0.61      4  64600         33         34         2      0       0  00:01:27                1
10.0.0.63      4  64600         33         34         2      0       0  00:01:27                1
```

#### Which release branch to backport (provide reason below if selected)

All branches with `bgp suppress-fib-pending` unconditionally enabled are affected.

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

- [x] SONiC.master.0-dirty-20260327.215611

#### Description for the changelog

Reduce BGP UPDATE relay delay from 1s to 50ms when suppress-fib-pending is enabled

#### Link to config_db schema for YANG module changes

N/A — no ConfigDB or YANG changes

#### A picture of a cute animal (not mandatory but encouraged)

🐸 (FRR frog)
