### PR TITLE
[orchagent] Add async swss.rec config knob support

### DIFF
--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -62,6 +62,12 @@ if [[ "$NAMESPACE_ID" ]]; then
     ORCHAGENT_ARGS+="-f swss.asic$NAMESPACE_ID.rec -j sairedis.asic$NAMESPACE_ID.rec "
 fi
 
+# Enable async swss recorder when explicitly configured
+ASYNC_SWSS_REC=$(sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "async_swss_rec")
+if [ "$ASYNC_SWSS_REC" == "enabled" ]; then
+    ORCHAGENT_ARGS+="-A "
+fi
+
 # Add platform specific arguments if necessary
 if [ "$platform" == "broadcom" ]; then
     ORCHAGENT_ARGS+="-m $MAC_ADDRESS"

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -19,6 +19,10 @@ module sonic-device_metadata {
 
     description "DEVICE_METADATA YANG Module for SONiC OS";
 
+    revision 2026-04-10 {
+        description "Added async_swss_rec field to control async swss recorder.";
+    }
+
     revision 2021-02-27 {
         description "Added frr_mgmt_framework_config field to handle BGP
             config DB schema events to configure FRR protocols.";
@@ -228,6 +232,15 @@ module sonic-device_metadata {
                     must "((current() = 'disabled') or (current() = 'enabled' and ../synchronous_mode = 'enable'))" {
                         error-message "ASIC synchronous mode must be enabled in order to enable suppress FIB pending feature";
                     }
+                }
+
+                leaf async_swss_rec {
+                    description "Enable asynchronous swss.rec recording in orchagent.";
+                    type enumeration {
+                        enum enabled;
+                        enum disabled;
+                    }
+                    default disabled;
                 }
                 leaf rack_mgmt_map {
                     type string {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

This change is the companion `sonic-buildimage` update for the async `swss.rec` support added in [`sonic-net/sonic-swss#4400`](https://github.com/sonic-net/sonic-swss/pull/4400).

It adds operational control for async `swss.rec` enablement through `DEVICE_METADATA|localhost|async_swss_rec`.

The `orchagent` startup script now reads `async_swss_rec` from `CONFIG_DB` and appends `-A` only when the knob is explicitly set to `enabled`.
This change also updates `sonic-device_metadata.yang` so `async_swss_rec` is modeled as part of `DEVICE_METADATA`, with:
- allowed values: `enabled` / `disabled`
- default: `disabled`

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Updated `dockers/docker-orchagent/orchagent.sh` to read `DEVICE_METADATA|localhost|async_swss_rec` from `CONFIG_DB` and append `-A` only when the knob is explicitly set to `enabled`.
- Updated `src/sonic-yang-models/yang-models/sonic-device_metadata.yang` to model `async_swss_rec` as part of `DEVICE_METADATA`, with allowed values `enabled` / `disabled` and default `disabled`.

#### How to verify it

- Confirmed that with no `async_swss_rec` setting, `orchagent` starts without `-A`.
- Confirmed that with `DEVICE_METADATA|localhost|async_swss_rec=enabled`, `orchagent.sh` appends `-A`.
- Confirmed on DUT that `orchagent` starts with `-A` when the knob is enabled.
- Confirmed the YANG model now includes `async_swss_rec` with `enabled` / `disabled` values and default `disabled`.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

Add `DEVICE_METADATA|localhost|async_swss_rec` support to control async `swss.rec` enablement in `orchagent`.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes

`DEVICE_METADATA` is modeled in `src/sonic-yang-models/yang-models/sonic-device_metadata.yang`; this change adds the `async_swss_rec` leaf there.

<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

