### PR TITLE
build_templates: marvell blacklist with kempld

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -873,6 +873,19 @@ fi
 ## copy blacklist file
 sudo cp $IMAGE_CONFIGS/platform/linux_kernel_bde.conf $FILESYSTEM_ROOT/etc/modprobe.d/
 
+# Marvell AMD64 blacklist with Kontron/kemld modules wich lead to
+# - occasional i2c SMBUS and KEMPLD bus enumeration swap with further PMON failure
+# - I2c-mux collision and bus-stuck on a Marvell device
+if [[ "$CONFIGURED_PLATFORM" == "marvell-prestera" && "$CONFIGURED_ARCH" == "amd64" ]]; then
+FILE="$FILESYSTEM_ROOT/etc/modprobe.d/50-kempld.conf"
+sudo mkdir -p "$(dirname "$FILE")"
+grep -q kempld_core "$FILE" 2>/dev/null || sudo tee -a "$FILE" > /dev/null <<'EOF'
+blacklist kempld_core
+blacklist gpio_kempld
+blacklist i2c_kempld
+EOF
+fi
+
 # Enable psample drivers to support sFlow on vs
 {% if sonic_asic_platform == "vs" %}
 sudo tee -a $FILESYSTEM_ROOT/etc/modules-load.d/modules.conf > /dev/null <<EOF


### PR DESCRIPTION
#### Why I did it
On Marvell-prestera AMD64 the Kontron/kemld modules are auto-installed on Kernel start-up
and this leads to:
- occasional i2c SMBUS and KEMPLD bus enumeration swap with further PMON failure
- I2c-mux collision and bus-stuck on a Marvell device

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Expand build_templates/sonic_debian_extension.j2
basic rootfs with blacklist file /etc/modprobe.d/50-kempld.conf specifically for Marvell AMD64

#### How to verify it
Check that fs.squashfs and initrd.img-XXXX-amd64 have  /etc/modprobe.d/50-kempld.conf inside

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

#### Tested branch (Please provide the tested image version)

#### Description for the changelog

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)
