### PR TITLE
[bgpcfgd]: Fix aggregate-address removal not including summary-only/a…

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
@@ -131,7 +131,9 @@ class AggregateAddressMgr(Manager):
             asn=bgp_asn,
             prefix=prefix,
             is_v4=is_v4,
-            is_remove=True
+            is_remove=True,
+            summary_only=data.get(SUMMARY_ONLY_KEY, COMMON_FALSE_STRING),
+            as_set=data.get(AS_SET_KEY, COMMON_FALSE_STRING)
         )
         cmd_list.extend(aggregates_cmds)
 
@@ -206,9 +208,9 @@ def generate_aggregate_address_commands(asn, prefix, is_v4, is_remove, summary_o
     ret_cmds.append("address-family ipv4" if is_v4 else "address-family ipv6")
     agg_cmd = "no " if is_remove else ""
     agg_cmd += "aggregate-address %s" % prefix
-    if not is_remove and summary_only == COMMON_TRUE_STRING:
+    if summary_only == COMMON_TRUE_STRING:
         agg_cmd += " %s" % SUMMARY_ONLY_KEY
-    if not is_remove and as_set == COMMON_TRUE_STRING:
+    if as_set == COMMON_TRUE_STRING:
         agg_cmd += " %s" % AS_SET_KEY
     ret_cmds.append(agg_cmd)
     ret_cmds.append("exit-address-family")

--- a/src/sonic-bgpcfgd/tests/test_aggregate.py
+++ b/src/sonic-bgpcfgd/tests/test_aggregate.py
@@ -1,6 +1,7 @@
 from bgpcfgd.directory import Directory
 from bgpcfgd.template import TemplateFabric
 from bgpcfgd.managers_aggregate_address import AggregateAddressMgr, BGP_AGGREGATE_ADDRESS_TABLE_NAME, BGP_BBR_TABLE_NAME
+from bgpcfgd.managers_aggregate_address import generate_aggregate_address_commands, COMMON_TRUE_STRING, COMMON_FALSE_STRING
 import pytest
 from swsscommon import swsscommon
 from unittest.mock import MagicMock, patch
@@ -210,7 +211,7 @@ def __del_handler_validate(
     except_cmds = [
         'router bgp 65001',
         'address-family ' + ('ipv4' if '.' in aggregate_prefix else 'ipv6'),
-        'no aggregate-address ' + aggregate_prefix,
+        'no aggregate-address ' + aggregate_prefix + (' summary-only' if summary_only == 'true' else '') + (' as-set' if as_set == 'true' else ''),
         'exit-address-family',
         'exit'
     ]
@@ -261,7 +262,7 @@ def __switch_bbr_state(
     del_cmds = [
         'router bgp 65001',
         'address-family ' + ('ipv4' if '.' in aggregate_prefix else 'ipv6'),
-        'no aggregate-address ' + aggregate_prefix,
+        'no aggregate-address ' + aggregate_prefix + (' summary-only' if summary_only == 'true' else '') + (' as-set' if as_set == 'true' else ''),
         'exit-address-family',
         'exit'
     ]
@@ -279,3 +280,128 @@ def __switch_bbr_state(
     assert [aggregate_prefix] == mgr.address_table.getKeys()
     _, data = mgr.address_table.get(aggregate_prefix)
     assert data == expected_state
+
+
+class TestGenerateAggregateAddressRemovalCommands:
+    """Tests that verify the removal command includes summary-only/as-set flags.
+
+    This is the regression test for the bug where 'no aggregate-address <prefix>'
+    was generated without the flags, causing FRR to silently ignore the removal
+    when the running config had 'aggregate-address <prefix> summary-only'.
+    """
+
+    def test_remove_with_summary_only(self):
+        cmds = generate_aggregate_address_commands(
+            asn="65001", prefix="10.100.0.0/16", is_v4=True,
+            is_remove=True, summary_only=COMMON_TRUE_STRING, as_set=COMMON_FALSE_STRING
+        )
+        assert "no aggregate-address 10.100.0.0/16 summary-only" in cmds
+
+    def test_remove_with_as_set(self):
+        cmds = generate_aggregate_address_commands(
+            asn="65001", prefix="10.100.0.0/16", is_v4=True,
+            is_remove=True, summary_only=COMMON_FALSE_STRING, as_set=COMMON_TRUE_STRING
+        )
+        assert "no aggregate-address 10.100.0.0/16 as-set" in cmds
+
+    def test_remove_with_summary_only_and_as_set(self):
+        cmds = generate_aggregate_address_commands(
+            asn="65001", prefix="10.100.0.0/16", is_v4=True,
+            is_remove=True, summary_only=COMMON_TRUE_STRING, as_set=COMMON_TRUE_STRING
+        )
+        assert "no aggregate-address 10.100.0.0/16 summary-only as-set" in cmds
+
+    def test_remove_without_flags(self):
+        cmds = generate_aggregate_address_commands(
+            asn="65001", prefix="10.100.0.0/16", is_v4=True,
+            is_remove=True, summary_only=COMMON_FALSE_STRING, as_set=COMMON_FALSE_STRING
+        )
+        assert "no aggregate-address 10.100.0.0/16" in cmds
+
+    def test_remove_ipv6_with_summary_only(self):
+        cmds = generate_aggregate_address_commands(
+            asn="65001", prefix="2001:db8::/32", is_v4=False,
+            is_remove=True, summary_only=COMMON_TRUE_STRING, as_set=COMMON_FALSE_STRING
+        )
+        assert "no aggregate-address 2001:db8::/32 summary-only" in cmds
+        assert "address-family ipv6" in cmds
+
+    def test_add_with_summary_only_still_works(self):
+        cmds = generate_aggregate_address_commands(
+            asn="65001", prefix="10.100.0.0/16", is_v4=True,
+            is_remove=False, summary_only=COMMON_TRUE_STRING, as_set=COMMON_FALSE_STRING
+        )
+        assert "aggregate-address 10.100.0.0/16 summary-only" in cmds
+
+
+class TestAddressDelHandlerPassesFlags:
+    """Tests that address_del_handler passes summary-only/as-set from state DB."""
+
+    def test_del_handler_with_summary_only_in_state(self):
+        """Reproduce the exact bug: add with summary-only=true, then delete.
+        The removal command must include 'summary-only'."""
+        mgr = constructor(bbr_status=BGP_BBR_STATUS_ENABLED)
+
+        # Set address with summary-only=true
+        attr = (
+            ('bbr-required', 'false'),
+            ('summary-only', 'true'),
+            ('as-set', 'false'),
+            ('aggregate-address-prefix-list', ''),
+            ('contributing-address-prefix-list', '')
+        )
+        mgr.set_handler("10.100.0.0/16", attr)
+
+        # Verify state DB has the flags
+        _, state_data = mgr.address_table.get("10.100.0.0/16")
+        assert state_data['summary-only'] == 'true'
+
+        # Now delete — the removal cmd must include summary-only
+        push_list_calls = []
+        mgr.cfg_mgr.push_list = lambda cmds: push_list_calls.append(cmds) or True
+        mgr.del_handler("10.100.0.0/16")
+
+        assert len(push_list_calls) == 1
+        assert "no aggregate-address 10.100.0.0/16 summary-only" in push_list_calls[0]
+
+    def test_bbr_disable_removes_with_summary_only(self):
+        """When BBR is disabled, on_bbr_change must generate removal with summary-only."""
+        mgr = constructor(bbr_status=BGP_BBR_STATUS_ENABLED)
+
+        # Set address with bbr-required=true and summary-only=true
+        attr = (
+            ('bbr-required', 'true'),
+            ('summary-only', 'true'),
+            ('as-set', 'false'),
+            ('aggregate-address-prefix-list', ''),
+            ('contributing-address-prefix-list', '')
+        )
+        mgr.set_handler("10.100.0.0/16", attr)
+
+        # Now switch BBR to disabled
+        push_list_calls = []
+        mgr.cfg_mgr.push_list = lambda cmds: push_list_calls.append(cmds) or True
+        mgr.directory.put(CONFIG_DB_NAME, BGP_BBR_TABLE_NAME, BGP_BBR_STATUS_KEY, BGP_BBR_STATUS_DISABLED)
+
+        assert len(push_list_calls) == 1
+        assert "no aggregate-address 10.100.0.0/16 summary-only" in push_list_calls[0]
+
+    def test_bbr_disable_removes_with_as_set(self):
+        """When BBR is disabled, on_bbr_change must generate removal with as-set."""
+        mgr = constructor(bbr_status=BGP_BBR_STATUS_ENABLED)
+
+        attr = (
+            ('bbr-required', 'true'),
+            ('summary-only', 'false'),
+            ('as-set', 'true'),
+            ('aggregate-address-prefix-list', ''),
+            ('contributing-address-prefix-list', '')
+        )
+        mgr.set_handler("10.100.0.0/16", attr)
+
+        push_list_calls = []
+        mgr.cfg_mgr.push_list = lambda cmds: push_list_calls.append(cmds) or True
+        mgr.directory.put(CONFIG_DB_NAME, BGP_BBR_TABLE_NAME, BGP_BBR_STATUS_KEY, BGP_BBR_STATUS_DISABLED)
+
+        assert len(push_list_calls) == 1
+        assert "no aggregate-address 10.100.0.0/16 as-set" in push_list_calls[0]


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When BBR is disabled or an aggregate address is deleted, the removal command generated by `bgpcfgd` does not include `summary-only` or `as-set` flags. FRR requires the `no aggregate-address` command to exactly match the form in running config. For example, `no aggregate-address 10.100.0.0/16` will **not** remove `aggregate-address 10.100.0.0/16 summary-only`, causing the aggregate route to persist silently in FRR.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Two changes in `managers_aggregate_address.py`:

1. **`generate_aggregate_address_commands()`**: Removed the `if not is_remove` guards on `summary-only` and `as-set` so these flags are appended to both add and remove commands.
2. **`address_del_handler()`**: Now passes `summary_only` and `as_set` from the state DB data to `generate_aggregate_address_commands()`, instead of relying on the default values (`"false"`).

Updated test_aggregate.py:
- Fixed existing test expectations to expect `summary-only`/`as-set` in removal commands.
- Added `TestGenerateAggregateAddressRemovalCommands` — 6 tests verifying `generate_aggregate_address_commands()` produces correct removal commands.
- Added `TestAddressDelHandlerPassesFlags` — 3 tests reproducing the exact bug scenarios (delete with `summary-only`, BBR disable with `summary-only`, BBR disable with `as-set`).

#### How to verify it
Run bgpcfgd unit tests:
```bash
cd src/sonic-bgpcfgd
python3 -m pytest tests/test_aggregate.py -v
```

Manual verification:
1. Configure an aggregate address with `summary-only=true` and `bbr-required=true`
2. Disable BBR
3. Verify `show running-config` in FRR no longer contains the aggregate-address entry

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fixed bgpcfgd aggregate-address removal failing silently when summary-only or as-set flags were set, because the FRR removal command did not include the matching flags.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

