### PR TITLE
[saibcm-modules-legacy-th]: fix ln -s failure when symlinks already exist

### DIFF
--- a/platform/broadcom/saibcm-modules-legacy-th/debian/rules
+++ b/platform/broadcom/saibcm-modules-legacy-th/debian/rules
@@ -93,10 +93,14 @@ build-arch-stamp:
 	cd /; sudo rm /lib/modules/$(KVER_ARCH)/source
 	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_COMMON)/ /lib/modules/$(KVER_ARCH)/source
 	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/ /lib/modules/$(KVER_ARCH)/build
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/include/generated
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/include/generated
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/module.lds /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/module.lds
-	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/include/config/ /usr/src/linux-headers-$(KVER_COMMON)/include/config
+	sudo rm -f /usr/src/linux-headers-$(KVER_COMMON)/include/generated
+	sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/include/generated
+	sudo rm -f /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/include/generated
+	sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/include/generated
+	sudo rm -f /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/module.lds
+	sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/module.lds /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/module.lds
+	sudo rm -f /usr/src/linux-headers-$(KVER_COMMON)/include/config
+	sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/include/config/ /usr/src/linux-headers-$(KVER_COMMON)/include/config
 	cd /; sudo cp /usr/src/linux-headers-$(KVER_ARCH)/Module.symvers /usr/src/linux-headers-$(KVER_COMMON)/Module.symvers
 
 	# Add here command to compile/build the package.


### PR DESCRIPTION
#### Why I did it

saibcm-modules-legacy-th/debian/rules used bare ln -s to create kernel header symlinks
without any existence guard, causing the build to fail with File exists when symlinks were
already created by the earlier saibcm-modules package.

Build order (sequential, defined in sai-modules.mk):
  saibcm-modules  ->  saibcm-modules-dnx  ->  saibcm-modules-legacy-th

All three packages attempt to create the same 4 symlinks. The first package succeeds;
legacy-th (running third) crashes.

##### Why rm -f + ln -s instead of if [ ! -e ] (the dnx approach)?

saibcm-modules-dnx uses if [ ! -e ] guard (skip if exists). That is appropriate for dnx
because it runs second in the build sequence and skipping is safe.

saibcm-modules-legacy-th runs third and last. Force-relink (rm -f + ln -s) is the better
choice because:
- It guarantees symlinks are always fresh and point to the current kernel version
- Stale symlinks from a previous build with a different KVER_ARCH are automatically corrected
- It is idempotent: re-running the build always produces correct state

if [ ! -e ] would silently leave a stale symlink from a prior build with a different kernel
version -- a subtle and hard-to-debug failure mode.

| Package                  | Build Order | Solution               |
|--------------------------|-------------|------------------------|
| saibcm-modules-dnx       | 2nd         | if [ ! -e ] (skip)     |
| saibcm-modules-legacy-th | 3rd (last)  | rm -f + ln -s (relink) |

##### Work item tracking
- Microsoft ADO: 37323261

#### How I did it

Replaced 4 bare ln -s calls in platform/broadcom/saibcm-modules-legacy-th/debian/rules
with rm -f + ln -s pairs (force-relink pattern).

#### How to verify it

Build sonic-aboot-broadcom.swi on master. Should complete without
ln: failed to create symbolic link ... File exists errors.

#### Which release branch to backport (provide reason below if selected)
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch
- [ ] pending CI

#### Description for the changelog

Fix saibcm-modules-legacy-th build failure: replace bare ln -s with rm -f + ln -s so
symlinks are always fresh regardless of prior build state.

#### Link to config_db schema for YANG module changes
N/A

Fixes #26449
