### PR TITLE
[Arista] Default autonegotiation should be disabled

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/hwsku.json
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/hwsku.json
@@ -1,260 +1,196 @@
 {
     "interfaces": {
         "Ethernet0": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet8": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet16": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet24": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet32": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet40": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet48": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet56": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet64": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet72": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet80": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet88": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet96": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet104": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet112": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet120": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet128": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet136": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet144": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet152": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet160": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet168": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet176": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet184": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet192": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet200": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet208": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet216": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet224": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet232": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet240": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet248": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet256": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet264": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet272": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet280": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet288": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet296": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet304": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet312": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet320": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet328": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet336": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet344": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet352": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet360": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet368": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet376": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet384": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet392": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet400": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet408": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet416": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet424": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet432": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet440": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet448": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet456": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet464": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet472": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet480": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet488": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet496": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet504": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         }
     }
 }

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/hwsku.json
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/hwsku.json
@@ -1,260 +1,196 @@
 {
     "interfaces": {
         "Ethernet0": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet8": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet16": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet24": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet32": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet40": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet48": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet56": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet64": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet72": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet80": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet88": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet96": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet104": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet112": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet120": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet128": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet136": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet144": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet152": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet160": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet168": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet176": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet184": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet192": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet200": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet208": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet216": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet224": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet232": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet240": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet248": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet256": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet264": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet272": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet280": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet288": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet296": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet304": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet312": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet320": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet328": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet336": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet344": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet352": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet360": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet368": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet376": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet384": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet392": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet400": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet408": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet416": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet424": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet432": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet440": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet448": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet456": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet464": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet472": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet480": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet488": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet496": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet504": {
-            "default_brkout_mode": "8x100G",
-            "autoneg": "on"
+            "default_brkout_mode": "8x100G"
         },
         "Ethernet512": {
             "default_brkout_mode": "1x10G"

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/hwsku.json
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/hwsku.json
@@ -1,260 +1,196 @@
 {
     "interfaces": {
         "Ethernet0": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet8": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet16": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet24": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet32": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet40": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet48": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet56": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet64": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet72": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet80": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet88": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet96": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet104": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet112": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet120": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet128": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet136": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet144": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet152": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet160": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet168": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet176": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet184": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet192": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet200": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet208": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet216": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet224": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet232": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet240": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet248": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet256": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet264": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet272": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet280": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet288": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet296": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet304": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet312": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet320": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet328": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet336": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet344": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet352": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet360": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet368": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet376": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet384": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet392": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet400": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet408": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet416": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet424": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet432": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet440": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet448": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet456": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet464": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet472": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet480": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet488": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet496": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet504": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         }
     }
 }

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128S2/hwsku.json
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128S2/hwsku.json
@@ -1,260 +1,196 @@
 {
     "interfaces": {
         "Ethernet0": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet8": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet16": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet24": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet32": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet40": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet48": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet56": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet64": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet72": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet80": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet88": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet96": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet104": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet112": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet120": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet128": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet136": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet144": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet152": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet160": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet168": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet176": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet184": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet192": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet200": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet208": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet216": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet224": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet232": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet240": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet248": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet256": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet264": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet272": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet280": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet288": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet296": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet304": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet312": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet320": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet328": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet336": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet344": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet352": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet360": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet368": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet376": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet384": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet392": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet400": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet408": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet416": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet424": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet432": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet440": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet448": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet456": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet464": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet472": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet480": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet488": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet496": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet504": {
-            "default_brkout_mode": "2x400G",
-            "autoneg": "on"
+            "default_brkout_mode": "2x400G"
         },
         "Ethernet512": {
             "default_brkout_mode": "1x10G"


### PR DESCRIPTION
Removed default enabling of auto negotiation in Arista hwsku. 
Ignoring Moby devices `7060X6-16PE-384C` as some hwsku require autoneg.
Also, ignoring Arista-720DT-48S because it requires autoneg for RJ45 BASE-T.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [x] msft-202503

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

