### PR TITLE
[dplane_fpm_sonic]: Skip MRIB routes to prevent FIB route deletion

### DIFF
--- a/src/sonic-frr/dplane_fpm_sonic/dplane_fpm_sonic.c
+++ b/src/sonic-frr/dplane_fpm_sonic/dplane_fpm_sonic.c
@@ -3381,6 +3381,20 @@ static int fpm_nl_process(struct zebra_dplane_provider *prov)
 		 * anyway.
 		 */
 		if (fnc->socket != -1 && fnc->connecting == false) {
+			enum dplane_op_e op = dplane_ctx_get_op(ctx);
+
+			/*
+			 * Skip multicast routes: MRIB routes flow through
+			 * the dataplane pipeline but should not be sent to
+			 * FPM. Without this filter, MRIB ROUTE_DELETE events
+			 * can remove valid unicast routes from APP_DB.
+			 */
+			if ((op == DPLANE_OP_ROUTE_DELETE ||
+			     op == DPLANE_OP_ROUTE_INSTALL ||
+			     op == DPLANE_OP_ROUTE_UPDATE) &&
+			    dplane_ctx_get_safi(ctx) == SAFI_MULTICAST)
+				goto skip;
+
 			frr_with_mutex (&fnc->ctxqueue_mutex) {
 				dplane_ctx_enqueue_tail(&fnc->ctxqueue, ctx);
 				cur_queue =
@@ -3391,7 +3405,7 @@ static int fpm_nl_process(struct zebra_dplane_provider *prov)
 				peak_queue = cur_queue;
 			continue;
 		}
-
+skip:
 		dplane_ctx_set_status(ctx, ZEBRA_DPLANE_REQUEST_SUCCESS);
 		dplane_provider_enqueue_out_ctx(prov, ctx);
 	}


### PR DESCRIPTION
#### Why I did it

Fix https://github.com/sonic-net/sonic-buildimage/issues/25173

FRR commit https://github.com/FRRouting/frr/commit/3bff65abc75e952a15b98666e7271189ac28a2bc changed behavior to allow MRIB routes through the dataplane pipeline, and upstream's `dplane_fpm_nl.c` was updated to filter them (See this [permalink](https://github.com/FRRouting/frr/blob/7d94895937ce058c654ef27ea39dd1bd55d75844/zebra/dplane_fpm_nl.c#L1785-L1806)). SONiC's `dplane_fpm_sonic.c` was not updated with the same filter, so MRIB ROUTE_DELETE events reach fpmsyncd and delete valid unicast routes from APP_DB.

#### How I did it

Added a `SAFI_MULTICAST` check in `fpm_nl_process()` within `dplane_fpm_sonic.c`, mirroring the upstream FRR fix in `dplane_fpm_nl.c`. Route operations (`ROUTE_DELETE`, `ROUTE_INSTALL`, `ROUTE_UPDATE`) with `SAFI_MULTICAST` are skipped and not enqueued to fpmsyncd.

#### How to verify it

See https://github.com/sonic-net/sonic-buildimage/issues/25173#issuecomment-4186559462 for issue replication instructions. After the fix, `show ip fib` should not miss `10.10.0.0/24`.

#### Description for the changelog

Skip MRIB routes in dplane_fpm_sonic to prevent FIB route deletion when connected routes are withdrawn.