### PR TITLE
[dhcp_server] Fix syslog blocked by caclmgrd catch-all DROP on bridge…

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -133,6 +133,12 @@ function preStartAction()
         echo "Cannot fetch system eeprom information. Setting chassis serial number to N/A."
         $SONIC_DB_CLI STATE_DB HSET 'DEVICE_METADATA|localhost' chassis_serial_number "N/A"
     fi
+{%- elif docker_container_name == "dhcp_server" %}
+    # dhcp_server is the only bridge-mode container. caclmgrd's catch-all DROP
+    # on the INPUT chain blocks its syslog (UDP 514) to host rsyslog.
+    # Restrict to docker0 interface to minimize security impact.
+    iptables -C INPUT -i docker0 -p udp --dport 514 -j ACCEPT -m comment --comment "dhcp_server_syslog" 2>/dev/null || \
+        iptables -I INPUT -i docker0 -p udp --dport 514 -j ACCEPT -m comment --comment "dhcp_server_syslog"
 {%- else %}
     : # nothing
 {%- endif %}
@@ -860,6 +866,10 @@ stop() {
         /usr/local/bin/container stop $DOCKERNAME
     {%- endif %}
     fi
+{%- if docker_container_name == "dhcp_server" %}
+    # Remove syslog iptables exception added during start
+    iptables -D INPUT -i docker0 -p udp --dport 514 -j ACCEPT -m comment --comment "dhcp_server_syslog" 2>/dev/null || true
+{%- endif %}
     {%- endif %}
 }
 


### PR DESCRIPTION
Fix syslog blocked by caclmgrd catch-all DROP on bridge-mode container

dhcp_server is the only container using bridge networking (NetworkMode: default). When control plane ACLs (CACL) are configured, caclmgrd adds a catch-all DROP rule at the end of the iptables INPUT chain, which blocks syslog (UDP 514) traffic from the container to the host rsyslog.

Add an iptables ACCEPT rule for UDP 514 during dhcp_server startup to allow syslog traffic through, and remove it on stop.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

On production MX devices, the `dhcp_server` container is the only container using bridge networking (`NetworkMode: default`). All other containers use host networking.

When control plane ACL (CACL) rules are configured in CONFIG_DB (e.g., `SSH_ACCESS_MGFX`, `SNMP_ACCESS_MGFX`, `BMC_ACL_NORTHBOUND` — types `CTRLPLANE` and `BMCDATA`), `caclmgrd` appends a catch-all `iptables -A INPUT -j DROP` at the end of the INPUT chain (line 841 in `caclmgrd`, triggered when `num_ctrl_plane_acl_rules > 0`).

This catch-all blocks all traffic not explicitly allowed — including syslog (UDP 514) from the dhcp_server container's bridge network to the host rsyslog. The container sends syslog to the docker0 gateway IP (e.g., `240.127.1.1:514`), which is correctly configured by PR #19303. However, the UDP packet is dropped by the catch-all before reaching rsyslog.

Lab devices are unaffected because they have no CACL rules (`num_ctrl_plane_acl_rules == 0`), so the catch-all DROP is never added.


##### Work item tracking
- Microsoft ADO **(number only)**: 38614814

#### How I did it
 
 Modified `files/build_templates/docker_image_ctl.j2` to add dhcp_server-specific logic:
 
 - **preStartAction()**: Insert `iptables -I INPUT -p udp --dport 514 -j ACCEPT` before the container starts (idempotent — checks with `-C` first)
 - **stop()**: Remove the rule with `iptables -D` when the container stops
 

#### How to verify it

End-to-end test on lab device (Nokia-7215, SONiC.20241110.22):

```
=== Step 1: Syslog works before CACL ===
$ docker exec dhcp_server python3 -c "import syslog; syslog.syslog(syslog.LOG_ERR, 'BEFORE_CACL_99999')"
$ sudo grep BEFORE_CACL /var/log/syslog
2026 Apr  7 14:51:55 bjw2-can-7215-1 ERR dhcp_server#-c: BEFORE_CACL_99999
→ Delivered ✅

=== Step 2: Add CACL rule to trigger catch-all DROP ===
$ sonic-db-cli CONFIG_DB hmset 'ACL_RULE|SSH_ONLY|RULE_1' 'PACKET_ACTION' 'ACCEPT' 'PRIORITY' '100' 'SRC_IP' '0.0.0.0/0' 'IP_PROTOCOL' '6' 'L4_DST_PORT' '22'
$ sudo systemctl restart caclmgrd

=== Step 3: Verify catch-all DROP appeared ===
$ sudo iptables -L INPUT -n | tail -1
DROP       0    --  0.0.0.0/0            0.0.0.0/0
→ Catch-all DROP present ✅

=== Step 4: Syslog blocked by catch-all ===
$ docker exec dhcp_server python3 -c "import syslog; syslog.syslog(syslog.LOG_ERR, 'AFTER_CACL_99999')"
$ sudo grep AFTER_CACL /var/log/syslog
(no output)
→ Blocked ✅

=== Step 5: Apply iptables fix ===
$ sudo iptables -I INPUT -p udp --dport 514 -j ACCEPT

=== Step 6: Syslog works after fix ===
$ docker exec dhcp_server python3 -c "import syslog; syslog.syslog(syslog.LOG_ERR, 'AFTER_FIX_99999')"
$ sudo grep AFTER_FIX /var/log/syslog
2026 Apr  7 14:52:55 bjw2-can-7215-1 ERR dhcp_server#-c: AFTER_FIX_99999
→ Delivered ✅
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202603

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 20241110.22
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix dhcp_server container syslog being silently dropped on devices with control plane ACLs by adding iptables ACCEPT rule for UDP 514 during container startup.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

