### PR TITLE
Added db migration logic to Pensando-Elba dpu

### DIFF
--- a/files/dsc/dpu.init
+++ b/files/dsc/dpu.init
@@ -102,10 +102,13 @@ function start_polaris()
         # Handle configuration migration (similar to rc.local pattern)
         if [ -d /host/old_config ]; then
             log_msg "First boot detected: migrating old configuration"
-            mv -f /host/old_config /etc/sonic/old_config
-            rm -rf /etc/sonic/old_config/old_config
-            touch /etc/sonic/pending_config_migration
-            log_msg "Configuration migration will be handled by config-setup.service"
+            if mv -f /host/old_config /etc/sonic/old_config; then
+                rm -rf /etc/sonic/old_config/old_config
+                touch /etc/sonic/pending_config_migration
+                log_msg "Configuration migration will be handled by config-setup.service"
+            else
+                log_msg "ERROR: failed to migrate /host/old_config"
+            fi
         else
             log_msg "First boot detected: no old configuration found"
             touch /etc/sonic/pending_config_initialization
@@ -254,4 +257,3 @@ force-reload|restart)
 esac
 
 exit 0
-

--- a/files/dsc/dpu.init
+++ b/files/dsc/dpu.init
@@ -98,6 +98,19 @@ function start_polaris()
         platform=$(grep 'onie_platform=' /host/machine.conf | cut -d '=' -f 2)
         log_msg "python3 -m pip install $device/$platform/sonic_platform-1.0-py3-none-any.whl"
         python3 -m pip install $device/$platform/sonic_platform-1.0-py3-none-any.whl
+
+        # Handle configuration migration (similar to rc.local pattern)
+        if [ -d /host/old_config ]; then
+            log_msg "First boot detected: migrating old configuration"
+            mv -f /host/old_config /etc/sonic/old_config
+            rm -rf /etc/sonic/old_config/old_config
+            touch /etc/sonic/pending_config_migration
+            log_msg "Configuration migration will be handled by config-setup.service"
+        else
+            log_msg "First boot detected: no old configuration found"
+            touch /etc/sonic/pending_config_initialization
+        fi
+
         rm /boot/first_boot
     fi
 
@@ -160,6 +173,11 @@ function start_polaris()
     if [ -z "$midplane_ip" ]; then
         log_msg "Warning: Failed to obtain IP address on $INTERFACE after $DHCP_MAX_RETRIES attempts"
         log_msg "DHCP server may not be available. Continuing without midplane IP."
+    fi
+
+    if ! systemctl is-active --quiet ssh.service; then
+        log_msg "ssh.service is not active; regenerating host keys and restarting ssh"
+        generate_ssh_host_keys
     fi
 }
 


### PR DESCRIPTION
#### Why I did it
Pensando-Elba dpu doesn't uses rc.local script for migration of config_db and configurations for various services. So have introduced mechanism to do similar via dpu.service during first boot post-installation of new image.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added first-boot detection to `dpu.init` to handle config migration when switching between SONiC images. On initial boot after upgrade, the script moves backed-up configs and sets a flag for `config-setup.service` to perform database migration.

Changes
- Detect `/boot/first_boot` marker
- Move `/host/old_config` → `/etc/sonic/old_config`
- Create `pending_config_migration` flag for config-setup.service
- Regenerate SSH host keys if ssh.service is inactive

Boot Flow After Image Upgrade
```
┌──────────────────────────────────────────────────────────────┐
│              sonic-installer install <image>                 │
│         Backup: /etc/sonic → /host/old_config/               │
│            Create marker: /boot/first_boot                   │
└─────────────────────────┬────────────────────────────────────┘
                          │
                          │ System reboot
                          │
┌─────────────────────────▼────────────────────────────────────┐
│                  dpu.service (dpu.init)                      │
│    Detect /boot/first_boot → move old_config to /etc/sonic  │
│         Touch /etc/sonic/pending_config_migration            │
└─────────────────────────┬────────────────────────────────────┘
                          │
                          │ After=dpu.service
                          │
┌─────────────────────────▼────────────────────────────────────┐
│                  database.service                            │
│              Start Redis (empty Config DB)                   │
└─────────────────────────┬────────────────────────────────────┘
                          │
                          │ After=database.service
                          │
┌─────────────────────────▼────────────────────────────────────┐
│                config-setup.service                          │
│   Detect pending_config_migration → restore /etc/sonic       │
│   Load config: sonic-cfggen -j config_db.json --write-to-db  │
│   Migrate schema: db_migrator.py -o migrate                  │
│        Set CONFIG_DB_INITIALIZED = "1" in Redis              │
└─────────────────────────┬────────────────────────────────────┘
                          │
                          │ Requires CONFIG_DB_INITIALIZED
                          │
┌─────────────────────────▼────────────────────────────────────┐
│           swss, syncd, pmon, other services                  │
│              Boot completes with migrated config             │
└──────────────────────────────────────────────────────────────
```

