### PR TITLE
[Mellanox] handle sysfs seek errors in SFP change-event polling

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -565,7 +565,11 @@ class Chassis(ChassisBase):
                 
                 sfp_index, fd, fd_type = self.registered_fds[fileno]
                 s = self._sfp_list[sfp_index]
-                fd.seek(0)
+                try:
+                    fd.seek(0)
+                except OSError as e:
+                    logger.log_warning(f'Failed to seek file {fd_type} for SFP {sfp_index}: {e}')
+                    continue
                 try:
                     fd_value = int(fd.read().strip())
                 except Exception as e:
@@ -696,7 +700,11 @@ class Chassis(ChassisBase):
                     continue
                 
                 sfp_index, fd = self.registered_fds[fileno]
-                fd.seek(0)
+                try:
+                    fd.seek(0)
+                except OSError as e:
+                    logger.log_warning(f'Failed to seek module sysfs fd for SFP {sfp_index}: {e}')
+                    continue
                 try:
                     fd.read()
                 except Exception as e:

--- a/platform/mellanox/mlnx-platform-api/tests/test_change_event.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_change_event.py
@@ -32,6 +32,91 @@ from sonic_platform import chassis
 from sonic_platform import sfp
 
 
+class TestChangeEventSeekFailure:
+    """Cover OSError from fd.seek(0) in change-event polling loops."""
+
+    @mock.patch('sonic_platform.sfp.SFP.get_fd_for_polling_legacy')
+    @mock.patch('select.poll')
+    @mock.patch('time.monotonic')
+    @mock.patch(
+        'sonic_platform.device_data.DeviceDataManager.is_module_host_management_mode',
+        mock.MagicMock(return_value=False),
+    )
+    @mock.patch('sonic_platform.device_data.DeviceDataManager.get_sfp_count', mock.MagicMock(return_value=1))
+    @mock.patch('sonic_platform.chassis.extract_RJ45_ports_index', mock.MagicMock(return_value=[]))
+    @mock.patch('sonic_platform.chassis.extract_cpo_ports_index', mock.MagicMock(return_value=[]))
+    @mock.patch('sonic_platform.sfp.SFP.get_module_status')
+    @mock.patch('sonic_platform.chassis.Chassis.wait_sfp_ready_for_use', mock.MagicMock(return_value=True))
+    def test_get_change_event_legacy_seek_fails(self, mock_status, mock_time, mock_create_poll, mock_get_fd):
+        c = chassis.Chassis()
+        c.get_sfp(1)
+        mock_status.return_value = sfp.SFP_STATUS_INSERTED
+
+        mock_poll = mock.MagicMock()
+        mock_create_poll.return_value = mock_poll
+        mock_poll.poll = mock.MagicMock(return_value=[(1, 10)])
+
+        mock_file = mock.MagicMock()
+        mock_get_fd.return_value = mock_file
+        mock_file.fileno = mock.MagicMock(return_value=1)
+        mock_file.seek.side_effect = OSError(5, 'seek failed')
+
+        mock_time.side_effect = [0, 1000]
+
+        _, change_event = c.get_change_event(1000)
+        assert 'sfp' in change_event and not change_event['sfp']
+        mock_file.seek.assert_called_with(0)
+        mock_file.read.assert_not_called()
+
+    @mock.patch('sonic_platform.wait_sfp_ready_task.WaitSfpReadyTask.get_ready_set')
+    @mock.patch('sonic_platform.sfp.SFP.get_fd')
+    @mock.patch('select.poll')
+    @mock.patch('time.monotonic')
+    @mock.patch(
+        'sonic_platform.device_data.DeviceDataManager.is_module_host_management_mode',
+        mock.MagicMock(return_value=True),
+    )
+    @mock.patch('sonic_platform.device_data.DeviceDataManager.get_sfp_count', mock.MagicMock(return_value=1))
+    @mock.patch('sonic_platform.chassis.extract_RJ45_ports_index', mock.MagicMock(return_value=[]))
+    @mock.patch('sonic_platform.chassis.extract_cpo_ports_index', mock.MagicMock(return_value=[]))
+    @mock.patch('sonic_platform.module_host_mgmt_initializer.ModuleHostMgmtInitializer.initialize', mock.MagicMock())
+    def test_get_change_event_module_host_management_seek_fails(
+        self, mock_time, mock_create_poll, mock_get_fd, mock_ready,
+    ):
+        c = chassis.Chassis()
+        c.initialize_sfp()
+        s = c._sfp_list[0]
+        s.state = sfp.STATE_SW_CONTROL
+
+        mock_poll = mock.MagicMock()
+        mock_create_poll.return_value = mock_poll
+        mock_poll.poll = mock.MagicMock(return_value=[(1, 10)])
+
+        mock_hw_present_file = mock.MagicMock()
+        mock_power_good_file = mock.MagicMock()
+        mock_hw_present_file.read = mock.MagicMock(return_value=sfp.SFP_STATUS_INSERTED)
+        mock_hw_present_file.fileno = mock.MagicMock(return_value=1)
+        mock_hw_present_file.seek.side_effect = OSError(5, 'seek failed')
+        mock_power_good_file.read = mock.MagicMock(return_value=1)
+        mock_power_good_file.fileno = mock.MagicMock(return_value=2)
+
+        def get_fd(fd_type):
+            if fd_type == 'hw_present':
+                return mock_hw_present_file
+            if fd_type == 'power_good':
+                return mock_power_good_file
+            return mock.MagicMock()
+
+        mock_get_fd.side_effect = get_fd
+        mock_ready.return_value = set()
+
+        mock_time.side_effect = [0, 1000]
+
+        _, change_event = c.get_change_event(1000)
+        assert 'sfp' in change_event and not change_event['sfp']
+        mock_hw_present_file.seek.assert_called_with(0)
+
+
 class TestChangeEvent:
     @mock.patch('sonic_platform.sfp.SFP.get_fd_for_polling_legacy')
     @mock.patch('select.poll')


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
An exception occurred in the SfpStateUpdateTask thread: OSError(19, 'No such device'). This happens because the fd.seek(0) call is not protected by proper error handling.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Hardened SFP change-event polling against seek(0) failures and backed it with focused UTs.

#### How to verify it
Run unit test and end to end test.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

