### PR TITLE
Fix typos across Makefiles, shell scripts, and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ endef
 .PHONY: $(PLATFORM_PATH)
 
 $(PLATFORM_PATH):
-	@echo "+++ Cheking $@ +++"
+	@echo "+++ Checking $@ +++"
 	$(PLATFORM_CHECKOUT_CMD)
 
 configure : $(PLATFORM_PATH)

--- a/Makefile.cache
+++ b/Makefile.cache
@@ -30,7 +30,7 @@
 # There are two types of source code packages used by the SONiC repo.
 #
 #         1. Module source code is maintained as part of main repo
-#                 Eg: sonic-utilities, Plaform files etc
+#                 Eg: sonic-utilities, Platform files etc
 #
 #             Some module source code is maintained outside the sonic repo, but
 #             the build framework is part of sonic main repo.
@@ -228,7 +228,7 @@ define GET_MOD_DEP_SHA
 	$(eval $(1)_DEP_MOD_SHA_FILES := $(foreach dfile,$($(1)_MOD_DEP_PKGS), \
 	                        $($(dfile)_DEP_FLAGS_FILE) $($(dfile)_MOD_HASH_FILE) $($(dfile)_SMOD_HASH_FILE)) )
 	$(eval $(1)_DEP_FILES_MISSING := $(filter-out $(wildcard $($(1)_DEP_MOD_SHA_FILES)),$($(1)_DEP_MOD_SHA_FILES)) )
