### PR TITLE
[azure-pipelines]: Fix Publish stage skipped when optional tests fail

### DIFF
--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -101,7 +101,7 @@ stages:
 
 - stage: Publish
   dependsOn: Test
-  condition: and(succeeded(), in(dependencies.Test.result, 'Succeeded'))
+  condition: and(not(canceled()), in(dependencies.Test.result, 'Succeeded', 'SucceededWithIssues'))
   jobs:
   - job: PublishAsLatest
     pool: sonicso1ES-amd64


### PR DESCRIPTION
#### Why I did it

The Publish stage in the `docker-sonic-mgmt` pipeline is skipped when the optional VPP test (`t1_lag_vpp_elastictest`, marked with `continueOnError: true`) fails. This is because the Publish stage condition only accepts `'Succeeded'` as the Test stage result, but Azure DevOps marks a stage as `'SucceededWithIssues'` when an optional job fails. As a result, even though the failure is expected to be non-blocking, the docker-sonic-mgmt image is not published.

Pipeline: https://dev.azure.com/mssonic/build/_build?definitionId=194&_a=summary

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Updated the Publish stage `condition` in `.azure-pipelines/docker-sonic-mgmt.yml` to also accept `'SucceededWithIssues'` as a valid Test stage result:

```yaml
# Before
condition: and(succeeded(), in(dependencies.Test.result, 'Succeeded'))

# After
condition: and(not(canceled()), in(dependencies.Test.result, 'Succeeded', 'SucceededWithIssues'))
```

Also changed `succeeded()` to `not(canceled())` because the `in(...)` check already gates on the dependency result — using `succeeded()` would be redundant and could conflict with `SucceededWithIssues`.

#### How to verify it

1. Trigger a PR build that modifies files under `dockers/docker-sonic-mgmt`.
2. If the optional VPP test fails, verify that the Publish stage still runs and publishes the `docker-sonic-mgmt:latest` image.
3. If a required test fails, verify that the Publish stage is still skipped.

#### Which release branch to backport (provide reason below if selected)

#### Tested branch (Please provide the tested image version)

#### Description for the changelog

Fix Publish stage in docker-sonic-mgmt pipeline being skipped when optional VPP test fails.

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)
