### PR TITLE
[build] Fix pip command fallback failures

### DIFF
--- a/sonic-slave-bookworm/Dockerfile.j2
+++ b/sonic-slave-bookworm/Dockerfile.j2
@@ -351,7 +351,6 @@ RUN apt-get update && apt-get install -y eatmydata && eatmydata apt-get install 
         dosfstools \
         qemu-kvm \
         libvirt-clients \
-        python3-pexpect \
 # For rasdaemon build
         libsqlite3-dev \
         libgettextpo-dev \
@@ -627,6 +626,9 @@ RUN eatmydata apt-get install -y vim
 
 # Install rsyslog
 RUN eatmydata apt-get install -y rsyslog
+
+# # For sonic vs image build
+RUN pip3 install pexpect
 
 {%- if CROSS_BUILD_ENVIRON == "y" %}
 RUN cd /usr/src/gtest && CXX=$CROSS_CXX CC=$CROSS_CC cmake . && make -C /usr/src/gtest

--- a/src/sonic-bmpcfgd/setup.py
+++ b/src/sonic-bmpcfgd/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
     install_requires = [
         'jinja2>=2.10',
         'netaddr==0.8.0',
-        'pyyaml==6.0.1',
+        'pyyaml>=6.0.1',
     ],
     entry_points={
         'console_scripts': [

--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -507,7 +507,10 @@ update_version_file()
     [ -f "$version_file" ] && package_versions="$package_versions $(cat $version_file)"
     declare -A versions
     for pacakge_version in $package_versions; do
-        package=$(echo $pacakge_version | awk -F"==" '{print $1}')
+        # convert package name to lower case to avoid the issue caused by the case sensitivity of pip package name 
+        #for example, "PyYAML" and "pyyaml" are the same package but with different case, 
+        # which will cause the issue when we merge the versions pyyaml==6.0.1 and PyYAML==6.0.3.
+        package=$(echo $pacakge_version | awk -F"==" '{print $1}' | tr '[:upper:]' '[:lower:]')
         version=$(echo $pacakge_version | awk -F"==" '{print $2}')
         if [ -z "$package" ] || [ -z "$version" ]; then
             continue


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The pip commands with constraints failed and fell back to original commands for the following two targets:

```
target/python-wheels/bookworm/sonic_utilities-1.2-py3-none-any.whl-install.log-error: uninstall-distutils-installed-package
target/python-wheels/bookworm/sonic_utilities-1.2-py3-none-any.whl-install.log-
target/python-wheels/bookworm/sonic_utilities-1.2-py3-none-any.whl-install.log-× Cannot uninstall pexpect 4.8.0
target/python-wheels/bookworm/sonic_utilities-1.2-py3-none-any.whl-install.log-╰─> It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.
target/python-wheels/bookworm/sonic_utilities-1.2-py3-none-any.whl-install.log:**Failed to run the command with constraint, try to install with the original command**

target/docker-sonic-bmp.gz.log-#14 1.794 The conflict is caused by:
target/docker-sonic-bmp.gz.log-#14 1.794     sonic-bmpcfgd-services 1.0 depends on pyyaml==6.0.1
target/docker-sonic-bmp.gz.log-#14 1.794     The user requested (constraint) pyyaml==6.0.1,==6.0.3
target/docker-sonic-bmp.gz.log-#14 1.794 
target/docker-sonic-bmp.gz.log-#14 1.794 Additionally, some packages in these conflicts have no matching distributions available for your environment:
target/docker-sonic-bmp.gz.log-#14 1.794     pyyaml
target/docker-sonic-bmp.gz.log-#14 1.794 
target/docker-sonic-bmp.gz.log-#14 1.794 To fix this you could try to:
target/docker-sonic-bmp.gz.log-#14 1.794 1. loosen the range of package versions you've specified
target/docker-sonic-bmp.gz.log-#14 1.794 2. remove package versions to allow pip to attempt to solve the dependency conflict
target/docker-sonic-bmp.gz.log-#14 1.794 
target/docker-sonic-bmp.gz.log-#14 1.796 ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
target/docker-sonic-bmp.gz.log:#14 1.873 **Failed to run the command with constraint, try to install with the original command**
```
This change is to mitigate the pip commands fallback issue.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
1. reinstalled pexpect 4.9.0 through pip3 so it is managed consistently by pip.
2. Relaxed the pyyaml dependency from ==6.0.1 to >=6.0.1 to avoid unnecessary install constraint failures while keeping the minimum required version.
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

