### PR TITLE
[supervisord-utilities-rs] Wait for syslog connection to be established

### DIFF
--- a/src/sonic-supervisord-utilities-rs/src/proc_exit_listener.rs
+++ b/src/sonic-supervisord-utilities-rs/src/proc_exit_listener.rs
@@ -11,6 +11,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, Read};
 use std::os::unix::io::AsRawFd;
+use std::thread;
 use std::process;
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
@@ -259,9 +260,19 @@ pub fn get_current_time() -> f64 {
 
 /// Main function with testable parameters
 pub fn main_with_args(args: Option<Vec<String>>) -> Result<()> {
-    // Initialize syslog logging to match Python version behavior
-    syslog::init_unix(syslog::Facility::LOG_USER, log::LevelFilter::Info)
-        .map_err(|e| SupervisorError::Parse(format!("Failed to initialize syslog: {}", e)))?;
+    // It is possible to get here before the syslog daemon has started
+    // Keep retrying if connection fails
+    loop {
+        match syslog::init_unix(syslog::Facility::LOG_USER, log::LevelFilter::Info) {
+            Ok(_) => {
+                break;
+            }
+            Err(e) => {
+                println!("Failed to initialize syslog: {}", e);
+                thread::sleep(Duration::from_secs(1));
+            }
+        }
+    }
 
     // Parse command line arguments
     let parsed_args = if let Some(args) = args {


### PR DESCRIPTION
#### Why I did it
The new Rust listener fails if it starts before the syslog daemon is initialized. This occurs because it attempts to connect to the socket without retrying on failure.

This wasn't an issue with the Python version since the Python syslog library would only establish the connection to the syslog daemon once the first message was being sent.

#### How I did it
The connection to the syslog daemon is repeatedly attempted on failure every second.

#### How to verify it
1. Run `sudo config reload`
2. Run `supervisorctl status` for any container (e.g swss)
3. Observe `RUNNING` instead of `FATAL`
4. Repeat at least ten times due the unpredictable nature of this issue

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)
- [x] 202511
This was introduced with https://github.com/sonic-net/sonic-buildimage/pull/24698.

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

-  [x] <!-- image version 1 --> 202511

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Wait for syslog connection to be established in supervisord-utilities-rs.

#### A picture of a cute animal (not mandatory but encouraged)
🐈🐱
