### PR TITLE
Use rsync stage in docker-gnmi-watchdog dockerfile j2 template

### DIFF
--- a/dockers/docker-gnmi-watchdog/Dockerfile.j2
+++ b/dockers/docker-gnmi-watchdog/Dockerfile.j2
@@ -38,10 +38,9 @@ COPY --from=builder /watchdog/target/release/watchdog /usr/bin/gnmi_watchdog
 RUN chmod +x /usr/bin/gnmi_watchdog
 
 FROM $BASE
+ARG image_version
 
 {{ rsync_from_builder_stage() }}
-
-ARG image_version
 ENV DEBIAN_FRONTEND=noninteractive
 ENV IMAGE_VERSION=$image_version
 ENTRYPOINT ["/usr/local/bin/supervisord"]


### PR DESCRIPTION
This makes it use the same style as other docker images templates.

This reduces the docker-gnmi-watchdog.gz tarball from 88297986 to 85639226 (2-3%)

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
As part of larger effort to reduce disk size.

##### Work item tracking
- Microsoft ADO **(number only)**: 36978848

#### How I did it
Made the docker-gnmi-watchdog dockerfile template use the same style as the other docker image files.

#### How to verify it
Build the old and new image and verify the size reduction.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Reduce the size of docker-gnmi-watchdog dockerfile template
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

