### PR TITLE
Fix route_check ijson performance by using Debian python3-ijson with yajl2_c backend

### DIFF
--- a/files/build/versions-public/host-image/versions-py3
+++ b/files/build/versions-public/host-image/versions-py3
@@ -23,7 +23,6 @@ filelock==3.25.2
 grpcio==1.66.2
 grpcio-tools==1.66.2
 idna==3.11
-ijson==3.2.3
 inflect==7.3.1
 inotify==0.2.12
 ipaddr==2.2.0

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -201,6 +201,10 @@ install_deb_package $debs_path/libyang_*.deb $debs_path/libyang-cpp_*.deb $debs_
 install_pip_package {{sonic_yang_models_py3_wheel_path}}
 
 # Install sonic-yang-mgmt Python3 package
+# Install python3-ijson from Debian repos first — provides the yajl2_c C extension backend.
+# This must happen before pip installs sonic-yang-mgmt (which depends on ijson>=3.2.3),
+# so pip can use the distro-provided python3-ijson package and avoid downloading from PyPI.
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install python3-ijson
 install_pip_package {{sonic_yang_mgmt_py3_wheel_path}}
 
 # Install some dependencies for pyangbind

--- a/src/sonic-yang-mgmt/setup.py
+++ b/src/sonic-yang-mgmt/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     install_requires = [
         'xmltodict==0.12.0',
-        'ijson==3.2.3',
+        'ijson>=3.2.3',
         'jsonpointer>=1.9',
         'jsondiff>=1.2.0',
         'tabulate==0.9.0'
@@ -37,7 +37,7 @@ setup(
     tests_require = [
         'pytest>3',
         'xmltodict==0.12.0',
-        'ijson==3.2.3',
+        'ijson>=3.2.3',
         'jsondiff>=1.2.0'
     ],
     setup_requires = [

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -283,7 +283,7 @@ setup(
     ],
     tests_require = [
         'pytest',
-        'ijson==3.2.3'
+        'ijson>=3.2.3'
     ],
     setup_requires = [
         'pytest-runner',
@@ -292,7 +292,7 @@ setup(
     extras_require = {
         "testing": [
             'pytest',
-            'ijson==3.2.3'
+            'ijson>=3.2.3'
         ],
     },
     include_package_data=True,


### PR DESCRIPTION
#### Why I did it
Fixes #23442

`route_check.py` takes 21+ minutes on Nokia chassis platforms with 100K+ routes because [sonic-utilities PR #4294](https://github.com/sonic-net/sonic-utilities/pull/4294) forced `IJSON_BACKEND=python` (pure-Python parser). The forced backend was a workaround for `yajl2_cffi` crashing under monit's `MemoryDenyWriteExecute=true` (CFFI JIT requires RWX memory).

The proper fix is to use the `yajl2_c` backend (C extension, NOT cffi) — it's 24× faster than `python` and fully compatible with `MemoryDenyWriteExecute=true`.

**Benchmark (50K routes, 10.1 MB JSON):**
| Backend | Time | MemoryDenyWriteExecute safe? |
|---------|------|------------------------------|
| python (current) | 3.16s | ✅ Yes |
| yajl2_c (this fix) | 0.13s | ✅ Yes |
| yajl2_cffi | 2.24s | ❌ No (crashes) |

#### How I did it
**Three-layer fix** — all three are needed because the build system has multiple mechanisms that force ijson version:

**1. Relaxed exact version pins in setup.py** (`==3.2.3` → `>=3.2.3`)
- `src/sonic-yang-mgmt/setup.py` — `install_requires` and `tests_require`
- `src/sonic-yang-models/setup.py` — `tests_require` and `extras_require["testing"]`

Without this, pip rejects Debian's ijson 3.4.0 (because 3.4.0 ≠ 3.2.3) and downloads 3.2.3 from PyPI.

**2. Early `apt-get install python3-ijson`** in `sonic_debian_extension.j2`
- Installs Debian's `python3-ijson` (3.4.0) with the `yajl2_c` C extension **before** `sonic-yang-mgmt` is pip-installed
- This way pip sees "Requirement already satisfied" and doesn't download from PyPI

**3. Removed `ijson==3.2.3` from build constraint file** (`files/build/versions-public/host-image/versions-py3`)
- `sonic-build-hooks` intercepts all pip3 commands and injects `--constraint versions-py3`
- Even with `>=3.2.3` in setup.py and apt's 3.4.0 pre-installed, the constraint file forced pip to download and install 3.2.3 from PyPI, **replacing** apt's 3.4.0
- Removing `ijson==3.2.3` from the constraint file allows pip to accept the pre-installed 3.4.0

#### How to verify it

**Build log evidence** (from this PR's VS image build):
```
Line 722: Get:1 .../python3-ijson_3.4.0-1_amd64.deb  ← apt installs 3.4.0 with yajl2_c
Line 740: Requirement already satisfied: ijson>=3.2.3 in /usr/lib/python3/dist-packages (3.4.0)  ← pip accepts it!
```

Compare to **before** (without constraint file fix): `Downloading ijson-3.2.3.tar.gz` → pip replaced apt's 3.4.0 with pure-Python 3.2.3.

**KVM testbed verification:**
```
admin@sonic:~$ python3 -c "import ijson; print(ijson.backend)"
yajl2_c
admin@sonic:~$ python3 -c "import ijson; print(ijson.__file__)"
/usr/lib/python3/dist-packages/ijson/__init__.py   ← Debian package, not pip
```

#### Companion PR
- **sonic-utilities PR**: https://github.com/sonic-net/sonic-utilities/pull/4436 (removes forced `IJSON_BACKEND=python` from route_check.py)
- ⚠️ **Merge order**: This buildimage PR must merge **first**, then the utilities PR. If reversed, images would lose the forced python backend while pip's ijson (without yajl2_c) is still installed.

#### Which release branch to backport
Master (and any branch where [sonic-utilities#4294](https://github.com/sonic-net/sonic-utilities/pull/4294) was cherry-picked)