### PR TITLE
[broadcom] Fix saibcm-modules symlink creation to be idempotent

### DIFF
--- a/platform/broadcom/saibcm-modules-legacy-th/debian/rules
+++ b/platform/broadcom/saibcm-modules-legacy-th/debian/rules
@@ -89,14 +89,12 @@ build-arch-stamp:
 
 	# create links
 	cd /; sudo mkdir -p /lib/modules/$(KVER_ARCH)
-	cd /; sudo rm /lib/modules/$(KVER_ARCH)/build
-	cd /; sudo rm /lib/modules/$(KVER_ARCH)/source
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_COMMON)/ /lib/modules/$(KVER_ARCH)/source
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/ /lib/modules/$(KVER_ARCH)/build
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/include/generated
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/include/generated
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/module.lds /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/module.lds
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/include/config/ /usr/src/linux-headers-$(KVER_COMMON)/include/config
+	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_COMMON)/ /lib/modules/$(KVER_ARCH)/source
+	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/ /lib/modules/$(KVER_ARCH)/build
+	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/include/generated
+	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/include/generated
+	cd /; sudo ln -sf /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/module.lds /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/module.lds
+	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/include/config/ /usr/src/linux-headers-$(KVER_COMMON)/include/config
 	cd /; sudo cp /usr/src/linux-headers-$(KVER_ARCH)/Module.symvers /usr/src/linux-headers-$(KVER_COMMON)/Module.symvers
 
 	# Add here command to compile/build the package.

--- a/platform/broadcom/saibcm-modules/debian/rules
+++ b/platform/broadcom/saibcm-modules/debian/rules
@@ -89,14 +89,12 @@ build-arch-stamp:
 
 	# create links
 	cd /; sudo mkdir -p /lib/modules/$(KVER_ARCH)
-	cd /; sudo rm /lib/modules/$(KVER_ARCH)/build
-	cd /; sudo rm /lib/modules/$(KVER_ARCH)/source
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_COMMON)/ /lib/modules/$(KVER_ARCH)/source
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/ /lib/modules/$(KVER_ARCH)/build
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/include/generated
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/include/generated
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/module.lds /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/module.lds
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/include/config/ /usr/src/linux-headers-$(KVER_COMMON)/include/config
+	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_COMMON)/ /lib/modules/$(KVER_ARCH)/source
+	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/ /lib/modules/$(KVER_ARCH)/build
+	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/include/generated
+	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/include/generated
+	cd /; sudo ln -sf /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/module.lds /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/module.lds
+	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/include/config/ /usr/src/linux-headers-$(KVER_COMMON)/include/config
 	cd /; sudo cp /usr/src/linux-headers-$(KVER_ARCH)/Module.symvers /usr/src/linux-headers-$(KVER_COMMON)/Module.symvers
 
 	# Add here command to compile/build the package.


### PR DESCRIPTION
#### What I did

Fixed `saibcm-modules` and `saibcm-modules-legacy-th` kernel module packages to use idempotent symlink creation (`ln -sf`/`ln -sfn`) instead of bare `ln -s`.

#### Why I did it

**All broadcom image builds (aboot + onie) are broken on current master.** The three Broadcom kernel module packages build sequentially:

1. `saibcm-modules` → creates symlinks in shared `linux-headers-*-common-sonic/`
2. `saibcm-modules-dnx` → has `if [ ! -e ]` guards, skips existing symlinks ✅
3. `saibcm-modules-legacy-th` → uses bare `ln -s`, **fails** because symlinks already exist ❌

Error:
```
ln: failed to create symbolic link '/usr/src/linux-headers-6.12.41+deb13-common-sonic/arch/x86/module.lds': File exists
```

This was introduced in PR #25192 (which copied `debian/rules` from `saibcm-modules` without the guards that `saibcm-modules-dnx` has) and persisted through PR #25871 (rename to `legacy-th`).

#### How I did it

- Replace `ln -s` with `ln -sfn` for directory symlinks (`-n` prevents creating a symlink *inside* an existing target directory)
- Replace `ln -s` with `ln -sf` for the `module.lds` file symlink
- Remove redundant `rm` before symlink creation (`ln -sf` handles this)
- Applied to both `saibcm-modules` and `saibcm-modules-legacy-th`

**Note:** `saibcm-modules-dnx` lives in a separate submodule (`sonic-net/saibcm-modules`) and already has `if [ ! -e ]` guards. A separate PR to that repo will normalize it to use `ln -sf` for consistency.

#### How to verify it

```bash
git clone --recurse-submodules https://github.com/sonic-net/sonic-buildimage.git
cd sonic-buildimage
make init
make configure PLATFORM=broadcom
make target/sonic-aboot-broadcom.swi
```

Without this fix: build fails at `opennsl-modules-legacy-th` with symlink error.
With this fix: all three kernel module packages build successfully.

Fixes #26449

/cc @lipxu