### PR TITLE
Build gperftools (tcmalloc) from source for docker-fpm-frr

### DIFF
--- a/dockers/docker-fpm-frr/Dockerfile.j2
+++ b/dockers/docker-fpm-frr/Dockerfile.j2
@@ -16,6 +16,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update   && \
     apt-get install -y  \
         iproute2        \
+        libgoogle-perftools4t64 \
         logrotate
 
 RUN groupadd -g ${frr_user_gid} frr


### PR DESCRIPTION
#### Why I did it

Install tcmalloc into the docker-fpm-frr container to prepare for FRR memory optimization. tcmalloc provides a more efficient memory allocator that reduces heap fragmentation compared to glibc malloc, which is a known issue with long-running FRR processes.

The stock Debian `libgoogle-perftools4` package already has working `MallocExtension_ReleaseToSystem()` via the `MADV_DONTNEED` code path (verified against gperftools 2.10 and 2.16 source — thanks @saiarcot895 for the thorough analysis), so no custom build or patches are needed.

This PR only installs the library — it does **not** enable or load tcmalloc. Activation (via `LD_PRELOAD` or FRR's native `--enable-gperf-tcmalloc`) will be handled in a separate follow-up PR.

Reference: [FRRouting/frr#19377](https://github.com/FRRouting/frr/pull/19377)

##### Work item tracking
- Microsoft ADO:

#### How I did it

Added `libgoogle-perftools4` (which provides `libtcmalloc.so.4`) to the apt-get install list in the docker-fpm-frr Dockerfile.

#### How to verify it

1. Build the image
2. Verify the library is present: `docker exec -it bgp ls -la /usr/lib/x86_64-linux-gnu/libtcmalloc*`
3. Verify the package is installed: `docker exec -it bgp dpkg -l | grep perftools`

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [x] master (CI passed)

#### Description for the changelog

Install tcmalloc (libgoogle-perftools4) into docker-fpm-frr container from Debian repos

#### Link to config_db schema for YANG module changes

N/A — no config_db or YANG changes

#### A picture of a cute animal (not mandatory but encouraged)

🐆