#### How to verify it
Did below test:
1. Made changes in configuration
```
root@sonic:/home/admin# config interface ip add Loopback1 11.11.11.11/32
root@sonic:/home/admin# config interface ip add Loopback0 12.12.12.12/32
root@sonic:/home/admin# show ip interfaces
Interface      Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
-------------  --------  -------------------  ------------  --------------  -------------
Ethernet0                20.0.200.4/28        up/up         N/A             N/A
Loopback0                12.12.12.12/32       up/up         N/A             N/A
Loopback1                11.11.11.11/32       up/up         N/A             N/A
docker0                  240.127.1.1/24       up/down       N/A             N/A
eth0-midplane            169.254.200.4/24     up/up         N/A             N/A
lo                       127.0.0.1/16         up/up         N/A             N/A
```
2. Took backup of config_db.
```
root@sonic:/home/admin# config save -y
Running command: /usr/local/bin/sonic-cfggen -d --print-data > /etc/sonic/config_db.json
```
3. Installation of new image
```
root@sonic:/home/admin# sonic-installer install sonic-pensando-20251104.23.bin -y
Installing image SONiC-OS-20251104.23 and setting it as default...
Command: bash ./sonic-pensando-20251104.23.bin
Removing old SONiC installation /host/image-20251104.11
Installing SONiC to /host/image-20251104.23
Archive:  fs.zip
   creating: /host/image-20251104.23/boot/
  inflating: /host/image-20251104.23/boot/elba-asic-psci.dtb
  inflating: /host/image-20251104.23/boot/elba-asic-psci-mtfuji.dtb
  inflating: /host/image-20251104.23/boot/config-6.12.41+deb13-sonic-arm64
  inflating: /host/image-20251104.23/boot/elba-asic-psci-lipari.dtb
  inflating: /host/image-20251104.23/boot/vmlinuz-6.12.41+deb13-sonic-arm64
  inflating: /host/image-20251104.23/boot/install_file
  inflating: /host/image-20251104.23/boot/initrd.img-6.12.41+deb13-sonic-arm64
  inflating: /host/image-20251104.23/boot/System.map-6.12.41+deb13-sonic-arm64
 extracting: /host/image-20251104.23/fs.squashfs
.
.
.
.
.
Installing SONiC in SONiC
ONIE Installer: platform: arm64-pensando-r0
onie_platform: arm64-elba-asic-flash128-r0

Command: config-setup backup <========================================= config backup
Taking backup of current configuration

Command: mkdir -p /tmp/image-20251104.23-fs
Command: mount -t squashfs /host/image-20251104.23/fs.squashfs /tmp/image-20251104.23-fs
Command: sonic-cfggen -d -y /tmp/image-20251104.23-fs/etc/sonic/sonic_version.yml -t /tmp/image-20251104.23-fs/usr/share/sonic/templates/sonic-environment.j2
Command: umount -r -f /tmp/image-20251104.23-fs
.
.
.
umount: /tmp/image-20251104.23-fs: not mounted.
Command: rm -rf /tmp/image-20251104.23-fs
Command: sync
Command: sync
Command: sync
Command: sleep 3
Done
```
4. Reboot the system. On bootup dpu.service will check first_boot flag and set migration flag
```
Starting dpu.service - dpu sw...
[   13.457118] ionic_mnic: loading out-of-tree module taints kernel.
[   13.463264] ionic_mnic: module verification failed: signature and/or required key missing - tainting kernel
[   13.480617] ionic Pensando Ethernet NIC Driver, ver 201803.01-10231-gb7d486895
.
.
.
python3 -m pip install /usr/share/sonic/device/arm64-elba-asic-flash128-r0/sonic_platform-1.0-py3-none-any.whl

Debian GNU/Linux 13 sonic ttyS0

sonic login: [   18.491547] cgroup: Unknown subsys name 'memory'
[   18.496468] cgroup: Unknown subsys name 'cpuset'
[   18.668254] running_store: kpcimgr will begin running on port 0
[   20.794076] First boot detected: migrating old configuration <======================= change
First boot detected: migrating old configuration
[   20.989425] Configuration migration will be handled by config-setup.service
Configuration migration will be handled by config-setup.service
[   21.004624] Waiting for interface eth0-midplane to be created by polaris container...
Waiting for interface eth0-midplane to be created by polaris container...
```
5. config-setup.service will take care of migration
```
root@sonic:/home/admin# cat /var/log/syslog | grep -i --text config-setup
2026-04-23T06:12:40.023358+00:00 sonic dpu[2464]: Configuration migration will be handled by config-setup.service
2026-04-23T06:12:40.023358+00:00 sonic dpu[2464]: Configuration migration will be handled by config-setup.service
2026-04-23T06:13:01.697462+00:00 sonic systemd[1]: Starting config-setup.service - Config initialization and migration service...
2026-04-23T06:13:01.697462+00:00 sonic systemd[1]: Starting config-setup.service - Config initialization and migration service...
2026-04-23T06:13:02.277960+00:00 sonic config-setup[4423]: Missing SONiC configuration minigraph.xml ...
2026-04-23T06:13:02.277960+00:00 sonic config-setup[4423]: Missing SONiC configuration minigraph.xml ...
2026-04-23T06:13:02.278150+00:00 sonic config-setup[4423]: Copying SONiC configuration snmp.yml ...
2026-04-23T06:13:02.278150+00:00 sonic config-setup[4423]: Copying SONiC configuration snmp.yml ...
2026-04-23T06:13:02.343666+00:00 sonic config-setup[4423]: Missing SONiC configuration acl.json ...
2026-04-23T06:13:02.343778+00:00 sonic config-setup[4423]: Missing SONiC configuration port_config.json ...
2026-04-23T06:13:02.343832+00:00 sonic config-setup[4423]: Copying SONiC configuration frr ...
2026-04-23T06:13:02.343666+00:00 sonic config-setup[4423]: Missing SONiC configuration acl.json ...
2026-04-23T06:13:02.343778+00:00 sonic config-setup[4423]: Missing SONiC configuration port_config.json ...
2026-04-23T06:13:02.343832+00:00 sonic config-setup[4423]: Copying SONiC configuration frr ...
2026-04-23T06:13:02.369384+00:00 sonic config-setup[4423]: Missing SONiC configuration telemetry ...
2026-04-23T06:13:02.369471+00:00 sonic config-setup[4423]: Missing SONiC configuration golden_config_db.json ...
2026-04-23T06:13:02.369384+00:00 sonic config-setup[4423]: Missing SONiC configuration telemetry ...
2026-04-23T06:13:02.369471+00:00 sonic config-setup[4423]: Missing SONiC configuration golden_config_db.json ...
2026-04-23T06:13:02.374445+00:00 sonic config-setup[4423]: Copying SONiC configuration config_db.json ...
2026-04-23T06:13:02.374445+00:00 sonic config-setup[4423]: Copying SONiC configuration config_db.json ...
2026-04-23T06:13:02.378503+00:00 sonic config-setup[4423]: Use config_db.json from old system... <============= change
2026-04-23T06:13:02.378559+00:00 sonic config-setup[4423]: Reloading existing config db...
2026-04-23T06:13:02.378503+00:00 sonic config-setup[4423]: Use config_db.json from old system...
2026-04-23T06:13:02.378559+00:00 sonic config-setup[4423]: Reloading existing config db...
```
6. verification
```
root@sonic:/home/admin# show ip interfaces
Interface      Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
-------------  --------  -------------------  ------------  --------------  -------------
Ethernet0                20.0.200.4/28        up/up         N/A             N/A
Loopback0                12.12.12.12/32       up/up         N/A             N/A
Loopback1                11.11.11.11/32       up/up         N/A             N/A
docker0                  240.127.1.1/24       up/down       N/A             N/A
eth0-midplane            169.254.200.4/24     up/up         N/A             N/A
lo                       127.0.0.1/16         up/up         N/A             N/A
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] SONiC-OS-20251104.23
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

