### PR TITLE
[Hw PFCWD feature] Update th5 parameter to support hw pfcwd.

### DIFF
--- a/device/nexthop/x86_64-nexthop_4010-r0/NH-4010-128x400G-2x25G/nh4010-r0-128x400-M_2x25.yaml
+++ b/device/nexthop/x86_64-nexthop_4010-r0/NH-4010-128x400G-2x25G/nh4010-r0-128x400-M_2x25.yaml
@@ -15696,7 +15696,7 @@ bcm_device:
             l2_hitbit_enable: 0
             pktio_mode: 1
             sai_pfc_defaults_disable: 1
-            pfc_deadlock_seq_control: 1
+            pfc_deadlock_seq_control: 0
             sai_mmu_custom_config: 1
             ftem_mem_entries: 65536
             sai_stats_support_mask: 0
@@ -15764,5 +15764,18 @@ device:
                 PFC_PRI: [0,7]
             :
                 TM_PRI_GRP_ID: 0
+
+...
+# TODO(Abhishek): Remove once we have sai attribute to set recovery mode
+# PFC Deadlock Recovery Configuration
+---
+device:
+    0:
+        TM_PFC_DEADLOCK_RECOVERY:
+            ?
+                PORT_ID: [[1,4], [11,14], [22,25], [33,36], [44,47], [55,58], [66,69], [77,80], [88,91], [99,102], [110,113], [121, 124], [132, 135], [143, 146], [154, 157], [165, 168], [176, 179], [187, 190], [198, 201], [209, 212], [220, 223], [231, 234], [242, 245], [253, 256], [264, 267], [275, 278], [286, 289], [297, 300], [308, 311], [319, 322], [330, 333], [341, 344], [274], [186]]
+                PFC_PRI: [3, 4]
+            :
+                RECOVERY_MODE: PFC_STATE_MODE
 
 ...

--- a/device/nexthop/x86_64-nexthop_4010-r0/NH-4010-256x200G-2x25G/nh4010-r0-256x200-M_2x25.yaml
+++ b/device/nexthop/x86_64-nexthop_4010-r0/NH-4010-256x200G-2x25G/nh4010-r0-256x200-M_2x25.yaml
@@ -17232,7 +17232,7 @@ bcm_device:
             l2_hitbit_enable: 0
             pktio_mode: 1
             sai_pfc_defaults_disable: 1
-            pfc_deadlock_seq_control: 1
+            pfc_deadlock_seq_control: 0
             sai_mmu_custom_config: 1
             ftem_mem_entries: 65536
             sai_stats_support_mask: 0
@@ -17300,5 +17300,18 @@ device:
                 PFC_PRI: [0,7]
             :
                 TM_PRI_GRP_ID: 0
+
+...
+# TODO(Abhishek): Remove once we have sai attribute to set recovery mode
+# PFC Deadlock Recovery Configuration
+---
+device:
+    0:
+        TM_PFC_DEADLOCK_RECOVERY:
+            ?
+                PORT_ID: [[1,8], [11,18], [22,29], [33,40], [44,51], [55,62], [66,73], [77,84], [88,95], [99,106], [110,117], [121, 128], [132, 139], [143, 150], [154, 161], [165, 172], [176, 183], [187, 194], [198, 205], [209, 216], [220, 227], [231, 238], [242, 249], [253, 260], [264, 271], [275, 282], [286, 293], [297, 304], [308, 315], [319, 326], [330, 337], [341, 344], [274], [186]]
+                PFC_PRI: [3, 4]
+            :
+                RECOVERY_MODE: PFC_STATE_MODE
 
 ...

--- a/device/nexthop/x86_64-nexthop_4010-r0/NH-4010/nh4010-r0-64x800-M_2x25.yaml
+++ b/device/nexthop/x86_64-nexthop_4010-r0/NH-4010/nh4010-r0-64x800-M_2x25.yaml
@@ -14930,7 +14930,7 @@ bcm_device:
             l2_hitbit_enable: 0
             pktio_mode: 1
             sai_pfc_defaults_disable: 1
-            pfc_deadlock_seq_control: 1
+            pfc_deadlock_seq_control: 0
             sai_mmu_custom_config: 1
             ftem_mem_entries: 65536
             sai_stats_support_mask: 0
@@ -14998,5 +14998,18 @@ device:
                 PFC_PRI: [0,7]
             :
                 TM_PRI_GRP_ID: 0
+
+...
+# TODO(Abhishek): Remove once we have sai attribute to set recovery mode
+# PFC Deadlock Recovery Configuration
+---
+device:
+    0:
+        TM_PFC_DEADLOCK_RECOVERY:
+            ?
+                PORT_ID: [[1,2], [11,12], [22,23], [33,34], [44,45], [55,56], [66,67], [77,78], [88,89], [99,100], [110,111], [121,122], [132,133], [143,144], [154,155], [165,166], [176,177], [187,188], [198,199], [209,210], [220,221], [231,232], [242,243], [253,254], [264,265], [275,276], [286,287], [297,298], [308,309], [319, 320], [330, 331], [341, 342], [274], [186]]
+                PFC_PRI: [3, 4]
+            :
+                RECOVERY_MODE: PFC_STATE_MODE
 
 ...

--- a/device/nexthop/x86_64-nexthop_4010-r1/NH-4010-128x400G-2x25G/nh4010-r1-128x400-M_2x25.yaml
+++ b/device/nexthop/x86_64-nexthop_4010-r1/NH-4010-128x400G-2x25G/nh4010-r1-128x400-M_2x25.yaml
@@ -15696,7 +15696,7 @@ bcm_device:
             l2_hitbit_enable: 0
             pktio_mode: 1
             sai_pfc_defaults_disable: 1
