### PR TITLE
[lldp] Fix lldp_syncd sync issue after config reload

### DIFF
--- a/src/sonic-dbsyncd.patch/0001-Fix-lldp_syncd-cache-issue-during-config-reload.patch
+++ b/src/sonic-dbsyncd.patch/0001-Fix-lldp_syncd-cache-issue-during-config-reload.patch
@@ -1,0 +1,40 @@
+From 8870375eb4f66d3bc9e78ed75e8da0c61b2f09c2 Mon Sep 17 00:00:00 2001
+From: Sumalatha G <sumalatha.g@xoriant.com>
+Date: Thu, 2 Apr 2026 17:28:26 +0530
+Subject: [PATCH] Fix lldp_syncd cache issue during config reload
+
+When 'config reload -f' is executed, the database tables are cleared,
+but lldp_syncd continues running in the lldp container. The daemon
+maintains an internal cache and only updates the database when the
+cache differs from new data. This causes LLDP_LOC_CHASSIS table to
+remain empty after reload if the chassis information hasn't changed.
+
+This fix adds a check to verify if the database table actually exists
+before relying solely on the cache comparison. If the table doesn't
+exist (indicating the DB was cleared), the daemon will repopulate it
+even if the cache hasn't changed.
+
+Fixes: sonic-net/sonic-buildimage#26297
+---
+ src/lldp_syncd/daemon.py | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/lldp_syncd/daemon.py b/src/lldp_syncd/daemon.py
+index e949ad1..9c104e8 100644
+--- a/src/lldp_syncd/daemon.py
++++ b/src/lldp_syncd/daemon.py
+@@ -380,7 +380,11 @@ class LldpSyncDaemon(SonicSyncDaemon):
+         # push local chassis data to APP DB
+         if 'local-chassis' in parsed_update:
+             chassis_update = parsed_update.pop('local-chassis')
+-            if chassis_update != self.chassis_cache:
++            # Check if table exists in DB - if not, the DB was cleared (e.g., during config reload)
++            db_table_exists = self.db_connector.exists(self.db_connector.APPL_DB,
++                                                       LldpSyncDaemon.LLDP_LOC_CHASSIS_TABLE)
++            # Update if cache differs OR if DB table doesn't exist (handles config reload -f case)
++            if chassis_update != self.chassis_cache or not db_table_exists:
+                 self.db_connector.delete(self.db_connector.APPL_DB,
+                                          LldpSyncDaemon.LLDP_LOC_CHASSIS_TABLE)
+                 for k, v in chassis_update.items():
+-- 
+2.43.0

--- a/src/sonic-dbsyncd.patch/series
+++ b/src/sonic-dbsyncd.patch/series
@@ -1,0 +1,1 @@
+0001-Fix-lldp_syncd-cache-issue-during-config-reload.patch


### PR DESCRIPTION
Issue: config reload -f can break lldp_syncd synchronization for LLDP_LOC_CHASSIS table

Root Cause:
During 'config reload -f', the database is cleared but the lldp container may continue running. lldp_syncd maintains an internal cache and only updates the database when the cached data differs from new data. This causes the LLDP_LOC_CHASSIS table to remain empty after reload when chassis information hasn't changed.

Fix:
Modified lldp_syncd to check if the database table exists before relying solely on cache comparison. If the table doesn't exist (indicating DB was cleared), the daemon will repopulate it even if the cache hasn't changed.

This ensures proper synchronization after config reload operations.

Fixes #26297

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix #26297: config reload -f leaves LLDP_LOC_CHASSIS table empty because lldp_syncd cache prevents database repopulation.


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added database existence check in lldp_syncd to force repopulation when table is missing after reload:
if chassis_update != self.chassis_cache or not db_table_exists:
    # Update database

#### How to verify it

redis-cli -n 0 HGETALL "LLDP_LOC_CHASSIS"  # Check initial state
sudo config reload -f -y                    # Reload
sleep 30                                    # Wait
redis-cli -n 0 HGETALL "LLDP_LOC_CHASSIS"  # Should be populated


#### Which release branch to backport (provide reason below if selected)

☑ All active branches (202305, 202311, 202405, 202411, 202505, 202511)

Reason: Critical bug affecting LLDP monitoring after config reload.

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
[lldp] Fix LLDP_LOC_CHASSIS not repopulating after config reload -f (#26297)

#### Link to config_db schema for YANG module changes
N/A