-	$(if $($(1)_DEP_FILES_MISSING), $(warning "[ DPKG ] Dependecy file(s) are not found for $(1) : $($(1)_DEP_FILES_MISSING)))
+	$(if $($(1)_DEP_FILES_MISSING), $(warning "[ DPKG ] Dependency file(s) are not found for $(1) : $($(1)_DEP_FILES_MISSING)))
 
 	# Include package dependencies hash values into package hash calculation
 	$(eval $(1)_DEP_PKGS_SHA := $(foreach dfile,$($(1)_MOD_DEP_PKGS),$($(dfile)_DEP_MOD_SHA) $($(dfile)_MOD_HASH)))
@@ -238,7 +238,7 @@ define GET_MOD_DEP_SHA
 endef
 
 
-# Retrive the list of files that are modified for the target. The files can be from
+# Retrieve the list of files that are modified for the target. The files can be from
 # 1. Any of dependent target is modified
 # 2. Files from the target dependency list
 # 3. Files from submodule dependency list if the target is a submodule
@@ -280,10 +280,10 @@ define LOAD_FROM_CACHE
 	$(eval $(1)_MOD_CACHE_FILE := $(1)-$($(1)_DEP_MOD_SHA)-$($(1)_MOD_HASH).tgz)
 	$(if $(MDEBUG), $(info $(1)_MODE_CACHE_FILE := $($(1)_MOD_CACHE_FILE)))
 
-	# Retrive and log files list that are modified for the target.
+	# Retrieve and log files list that are modified for the target.
 	$(call GET_MODIFIED_FILES,$(1))
 	$(if $($(1)_FILES_MODIFIED),
-		echo "Target $(1) dependencies are modifed - global cache skipped" >> $($(1)_DST_PATH)/$(1).log
+		echo "Target $(1) dependencies are modified - global cache skipped" >> $($(1)_DST_PATH)/$(1).log
 		echo "Modified dependencies are : [$($(1)_FILES_MODIFIED)] " >> $($(1)_DST_PATH)/$(1).log
 		$(eval $(1)_CACHE_DIR := $(SONIC_DPKG_LOCAL_CACHE_DIR)))
 
@@ -329,13 +329,13 @@ define SAVE_INTO_CACHE
 	$(eval $(1)_MOD_CACHE_FILE  := $(1)-$($(1)_DEP_MOD_SHA)-$($(1)_MOD_HASH).tgz)
 	$(if $(MDEBUG), $(info $(1)_MOD_CACHE_FILE := $($(1)_MOD_CACHE_FILE)))
 
-	# Retrive and log files list that are modified for the target.
+	# Retrieve and log files list that are modified for the target.
 	$(call GET_MODIFIED_FILES,$(1))
 
 	$(eval MOD_CACHE_FILE=$($(1)_MOD_CACHE_FILE))
 	$(call MOD_LOCK,$(1),$(SONIC_DPKG_CACHE_DIR),$(MOD_CACHE_LOCK_SUFFIX),$(MOD_CACHE_LOCK_TIMEOUT))
 	$(if $($(1)_FILES_MODIFIED),
-		echo "Target $(1) dependencies are modifed - global save cache skipped" >> $($(1)_DST_PATH)/$(1).log
+		echo "Target $(1) dependencies are modified - global save cache skipped" >> $($(1)_DST_PATH)/$(1).log
 		$(eval $(1)_CACHE_DIR := $(SONIC_DPKG_LOCAL_CACHE_DIR))
 	 )
 	cp $($(1)_DST_PATH)/$(1).log $($(1)_DST_PATH)/$(1).cached.log
@@ -484,7 +484,7 @@ $(foreach pkg, $(SONIC_MAKE_DEBS) $(SONIC_DPKG_DEBS) $(SONIC_ONLINE_DEBS) $(SONI
 # DPGK framework creates three dependency files for each target.
 #         1. Flags file (.flags)
 #         2. Dependency file (.dep),
-#         3. Dependecy SHA hash file (.sha)
+#         3. Dependency SHA hash file (.sha)
 #         4. If the target is a submodule, corresponding dependency file and hash file are created
 #             sub module dependency file (.smdep)
 #             sub module hash file (.smsha)
@@ -503,9 +503,9 @@ $(foreach pkg, $(SONIC_MAKE_DEBS) $(SONIC_DPKG_DEBS) $(SONIC_ONLINE_DEBS) $(SONI
 #                     SONIC_SANITIZER_ON=y
 #                     etc
 #                 If any of the ENV flag variables are modified, the target needs to be rebuilt as
-#                 the content of flag file is changed becase of value of ENV variable is changed.
+#                 the content of flag file is changed because of value of ENV variable is changed.
 #
-# [2] .dep => contains the dependency files list for a target. Eeach traget can have one or more dependency files.
+# [2] .dep => contains the dependency files list for a target. Each target can have one or more dependency files.
 #                 If any of the ENV flag variables are modified, the target needs to be rebuilt.
 #                 For example: Dependency files list for 'bash' module
 #                     rules/bash.mk
@@ -528,9 +528,9 @@ $(foreach pkg, $(SONIC_MAKE_DEBS) $(SONIC_DPKG_DEBS) $(SONIC_ONLINE_DEBS) $(SONI
 
 
 
-# ruiles for <.flags> file creation
+# rules for <.flags> file creation
 #
-# Each target defines a variable called '_DEP_FLAGS' that contais  a list of environment flags for that target and
+# Each target defines a variable called '_DEP_FLAGS' that contains  a list of environment flags for that target and
 # that indicates that target needs to be rebuilt if any of the dependent flags are changed.
 # An environmental dependency flags file is created with the name as ‘<target name>.flags’  for each target.
 # This file contains the values of target environment flags and gets updated only when there is a change in the flag's value.

--- a/README.buildsystem.md
+++ b/README.buildsystem.md
@@ -119,7 +119,7 @@ SONIC_PYTHON_STDEB_DEBS += $(SOME_NEW_DEB) # add package to this target group
 
 **SONIC_MAKE_DEBS**  
 This is a bit more flexible case.
-If you have to do some specific type of build or apply paths prior to build, just define your own Makefile and add it to buildimage.
+If you have to do some specific type of build or apply patches prior to build, just define your own Makefile and add it to buildimage.
 Define:
 ```make
 SOME_NEW_DEB = some_new_deb.deb # name of your package
@@ -267,7 +267,7 @@ _Recommend: Rename image built using INSTALL_DEBUG_TOOLS=y to mark it explicit. 
         * start process under dbg
         * attach gdb to running process
     * Set required source dir from under /src as needed
-    * May use /debug to record all geb logs or any spew from debug session.
+    * May use /debug to record all gdb logs or any spew from debug session.
     
   ### To enhance debug dockers
   * Add to `<docker name>_DBG_IMAGE_PACKAGES`, additional debug tools that will be pre-installed during build.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ All SONiC project build pipelines can be found at [Download Portal for SONiC Ima
 Following are the instructions on how to build an [(ONIE)](https://github.com/opencomputeproject/onie)
 compatible network operating system (NOS) installer image for network switches,
 and also how to build docker images running inside the NOS.
-Note that SONiC images are build per ASIC platform.
+Note that SONiC images are built per ASIC platform.
 Switches using the same ASIC platform share a common image.
 For a list of supported switches and ASIC, please refer to this [list](https://github.com/sonic-net/SONiC/wiki/Supported-Devices-and-Platforms)
 
@@ -132,7 +132,7 @@ pip3 install --user jinjanator
   * If you are using Linux kernel 5.3 or newer, then you must use Docker 20.10.10 or newer. This is because older Docker versions did not allow the `clone3` syscall, which is now used in Bookworm.
 
 > Note: If a previous installation of Docker using snap was present on the
-> system, remove it and also remove docker from snap before reinstallating docker.
+> system, remove it and also remove docker from snap before reinstalling docker.
 > This will avoid [known bugs that falsely report read-only filesystems issues](https://stackoverflow.com/questions/52526219/docker-mkdir-read-only-file-system)
 > during the build process.
 

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -422,7 +422,7 @@ sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "echo 'MODULES=most' >> /etc/in
 sudo mkdir -p /etc/initramfs-tools/scripts/init-premount
 sudo mkdir -p /etc/initramfs-tools/hooks
 
-# Copy the network setup scriptgit
+# Copy the network setup script
 sudo cp files/scripts/network_setup.sh /etc/initramfs-tools/scripts/init-premount/network_setup.sh
 
 # Copy the hook file
@@ -479,7 +479,7 @@ sudo mkdir $FILESYSTEM_ROOT/etc/systemd/system/ssh.service.d
 sudo cp files/sshd/override.conf $FILESYSTEM_ROOT/etc/systemd/system/ssh.service.d/override.conf
 # Config sshd
 # 1. Set 'UseDNS' to 'no'
-# 2. Configure sshd to close all SSH connetions after 15 minutes of inactivity
+# 2. Configure sshd to close all SSH connections after 15 minutes of inactivity
 sudo augtool -r $FILESYSTEM_ROOT <<'EOF'
 touch /files/etc/ssh/sshd_config/EmptyLineHack
 rename /files/etc/ssh/sshd_config/EmptyLineHack ""
@@ -535,7 +535,7 @@ sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install 'docke
 # Install scapy
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install python3-scapy
 
-## Note: keep pip installed for maintainance purpose
+## Note: keep pip installed for maintenance purpose
 
 # Install GCC, needed for building/installing some Python packages
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install gcc
@@ -694,7 +694,7 @@ if [[ $SECURE_UPGRADE_MODE == 'dev' || $SECURE_UPGRADE_MODE == "prod" ]]; then
 	sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt -y --allow-downgrades install $basename_deb_packages
 	sudo rm $FILESYSTEM_ROOT/grub-efi*.deb
 
-    # debian secure boot dependecies
+    # debian secure boot dependencies
     sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install      \
         shim-unsigned
 
@@ -876,7 +876,7 @@ sudo mkdir $FILESYSTEM_ROOT/host
 
 
 if [[ "$CHANGE_DEFAULT_PASSWORD" == "y" ]]; then
-    ## Expire default password for exitsing users that can do login
+    ## Expire default password for existing users that can do login
     default_users=$(cat $FILESYSTEM_ROOT/etc/passwd | grep "/home"|  grep ":/bin/bash\|:/bin/sh" | awk -F ":" '{print $1}' 2> /dev/null)
     for user in $default_users
     do

--- a/build_image.sh
+++ b/build_image.sh
@@ -174,7 +174,7 @@ elif [ "$IMAGE_TYPE" = "kvm" ]; then
     # Generate single asic KVM image
     generate_kvm_image
     if [ "$BUILD_MULTIASIC_KVM" == "y" ]; then
-        # Genrate 4-asic KVM image
+        # Generate 4-asic KVM image
         generate_kvm_image 4
         # Generate 6-asic KVM image
         generate_kvm_image 6

--- a/slave.mk
+++ b/slave.mk
@@ -567,7 +567,7 @@ include Makefile.cache
 
 ###############################################################################
 ## Generic rules section
-## All rules must go after includes for propper targets expansion
+## All rules must go after includes for proper targets expansion
 ###############################################################################
 
 export kernel_procure_method=$(KERNEL_PROCURE_METHOD)
@@ -1258,7 +1258,7 @@ $(addprefix $(TARGET_PATH)/, $(DOCKER_IMAGES)) : $(TARGET_PATH)/%.gz : .platform
 		$(eval export $(subst -,_,$(notdir $($*.gz_PATH)))_dbgs=$(shell printf "$(subst $(SPACE),\n,$(call expand,$($*.gz_DBG_PACKAGES)))\n" | awk '!a[$$0]++'))
 		$(eval export $(subst -,_,$(notdir $($*.gz_PATH)))_pkgs=$(shell printf "$(subst $(SPACE),\n,$(call expand,$($*.gz_APT_PACKAGES)))\n" | awk '!a[$$0]++'))
 		if [ -d $($*.gz_PATH)/cli-plugin-tests/ ] && [ ! "$(BUILD_SKIP_TEST)" = "y" ]; then pushd $($*.gz_PATH)/cli-plugin-tests; PATH=$(VIRTENV_BIN_CROSS_PYTHON$($(SONIC_UTILITIES_PY3)_PYTHON_VERSION)):${PATH} PYTHONPATH=$(shell realpath $($*.gz_PATH)):${PYTHONPATH} pytest-$($(SONIC_UTILITIES_PY3)_PYTHON_VERSION) -v $(LOG); popd; fi
-		# Label docker image with componenets versions
+		# Label docker image with components versions
 		$(eval export $(subst -,_,$(notdir $($*.gz_PATH)))_labels=$(foreach component,\
 			$(call expand,$($*.gz_DEPENDS),RDEPENDS) \
 			$(call expand,$($*.gz_PYTHON_DEBS)) \


### PR DESCRIPTION
#### Why I did it

Fix spelling typos found across Makefiles, shell scripts, and documentation files in the root directory. These are cosmetic fixes in comments, echo messages, and documentation — no logic or functional changes.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Fixed 21 typos across 7 files:

- **Makefile**: `Cheking` → `Checking`
- **Makefile.cache** (10 typos): `Plaform` → `Platform`, `Dependecy` → `Dependency`, `Retrive` → `Retrieve`, `modifed` → `modified` (×2), `ruiles` → `rules`, `contais` → `contains`, `becase` → `because`, `Eeach traget` → `Each target`
- **slave.mk**: `propper` → `proper`, `componenets` → `components`
- **build_debian.sh**: `scriptgit` → `script`, `maintainance` → `maintenance`, `connetions` → `connections`, `dependecies` → `dependencies`, `exitsing` → `existing`
- **build_image.sh**: `Genrate` → `Generate`
- **README.md**: `are build per` → `are built per`, `reinstallating` → `reinstalling`
- **README.buildsystem.md**: `apply paths prior` → `apply patches prior`, `geb logs` → `gdb logs`

#### How to verify it

All changes are in comments, echo strings, and documentation. No functional impact. Verify by reviewing the diff — each change is a straightforward spelling correction.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] N/A — cosmetic/comment-only changes, no functional impact

#### Description for the changelog

Fix 21 spelling typos in Makefiles, shell scripts, and documentation files.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

🐛 ← the typo bug, now squashed