### PR TITLE
[bgpcfgd]: Validate aggregate address prefix and reject prefixes with host bits set

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
@@ -127,11 +127,11 @@ class AggregateAddressMgr(Manager):
 
     def del_handler(self, key):
         address_state = self.get_address_from_state_db(key)
-        if address_state.get(ADDRESS_STATE_KEY) == ADDRESS_ACTIVE_STATE:
+        if address_state.get(ADDRESS_STATE_KEY) == ADDRESS_INACTIVE_STATE:
+            log_info("AggregateAddressMgr::address %s is inactive, skip FRR removal" % key2prefix(key))
+        else:
             if self.address_del_handler(key, address_state):
                 log_info("AggregateAddressMgr::delete address %s success" % key)
-        else:
-            log_info("AggregateAddressMgr::address %s is not active, skip FRR removal" % key2prefix(key))
         self.del_address_state(key)
         return True
 

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
@@ -1,3 +1,5 @@
+import ipaddress
+
 from swsscommon import swsscommon
 
 from .log import log_info, log_err
@@ -77,6 +79,12 @@ class AggregateAddressMgr(Manager):
     def address_set_handler(self, key, data):
         bgp_asn = self.directory.get_slot(CONFIG_DB_NAME, swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)["localhost"]["bgp_asn"]
         prefix = key2prefix(key)
+
+        valid, reason = validate_prefix(prefix)
+        if not valid:
+            log_err("AggregateAddressMgr::invalid aggregate prefix %s: %s" % (prefix, reason))
+            return False
+
         is_v4 = '.' in prefix
         cmd_list = []
 
@@ -198,6 +206,15 @@ class AggregateAddressMgr(Manager):
 def key2prefix(key):
     prefix = key.split("|")[-1]
     return prefix
+
+
+def validate_prefix(prefix):
+    """Return (True, None) if prefix is a valid network address, or (False, reason) otherwise."""
+    try:
+        ipaddress.ip_network(prefix, strict=True)
+    except ValueError as e:
+        return False, str(e)
+    return True, None
 
 
 def generate_aggregate_address_commands(asn, prefix, is_v4, is_remove, summary_only=COMMON_FALSE_STRING, as_set=COMMON_FALSE_STRING):

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
@@ -88,7 +88,7 @@ class AggregateAddressMgr(Manager):
             log_err("AggregateAddressMgr::invalid aggregate prefix %s: %s" % (prefix, reason))
             return False
 
