### PR TITLE
Change gNMI default port from 8080 to 8082

### DIFF
--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -62,7 +62,7 @@ fi
 
 # If no configuration entry exists for TELEMETRY, create one default port
 if [ -z "$GNMI" ]; then
-    PORT=8080
+    PORT=8082
 else
     PORT=$(extract_field "$GNMI" '.port')
     if ! [[ $PORT =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
## Problem
When no ConfigDB GNMI entry exists, both the gNMI container (`gnmi-native.sh`) and the telemetry container (`telemetry.sh`) fall back to port 8080. If both containers are running without explicit configuration, they collide on the same port.

## Change
Change the gNMI container's default fallback port from 8080 to 8082. The telemetry container retains its 8080 default.

## Files Changed
- `dockers/docker-sonic-gnmi/gnmi-native.sh` — default `PORT=8080` → `PORT=8082`