### PR TITLE
Revert "[action] [PR:26292] [platform/broadcom]: Remove static warmboot mount from docker-syncd-brcm-legacy-th.mk"

### DIFF
--- a/platform/broadcom/docker-syncd-brcm-legacy-th-rpc.mk
+++ b/platform/broadcom/docker-syncd-brcm-legacy-th-rpc.mk
@@ -22,6 +22,7 @@ $(DOCKER_SYNCD_BRCM_LEGACY_TH_RPC)_VERSION = 1.0.0+rpc
 $(DOCKER_SYNCD_BRCM_LEGACY_TH_RPC)_PACKAGE_NAME = syncd-legacy-th
 $(DOCKER_SYNCD_BRCM_LEGACY_TH_RPC)_RUN_OPT += --privileged -t
 $(DOCKER_SYNCD_BRCM_LEGACY_TH_RPC)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
+$(DOCKER_SYNCD_BRCM_LEGACY_TH_RPC)_RUN_OPT += -v /host/warmboot:/var/warmboot
 $(DOCKER_SYNCD_BRCM_LEGACY_TH_RPC)_RUN_OPT += -v /var/run/docker-syncd:/var/run/sswsyncd
 $(DOCKER_SYNCD_BRCM_LEGACY_TH_RPC)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 

--- a/platform/broadcom/docker-syncd-brcm-legacy-th.mk
+++ b/platform/broadcom/docker-syncd-brcm-legacy-th.mk
@@ -42,6 +42,7 @@ $(DOCKER_SYNCD_LEGACY_TH_BASE)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_LEGACY_TH_BASE)_RUN_OPT += --privileged -t
 $(DOCKER_SYNCD_LEGACY_TH_BASE)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_LEGACY_TH_BASE)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
+$(DOCKER_SYNCD_LEGACY_TH_BASE)_RUN_OPT += -v /host/warmboot:/var/warmboot
 
 $(DOCKER_SYNCD_LEGACY_TH_BASE)_BASE_IMAGE_FILES += bcmcmd:/usr/bin/bcmcmd
 $(DOCKER_SYNCD_LEGACY_TH_BASE)_BASE_IMAGE_FILES += bcmsh:/usr/bin/bcmsh


### PR DESCRIPTION
ADO link 37449106

Reverts sonic-net/sonic-buildimage#26495

When this change was in, the following was seen during warmboot up:
```
2026 Apr  8 00:27:31.967800 str2-7060cx-32s-29 ERR syncd#syncd: [none] SAI_API_SWITCH:platformInit:1762 Unit 0: stable cache file not created
2026 Apr  8 00:27:31.968731 str2-7060cx-32s-29 INFO syncd#supervisord: syncd SOC unit 0 attached to PCI device BCM56960_B1#015
2026 Apr  8 00:27:31.968822 str2-7060cx-32s-29 INFO syncd#supervisord: syncd WARNING: bcm common command PortMod not alphabetized#015
2026 Apr  8 00:27:31.968876 str2-7060cx-32s-29 INFO syncd#supervisord: syncd Unit 0: Error opening scache file /var/warmboot/brcm_bcm_scache#015
```
This was a hard failure and warmboot would not succeed.

The problem is that the original change assummed that this change https://github.com/sonic-net/sonic-buildimage/pull/25071 was present on 202511 branch, however that is only on master.

To fix, reverted 26495