### PR TITLE
Remove port name from alias when it appears as both name and alias

### DIFF
--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -244,7 +244,13 @@ def parse_port_config_file(port_config_file):
             # alias to asic_port_name mapping
             if 'asic_port_name' in data:
                 port_alias_asic_map[data['alias']] = data['asic_port_name'].strip()
+
+    for alias in list(port_alias_map.keys()):
+        if alias in ports:
+            del port_alias_map[alias]
+
     return (ports, port_alias_map, port_alias_asic_map)
+
 
 class BreakoutCfg(object):
 
@@ -446,7 +452,8 @@ def parse_platform_json_file(hwsku_json_file, platform_json_file):
         raise Exception("Ports dictionary is None")
 
     for i in ports.keys():
-        port_alias_map[ports[i]["alias"]]= i
+        if ports[i]["alias"] not in ports:
+            port_alias_map[ports[i]["alias"]]= i
     return (ports, port_alias_map, port_alias_asic_map)
 
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