-        is_v4 = '.' in prefix
+        is_v4 = ipaddress.ip_network(prefix, strict=True).version == 4
         cmd_list = []
 
         aggregates_cmds = generate_aggregate_address_commands(
@@ -138,7 +138,7 @@ class AggregateAddressMgr(Manager):
     def address_del_handler(self, key, data):
         bgp_asn = self.directory.get_slot(CONFIG_DB_NAME, swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)["localhost"]["bgp_asn"]
         prefix = key2prefix(key)
-        is_v4 = '.' in prefix
+        is_v4 = ipaddress.ip_network(prefix, strict=False).version == 4
         cmd_list = []
 
         aggregates_cmds = generate_aggregate_address_commands(

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
@@ -52,7 +52,7 @@ class AggregateAddressMgr(Manager):
                 if self.address_set_handler(address[0], address[1]):
                     self.set_address_state(address[0], address[1], ADDRESS_ACTIVE_STATE)
                 else:
-                    log_err("AggregateAddressMgr::set address %s failed during BBR change" % key2prefix(address[0]))
+                    log_err("AggregateAddressMgr::set address %s failed during BBR change (validation or FRR push error)" % key2prefix(address[0]))
                     self.set_address_state(address[0], address[1], ADDRESS_INACTIVE_STATE)
         elif bbr_status == BGP_BBR_STATUS_DISABLED:
             log_info("AggregateAddressMgr::BBR state changed to %s with bbr_required addresses %s" % (bbr_status, addresses))
@@ -75,7 +75,7 @@ class AggregateAddressMgr(Manager):
             if self.address_set_handler(key, data):
                 self.set_address_state(key, data, ADDRESS_ACTIVE_STATE)
             else:
-                log_err("AggregateAddressMgr::set address %s failed" % key2prefix(key))
+                log_err("AggregateAddressMgr::set address %s failed (validation or FRR push error)" % key2prefix(key))
                 self.set_address_state(key, data, ADDRESS_INACTIVE_STATE)
         return True
 
@@ -83,12 +83,12 @@ class AggregateAddressMgr(Manager):
         bgp_asn = self.directory.get_slot(CONFIG_DB_NAME, swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)["localhost"]["bgp_asn"]
         prefix = key2prefix(key)
 
-        valid, reason = validate_prefix(prefix)
-        if not valid:
+        net, reason = validate_prefix(prefix)
+        if net is None:
             log_err("AggregateAddressMgr::invalid aggregate prefix %s: %s" % (prefix, reason))
             return False
 
-        is_v4 = ipaddress.ip_network(prefix, strict=True).version == 4
+        is_v4 = net.version == 4
         cmd_list = []
 
         aggregates_cmds = generate_aggregate_address_commands(
@@ -138,7 +138,8 @@ class AggregateAddressMgr(Manager):
     def address_del_handler(self, key, data):
         bgp_asn = self.directory.get_slot(CONFIG_DB_NAME, swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)["localhost"]["bgp_asn"]
         prefix = key2prefix(key)
-        is_v4 = ipaddress.ip_network(prefix, strict=False).version == 4
+        net, _ = validate_prefix(prefix)
+        is_v4 = net.version == 4 if net else False
         cmd_list = []
 
         aggregates_cmds = generate_aggregate_address_commands(
@@ -215,14 +216,14 @@ def key2prefix(key):
 
 
 def validate_prefix(prefix):
-    """Return (True, None) if prefix is a valid network address, or (False, reason) otherwise."""
+    """Return (network, None) if prefix is valid, or (None, reason) otherwise."""
     if '/' not in prefix:
-        return False, "missing prefix length"
+        return None, "missing prefix length"
     try:
-        ipaddress.ip_network(prefix, strict=True)
+        net = ipaddress.ip_network(prefix, strict=True)
     except ValueError as e:
-        return False, str(e)
-    return True, None
+        return None, str(e)
+    return net, None
 
 
 def generate_aggregate_address_commands(asn, prefix, is_v4, is_remove, summary_only=COMMON_FALSE_STRING, as_set=COMMON_FALSE_STRING):

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
@@ -52,7 +52,7 @@ class AggregateAddressMgr(Manager):
                 if self.address_set_handler(address[0], address[1]):
                     self.set_address_state(address[0], address[1], ADDRESS_ACTIVE_STATE)
                 else:
-                    log_err("AggregateAddressMgr::set address %s failed during BBR change (validation or FRR push error)" % key2prefix(address[0]))
+                    log_info("AggregateAddressMgr::set address %s failed during BBR change (validation or FRR push error)" % key2prefix(address[0]))
                     self.set_address_state(address[0], address[1], ADDRESS_INACTIVE_STATE)
         elif bbr_status == BGP_BBR_STATUS_DISABLED:
             log_info("AggregateAddressMgr::BBR state changed to %s with bbr_required addresses %s" % (bbr_status, addresses))
@@ -64,18 +64,24 @@ class AggregateAddressMgr(Manager):
 
     def set_handler(self, key, data):
         data = dict(data)
+        prefix = key2prefix(key)
+        net, reason = validate_prefix(prefix)
+        if net is None:
+            log_err("AggregateAddressMgr::invalid aggregate prefix %s: %s" % (prefix, reason))
+            self.set_address_state(key, data, ADDRESS_INACTIVE_STATE)
+            return True
         bbr_status = self.directory.get(CONFIG_DB_NAME, BGP_BBR_TABLE_NAME, BGP_BBR_STATUS_KEY)
         if bbr_status not in (BGP_BBR_STATUS_ENABLED, BGP_BBR_STATUS_DISABLED):
-            log_info("AggregateAddressMgr::BBR state is unknown. Skip the address %s" % key2prefix(key))
+            log_info("AggregateAddressMgr::BBR state is unknown. Skip the address %s" % prefix)
             self.set_address_state(key, data, ADDRESS_INACTIVE_STATE)
         elif bbr_status == BGP_BBR_STATUS_DISABLED and data.get(BBR_REQUIRED_KEY, COMMON_FALSE_STRING) == COMMON_TRUE_STRING:
-            log_info("AggregateAddressMgr::BBR is disabled and bbr-required is set to true. Skip the address %s" % key2prefix(key))
+            log_info("AggregateAddressMgr::BBR is disabled and bbr-required is set to true. Skip the address %s" % prefix)
             self.set_address_state(key, data, ADDRESS_INACTIVE_STATE)
         else:
             if self.address_set_handler(key, data):
                 self.set_address_state(key, data, ADDRESS_ACTIVE_STATE)
             else:
-                log_err("AggregateAddressMgr::set address %s failed (validation or FRR push error)" % key2prefix(key))
+                log_info("AggregateAddressMgr::set address %s failed (validation or FRR push error)" % prefix)
                 self.set_address_state(key, data, ADDRESS_INACTIVE_STATE)
         return True
 

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
@@ -216,6 +216,8 @@ def key2prefix(key):
 
 def validate_prefix(prefix):
     """Return (True, None) if prefix is a valid network address, or (False, reason) otherwise."""
+    if '/' not in prefix:
+        return False, "missing prefix length"
     try:
         ipaddress.ip_network(prefix, strict=True)
     except ValueError as e:

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
@@ -70,11 +70,15 @@ class AggregateAddressMgr(Manager):
             log_err("AggregateAddressMgr::invalid aggregate prefix %s: %s" % (prefix, reason))
             self.set_address_state(key, data, ADDRESS_INACTIVE_STATE)
             return True
-        bbr_status = self.directory.get(CONFIG_DB_NAME, BGP_BBR_TABLE_NAME, BGP_BBR_STATUS_KEY)
-        if bbr_status not in (BGP_BBR_STATUS_ENABLED, BGP_BBR_STATUS_DISABLED):
-            log_info("AggregateAddressMgr::BBR state is unknown. Skip the address %s" % prefix)
+        if self.directory.path_exist(CONFIG_DB_NAME, BGP_BBR_TABLE_NAME, BGP_BBR_STATUS_KEY):
+            bbr_status = self.directory.get(CONFIG_DB_NAME, BGP_BBR_TABLE_NAME, BGP_BBR_STATUS_KEY)
+        else:
+            bbr_status = ""
+        bbr_required = data.get(BBR_REQUIRED_KEY, COMMON_FALSE_STRING) == COMMON_TRUE_STRING
+        if bbr_status not in (BGP_BBR_STATUS_ENABLED, BGP_BBR_STATUS_DISABLED) and bbr_required:
+            log_info("AggregateAddressMgr::BBR state is unknown and bbr-required is true. Skip the address %s" % prefix)
             self.set_address_state(key, data, ADDRESS_INACTIVE_STATE)
-        elif bbr_status == BGP_BBR_STATUS_DISABLED and data.get(BBR_REQUIRED_KEY, COMMON_FALSE_STRING) == COMMON_TRUE_STRING:
+        elif bbr_status == BGP_BBR_STATUS_DISABLED and bbr_required:
             log_info("AggregateAddressMgr::BBR is disabled and bbr-required is set to true. Skip the address %s" % prefix)
             self.set_address_state(key, data, ADDRESS_INACTIVE_STATE)
         else:
@@ -229,8 +233,6 @@ def validate_prefix(prefix):
         net = ipaddress.ip_network(prefix, strict=True)
     except ValueError as e:
         return None, str(e)
-    if net.prefixlen == net.max_prefixlen:
-        return None, "host prefix /%d not useful for aggregation" % net.prefixlen
     return net, None
 
 

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
@@ -127,9 +127,12 @@ class AggregateAddressMgr(Manager):
 
     def del_handler(self, key):
         address_state = self.get_address_from_state_db(key)
-        if self.address_del_handler(key, address_state):
-            log_info("AggregateAddressMgr::delete address %s success" % key)
-            self.del_address_state(key)
+        if address_state.get(ADDRESS_STATE_KEY) == ADDRESS_ACTIVE_STATE:
+            if self.address_del_handler(key, address_state):
+                log_info("AggregateAddressMgr::delete address %s success" % key)
+        else:
+            log_info("AggregateAddressMgr::address %s is not active, skip FRR removal" % key2prefix(key))
+        self.del_address_state(key)
         return True
 
     def address_del_handler(self, key, data):

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
@@ -51,6 +51,9 @@ class AggregateAddressMgr(Manager):
             for address in addresses:
                 if self.address_set_handler(address[0], address[1]):
                     self.set_address_state(address[0], address[1], ADDRESS_ACTIVE_STATE)
+                else:
+                    log_info("AggregateAddressMgr::set address %s failed during BBR change" % key2prefix(address[0]))
+                    self.set_address_state(address[0], address[1], ADDRESS_INACTIVE_STATE)
         elif bbr_status == BGP_BBR_STATUS_DISABLED:
             log_info("AggregateAddressMgr::BBR state changed to %s with bbr_required addresses %s" % (bbr_status, addresses))
             for address in addresses:

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
@@ -229,6 +229,8 @@ def validate_prefix(prefix):
         net = ipaddress.ip_network(prefix, strict=True)
     except ValueError as e:
         return None, str(e)
+    if net.prefixlen == net.max_prefixlen:
+        return None, "host prefix /%d not useful for aggregation" % net.prefixlen
     return net, None
 
 

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_aggregate_address.py
@@ -52,7 +52,7 @@ class AggregateAddressMgr(Manager):
                 if self.address_set_handler(address[0], address[1]):
                     self.set_address_state(address[0], address[1], ADDRESS_ACTIVE_STATE)
                 else:
-                    log_info("AggregateAddressMgr::set address %s failed during BBR change" % key2prefix(address[0]))
+                    log_err("AggregateAddressMgr::set address %s failed during BBR change" % key2prefix(address[0]))
                     self.set_address_state(address[0], address[1], ADDRESS_INACTIVE_STATE)
         elif bbr_status == BGP_BBR_STATUS_DISABLED:
             log_info("AggregateAddressMgr::BBR state changed to %s with bbr_required addresses %s" % (bbr_status, addresses))
@@ -75,7 +75,7 @@ class AggregateAddressMgr(Manager):
             if self.address_set_handler(key, data):
                 self.set_address_state(key, data, ADDRESS_ACTIVE_STATE)
             else:
-                log_info("AggregateAddressMgr::set address %s failed" % key2prefix(key))
+                log_err("AggregateAddressMgr::set address %s failed" % key2prefix(key))
                 self.set_address_state(key, data, ADDRESS_INACTIVE_STATE)
         return True
 

--- a/src/sonic-bgpcfgd/tests/test_aggregate.py
+++ b/src/sonic-bgpcfgd/tests/test_aggregate.py
@@ -80,7 +80,7 @@ def set_del_test(mgr, op, args, expected_cmds=None):
         assert not set_del_test.push_list_called, "cfg_mgr.push_list was called"
 
 
-@pytest.mark.parametrize("aggregate_prefix", ["192.168.1.1", "2ff::/64"])
+@pytest.mark.parametrize("aggregate_prefix", ["192.168.1.0/24", "2ff::/64"])
 @pytest.mark.parametrize("bbr_status", [BGP_BBR_STATUS_ENABLED, BGP_BBR_STATUS_DISABLED])
 @pytest.mark.parametrize("bbr_required", ["true", "false"])
 @pytest.mark.parametrize("switch_bbr_state", [False, True])

--- a/src/sonic-bgpcfgd/tests/test_aggregate.py
+++ b/src/sonic-bgpcfgd/tests/test_aggregate.py
@@ -208,6 +208,10 @@ def __del_handler_validate(
     aggregate_address_prefix_list,
     contributing_address_prefix_list
 ):
+    # Check if the entry is currently active; only active entries trigger FRR removal
+    _, current_data = mgr.address_table.get(aggregate_prefix)
+    is_active = current_data and current_data.get('state') == 'active'
+
     except_cmds = [
         'router bgp 65001',
         'address-family ' + ('ipv4' if '.' in aggregate_prefix else 'ipv6'),
@@ -223,7 +227,7 @@ def __del_handler_validate(
         mgr,
         "DEL",
         (aggregate_prefix,),
-        except_cmds
+        except_cmds if is_active else None
     )
     assert aggregate_prefix not in mgr.address_table.getKeys()
     assert not mgr.address_table.get(aggregate_prefix)[1], "Address should be removed from the table"
@@ -293,15 +297,14 @@ def __switch_bbr_state(
     ("10.100.1.0/23", False),   # host bits set
     ("192.168.1.1/24", False),  # host bits set
     ("2001:db8::1/32", False),  # host bits set
-    ("192.168.1.1", False),     # missing prefix length
-    ("10.0.0.1", False),        # missing prefix length
 ])
 def test_validate_prefix(prefix, expected):
-    valid, reason = validate_prefix(prefix)
-    assert valid == expected
+    net, reason = validate_prefix(prefix)
     if expected:
+        assert net is not None
         assert reason is None
     else:
+        assert net is None
         assert reason is not None
 
 
@@ -324,3 +327,28 @@ def test_host_bits_set_rejected(bad_prefix):
     # State should be inactive
     _, data = mgr.address_table.get(bad_prefix)
     assert data["state"] == "inactive"
+
+
+@pytest.mark.parametrize("bad_prefix", [
+    "10.100.0.1/24",
+    "10.100.1.0/23",
+])
+def test_inactive_entry_skips_frr_removal(bad_prefix):
+    """del_handler must skip FRR removal for inactive entries and clean up STATE_DB."""
+    mgr = constructor(bbr_status=BGP_BBR_STATUS_ENABLED)
+    attr = (
+        ('bbr-required', 'false'),
+        ('summary-only', 'false'),
+        ('as-set', 'false'),
+        ('aggregate-address-prefix-list', ''),
+        ('contributing-address-prefix-list', ''),
+    )
+    # Set invalid prefix -> state = inactive
+    set_del_test(mgr, "SET", (bad_prefix, attr), None)
+    assert mgr.address_table.get(bad_prefix)[1]["state"] == "inactive"
+
+    # Del should NOT push any commands to FRR
+    set_del_test(mgr, "DEL", (bad_prefix,), None)
+
+    # STATE_DB entry should be cleaned up
+    assert bad_prefix not in mgr.address_table.getKeys()

--- a/src/sonic-bgpcfgd/tests/test_aggregate.py
+++ b/src/sonic-bgpcfgd/tests/test_aggregate.py
@@ -293,6 +293,8 @@ def __switch_bbr_state(
     ("10.100.1.0/23", False),   # host bits set
     ("192.168.1.1/24", False),  # host bits set
     ("2001:db8::1/32", False),  # host bits set
+    ("192.168.1.1", False),     # missing prefix length
+    ("10.0.0.1", False),        # missing prefix length
 ])
 def test_validate_prefix(prefix, expected):
     valid, reason = validate_prefix(prefix)

--- a/src/sonic-bgpcfgd/tests/test_aggregate.py
+++ b/src/sonic-bgpcfgd/tests/test_aggregate.py
@@ -80,7 +80,7 @@ def set_del_test(mgr, op, args, expected_cmds=None):
         assert not set_del_test.push_list_called, "cfg_mgr.push_list was called"
 
 
-@pytest.mark.parametrize("aggregate_prefix", ["192.168.1.1", "2ff::1/64"])
+@pytest.mark.parametrize("aggregate_prefix", ["192.168.1.1", "2ff::/64"])
 @pytest.mark.parametrize("bbr_status", [BGP_BBR_STATUS_ENABLED, BGP_BBR_STATUS_DISABLED])
 @pytest.mark.parametrize("bbr_required", ["true", "false"])
 @pytest.mark.parametrize("switch_bbr_state", [False, True])

--- a/src/sonic-bgpcfgd/tests/test_aggregate.py
+++ b/src/sonic-bgpcfgd/tests/test_aggregate.py
@@ -1,6 +1,7 @@
 from bgpcfgd.directory import Directory
 from bgpcfgd.template import TemplateFabric
 from bgpcfgd.managers_aggregate_address import AggregateAddressMgr, BGP_AGGREGATE_ADDRESS_TABLE_NAME, BGP_BBR_TABLE_NAME
+from bgpcfgd.managers_aggregate_address import validate_prefix
 import pytest
 from swsscommon import swsscommon
 from unittest.mock import MagicMock, patch
@@ -279,3 +280,45 @@ def __switch_bbr_state(
     assert [aggregate_prefix] == mgr.address_table.getKeys()
     _, data = mgr.address_table.get(aggregate_prefix)
     assert data == expected_state
+
+
+@pytest.mark.parametrize("prefix,expected", [
+    ("10.100.0.0/16", True),
+    ("10.100.1.0/24", True),
+    ("192.168.0.0/24", True),
+    ("2001:db8::/32", True),
+    ("0.0.0.0/0", True),
+    ("::/0", True),
+    ("10.100.0.1/24", False),   # host bits set
+    ("10.100.1.0/23", False),   # host bits set
+    ("192.168.1.1/24", False),  # host bits set
+    ("2001:db8::1/32", False),  # host bits set
+])
+def test_validate_prefix(prefix, expected):
+    valid, reason = validate_prefix(prefix)
+    assert valid == expected
+    if expected:
+        assert reason is None
+    else:
+        assert reason is not None
+
+
+@pytest.mark.parametrize("bad_prefix", [
+    "10.100.0.1/24",
+    "10.100.1.0/23",
+])
+def test_host_bits_set_rejected(bad_prefix):
+    """address_set_handler must return False for prefixes with host bits set."""
+    mgr = constructor(bbr_status=BGP_BBR_STATUS_ENABLED)
+    attr = (
+        ('bbr-required', 'false'),
+        ('summary-only', 'false'),
+        ('as-set', 'false'),
+        ('aggregate-address-prefix-list', ''),
+        ('contributing-address-prefix-list', ''),
+    )
+    # push_list must NOT be called
+    set_del_test(mgr, "SET", (bad_prefix, attr), None)
+    # State should be inactive
+    _, data = mgr.address_table.get(bad_prefix)
+    assert data["state"] == "inactive"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

When an invalid aggregate address prefix (e.g., 10.100.0.1/24 with host bits set) is configured in CONFIG_DB, bgpcfgd silently accepts it and pushes invalid commands to FRR. This can cause unexpected BGP behavior. Adding prefix validation with a clear error log makes it easier to diagnose misconfiguration.

##### Work item tracking
- Microsoft ADO **(number only)**: 37506197

#### How I did it

Added a validate_prefix() function in managers_aggregate_address.py that uses Python's ipaddress.ip_network(prefix, strict=True) to verify the prefix is a valid network address (no host bits set).
Called validate_prefix() at the beginning of address_set_handler(). If validation fails, the handler logs an error (log_err) with the prefix and reason, and returns False to skip the invalid entry.
Added unit tests for validate_prefix() covering valid prefixes (e.g., 10.100.0.0/16, 2001:db8::/32, 0.0.0.0/0) and invalid prefixes with host bits set.
Added integration-style test test_host_bits_set_rejected verifying that address_set_handler rejects bad prefixes, does not push commands, and marks state as inactive.

#### How to verify it
All tests including test_validate_prefix and test_host_bits_set_rejected should pass.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202603

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] <!-- image version 1 --> SONiC.20251110.19
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add prefix validation in bgpcfgd aggregate address manager to reject prefixes with host bits set and log an error.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

