### PR TITLE
Signing out-of-tree kernel modules

### DIFF
--- a/platform/broadcom/sonic-platform-modules-nexthop/debian/rules
+++ b/platform/broadcom/sonic-platform-modules-nexthop/debian/rules
@@ -42,7 +42,6 @@ override_dh_auto_build:
 		set -e; \
 		if [ -f $(MOD_SRC_DIR)/$${mod}/modules/Makefile ]; then \
 			$(MAKE) -C $(KERNEL_BUILD) M=$(MOD_SRC_DIR)/$${mod}/modules modules; \
-			./sign-modules.sh $(MOD_SRC_DIR)/$${mod}/modules; \
 		fi; \
 	done)
 	python3 setup.py bdist_wheel -d $(MOD_SRC_DIR)

--- a/scripts/signing_secure_boot_dev.sh
+++ b/scripts/signing_secure_boot_dev.sh
@@ -118,4 +118,21 @@ mv ${CURR_VMLINUZ}-signed ${CURR_VMLINUZ}
 #########################
 ./scripts/signing_kernel_modules.sh -l ${LINUX_KERNEL_VERSION} -c ${PEM_CERT} -p ${PEM_PRIV_KEY} -k ${FS_ROOT}/usr/lib/modules
 
+# Out-of-tree kernel modules signing
+tmpdir=/tmp/deb_extract_root
+for deb in $(find $FS_ROOT/platform -type f -name "*.deb")
+do
+    mkdir $tmpdir
+    dpkg-deb -R $deb $tmpdir
+    ./scripts/signing_kernel_modules.sh -l $LINUX_KERNEL_VERSION \
+                                        -c $PEM_CERT \
+                                        -p $PEM_PRIV_KEY \
+                                        -k $tmpdir
+    (cd $tmpdir; md5sum $(find . -path ./DEBIAN -prune -o -type f -print | cut -c3-) > DEBIAN/md5sums)
+    sudo dpkg-deb -b $tmpdir $deb
+    rm -rf $tmpdir
+done
+# Rescan packages and update Packages index
+dpkg-scanpackages $FS_ROOT/platform/common | gzip -c > $FS_ROOT/platform/common/Packages.gz
+
 echo "$0 signing & verifying EFI files and Kernel Modules DONE"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

While in-tree and pre-installed linux kernel modules are signing by dev signing key, the out-of-kernel modules packaged in deb files for individual platforms are not signed. In order for those modules in deb files to be signed properly, individual make files would currently have to perform its own signing procedure before packaging ko files.
This is impractical in the context of production signing since every package would need to be aware of sonic build specifics. 
Instead of signing kernel modules by individual modules build, those ko files in deb files should be signed at one place as it is already done for in-tree/pre-installed kernel modules.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

After signing in-tree kernel modules in the signinig_secure_boot_dev.sh, the out-of-tree kernel modules in deb files are signed by 1)  extract deb files in a tmp directory and 2) run signing_kernel_modules.sh to the extracted files, and then 3) rebuild the deb file.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
confirmed that all ko files in deb packages are properly signed.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