-            pfc_deadlock_seq_control: 1
+            pfc_deadlock_seq_control: 0
             sai_mmu_custom_config: 1
             ftem_mem_entries: 65536
             sai_stats_support_mask: 0
@@ -15764,5 +15764,18 @@ device:
                 PFC_PRI: [0,7]
             :
                 TM_PRI_GRP_ID: 0
+
+...
+# TODO(Abhishek): Remove once we have sai attribute to set recovery mode
+# PFC Deadlock Recovery Configuration
+---
+device:
+    0:
+        TM_PFC_DEADLOCK_RECOVERY:
+            ?
+                PORT_ID: [[1,4], [11,14], [22,25], [33,36], [44,47], [55,58], [66,69], [77,80], [88,91], [99,102], [110,113], [121, 124], [132, 135], [143, 146], [154, 157], [165, 168], [176, 179], [187, 190], [198, 201], [209, 212], [220, 223], [231, 234], [242, 245], [253, 256], [264, 267], [275, 278], [286, 289], [297, 300], [308, 311], [319, 322], [330, 333], [341, 344], [274], [186]]
+                PFC_PRI: [3, 4]
+            :
+                RECOVERY_MODE: PFC_STATE_MODE
 
 ...

--- a/device/nexthop/x86_64-nexthop_4010-r1/NH-4010-256x200G-2x25G/nh4010-r1-256x200-M_2x25.yaml
+++ b/device/nexthop/x86_64-nexthop_4010-r1/NH-4010-256x200G-2x25G/nh4010-r1-256x200-M_2x25.yaml
@@ -17232,7 +17232,7 @@ bcm_device:
             l2_hitbit_enable: 0
             pktio_mode: 1
             sai_pfc_defaults_disable: 1
-            pfc_deadlock_seq_control: 1
+            pfc_deadlock_seq_control: 0
             sai_mmu_custom_config: 1
             ftem_mem_entries: 65536
             sai_stats_support_mask: 0
@@ -17300,5 +17300,18 @@ device:
                 PFC_PRI: [0,7]
             :
                 TM_PRI_GRP_ID: 0
+
+...
+# TODO(Abhishek): Remove once we have sai attribute to set recovery mode
+# PFC Deadlock Recovery Configuration
+---
+device:
+    0:
+        TM_PFC_DEADLOCK_RECOVERY:
+            ?
+                PORT_ID: [[1,8], [11,18], [22,29], [33,40], [44,51], [55,62], [66,73], [77,84], [88,95], [99,106], [110,117], [121, 128], [132, 139], [143, 150], [154, 161], [165, 172], [176, 183], [187, 194], [198, 205], [209, 216], [220, 227], [231, 238], [242, 249], [253, 260], [264, 271], [275, 282], [286, 293], [297, 304], [308, 315], [319, 326], [330, 337], [341, 344], [274], [186]]
+                PFC_PRI: [3, 4]
+            :
+                RECOVERY_MODE: PFC_STATE_MODE
 
 ...

--- a/device/nexthop/x86_64-nexthop_4010-r1/NH-4010/nh4010-r1-64x800-M_2x25.yaml
+++ b/device/nexthop/x86_64-nexthop_4010-r1/NH-4010/nh4010-r1-64x800-M_2x25.yaml
@@ -14930,7 +14930,7 @@ bcm_device:
             l2_hitbit_enable: 0
             pktio_mode: 1
             sai_pfc_defaults_disable: 1
-            pfc_deadlock_seq_control: 1
+            pfc_deadlock_seq_control: 0
             sai_mmu_custom_config: 1
             ftem_mem_entries: 65536
             sai_stats_support_mask: 0
@@ -14998,5 +14998,18 @@ device:
                 PFC_PRI: [0,7]
             :
                 TM_PRI_GRP_ID: 0
+
+...
+# TODO(Abhishek): Remove once we have sai attribute to set recovery mode
+# PFC Deadlock Recovery Configuration
+---
+device:
+    0:
+        TM_PFC_DEADLOCK_RECOVERY:
+            ?
+                PORT_ID: [[1,2], [11,12], [22,23], [33,34], [44,45], [55,56], [66,67], [77,78], [88,89], [99,100], [110,111], [121,122], [132,133], [143,144], [154,155], [165,166], [176,177], [187,188], [198,199], [209,210], [220,221], [231,232], [242,243], [253,254], [264,265], [275,276], [286,287], [297,298], [308,309], [319, 320], [330, 331], [341, 342], [274], [186]]
+                PFC_PRI: [3, 4]
+            :
+                RECOVERY_MODE: PFC_STATE_MODE
 
 ...


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Enable hardware-based PFC (Priority Flow Control) deadlock detection and recovery on NH-4010 platform. 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Changed pfc_deadlock_seq_control from 1 to 0 in bcm_device configuration to disable manual recovery in hw pfcwd
Added TM_PFC_DEADLOCK_RECOVERY configuration section with:
-  PFC_PRI set to [3, 4] for priority classes 3 and 4
-  RECOVERY_MODE set to PFC_STATE_MODE for hardware-based recovery

#### How to verify it
Validate lt table corresponding to th5 platform using command.
`lt TM_PFC_DEADLOCK_RECOVERY  traverse -l port_id==<port-id>`
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Enable hardware-based PFC deadlock recovery for NH-4010 platform across all SKUs (64x800G, 128x400G, 256x200G)
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

