### PR TITLE
[slave.mk]: Add linux-kbuild install dependency to installer target

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -165,9 +165,6 @@ fi
 ## Update initramfs for booting with squashfs+overlay
 cat files/initramfs-tools/modules | sudo tee -a $FILESYSTEM_ROOT/etc/initramfs-tools/modules > /dev/null
 
-## Install kbuild for sign-file into docker image (not fsroot)
-sudo LANG=C DEBIAN_FRONTEND=noninteractive apt -y --allow-downgrades install ./$debs_path/linux-kbuild-${LINUX_KERNEL_VERSION}*_${CONFIGURED_ARCH}.deb
-
 ## Hook into initramfs: change fs type from vfat to ext4 on arista switches
 sudo mkdir -p $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/
 sudo cp files/initramfs-tools/arista-convertfs $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/arista-convertfs

--- a/slave.mk
+++ b/slave.mk
@@ -1520,7 +1520,8 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
         $(addprefix $(PYTHON_WHEELS_PATH)/,$(SONIC_YANG_MGMT_PY3)) \
         $(addprefix $(PYTHON_WHEELS_PATH)/,$(SYSTEM_HEALTH)) \
         $(addprefix $(PYTHON_WHEELS_PATH)/,$(SONIC_HOST_SERVICES_PY3)) \
-        $$(addprefix $(TARGET_PATH)/,$$($$*_RFS_DEPENDS))
+        $$(addprefix $(TARGET_PATH)/,$$($$*_RFS_DEPENDS)) \
+        $(addprefix $(IMAGE_DISTRO_DEBS_PATH)/,$(LINUX_KBUILD)-install)
 
 	$(HEADER)
 	# Pass initramfs and linux kernel explicitly. They are used for all platforms


### PR DESCRIPTION
#### Why I did it

Fix https://github.com/sonic-net/sonic-buildimage/issues/26483

Currently, the `linux-kbuild` package (which provides the `sign-file` utility) is only installed into the sonic-slave container during the `rfs.squashfs` build step in `build_debian.sh`.

On incremental rebuilds, the `rfs.squashfs` target is not rebuilt, so `linux-kbuild` is never re-installed into the container, causing the signing step to fail with `ERROR: LOCAL_SIGN_FILE=... file does not exist`.

#### How I did it
* Added `$(LINUX_KBUILD)-install` as a dependency to the `$(SONIC_INSTALLERS)` target in `slave.mk`
* This ensures the `linux-kbuild` package is installed into the sonic-slave container before `.bin` generation, regardless of whether the `rfs.squashfs` target was rebuilt
* This approach was suggested by @saiarcot895 as the preferred fix, since it records the dependency explicitly in make rather than relying on a side effect of the squashfs build step

#### How to verify it
1. Build a signed image: `make ENABLE_ZTP=y all`
2. Move the output: `mv target/sonic.bin target/sonic.ztp.bin`
3. Build again with different flags: `make ENABLE_ZTP=n all`
4. Verify the second build completes without `sign-file` errors

#### Description for the changelog
* Fixed incremental rebuild failure for signed images by adding linux-kbuild install dependency to the installer target