### PR TITLE
Set sai_ecmp_group_members_increment=8 for all Broadcom DNX platforms

### DIFF
--- a/device/arista/x86_64-arista_7280cr3_32d4/Arista-7280CR3-C32D4/jr2-a7280cr3-32d4-32x100G+4x400G.config.bcm
+++ b/device/arista/x86_64-arista_7280cr3_32d4/Arista-7280CR3-C32D4/jr2-a7280cr3-32d4-32x100G+4x400G.config.bcm
@@ -751,3 +751,4 @@ dma_desc_aggregator_buff_size_kb.BCM8869X=100
 dma_desc_aggregator_timeout_usec.BCM8869X=1000
 dma_desc_aggregator_enable_specific_MDB_LPM.BCM8869X=1
 dma_desc_aggregator_enable_specific_MDB_FEC.BCM8869X=1
+sai_ecmp_group_members_increment=8

--- a/device/arista/x86_64-arista_7280cr3_32d4/Arista-7280CR3-C40/jr2-a7280cr3-32d4-40x100G.config.bcm
+++ b/device/arista/x86_64-arista_7280cr3_32d4/Arista-7280CR3-C40/jr2-a7280cr3-32d4-40x100G.config.bcm
@@ -768,3 +768,4 @@ dma_desc_aggregator_buff_size_kb.BCM8869X=100
 dma_desc_aggregator_timeout_usec.BCM8869X=1000
 dma_desc_aggregator_enable_specific_MDB_LPM.BCM8869X=1
 dma_desc_aggregator_enable_specific_MDB_FEC.BCM8869X=1
+sai_ecmp_group_members_increment=8

--- a/device/arista/x86_64-arista_7280cr3_32p4/Arista-7280CR3-C28S8/jr2-a7280cr3-32p4-28x100G-8x10G.config.bcm
+++ b/device/arista/x86_64-arista_7280cr3_32p4/Arista-7280CR3-C28S8/jr2-a7280cr3-32p4-28x100G-8x10G.config.bcm
@@ -739,3 +739,4 @@ dma_desc_aggregator_buff_size_kb.BCM8869X=100
 dma_desc_aggregator_timeout_usec.BCM8869X=1000
 dma_desc_aggregator_enable_specific_MDB_LPM.BCM8869X=1
 dma_desc_aggregator_enable_specific_MDB_FEC.BCM8869X=1
+sai_ecmp_group_members_increment=8

--- a/device/arista/x86_64-arista_7280cr3_32p4/Arista-7280CR3-C32P4/jr2-a7280cr3-32p4-32x100G+4x400G.config.bcm
+++ b/device/arista/x86_64-arista_7280cr3_32p4/Arista-7280CR3-C32P4/jr2-a7280cr3-32p4-32x100G+4x400G.config.bcm
@@ -741,3 +741,4 @@ dma_desc_aggregator_buff_size_kb.BCM8869X=100
 dma_desc_aggregator_timeout_usec.BCM8869X=1000
 dma_desc_aggregator_enable_specific_MDB_LPM.BCM8869X=1
 dma_desc_aggregator_enable_specific_MDB_FEC.BCM8869X=1
+sai_ecmp_group_members_increment=8

--- a/device/arista/x86_64-arista_7280cr3_32p4/Arista-7280CR3-C40/jr2-a7280cr3-32p4-40x100G.config.bcm
+++ b/device/arista/x86_64-arista_7280cr3_32p4/Arista-7280CR3-C40/jr2-a7280cr3-32p4-40x100G.config.bcm
@@ -759,3 +759,4 @@ dma_desc_aggregator_buff_size_kb.BCM8869X=100
 dma_desc_aggregator_timeout_usec.BCM8869X=1000
 dma_desc_aggregator_enable_specific_MDB_LPM.BCM8869X=1
 dma_desc_aggregator_enable_specific_MDB_FEC.BCM8869X=1
+sai_ecmp_group_members_increment=8

--- a/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/0/jr2p-a7280dra3-36-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/0/jr2p-a7280dra3-36-36x400G.config.bcm
@@ -986,3 +986,4 @@ sai_pfc_dlr_init_capability=0
 sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
 sai_lag_default_crc_hash=1
+sai_ecmp_group_members_increment=8

