### PR TITLE
[SONiC-only] [202411] bgpd: reduce suppress-fib advertisement delay from 1s to 50ms

### DIFF
--- a/src/sonic-frr/patch/0065-SONiC-ONLY-bgpd-reduce-suppress-fib-advertisement-delay-to-50ms.patch
+++ b/src/sonic-frr/patch/0065-SONiC-ONLY-bgpd-reduce-suppress-fib-advertisement-delay-to-50ms.patch
@@ -1,0 +1,60 @@
+From 003c96fd2f4e0ed42dfcfc463c9d143e4c2c411c Mon Sep 17 00:00:00 2001
+From: Deepak Singhal <deepsinghal@microsoft.com>
+Date: Sat, 4 Apr 2026 06:43:05 +0000
+Subject: [PATCH] SONiC-ONLY: bgpd: reduce suppress-fib advertisement delay to
+ 50ms
+
+When bgp suppress-fib-pending is enabled, BGP_UPDATE_GROUP_TIMER_ON adds
+a batching delay after FIB confirmation before advertising routes. The
+default value of BGP_DEFAULT_UPDATE_ADVERTISEMENT_TIME (1 second) causes
+an additional 1-second delay on every route relay.
+
+This is a SONiC-only interim patch. The upstream FRR PR
+(FRRouting/frr#21384) adds a configurable knob. Once that lands in
+the FRR version used by SONiC (target: 202611), this patch should be
+removed and replaced with the upstream knob.
+
+Replace BGP_DEFAULT_UPDATE_ADVERTISEMENT_TIME with a new constant
+BGP_SUPPRESS_FIB_ADV_DELAY_MSEC (50ms) and reference it in the
+BGP_UPDATE_GROUP_TIMER_ON macro. Remove the now-unused
+BGP_DEFAULT_UPDATE_ADVERTISEMENT_TIME define.
+
+Ticket: sonic-net/sonic-buildimage#26345
+Ticket: FRRouting/frr#21298
+Signed-off-by: Deepak Singhal <deepsinghal@microsoft.com>
+---
+ bgpd/bgp_fsm.h | 3 +--
+ bgpd/bgpd.h    | 3 ++-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/bgpd/bgp_fsm.h b/bgpd/bgp_fsm.h
+index 2e96ac4c10..eae5c80741 100644
+--- a/bgpd/bgp_fsm.h
++++ b/bgpd/bgp_fsm.h
+@@ -33,8 +33,7 @@ enum bgp_fsm_state_progress {
+ 		if (BGP_SUPPRESS_FIB_ENABLED(peer->bgp) &&                            \
+ 		    PEER_ROUTE_ADV_DELAY(peer))                                       \
+ 			event_add_timer_msec(bm->master, (F), connection,             \
+-					     (BGP_DEFAULT_UPDATE_ADVERTISEMENT_TIME * \
+-					      1000),                                  \
++					     BGP_SUPPRESS_FIB_ADV_DELAY_MSEC,         \
+ 					     (T));                                    \
+ 		else                                                                  \
+ 			event_add_timer_msec(bm->master, (F), connection, 0,          \
+diff --git a/bgpd/bgpd.h b/bgpd/bgpd.h
+index 0f69095323..3b3cd30ee0 100644
+--- a/bgpd/bgpd.h
++++ b/bgpd/bgpd.h
+@@ -2057,7 +2057,8 @@ struct bgp_nlri {
+ #define BGP_DEFAULT_STALEPATH_TIME             360
+ #define BGP_DEFAULT_SELECT_DEFERRAL_TIME       360
+ #define BGP_DEFAULT_RIB_STALE_TIME             500
+-#define BGP_DEFAULT_UPDATE_ADVERTISEMENT_TIME  1
++/* Post-FIB-confirmation batching delay for suppress-fib advertisement (ms) */
++#define BGP_SUPPRESS_FIB_ADV_DELAY_MSEC       50
+ 
+ /* BGP Long-lived Graceful Restart */
+ #define BGP_DEFAULT_LLGR_STALE_TIME 0
+-- 
+2.34.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -44,3 +44,4 @@
 0062-zebra-lib-use-internal-rbtree-per-ns.patch
 0063-lib-Return-duplicate-prefix-list-entry-test.patch
 0064-mgmtd-clean-session-config-only-when-it-is-needed.patch
+0065-SONiC-ONLY-bgpd-reduce-suppress-fib-advertisement-delay-to-50ms.patch


### PR DESCRIPTION
> **Note:** This is a SONiC-only patch that reduces the suppress-fib advertisement batching delay from 1s to 50ms. The upstream FRR PR ([FRRouting/frr#21384](https://github.com/FRRouting/frr/pull/21384)) adds a configurable knob for this, which will be available on master/202611+.

#### Why I did it

Backport of #26442 (merged) to 202411.

When `bgp suppress-fib-pending` is enabled in FRR (unconditionally configured by bgpcfgd since 202411 via `apply_op()`), the `BGP_UPDATE_GROUP_TIMER_ON` macro in `bgp_fsm.h` adds an **additional 1-second batching delay** to BGP UPDATE advertisement after FIB confirmation.

Fixes #26345

##### Work item tracking
- Microsoft ADO: 37212783

#### How I did it

Added FRR patch that:
1. Introduces `BGP_SUPPRESS_FIB_ADV_DELAY_MSEC` (50ms) as a named constant in `bgpd/bgpd.h`
2. Changes `BGP_UPDATE_GROUP_TIMER_ON` macro in `bgpd/bgp_fsm.h` to use the new constant instead of `BGP_DEFAULT_UPDATE_ADVERTISEMENT_TIME * 1000` (was 1000ms)
3. Removes the `BGP_DEFAULT_UPDATE_ADVERTISEMENT_TIME` define in `bgpd/bgpd.h` (no longer needed — replaced by the new constant)

#### How to verify it

See master PR #26442 for detailed verification results.

#### Description for the changelog

Reduce BGP UPDATE relay delay from 1s to 50ms when suppress-fib-pending is enabled