### PR TITLE
[scripts] Add Generic HWSKU template duplication analysis for device templates

### DIFF
--- a/scripts/analyze_device_templates.py
+++ b/scripts/analyze_device_templates.py
@@ -85,8 +85,10 @@ def collect_records(device_root: str) -> List[FileRecord]:
     records: List[FileRecord] = []
     target_set = set(TARGET_FILENAMES)
 
-    for root, _, filenames in os.walk(device_root):
-        for filename in filenames:
+    for root, dirnames, filenames in os.walk(device_root):
+        # Sort traversal state to keep output deterministic across filesystems.
+        dirnames.sort()
+        for filename in sorted(filenames):
             if filename not in target_set:
                 continue
 
@@ -154,7 +156,7 @@ def build_type_report(records: List[FileRecord], top_groups: int, top_hotspots: 
             }
         )
 
-    hotspots.sort(key=lambda item: (item["variants"], item["files"], item["platform"]), reverse=True)
+    hotspots.sort(key=lambda item: (-item["variants"], -item["files"], item["platform"]))
     hotspots = hotspots[:top_hotspots]
 
     return {
@@ -281,6 +283,9 @@ def main() -> int:
 
     if args.top_groups < 1 or args.top_hotspots < 1:
         print("error: --top-groups and --top-hotspots must be >= 1", file=sys.stderr)
+        return 2
+    if args.json_indent < 0:
+        print("error: --json-indent must be >= 0", file=sys.stderr)
         return 2
 
     device_root = os.path.join(os.getcwd(), "device")


### PR DESCRIPTION
#### Why I did it

This PR adds objective, read-only data tooling to support Generic HWSKU/template consolidation discussions without changing runtime behavior.

Current onboarding/maintenance discussions need baseline numbers on duplication and platform-level variant conflicts for common device template files. This PR provides that evidence.

##### Work item tracking
- Microsoft ADO (number only): N/A

Supports:
- #25747
- #25718
- #25720
- #25716

#### How I did it

Added one new script:
- [scripts/analyze_device_templates.py](scripts/analyze_device_templates.py)

The script scans the device tree for:
- buffers.json.j2
- qos.json.j2
- hwsku.json
- sai.profile
- pg_profile_lookup.ini

It reports:
- total files per target type
- unique content variants (hash-based)
- duplication ratio
- largest duplicate groups
- per-platform conflict hotspots (same platform with multiple content variants)

Implementation details:
- Read-only analysis only (no file modifications)
- No third-party dependencies
- Line-ending normalization before hashing (CRLF/LF) to avoid false differences
- Optional machine-readable output via --json

#### How to verify it

Run from repository root:
- py -3 scripts/analyze_device_templates.py
- py -3 scripts/analyze_device_templates.py --json
- py -3 -m py_compile scripts/analyze_device_templates.py

Sample measured summary from current tree:
- Overall: 1482 files, 695 unique variants, 787 duplicated files, 53.10% duplication
- buffers.json.j2: 282 total, 56 unique, 80.14% duplication
- qos.json.j2: 292 total, 67 unique, 77.05% duplication
- hwsku.json: 185 total, 148 unique, 20.00% duplication
- sai.profile: 463 total, 325 unique, 29.81% duplication
- pg_profile_lookup.ini: 260 total, 99 unique, 61.92% duplication

Observed recurring hotspot examples:
- device/mellanox/x86_64-mlnx_msn4700-r0
- device/arista/x86_64-arista_7060x6_64pe_b
- device/nexthop/x86_64-nexthop_4010-r1

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

Reason: N/A (data-analysis script only, no bug fix/behavior change).

#### Tested branch (Please provide the tested image version)

- [ ] N/A (script-only change; no image/runtime behavior change)

#### Description for the changelog

Add a read-only device template analysis script to quantify duplication and platform-level variant hotspots for Generic HWSKU discussions.

#### Link to config_db schema for YANG module changes

N/A (no YANG/config_db schema changes)