--- a/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/1/jr2p-a7280dra3-36-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/1/jr2p-a7280dra3-36-36x400G.config.bcm
@@ -985,3 +985,4 @@ sai_pfc_dlr_init_capability=0
 sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
 sai_lag_default_crc_hash=1
+sai_ecmp_group_members_increment=8

--- a/device/arista/x86_64-arista_7280r4_32qf_32df/Arista-7280R4-32QF-32DF-64O/q3d-a7280R4-32QFx400G-32DFx400G.config.bcm
+++ b/device/arista/x86_64-arista_7280r4_32qf_32df/Arista-7280R4-32QF-32DF-64O/q3d-a7280R4-32QFx400G-32DFx400G.config.bcm
@@ -1272,3 +1272,4 @@ sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
+sai_ecmp_group_members_increment=8

--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
@@ -866,3 +866,4 @@ sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=58
 appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
+sai_ecmp_group_members_increment=8

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1020,3 +1020,4 @@ sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
+sai_ecmp_group_members_increment=8

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1020,3 +1020,4 @@ sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
+sai_ecmp_group_members_increment=8

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1037,3 +1037,4 @@ sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
+sai_ecmp_group_members_increment=8

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1037,3 +1037,4 @@ sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
+sai_ecmp_group_members_increment=8

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1057,3 +1057,4 @@ sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
+sai_ecmp_group_members_increment=8

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1057,3 +1057,4 @@ sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
+sai_ecmp_group_members_increment=8

--- a/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O32-C32/nh5010-default.bcm
+++ b/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O32-C32/nh5010-default.bcm
@@ -2269,3 +2269,4 @@ macsec_fips_enable=1
 xflow_macsec_secure_chan_to_num_secure_assoc=4
 xflow_macsec_secure_chan_to_num_secure_assoc_encrypt=2
 xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=4
+sai_ecmp_group_members_increment=8

--- a/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/defaults/nh5010.bcm
+++ b/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/defaults/nh5010.bcm
@@ -2276,3 +2276,4 @@ macsec_fips_enable=1
 xflow_macsec_secure_chan_to_num_secure_assoc=4
 xflow_macsec_secure_chan_to_num_secure_assoc_encrypt=2
 xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=4
+sai_ecmp_group_members_increment=8

--- a/device/nokia/x86_64-nokia_ixr7250_x1b-r0/Nokia-IXR7250-X1b/q2cp-nokia-24x100g-12x400g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250_x1b-r0/Nokia-IXR7250-X1b/q2cp-nokia-24x100g-12x400g-config.bcm
@@ -1682,3 +1682,4 @@ sai_pfc_dlr_init_capability=0
 trunk_group_max_members=16
 sai_default_cpu_tx_tc=7
 sai_instru_stat_accum_enable=1
+sai_ecmp_group_members_increment=8

--- a/device/nokia/x86_64-nokia_ixr7250_x3b-r0/Nokia-IXR7250-X3B/0/jr2cp-nokia-18x400g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250_x3b-r0/Nokia-IXR7250-X3B/0/jr2cp-nokia-18x400g-config.bcm
@@ -2153,3 +2153,4 @@ trunk_group_max_members=16
 sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
 sai_instru_stat_accum_enable=1
+sai_ecmp_group_members_increment=8

--- a/device/nokia/x86_64-nokia_ixr7250_x3b-r0/Nokia-IXR7250-X3B/1/jr2cp-nokia-18x400g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250_x3b-r0/Nokia-IXR7250-X3B/1/jr2cp-nokia-18x400g-config.bcm
@@ -2157,3 +2157,4 @@ trunk_group_max_members=16
 sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
 sai_instru_stat_accum_enable=1
+sai_ecmp_group_members_increment=8

--- a/device/nokia/x86_64-nokia_ixr7250_x4-r0/Nokia-IXR7250-X4/q3d-nokia-32x800g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250_x4-r0/Nokia-IXR7250-X4/q3d-nokia-32x800g-config.bcm
@@ -1353,3 +1353,4 @@ sai_disable_srcmacqedstmac_ctrl=1
 trunk_group_max_members=16
 sai_default_cpu_tx_tc=7
 sai_tc_based_queue_stats_enable=0
+sai_ecmp_group_members_increment=8

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/jr2cp-nokia-18x100g-4x25g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/jr2cp-nokia-18x100g-4x25g-config.bcm
@@ -2103,3 +2103,4 @@ sai_disable_srcmacqedstmac_ctrl=1
 sai_instru_stat_accum_enable=1
 appl_param_active_links_thr_low=1
 appl_param_active_links_thr_high=112
