### PR TITLE
start using cli-client: 10x faster show commands with fast autocompletion

### DIFF
--- a/files/image_config/bash/bash.bashrc
+++ b/files/image_config/bash/bash.bashrc
@@ -28,6 +28,12 @@ PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
 #    ;;
 #esac
 
+# cli-client routes to cli-server, a pre-fork server that avoids Python interpreter startup overhead.
+# First call starts cli-server in the background and runs normally; subsequent calls are fast.
+if command -v cli-client &>/dev/null; then
+    show() { cli-client show "$@"; }
+fi
+
 # enable bash completion in interactive shells
 if ! shopt -oq posix; then
     if [ -f /usr/share/bash-completion/bash_completion ]; then


### PR DESCRIPTION
#### Why I did it

The SONiC `show` command is a Python Click application. Each invocation starts a new Python interpreter, imports dozens of modules (Click, natsort, tabulate, sonic_py_common, swsscommon, etc.), and only then executes the actual command. This startup overhead is **~1 second per call** — noticeable and frustrating during interactive troubleshooting sessions where operators run many `show` commands in quick succession.

This change is the **sonic-buildimage half** of a two-part feature (the other half is in [sonic-utilities](https://github.com/sonic-net/sonic-utilities/pull/4449)). Together they eliminate the repeated startup cost by:

1. **cli-server** (sonic-utilities): a pre-fork Python server that imports the CLI entry point once, then `fork()`s a ready-to-run child for each request.
2. **cli-client** (sonic-utilities): a bash wrapper that connects to the server over a localhost TCP socket, sends `argv`/`cwd`/`env`, and streams tagged output back.
3. **bash.bashrc** (this PR): registers `show` as a shell function that delegates to `cli-client`.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added a guarded block to `files/image_config/bash/bash.bashrc` that defines a shell function for `show`:

```bash
if command -v cli-client &>/dev/null; then
    show() { cli-client show "$@"; }
fi
```

Key design decisions:

- **Guarded by `command -v`**: the function is only defined when `cli-client` is installed on PATH. Systems without the server package behave exactly as before — the original `show` console-script entry point is invoked directly.
- **Shell function, not alias**: a function correctly forwards all arguments (including quoted strings and globs) and composes properly with pipes, redirects, and subshells.
- **Transparent fallback**: even when the function is active, `cli-client` itself falls back to direct execution if the server is not yet running or is unreachable. The very first call starts the server in the background and runs the command normally; all subsequent calls are fast.
- **No behavioral change**: stdout, stderr, exit codes, signal handling (Ctrl-C), and environment propagation are preserved identically.

#### How to verify it

1. **Without cli-client installed** (backward compatibility):
   ```
   # Confirm show still work as before
   show version
   # Verify no shell function is defined
   type show    # should say "show is /usr/local/bin/show"
   ```

2. **With cli-client installed** (accelerated path):
   ```
   # First call — normal speed, server starts in background
   time show

   # Second call — near-instant (~50ms vs ~1s)
   time show

   # Verify the function is active
   type show    # should say "show is a function"

   # Verify signal forwarding (Ctrl-C should interrupt cleanly)
   show interfaces status   # press Ctrl-C mid-output

   # Verify exit codes propagate
   show nonexistent-command; echo $?   # should be non-zero
    ```

3. **Server lifecycle**:
   ```
   # Check server is running
   ls /tmp/cli-server/show.*

   # Server auto-exits after idle timeout (default 4 hours)
   # Or kill it manually:
   kill $(cat /tmp/cli-server/show.pid)

   # Next show command will restart the server transparently
   show version
   ```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] 202511
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add bash shell function to route `show` through cli-server pre-fork server, reducing CLI startup latency from ~1s to ~50ms.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### A picture of a cute animal (not mandatory but encouraged)

There is a cute fix with IOS style ? support
https://github.com/sonic-net/sonic-buildimage/pull/26813
