### PR TITLE
Runtime knob for Southbound ZMQ

### DIFF
--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -35,8 +35,11 @@ fi
 # Set zmq mode by default for smartswitch DPU and increase the max bulk limit
 # Otherwise, set synchronous mode if it is enabled in CONFIG_DB
 SYNC_MODE=$(echo $SWSS_VARS | jq -r '.synchronous_mode')
+SOUTHBOUND_ZMQ=$(echo $SWSS_VARS | jq -r '.orch_southbound_zmq_enabled')
 if [ "$LOCALHOST_SWITCHTYPE" == "dpu" ]; then
     ORCHAGENT_ARGS+="-z zmq_sync -k 65536 "
+elif [ "$SOUTHBOUND_ZMQ" == "true" ]; then
+    ORCHAGENT_ARGS+="-z zmq_sync "
 elif [ "$SYNC_MODE" == "enable" ]; then
     ORCHAGENT_ARGS+="-s "
 fi

--- a/files/build_templates/swss_vars.j2
+++ b/files/build_templates/swss_vars.j2
@@ -12,5 +12,6 @@
     {% endif -%}
     "dual_tor": {% if DEVICE_METADATA.localhost.type == "ToRRouter" and DEVICE_METADATA.localhost.subtype == "DualToR" %}"enable"{% else %}"disable"{% endif %},
     "dscp_remapping": {% if SYSTEM_DEFAULTS is defined and SYSTEM_DEFAULTS.tunnel_qos_remap is defined and SYSTEM_DEFAULTS.tunnel_qos_remap.status == "enabled" %}"enable"{% else %}"disable"{% endif %},
+    "orch_southbound_zmq_enabled": {% if DEVICE_METADATA.localhost.orch_southbound_zmq_enabled is defined and DEVICE_METADATA.localhost.orch_southbound_zmq_enabled == "true" %}"true"{% else %}"false"{% endif %},
     "switch_type": "{{ DEVICE_METADATA.localhost.switch_type }}"
 }

--- a/platform/vs/docker-sonic-vs/orchagent.sh
+++ b/platform/vs/docker-sonic-vs/orchagent.sh
@@ -49,9 +49,12 @@ fi
 # Set zmq mode by default for DPU vs
 # Otherwise, set synchronous mode if it is enabled in CONFIG_DB
 SYNC_MODE=$(echo $SWSS_VARS | jq -r '.synchronous_mode')
+SOUTHBOUND_ZMQ=$(echo $SWSS_VARS | jq -r '.orch_southbound_zmq_enabled')
 
 if [ "$SWITCH_TYPE" == "dpu" ]; then
     ORCHAGENT_ARGS+="-z zmq_sync -k 65536 "
+elif [ "$SOUTHBOUND_ZMQ" == "true" ]; then
+    ORCHAGENT_ARGS+="-z zmq_sync "
 elif [ "$SYNC_MODE" == "enable" ]; then
     ORCHAGENT_ARGS+="-s "
 fi

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -318,6 +318,12 @@ module sonic-device_metadata {
                     default "false";
                 }
 
+                leaf orch_southbound_zmq_enabled {
+                    type boolean;
+                    description "Enable ZMQ feature between orchagent and syncd (southbound).";
+                    default "false";
+                }
+
                 leaf syslog_with_osversion {
                     type boolean;
                     description "Enable syslog with OS version feature.";


### PR DESCRIPTION
#### Why I did it
Enable runtime control of ZMQ communication between orchagent and syncd (southbound) via a CONFIG_DB knob.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

1. Added orch_southbound_zmq_enabled leaf to sonic-device_metadata.yang with default false.
2. Added orch_southbound_zmq_enabled to swss_vars.j2 so the value is rendered from CONFIG_DB's DEVICE_METADATA into SWSS_VARS available to container startup scripts.
3. Modified orchagent.sh to read the knob from SWSS_VARS (via jq) and start orchagent with -z zmq_sync when enabled.

#### How to verify it

1. Enable the knob: sonic-db-cli CONFIG_DB hset "DEVICE_METADATA|localhost" "orch_southbound_zmq_enabled" "true"
2. Restart swss: sudo systemctl restart swss
3. Verify orchagent started with ZMQ flags: ps aux | grep orchagent should show -z zmq_sync

#### Description for the changelog
Add runtime CONFIG_DB knob (orch_southbound_zmq_enabled) to enable ZMQ communication between orchagent and syncd for southbound route programming.

#### Related PRs:
https://github.com/sonic-net/sonic-sairedis/pull/1835
https://github.com/sonic-net/sonic-swss/pull/4556