### PR TITLE
[ctrmgrd]: Remove debug placeholder from container state DB update

### DIFF
--- a/src/sonic-ctrmgrd/ctrmgr/container_startup.py
+++ b/src/sonic-ctrmgrd/ctrmgr/container_startup.py
@@ -173,7 +173,6 @@ def update_state(state_db, feature, owner=None, version=None):
             CURRENT_OWNER: owner,
             DOCKER_ID: get_docker_id() if owner != "local" else feature,
             UPD_TIMESTAMP: str(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")),
-            "hello": "world",
             VERSION: version
             }
 

--- a/src/sonic-ctrmgrd/tests/ctrmgrd_test.py
+++ b/src/sonic-ctrmgrd/tests/ctrmgrd_test.py
@@ -401,7 +401,6 @@ labels_test_data = {
                 common_test.KUBE_LABEL_TABLE: {
                     "SET": {
                         "foo": "bar",
-                        "hello": "world"
                     }
                 }
             }
@@ -411,7 +410,6 @@ labels_test_data = {
                 "xyz": {
                     "xxx": {
                         "foo": "bar",
-                        "hello": "world"
                     }
                 }
             }
@@ -421,7 +419,6 @@ labels_test_data = {
                 common_test.KUBE_LABEL_TABLE: {
                     "SET": {
                         "foo": "bar",
-                        "hello": "world"
                     }
                 }
             }
@@ -429,7 +426,6 @@ labels_test_data = {
         common_test.KUBE_CMD: {
             common_test.KUBE_WR: {
                 "foo": "bar",
-                "hello": "world"
             }
         }
     },
@@ -442,7 +438,6 @@ labels_test_data = {
                 common_test.KUBE_LABEL_TABLE: {
                     "SET": {
                         "foo": "bar",
-                        "hello": "world"
                     }
                 }
             }
@@ -452,7 +447,6 @@ labels_test_data = {
                 common_test.KUBE_LABEL_TABLE: {
                     "SET": {
                         "foo": "bar",
-                        "hello": "world"
                     }
                 }
             }
@@ -468,7 +462,6 @@ labels_test_data = {
                 common_test.KUBE_LABEL_TABLE: {
                     "SET": {
                         "foo": "bar",
-                        "hello": "world"
                     }
                 }
             }
@@ -478,7 +471,6 @@ labels_test_data = {
                 common_test.KUBE_LABEL_TABLE: {
                     "SET": {
                         "foo": "bar",
-                        "hello": "world"
                     }
                 }
             }
@@ -486,7 +478,6 @@ labels_test_data = {
         common_test.KUBE_CMD: {
             common_test.KUBE_WR: {
                 "foo": "bar",
-                "hello": "world"
             }
         }
     }


### PR DESCRIPTION
Why I did it

The `update_state()` function in `container_startup.py` writes a `"hello": "world"` key into the container state DB entry on every container startup. This is a debug artifact that should not be in production code.

How I did it

Removed the placeholder key from the `update_state()` dict and updated the corresponding test fixtures in `ctrmgrd_test.py` to match.

How to verify it

Run `pytest src/sonic-ctrmgrd/tests/` — all tests pass.