### PR TITLE
[Mellanox] Fix create_only_config_db_buffers not loaded on multi-ASIC platforms

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -511,6 +511,13 @@ start() {
     if [ -d "$HWSKU_FOLDER" ]; then
         if [ -f "$HWSKU_FOLDER/create_only_config_db_buffers.json" ]; then
             CREATE_ONLY_CONFIG_DB_BUFFERS_JSON_FOUND=true
+        elif [ -n "$DEV" ]; then
+            # Multi-ASIC: check per-ASIC directory, then common/
+            if [ -f "$HWSKU_FOLDER/$DEV/create_only_config_db_buffers.json" ]; then
+                CREATE_ONLY_CONFIG_DB_BUFFERS_JSON_FOUND=true
+            elif [ -f "$HWSKU_FOLDER/common/create_only_config_db_buffers.json" ]; then
+                CREATE_ONLY_CONFIG_DB_BUFFERS_JSON_FOUND=true
+            fi
         fi
 
         SUPPORTING_BULK_COUNTER_GROUPS="$HWSKU_FOLDER/supporting_bulk_counter_groups"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

On multi-ASIC platforms, the `create_only_config_db_buffers` flag is never set in CONFIG_DB because `docker_image_ctl.j2` only looks for `create_only_config_db_buffers.json` in the hwsku root directory, but multi-ASIC hwsku directories store this file in per-ASIC subdirectories (`0/`, `1/`, ...) and `common/`.


Without this flag, orchagent registers flex counters for all 16 queues per port (0-15) instead of only the queues with buffer profiles (0-7). The SAI bulk stats function rejects queues 8-15, triggering a per-object fallback loop on syncd's main thread that blocks it.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

 On a multi-ASIC platform:

```bash
# Verify the flag is set in CONFIG_DB after boot
sonic-cfggen -n asic0 -d -v 'DEVICE_METADATA.localhost.create_only_config_db_buffers'
# Expected: "true"

# Verify no TIMEOUT errors in syslog
grep -c "TIMEOUT" /var/log/syslog
# Expected: 0

# Verify no bulk counter fallback
grep -c "Enhanced queue counter disabled" /var/log/syslog
# Expected: 0

# Verify syncd main threads are not blocked
for i in 0 1 2 3; do
    pid=$(docker top syncd${i} -eo pid,comm | awk '/syncd/{print $1; exit}')
    echo "syncd$i: $(cat /proc/$pid/wchan)"
done
# Expected: all "do_epoll_wait"
```


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

