### PR TITLE
Install PTF module in syncd-rpc container

### DIFF
--- a/platform/broadcom/docker-syncd-brcm-dnx-rpc/Dockerfile.j2
+++ b/platform/broadcom/docker-syncd-brcm-dnx-rpc/Dockerfile.j2
@@ -50,6 +50,7 @@ RUN pip3 install cffi==1.16.0    \
  && mkdir -p /opt       \
  && cd /opt             \
  && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \
+ && mkdir ptf && cd ptf && wget https://raw.githubusercontent.com/p4lang/ptf/master/src/ptf/afpacket.py && touch __init__.py \
  && apt-get clean -y; apt-get autoclean -y; apt-get autoremove -y \
  && rm -rf /root/deps
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixes https://github.com/sonic-net/sonic-mgmt/issues/18479
`Regression: ptf_nn_agent is not running in syncd_rpc containers`

PTF calls from syncd_rpc freeze without the agent.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Pushing Change on behalf of @ysmanman and @veronica-arista

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] msft-202503
- [x] 202511

#### Tested branch (Please provide the tested image version)
202511

