### PR TITLE
[docker-ptf]: Upgrade PTF to v0.11.0 with pynng support

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -217,7 +217,7 @@ RUN rm -rf /debs \
 {% endif %}
     && mkdir -p /opt       \
     && cd /opt             \
-    && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py
+    && wget https://raw.githubusercontent.com/p4lang/ptf/main/ptf_nn/ptf_nn_agent.py
 
 {% if PTF_ENV_PY_VER == "py3" %}
 RUN curl -L -o tacacs.tar.gz https://shrubbery.net/pub/tac_plus/tacacs-F4.0.4.31.tar.gz\
@@ -285,7 +285,7 @@ RUN pip3 install Flask   \
 {% endif %}
     && pip3 install Cython \
     && pip3 install cffi    \
-    && pip3 install nnpy    \
+    && pip3 install pynng    \
     && pip3 install dpkt    \
     && pip3 install ipaddress \
     && pip3 install pysubnettree \

--- a/rules/ptf-py3.mk
+++ b/rules/ptf-py3.mk
@@ -1,6 +1,6 @@
 # ptf package
 
-PTF_PY3 = ptf-0.10.0.post0-py3-none-any.whl
+PTF_PY3 = ptf-0.11.0.post2-py3-none-any.whl
 $(PTF_PY3)_SRC_PATH = $(SRC_PATH)/ptf-py3
 $(PTF_PY3)_PYTHON_VERSION = 3
 $(PTF_PY3)_TEST = n


### PR DESCRIPTION
#### Why I did it

PTF commit `ebc00f94` (p4lang/ptf#234, "Replace nnpy with pynng", merged April 5 2026) broke `copp/test_copp.py` across **all platforms**.

Root cause chain:
1. `copp_utils.py` downloads `ptf_nn_agent.py` from an unpinned upstream URL at test runtime → gets the new **pynng**-based version
2. PTF container's `dataplane.py` is from the pinned `src/ptf-py3` submodule (v0.10.0) → still uses **nnpy** (nanomsg wire protocol)
3. NNG vs nanomsg wire protocol mismatch → port 10900 never binds → `TASK_TIMEOUT=600` fires → SSH EOF exactly 10 minutes into every copp test

This PR is the PTF container side fix. The companion DUT-side fix is sonic-net/sonic-mgmt#23719.

##### Work item tracking
- Microsoft ADO: 37433906

#### How I did it

- Bumped `src/ptf-py3` submodule from v0.10.0 (`978598dd`) to v0.11.0 (`ebc00f94`) — picks up pynng-based `dataplane.py`
- Updated `rules/ptf-py3.mk`: `ptf-0.10.0.post0` → `ptf-0.11.0.post2` (version from `git describe --tags`)
- `Dockerfile.j2`: replaced `pip3 install nnpy` with `pip3 install pynng` in the py3 section
- `Dockerfile.j2`: fixed `ptf_nn_agent.py` wget URL from `master` → `main` (branch was renamed)

The `pip install nnpy` in the `mixed` (py2) image section is intentionally kept for Python 2 backward compatibility on buster platforms.

#### How to verify it

After this PR merges and a new docker-ptf image is built, `copp/test_copp.py` should complete successfully on all platforms instead of timing out at exactly 10 minutes.

#### Which release branch to backport (provide reason below if selected)
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511 — regression affects 202511 nightly runs

#### Tested branch (Please provide the tested image version)
- [ ] <!-- image version 1 -->

#### Description for the changelog
Upgrade docker-ptf PTF package from v0.10.0 to v0.11.0, migrating from nnpy to pynng to fix copp test timeouts across all platforms.