### PR TITLE
Fix bgpmon vtysh error during warm/fast boot BGP container shutdown

### DIFF
--- a/files/scripts/bgp.sh
+++ b/files/scripts/bgp.sh
@@ -69,7 +69,7 @@ stop() {
 
     # Kill bgpd to start the bgp graceful restart procedure
     if [[ x"$WARM_BOOT" == x"true" ]] || [[ x"$FAST_BOOT" == x"true" ]]; then
-        debug "Kill zebra first"
+        debug "Kill zebra and bgpd"
         /usr/bin/docker exec -i bgp pkill -9 zebra || [ $? == 1 ]
         /usr/bin/docker exec -i bgp pkill -9 bgpd || [ $? == 1 ]
     fi

--- a/src/sonic-bgpcfgd/bgpmon/bgpmon.py
+++ b/src/sonic-bgpcfgd/bgpmon/bgpmon.py
@@ -84,7 +84,10 @@ class BgpStateGet:
             try:
                 rc, output = getstatusoutput_noshell(cmd)
                 if rc:
-                    syslog.syslog(syslog.LOG_ERR, "*ERROR* Failed with rc:{} when execute: {}".format(rc, cmd))
+                    if os.system('pgrep -x bgpd > /dev/null 2>&1') != 0 or os.system('pgrep -x zebra > /dev/null 2>&1') != 0:
+                        syslog.syslog(syslog.LOG_WARNING, "vtysh failed (rc={}), bgpd or zebra not running — container may be shutting down".format(rc))
+                    else:
+                        syslog.syslog(syslog.LOG_ERR, "*ERROR* Failed with rc:{} when execute: {}".format(rc, cmd))
                     return
                 if len(output) == 0:
                     syslog.syslog(syslog.LOG_WARNING, "*WARNING* output none when execute: {}".format(cmd))

--- a/src/sonic-bgpcfgd/bgpmon/bgpmon.py
+++ b/src/sonic-bgpcfgd/bgpmon/bgpmon.py
@@ -84,7 +84,9 @@ class BgpStateGet:
             try:
                 rc, output = getstatusoutput_noshell(cmd)
                 if rc:
-                    if os.system('pgrep -x bgpd > /dev/null 2>&1') != 0 or os.system('pgrep -x zebra > /dev/null 2>&1') != 0:
+                    bgpd_rc, _ = getstatusoutput_noshell(["pgrep", "-x", "bgpd"])
+                    zebra_rc, _ = getstatusoutput_noshell(["pgrep", "-x", "zebra"])
+                    if bgpd_rc != 0 or zebra_rc != 0:
                         syslog.syslog(syslog.LOG_WARNING, "vtysh failed (rc={}), bgpd or zebra not running — container may be shutting down".format(rc))
                     else:
                         syslog.syslog(syslog.LOG_ERR, "*ERROR* Failed with rc:{} when execute: {}".format(rc, cmd))

--- a/src/sonic-bgpcfgd/bgpmon/bgpmon.py
+++ b/src/sonic-bgpcfgd/bgpmon/bgpmon.py
@@ -87,7 +87,7 @@ class BgpStateGet:
                     bgpd_rc, _ = getstatusoutput_noshell(["pgrep", "-x", "bgpd"])
                     zebra_rc, _ = getstatusoutput_noshell(["pgrep", "-x", "zebra"])
                     if bgpd_rc != 0 or zebra_rc != 0:
-                        syslog.syslog(syslog.LOG_WARNING, "vtysh failed (rc={}), bgpd or zebra not running — container may be shutting down".format(rc))
+                        syslog.syslog(syslog.LOG_WARNING, "vtysh failed (rc={}) when execute: {} Output: {} bgpd or zebra not running — container may be shutting down".format(rc, cmd, output[:200] if output else ""))
                     else:
                         syslog.syslog(syslog.LOG_ERR, "*ERROR* Failed with rc:{} when execute: {}".format(rc, cmd))
                     return

--- a/src/sonic-bgpcfgd/bgpmon/bgpmon.py
+++ b/src/sonic-bgpcfgd/bgpmon/bgpmon.py
@@ -84,9 +84,7 @@ class BgpStateGet:
             try:
                 rc, output = getstatusoutput_noshell(cmd)
                 if rc:
-                    bgpd_rc, _ = getstatusoutput_noshell(["pgrep", "-x", "bgpd"])
-                    zebra_rc, _ = getstatusoutput_noshell(["pgrep", "-x", "zebra"])
-                    if bgpd_rc != 0 or zebra_rc != 0:
+                    if os.system('pgrep -x bgpd > /dev/null 2>&1') != 0 or os.system('pgrep -x zebra > /dev/null 2>&1') != 0:
                         syslog.syslog(syslog.LOG_WARNING, "vtysh failed (rc={}) when execute: {} Output: {} bgpd or zebra not running — container may be shutting down".format(rc, cmd, output[:200] if output else ""))
                     else:
                         syslog.syslog(syslog.LOG_ERR, "*ERROR* Failed with rc:{} when execute: {}".format(rc, cmd))

--- a/src/sonic-bgpcfgd/tests/test_bgpmon.py
+++ b/src/sonic-bgpcfgd/tests/test_bgpmon.py
@@ -1,0 +1,76 @@
+import pytest
+import json
+from unittest.mock import MagicMock, patch, call
+import syslog
+import bgpmon.bgpmon
+from bgpmon.bgpmon import BgpStateGet
+
+
+@pytest.fixture
+@patch('swsscommon.swsscommon.RedisPipeline')
+@patch('swsscommon.swsscommon.SonicV2Connector')
+def bgp_mon(mock_conn, mock_pipe):
+    mock_db = mock_conn.return_value
+    mock_db.STATE_DB = 'STATE_DB'
+    m = BgpStateGet()
+    return m
+
+
+@patch('bgpmon.bgpmon.getstatusoutput_noshell', return_value=(1, ""))
+@patch('os.system', return_value=1)
+@patch('syslog.syslog')
+def test_vtysh_fail_both_daemons_down(mocked_syslog, mocked_os_system, mocked_cmd, bgp_mon):
+    """When vtysh fails and neither bgpd nor zebra is running, log WARNING."""
+    bgp_mon.get_all_neigh_states()
+    mocked_syslog.assert_called_once()
+    level, msg = mocked_syslog.call_args[0]
+    assert level == syslog.LOG_WARNING
+    assert "bgpd or zebra not running" in msg
+    assert "container may be shutting down" in msg
+
+
+@patch('bgpmon.bgpmon.getstatusoutput_noshell', return_value=(1, ""))
+@patch('os.system', return_value=0)
+@patch('syslog.syslog')
+def test_vtysh_fail_both_daemons_running(mocked_syslog, mocked_os_system, mocked_cmd, bgp_mon):
+    """When vtysh fails but bgpd and zebra ARE running, log ERR."""
+    bgp_mon.get_all_neigh_states()
+    mocked_syslog.assert_called_once()
+    level, msg = mocked_syslog.call_args[0]
+    assert level == syslog.LOG_ERR
+    assert "*ERROR* Failed with rc:1 when execute" in msg
+
+
+@patch('bgpmon.bgpmon.getstatusoutput_noshell', return_value=(1, ""))
+@patch('os.system', side_effect=[1, 0])
+@patch('syslog.syslog')
+def test_vtysh_fail_only_bgpd_down(mocked_syslog, mocked_os_system, mocked_cmd, bgp_mon):
+    """When vtysh fails and only bgpd is down (first pgrep fails), log WARNING."""
+    bgp_mon.get_all_neigh_states()
+    mocked_syslog.assert_called_once()
+    level, msg = mocked_syslog.call_args[0]
+    assert level == syslog.LOG_WARNING
+    assert "bgpd or zebra not running" in msg
+
+
+@patch('bgpmon.bgpmon.getstatusoutput_noshell', return_value=(1, ""))
+@patch('os.system', side_effect=[0, 1])
+@patch('syslog.syslog')
+def test_vtysh_fail_only_zebra_down(mocked_syslog, mocked_os_system, mocked_cmd, bgp_mon):
+    """When vtysh fails and only zebra is down (second pgrep fails), log WARNING."""
+    bgp_mon.get_all_neigh_states()
+    mocked_syslog.assert_called_once()
+    level, msg = mocked_syslog.call_args[0]
+    assert level == syslog.LOG_WARNING
+    assert "bgpd or zebra not running" in msg
+
+
+@patch('bgpmon.bgpmon.getstatusoutput_noshell', return_value=(1, "some vtysh error output here"))
+@patch('os.system', return_value=1)
+@patch('syslog.syslog')
+def test_vtysh_fail_warning_includes_output(mocked_syslog, mocked_os_system, mocked_cmd, bgp_mon):
+    """WARNING message includes truncated vtysh output."""
+    bgp_mon.get_all_neigh_states()
+    level, msg = mocked_syslog.call_args[0]
+    assert level == syslog.LOG_WARNING
+    assert "some vtysh error output here" in msg


### PR DESCRIPTION
#### Why I did it
Fixes: https://github.com/sonic-net/sonic-buildimage/issues/21186

During warm/fast boot, `bgp.sh stop()` kills `zebra` and `bgpd` inside the BGP
container before the container itself stops. However, `bgpmon` has
`autorestart=true` in supervisord and stays alive, polling FRR via
`vtysh -c 'show bgp summary json'` every 15 seconds. If a poll fires in the
short window between the `pkill` calls and the container fully stopping,
`vtysh` fails because the FRR daemons are already gone, producing a misleading
syslog error: `ERR bgp#bgpmon: ERROR Failed with rc:1 when execute: ['vtysh', '-c', 'show bgp summary json']`


This race is benign (the container is on its way down) but it pollutes logs
and gets flagged as an error.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

**Approach considered and rejected: stop bgpmon before killing FRR**
Adding `supervisorctl stop bgpmon || true` in `bgp.sh stop()` ahead of the
`pkill` commands eliminates the race, but it adds roughly 200–400 ms to BGP
warm restart because of the extra Unix-socket round-trip to supervisord.
`pkill -9 bgpmon` is not an option either, since supervisord is configured to
auto-restart it (see #5460).

**Approach taken: downgrade the log level when FRR daemons are not running**
In `src/sonic-bgpcfgd/bgpmon/bgpmon.py`, when the `vtysh` call fails, check
whether `bgpd` and `zebra` are actually running via `pgrep`:
- If either daemon is not running, the container is almost certainly shutting
  down — log a `WARNING` with extra context (`rc`, command, truncated vtysh
  output) instead of an `ERROR`.
- If both daemons are running, keep the existing `ERROR` so genuine failures
  are still surfaced.

This removes the noisy error from the warm/fast-boot shutdown window without
adding any reboot overhead.

Also fixed a stale `debug` message in `files/scripts/bgp.sh`
(`"Kill zebra first"` → `"Kill zebra and bgpd"`), since both daemons are
killed at that step.

Added unit tests in `src/sonic-bgpcfgd/tests/test_bgpmon.py` covering:
- both `bgpd` and `zebra` down → `WARNING`
- both running → `ERROR` (original behavior)
- only `bgpd` down → `WARNING`
- only `zebra` down → `WARNING`
- `WARNING` message includes truncated `vtysh` output

#### How to verify it
1. Trigger a warm or fast reboot (or `systemctl restart bgp`) on a SONiC device.
2. Run `show logging | grep bgpmon` and confirm there is no
   `*ERROR* Failed with rc:1 when execute: ['vtysh', ...]` during the BGP
   container shutdown window. A single `WARNING` with
   `bgpd or zebra not running — container may be shutting down` is expected
   instead.
3. Under normal operation (both `bgpd` and `zebra` running), genuine `vtysh`
   failures continue to log at `ERR`.
4. Run unit tests: `pytest src/sonic-bgpcfgd/tests/test_bgpmon.py`.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
bgpmon: log `vtysh` failures as `WARNING` (instead of `ERROR`) when `bgpd` or
`zebra` is not running, to suppress the noisy shutdown-window error during BGP
container warm/fast boot.

#### Link to config_db schema for YANG module changes
N/A

#### A picture of a cute animal (not mandatory but encouraged)
