### PR TITLE
[functions.sh] Quote variable expansions in docker_try_rmi

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -40,13 +40,13 @@ die() {
 docker_try_rmi() {
     local image_name="$1"
     ## Note: inspect output has quotation characters, so sed to remove it as an argument
-    local image_id=$(docker inspect --format="{{json .Id}}" $image_name | sed -e 's/^"//' -e 's/"$//')
+    local image_id=$(docker inspect --format="{{json .Id}}" "$image_name" | sed -e 's/^"//' -e 's/"$//')
     [ -z "$image_id" ] || {
         ## Remove all the exited containers from this image
-        docker ps -a -q -f "status=exited" -f "ancestor=$1" | xargs --no-run-if-empty docker rm
+        docker ps -a -q -f "status=exited" -f "ancestor=$image_name" | xargs --no-run-if-empty docker rm
         ## Note: If there are running containers from this image, the build system is in an
         ##   unexpected state. The 'rmi' will fail and we need investigate the build environment.
-        docker rmi $image_name
+        docker rmi "$image_name"
     }
 }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

`docker_try_rmi()` in `functions.sh` passes `$image_name` to `docker inspect` and `docker rmi` without quotes. Unquoted variable expansion in bash is subject to word splitting (on `$IFS`) and pathname/glob expansion before the resulting words are handed to the command.

This is a defensive shell-correctness fix: the function should pass its argument to `docker` as a single token regardless of what the caller provides. Quoting closes a class of unintended behavior where the shell could interpret part of the value rather than passing it through opaquely.

There is no functional change for well-formed image names.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Wrapped the two `$image_name` expansions in double quotes:

- `docker inspect --format="{{json .Id}}" "$image_name"`
- `docker rmi "$image_name"`

The local declaration (`local image_name="$1"`) and the `-f "ancestor=$1"` filter were already quoted and are unchanged.

#### How to verify it

This is a **build-time-only** change — `docker_try_rmi()` is invoked from `build_docker.sh` and `get_docker-base.sh` during `make`, on the build host. It is not installed into the image. A clean image build is therefore the complete validation.

1. Full VS image build (`make target/sonic-vs.img.gz`) — completes cleanly; `docker_try_rmi` runs during the docker image cleanup path with quoted args, no behavior change.
2. `bash -n functions.sh` — syntax check passes.
3. Optional: `shellcheck functions.sh` — SC2086 warnings on these two lines are cleared.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

Low-risk two-line shell-hardening change. Backport at maintainer discretion — applies cleanly to all listed branches but is not urgent for any specific release.

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Quote `$image_name` in `docker_try_rmi` to prevent shell word-splitting and glob expansion.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

N/A — no YANG or config_db changes.

#### A picture of a cute animal (not mandatory but encouraged)

🦔
