### PR TITLE
fix: resolve April 2026 docker-sonic-mgmt security vulnerabilities

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -3,7 +3,9 @@ FROM {{ prefix }}ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y \
     apt-transport-https \
     apt-utils \
     bats \
@@ -41,7 +43,10 @@ RUN apt-get update && apt-get install -y \
     sudo \
     tcpdump \
     telnet \
-    vim
+    vim \
+    && apt-get autoremove -y \
+    && apt-get autoclean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Ubuntu 24.04 recommends installing pip packages in a virtual environment
 # Create a virtual environment at /opt/venv and install all required python packages there
@@ -53,7 +58,8 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN sed -i 's|^PATH="|PATH="/opt/venv/bin:|' /etc/environment \
     && sed -i 's|secure_path="\([^"]*\)"|secure_path="/opt/venv/bin:\1"|' /etc/sudoers
 
-RUN pip install --no-cache-dir \
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir \
     aiohttp \
     allure-pytest \
     ansible==11.10.0 \
@@ -64,7 +70,7 @@ RUN pip install --no-cache-dir \
     celery[redis] \
     cffi \
     contextlib2 \
-    cryptography \
+    "cryptography>=46.0.7,<47" \
     ctypesgen \
     debugpy \
     dpkt \
@@ -87,14 +93,15 @@ RUN pip install --no-cache-dir \
     ncclient \
     netaddr \
     netmiko \
-    opentelemetry-api==1.27.0 \
-    opentelemetry-sdk==1.27.0 \
-    opentelemetry-exporter-otlp==1.27.0 \
+    opentelemetry-api==1.41.0 \
+    opentelemetry-sdk==1.41.0 \
+    opentelemetry-exporter-otlp==1.41.0 \
     pandas \
     paramiko \
     passlib \
     pexpect \
     prettytable \
+    "protobuf>=6.33.5,<8" \
     psutil \
     ptf \
     pyasn1 \
@@ -152,6 +159,11 @@ RUN install -m 0755 -d /etc/apt/keyrings \
     && apt-get update  \
     && apt-get install -y docker-ce-cli \
     && curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+
+# Patch Azure CLI's bundled cryptography for CVE-2026-39892
+RUN az_site_packages=$(/opt/az/bin/python -c "import site; print(site.getsitepackages()[0])") \
+    && /opt/az/bin/python -m pip install --no-cache-dir --target "$az_site_packages" 'cryptography>=46.0.7,<47' \
+    && find "$az_site_packages" -name 'cryptography-46.0.6*' -type d -exec rm -rf {} + 2>/dev/null; true
 
 # Install dash-api
 RUN tmpdir=$(mktemp -d) \


### PR DESCRIPTION
Pin protobuf>=6.33.5 to fix CVE-2025-4565 and CVE-2026-0994. Pin cryptography>=46.0.7 to fix CVE-2026-39892.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