+sai_ecmp_group_members_increment=8

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/jr2cp-nokia-18x100g-4x25g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/jr2cp-nokia-18x100g-4x25g-config.bcm
@@ -2104,3 +2104,4 @@ sai_disable_srcmacqedstmac_ctrl=1
 sai_instru_stat_accum_enable=1
 appl_param_active_links_thr_low=1
 appl_param_active_links_thr_high=112
+sai_ecmp_group_members_increment=8

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/jr2cp-nokia-18x400g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/jr2cp-nokia-18x400g-config.bcm
@@ -2104,3 +2104,4 @@ sai_disable_srcmacqedstmac_ctrl=1
 sai_instru_stat_accum_enable=1
 appl_param_active_links_thr_low=1
 appl_param_active_links_thr_high=112
+sai_ecmp_group_members_increment=8

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/jr2cp-nokia-18x400g-config.bcm
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/jr2cp-nokia-18x400g-config.bcm
@@ -2106,3 +2106,4 @@ sai_disable_srcmacqedstmac_ctrl=1
 sai_instru_stat_accum_enable=1
 appl_param_active_links_thr_low=1
 appl_param_active_links_thr_high=112
+sai_ecmp_group_members_increment=8

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -366,3 +366,4 @@ appl_param_rcy_mirror_ports_range
 rcy_mirror_to_forward_port_map
 port_priorities_sch
 sai_lag_default_crc_hash
+sai_ecmp_group_members_increment


### PR DESCRIPTION
#### Why I did it

Most datacenter networks size ECMP paths in multiples of 8 (8, 16, 32, 64 members).
On DNX platforms, The default SAI dynamic ECMP FEC increment of 4 causes unnecessary reallocation churn —
every time an ECMP group grows past a 4-member boundary (4→5, 8→9, 12→13, …), the
SAI SDK must allocate a new larger FEC block, copy all existing members, reprogram the
ECMP group pointer, and free the old block.

With increment=8, allocations align with real-world ECMP sizing and the hardware's
native token unit. A 2-member group pre-allocates 8 FEC slots; only when it exceeds 8
does reallocation occur (to 16). This cuts reallocation events in half for typical
deployments and improves route programming performance during convergence events.

The property `sai_ecmp_group_members_increment` is a Broadcom SAI-specific config knob,
only meaningful on DNX platforms (Jericho2, J2C+, Qumran3D chip families).

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Appended `sai_ecmp_group_members_increment=8` to all 25 Broadcom DNX `.config.bcm`
files and added the property name to `src/sonic-device-data/tests/permitted_list`.

Affected platforms across 3 vendors:
- **Arista**: 7280CR3, 7280DR3A, 7280R4, 7800R3, 7800R3A (fixed + chassis linecards)
- **Nokia**: IXR7250-X1b, IXR7250-X3B, IXR7250-X4, IXR7250E (fixed + chassis linecards)
- **NextHop**: NH-5010

#### How to verify it

Validated on real Broadcom DNX hardware across two chip families:

| Chip | Test | Result |
|------|------|--------|
| BCM88850 (J2C+) | `test_ecmp_increment_config_present` | PASSED ✅ |
| BCM88870 (Q3D) | `test_ecmp_increment_config_present` | PASSED ✅ |
| BCM88870 (Q3D) | `test_ecmp_increment_fec_lifecycle` | PASSED ✅ |

FEC lifecycle verification (3-phase test on Q3D):
- **Phase 1**: 2-NH ECMP route → syncd syslog shows `num_fec(8)` ✅
- **Phase 2**: 9-NH ECMP route (exceeds 8-slot) → syslog shows `num_fec(16)` ✅
- **Phase 3**: Delete route → CRM `nexthop_group_member_used` returns to baseline ✅

#### Which release branch to backport (provide reason below if selected)

_None initially — land on master first._

#### Tested branch (Please provide the tested image version)

- [x] master (built from this branch, deployed to real DNX hardware)

#### Description for the changelog

Set ECMP group members increment to 8 for all Broadcom DNX platforms to align FEC allocation with datacenter ECMP sizing and reduce reallocation churn.

#### A picture of a cute animal (not mandatory but encouraged)

🦔