### PR TITLE
[SONiC-only] zebra: skip if_add_update in speed timer for unready interfaces

### DIFF
--- a/src/sonic-frr/patch/0066-SONiC-ONLY-zebra-skip-if-add-update-in-speed-timer-for-unready-ifp.patch
+++ b/src/sonic-frr/patch/0066-SONiC-ONLY-zebra-skip-if-add-update-in-speed-timer-for-unready-ifp.patch
@@ -1,0 +1,48 @@
+From 2c69d638436f6e809c9fa2bbf8f2f8f3199f8db3 Mon Sep 17 00:00:00 2001
+From: Deepak Singhal <deepsinghal@microsoft.com>
+Date: Thu, 2 Apr 2026 05:00:25 +0000
+Subject: [PATCH] SONiC-ONLY: zebra: skip if_add_update in speed timer for unready
+ interfaces
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The if_zebra_speed_update() timer fires 15 seconds after interface creation,
+regardless of whether the interface has received an RTM_NEWLINK from the kernel.
+For interfaces created during FRR config replay (frr.conf), the ifindex is still
+IFINDEX_INTERNAL (0) if RTM_NEWLINK hasn't been processed yet.
+
+Calling if_add_update() with ifindex=0 sets ZEBRA_INTERFACE_ACTIVE prematurely.
+When RTM_NEWLINK later arrives, the interface is already marked active, causing
+the handler to take the "update" branch instead of the "new" branch. The update
+branch calls set_ifindex() but does NOT call if_add_update()/zebra_ns_link_ifp(),
+so the interface is never linked into the per-NS ifindex rbtree. This causes
+if_lookup_by_index_per_ns() to fail silently for that interface, breaking route
+and nexthop resolution — a silent routing failure.
+
+Guard the if_add_update() call in the speed timer so it only runs when the
+interface has a valid (non-zero) kernel ifindex. The speed value is still
+recorded on the interface struct regardless.
+
+Signed-off-by: Deepak Singhal <deepsinghal@microsoft.com>
+---
+ zebra/interface.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/zebra/interface.c b/zebra/interface.c
+index 52c2619eed..f9b31260a3 100644
+--- a/zebra/interface.c
++++ b/zebra/interface.c
+@@ -81,7 +81,8 @@ static void if_zebra_speed_update(struct event *thread)
+ 		zlog_info("%s: %s old speed: %u new speed: %u", __func__,
+ 			  ifp->name, ifp->speed, new_speed);
+ 		if_update_state_speed(ifp, new_speed);
+-		if_add_update(ifp);
++		if (ifp->ifindex != IFINDEX_INTERNAL)
++			if_add_update(ifp);
+ 		changed = true;
+ 	}
+ 
+-- 
+2.34.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -20,3 +20,4 @@
 0027-Dont-skip-kernel-routes-uninstall.patch
 0064-bgpd-Prevent-unnecessary-re-install-of-routes.patch
 0065-SONiC-ONLY-bgpd-reduce-suppress-fib-advertisement-delay-to-50ms.patch
+0066-SONiC-ONLY-zebra-skip-if-add-update-in-speed-timer-for-unready-ifp.patch


### PR DESCRIPTION
> **Note:** This is a SONiC-only interim patch. The upstream FRR PR ([FRRouting/frr#19804](https://github.com/FRRouting/frr/pull/19804)) redesigns the speed timer to only start after RTM_NEWLINK, eliminating the race entirely. Once that lands in the FRR version used by SONiC, this patch should be removed.

#### Why I did it

Fixes #26457

On high-port-count devices (512+ ports with 362+ routed L3 interfaces), the `if_zebra_speed_update()` timer fires before `RTM_NEWLINK` assigns a real ifindex. This calls `if_add_update()` with `ifindex = IFINDEX_INTERNAL (0)`, which sets `ZEBRA_INTERFACE_ACTIVE` prematurely.

When `RTM_NEWLINK` later arrives, it sees the interface is already ACTIVE and takes the update branch (Branch 3) instead of the new-interface branch (Branch 1). Branch 3 only calls `if_set_index()` — it does **not** call `zebra_ns_link_ifp()`, so the interface is never linked into the per-NS ifindex rbtree. This causes:

- `if_lookup_by_index_per_ns()` returns NULL for affected interfaces
- `RTM_NEWADDR` silently dropped → no connected route installed
- BGP sessions cannot form on affected ports
- Nexthops blackholed silently

The existing `IFINDEX_INTERNAL` guard in `zebra_ns_link_ifp()` (Option A, already present in master via FRR 10.5.1) prevents the crash but does **not** prevent the silent routing failure.

##### Work item tracking
- Microsoft ADO: 37114309

#### How I did it

Added a guard in `if_zebra_speed_update()` to skip the `if_add_update()` call when `ifp->ifindex == IFINDEX_INTERNAL`. The speed value is still recorded on the interface struct regardless.

```diff
 if (new_speed != ifp->speed) {
     if_update_state_speed(ifp, new_speed);
-    if_add_update(ifp);
+    if (ifp->ifindex != IFINDEX_INTERNAL)
+        if_add_update(ifp);
     changed = true;
 }
```

This ensures the speed timer never sets ACTIVE before RTM_NEWLINK has assigned a real ifindex, so RTM_NEWLINK always takes Branch 1 (new interface path) which properly calls `zebra_ns_link_ifp()`.

Files changed:
- `src/sonic-frr/patch/0065-SONiC-ONLY-zebra-skip-if-add-update-in-speed-timer-for-unready-ifp.patch` (new)
- `src/sonic-frr/patch/series` (added entry)

#### How to verify it

1. Build VS image and deploy on a T0 KVM testbed
2. Verify all interfaces have valid ifindex: `docker exec bgp vtysh -c "show interface json"` — all `index` fields should be > 0
3. Run `config reload` and re-verify
4. Verification test: [sonic-mgmt PR (pending)](https://github.com/deepak-singhal0408/sonic-mgmt/tree/fix/zebra-interface-consistency-test)

**Test results (VS KVM T0 testbed, image `SONiC.fix_zebra-speed-timer-race.0-3fb1b60fa`):**
- ✅ `test_interface_ifindex_after_boot` — 32/32 interfaces valid ifindex
- ✅ `test_interface_ifindex_after_config_reload` — 32/32 interfaces valid after reload

#### Which release branch to backport (provide reason below if selected)

Speed timer race affects all branches that have the rbtree rewrite patch (0062). On 202411, this fix also requires Option A (PR #24358, pending).

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [x] 202411
- [x] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

- [x] SONiC.fix_zebra-speed-timer-race.0-3fb1b60fa (master + this patch, FRR 10.5.1)


#### FRR Upstream

This is an interim SONiC fix. The complete upstream solution is [FRRouting/frr#19804](https://github.com/FRRouting/frr/pull/19804) (by mjstapp), which redesigns the speed timer to only start after RTM_NEWLINK, eliminating the race entirely. Our Option C patch will be superseded when SONiC upgrades FRR to a version containing that fix.

Related: [FRRouting/frr#19792](https://github.com/FRRouting/frr/issues/19792) (original bug report), [FRRouting/frr#19794](https://github.com/FRRouting/frr/pull/19794) (Option A — crash guard only, merged).

#### Description for the changelog

Guard if_add_update() in zebra speed timer to prevent silent routing failure when ifindex is not yet assigned on high-port-count devices.

#### Link to config_db schema for YANG module changes

N/A — no config_db or YANG changes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

