### PR TITLE
Fix cname yang model validation issue from telemetry-sidecar

### DIFF
--- a/dockers/docker-telemetry-sidecar/cli-plugin-tests/test_systemd_stub.py
+++ b/dockers/docker-telemetry-sidecar/cli-plugin-tests/test_systemd_stub.py
@@ -189,22 +189,22 @@ def ss(tmp_path, monkeypatch):
     # Isolate POST_COPY_ACTIONS
     monkeypatch.setattr(ss, "POST_COPY_ACTIONS", {}, raising=True)
 
-    # Mock _get_branch_name to return "master" by default (avoids real file/nsenter I/O)
-    # Use "master" because it falls through to the default (non-branch-specific) path.
-    monkeypatch.setattr(ss, "_get_branch_name", lambda: "master")
+    # Mock _get_branch_name to return "202412" by default (avoids real file/nsenter I/O)
+    # Use "202412" because it is in the supported branch list.
+    monkeypatch.setattr(ss, "_get_branch_name", lambda: "202412")
 
     # Reset the one-shot cleanup flag so each test starts fresh
     ss._stale_unit_cleaned = False
     monkeypatch.setattr(ss, "_STALE_UNIT_CLEANUP_ENABLED", True)
 
-    # Provide a default container_checker in both filesystems so the auto-appended
+    # Provide the branch-specific container_checker in both filesystems so the auto-appended
     # SyncItem from ensure_sync() is always satisfied and is a no-op.
-    container_fs["/usr/share/sonic/systemd_scripts/container_checker"] = b"default-checker"
+    container_fs["/usr/share/sonic/systemd_scripts/container_checker_202412"] = b"default-checker"
     host_fs["/bin/container_checker"] = b"default-checker"
 
-    # Provide a default service_checker.py in both filesystems so the auto-appended
+    # Provide the branch-specific service_checker.py in both filesystems so the auto-appended
     # SyncItem from ensure_sync() is always satisfied and is a no-op.
-    container_fs["/usr/share/sonic/systemd_scripts/service_checker.py"] = b"default-service-checker"
+    container_fs["/usr/share/sonic/systemd_scripts/service_checker.py_202412"] = b"default-service-checker"
     host_fs["/usr/local/lib/python3.11/dist-packages/health_checker/service_checker.py"] = b"default-service-checker"
 
     return ss, container_fs, host_fs, commands, config_db
@@ -425,7 +425,7 @@ def test_reconcile_enables_user_auth_and_cname(ss):
     ss, container_fs, host_fs, commands, config_db = ss
     # Set module-level flags directly (they're read inside reconcile)
     ss.GNMI_VERIFY_ENABLED = True
-    ss.GNMI_CLIENT_CERTS = [{"cname": "fake-infra-ca.test.example.com", "role": "gnmi_show_readonly"}]
+    ss.GNMI_CLIENT_CERTS = [{"cname": "fake-infra-ca.test.example.com", "role": ["gnmi_show_readonly"]}]
 
     # Precondition: empty DB
     assert config_db == {}
@@ -434,16 +434,16 @@ def test_reconcile_enables_user_auth_and_cname(ss):
 
     assert config_db.get("TELEMETRY|gnmi", {}).get("user_auth") == "cert"
     # CNAME hash must exist with role=gnmi_show_readonly
-    assert config_db.get("GNMI_CLIENT_CERT|fake-infra-ca.test.example.com", {}).get("role") == "gnmi_show_readonly"
+    assert config_db.get("GNMI_CLIENT_CERT|fake-infra-ca.test.example.com", {}).get("role") == ["gnmi_show_readonly"]
 
 
 def test_reconcile_disabled_removes_cname(ss):
     ss, container_fs, host_fs, commands, config_db = ss
     ss.GNMI_VERIFY_ENABLED = False
-    ss.GNMI_CLIENT_CERTS = [{"cname": "fake-infra-ca.test.example.com", "role": "gnmi_show_readonly"}]
+    ss.GNMI_CLIENT_CERTS = [{"cname": "fake-infra-ca.test.example.com", "role": ["gnmi_show_readonly"]}]
 
     # Seed an existing entry to be removed
-    config_db["GNMI_CLIENT_CERT|fake-infra-ca.test.example.com"] = {"role": "gnmi_show_readonly"}
+    config_db["GNMI_CLIENT_CERT|fake-infra-ca.test.example.com"] = {"role": ["gnmi_show_readonly"]}
 
     ss.reconcile_config_db_once()
 
@@ -453,15 +453,78 @@ def test_reconcile_multiple_cnames(ss):
     ss, container_fs, host_fs, commands, config_db = ss
     ss.GNMI_VERIFY_ENABLED = True
     ss.GNMI_CLIENT_CERTS = [
-        {"cname": "fake-client.test.example.com", "role": "admin"},
-        {"cname": "fake-server.test.example.com", "role": '["gnmi_show_readonly","admin"]'},
+        {"cname": "fake-client.test.example.com", "role": ["admin"]},
+        {"cname": "fake-server.test.example.com", "role": ["gnmi_show_readonly", "admin"]},
     ]
     assert config_db == {}
     ss.reconcile_config_db_once()
 
     assert config_db.get("TELEMETRY|gnmi", {}).get("user_auth") == "cert"
-    assert config_db.get("GNMI_CLIENT_CERT|fake-client.test.example.com", {}).get("role") == "admin"
-    assert config_db.get("GNMI_CLIENT_CERT|fake-server.test.example.com", {}).get("role") == '["gnmi_show_readonly","admin"]'
+    assert config_db.get("GNMI_CLIENT_CERT|fake-client.test.example.com", {}).get("role") == ["admin"]
+    assert config_db.get("GNMI_CLIENT_CERT|fake-server.test.example.com", {}).get("role") == ["gnmi_show_readonly", "admin"]
+
+def test_reconcile_rewrites_stale_json_string_role(ss):
+    """Reconcile must rewrite a stale JSON-string role into a proper list for YANG compliance."""
+    ss, container_fs, host_fs, commands, config_db = ss
+    ss.GNMI_VERIFY_ENABLED = True
+    ss.GNMI_CLIENT_CERTS = [
+        {"cname": "fake-client.test.example.com", "role": ["admin"]},
+    ]
+
+    # Seed a stale entry with old JSON-string format — stored as a string, not a list
+    config_db["GNMI_CLIENT_CERT|fake-client.test.example.com"] = {"role": '["admin"]'}
+
+    ss.reconcile_config_db_once()
+
+    # Must be rewritten as a proper list so YANG leaf-list validation passes
+    assert config_db.get("GNMI_CLIENT_CERT|fake-client.test.example.com", {}).get("role") == ["admin"]
+
+def test_reconcile_rewrites_plain_string_role(ss):
+    """Reconcile must rewrite a plain-string role into a list for YANG leaf-list compliance."""
+    ss, container_fs, host_fs, commands, config_db = ss
+    ss.GNMI_VERIFY_ENABLED = True
+    ss.GNMI_CLIENT_CERTS = [
+        {"cname": "fake-client.test.example.com", "role": ["gnmi_show_readonly"]},
+    ]
+
+    # Seed entry with old plain-string format (causes YANG 'Duplicated instance' errors)
+    config_db["GNMI_CLIENT_CERT|fake-client.test.example.com"] = {"role": "gnmi_show_readonly"}
+
+    ss.reconcile_config_db_once()
+
+    # Must be rewritten as a proper list
+    assert config_db.get("GNMI_CLIENT_CERT|fake-client.test.example.com", {}).get("role") == ["gnmi_show_readonly"]
+
+def test_reconcile_overwrites_when_role_differs(ss):
+    """Reconcile must overwrite when the stored role differs from the desired one."""
+    ss, container_fs, host_fs, commands, config_db = ss
+    ss.GNMI_VERIFY_ENABLED = True
+    ss.GNMI_CLIENT_CERTS = [
+        {"cname": "fake-client.test.example.com", "role": ["admin", "gnmi_show_readonly"]},
+    ]
+
+    # Seed an entry with a different role
+    config_db["GNMI_CLIENT_CERT|fake-client.test.example.com"] = {"role": ["admin"]}
+
+    ss.reconcile_config_db_once()
+
+    # Must be overwritten with the new role list
+    assert config_db.get("GNMI_CLIENT_CERT|fake-client.test.example.com", {}).get("role") == ["admin", "gnmi_show_readonly"]
+
+def test_reconcile_skips_when_role_matches(ss):
+    """Reconcile should not rewrite if the role already matches."""
+    ss, container_fs, host_fs, commands, config_db = ss
+    ss.GNMI_VERIFY_ENABLED = True
+    ss.GNMI_CLIENT_CERTS = [
+        {"cname": "fake-client.test.example.com", "role": ["admin"]},
+    ]
+
+    # Seed an entry that already matches
+    config_db["GNMI_CLIENT_CERT|fake-client.test.example.com"] = {"role": ["admin"]}
+
+    ss.reconcile_config_db_once()
+
+    assert config_db.get("GNMI_CLIENT_CERT|fake-client.test.example.com", {}).get("role") == ["admin"]
 
 # ─────────────────────────── Tests for _parse_client_certs ───────────────────────────
 
@@ -494,15 +557,22 @@ class TestParseClientCerts:
         certs = self._import_with_env({
             "GNMI_CLIENT_CERTS": '[{"cname": "client.gbl", "role": "admin"}]'
         })
-        assert certs == [{"cname": "client.gbl", "role": "admin"}]
+        assert certs == [{"cname": "client.gbl", "role": ["admin"]}]
 
     def test_valid_json_multiple_entries(self):
         certs = self._import_with_env({
             "GNMI_CLIENT_CERTS": '[{"cname": "a.gbl", "role": "admin"}, {"cname": "b.gbl", "role": "readonly"}]'
         })
         assert len(certs) == 2
-        assert certs[0] == {"cname": "a.gbl", "role": "admin"}
-        assert certs[1] == {"cname": "b.gbl", "role": "readonly"}
+        assert certs[0] == {"cname": "a.gbl", "role": ["admin"]}
+        assert certs[1] == {"cname": "b.gbl", "role": ["readonly"]}
+
+    def test_role_as_json_list(self):
+        """role provided as a JSON array should be preserved as a list."""
+        certs = self._import_with_env({
+            "GNMI_CLIENT_CERTS": '[{"cname": "s.gbl", "role": ["gnmi_show_readonly", "admin"]}]'
+        })
+        assert certs == [{"cname": "s.gbl", "role": ["gnmi_show_readonly", "admin"]}]
 
     def test_non_array_json_falls_back_to_legacy(self):
         certs = self._import_with_env({
@@ -510,48 +580,48 @@ class TestParseClientCerts:
             "TELEMETRY_CLIENT_CNAME": "legacy.gbl",
             "GNMI_CLIENT_ROLE": "readonly",
         })
-        assert certs == [{"cname": "legacy.gbl", "role": "readonly"}]
+        assert certs == [{"cname": "legacy.gbl", "role": ["readonly"]}]
 
     def test_invalid_json_falls_back_to_legacy(self):
         certs = self._import_with_env({
             "GNMI_CLIENT_CERTS": "not-json!",
             "TELEMETRY_CLIENT_CNAME": "fallback.gbl",
         })
-        assert certs == [{"cname": "fallback.gbl", "role": "gnmi_show_readonly"}]
+        assert certs == [{"cname": "fallback.gbl", "role": ["gnmi_show_readonly"]}]
 
     def test_entry_not_dict_falls_back(self):
         certs = self._import_with_env({
             "GNMI_CLIENT_CERTS": '["not-a-dict"]',
             "TELEMETRY_CLIENT_CNAME": "fb.gbl",
         })
-        assert certs == [{"cname": "fb.gbl", "role": "gnmi_show_readonly"}]
+        assert certs == [{"cname": "fb.gbl", "role": ["gnmi_show_readonly"]}]
 
     def test_entry_missing_role_falls_back(self):
         certs = self._import_with_env({
             "GNMI_CLIENT_CERTS": '[{"cname": "x.gbl"}]',
             "TELEMETRY_CLIENT_CNAME": "fb.gbl",
         })
-        assert certs == [{"cname": "fb.gbl", "role": "gnmi_show_readonly"}]
+        assert certs == [{"cname": "fb.gbl", "role": ["gnmi_show_readonly"]}]
 
     def test_entry_empty_cname_falls_back(self):
         certs = self._import_with_env({
             "GNMI_CLIENT_CERTS": '[{"cname": "  ", "role": "admin"}]',
             "TELEMETRY_CLIENT_CNAME": "fb.gbl",
         })
-        assert certs == [{"cname": "fb.gbl", "role": "gnmi_show_readonly"}]
+        assert certs == [{"cname": "fb.gbl", "role": ["gnmi_show_readonly"]}]
 
     def test_legacy_single_entry(self):
         certs = self._import_with_env({
             "TELEMETRY_CLIENT_CNAME": "legacy.gbl",
             "GNMI_CLIENT_ROLE": "admin",
         })
-        assert certs == [{"cname": "legacy.gbl", "role": "admin"}]
+        assert certs == [{"cname": "legacy.gbl", "role": ["admin"]}]
 
     def test_legacy_default_role(self):
         certs = self._import_with_env({
             "TELEMETRY_CLIENT_CNAME": "legacy.gbl",
         })
-        assert certs == [{"cname": "legacy.gbl", "role": "gnmi_show_readonly"}]
+        assert certs == [{"cname": "legacy.gbl", "role": ["gnmi_show_readonly"]}]
 
     def test_no_env_returns_empty(self):
         certs = self._import_with_env({})
@@ -561,7 +631,7 @@ class TestParseClientCerts:
         certs = self._import_with_env({
             "GNMI_CLIENT_CERTS": '[{"cname": " client.gbl ", "role": " admin "}]'
         })
-        assert certs == [{"cname": "client.gbl", "role": "admin"}]
+        assert certs == [{"cname": "client.gbl", "role": ["admin"]}]
 
 
 # ─────────────────────────── Tests for _get_branch_name ───────────────────────────
@@ -679,22 +749,18 @@ def test_ensure_sync_uses_202411_checker(ss):
     assert host_fs["/bin/container_checker"] == b"checker-202411"
 
 
-def test_ensure_sync_uses_default_checker(ss):
-    """When branch is not 202411, ensure_sync uses the default container_checker."""
+def test_ensure_sync_aborts_for_unsupported_branch(ss):
+    """When branch is not in the supported list, ensure_sync aborts and returns False."""
     ss_mod, container_fs, host_fs, commands, config_db = ss
 
-    # _get_branch_name already returns "202412" from fixture default
+    ss_mod._get_branch_name = lambda: "master"
 
-    # Provide the default checker in the container and a different one on host
-    container_fs["/usr/share/sonic/systemd_scripts/container_checker"] = b"checker-default"
     host_fs["/bin/container_checker"] = b"old-checker"
 
-    # Clear SYNC_ITEMS to focus only on the container_checker logic
-    ss_mod.SYNC_ITEMS[:] = []
-
     ok = ss_mod.ensure_sync()
-    assert ok is True
-    assert host_fs["/bin/container_checker"] == b"checker-default"
+    assert ok is False
+    # Nothing should be synced
+    assert host_fs["/bin/container_checker"] == b"old-checker"
 
 
 def test_ensure_sync_202411_missing_checker_fails(ss):
@@ -737,21 +803,18 @@ def test_ensure_sync_uses_202411_service_checker(ss):
     assert host_fs[ss_mod.HOST_SERVICE_CHECKER] == b"service-checker-202411"
 
 
-def test_ensure_sync_uses_default_service_checker(ss):
-    """When branch is not 202411, ensure_sync uses the default service_checker.py."""
+def test_ensure_sync_aborts_service_checker_for_unsupported_branch(ss):
+    """When branch is not in the supported list, ensure_sync aborts without syncing service_checker."""
     ss_mod, container_fs, host_fs, commands, config_db = ss
 
-    # _get_branch_name already returns "202412" from fixture default
+    ss_mod._get_branch_name = lambda: "master"
 
-    # Provide the default service_checker in the container and a different one on host
-    container_fs["/usr/share/sonic/systemd_scripts/service_checker.py"] = b"service-checker-default"
     host_fs[ss_mod.HOST_SERVICE_CHECKER] = b"old-service-checker"
 
-    ss_mod.SYNC_ITEMS[:] = []
-
     ok = ss_mod.ensure_sync()
-    assert ok is True
-    assert host_fs[ss_mod.HOST_SERVICE_CHECKER] == b"service-checker-default"
+    assert ok is False
+    # service_checker should NOT be overwritten
+    assert host_fs[ss_mod.HOST_SERVICE_CHECKER] == b"old-service-checker"
 
 
 def test_ensure_sync_202411_missing_service_checker_fails(ss):

--- a/dockers/docker-telemetry-sidecar/systemd_stub.py
+++ b/dockers/docker-telemetry-sidecar/systemd_stub.py
@@ -32,16 +32,21 @@ def _parse_client_certs() -> List[Dict[str, str]]:
             entries = json.loads(raw)
             if not isinstance(entries, list):
                 raise ValueError("GNMI_CLIENT_CERTS must be a JSON array")
-            normalized: List[Dict[str, str]] = []
+            normalized: list = []
             for e in entries:
                 if not isinstance(e, dict):
                     raise ValueError(f"Each entry must be an object: {e!r}")
                 if "cname" not in e or "role" not in e:
                     raise ValueError(f"Each entry needs 'cname' and 'role': {e}")
                 cname = str(e.get("cname", "")).strip()
-                role = str(e.get("role", "")).strip()
+                role_raw = e.get("role", "")
+                if isinstance(role_raw, list):
+                    role = [str(r).strip() for r in role_raw if str(r).strip()]
+                else:
+                    s = str(role_raw).strip()
+                    role = [s] if s else []
                 if not cname or not role:
-                    raise ValueError(f"'cname' and 'role' must be non-empty strings: {e}")
+                    raise ValueError(f"'cname' and 'role' must be non-empty: {e}")
                 normalized.append({"cname": cname, "role": role})
             return normalized
         except (json.JSONDecodeError, ValueError) as exc:
@@ -51,7 +56,7 @@ def _parse_client_certs() -> List[Dict[str, str]]:
     cname = os.getenv("TELEMETRY_CLIENT_CNAME", "").strip()
     role = os.getenv("GNMI_CLIENT_ROLE", "gnmi_show_readonly").strip()
     if cname:
-        return [{"cname": cname, "role": role}]
+        return [{"cname": cname, "role": [role]}]
     return []
 
 
@@ -174,14 +179,42 @@ def _ensure_user_auth_cert() -> None:
             logger.log_error("Failed to set TELEMETRY|gnmi.user_auth=cert")
 
 
-def _ensure_cname_present(cname: str, role: str) -> None:
+def _normalize_role(value) -> List[str]:
+    """Normalize a role value from CONFIG_DB into a canonical List[str].
+
+    Handles:
+      - list (correct format from ConfigDBConnector leaf-list) → as-is
+      - plain string "admin" → ["admin"]
+      - JSON-encoded string '["admin","readonly"]' → ["admin", "readonly"]
+    """
+    if isinstance(value, list):
+        return [str(v).strip() for v in value if str(v).strip()]
+    if not isinstance(value, str) or not value.strip():
+        return []
+    s = value.strip()
+    if s.startswith("["):
+        try:
+            parsed = json.loads(s)
+            if isinstance(parsed, list):
+                return [str(v).strip() for v in parsed if str(v).strip()]
+        except (json.JSONDecodeError, ValueError):
+            pass
+    return [s]
+
+
+def _ensure_cname_present(cname: str, role: List[str]) -> None:
     key = f"GNMI_CLIENT_CERT|{cname}"
     entry = db_hgetall(key)
-    if not entry:
-        if db_hset(key, "role", role):
-            logger.log_notice(f"Created {key} with role={role}")
+    stored_role = entry.get("role") if entry else None
+    if entry and isinstance(stored_role, list) and _normalize_role(stored_role) == role:
+        return
+    if db_hset(key, "role", role):
+        if entry:
+            logger.log_notice(f"Updated {key} role={role} (was: {entry.get('role')})")
         else:
-            logger.log_error(f"Failed to create {key}")
+            logger.log_notice(f"Created {key} with role={role}")
+    else:
+        logger.log_error(f"Failed to set {key}")
 
 
 def _ensure_cname_absent(cname: str) -> None:
@@ -265,17 +298,13 @@ def ensure_sync() -> bool:
     _cleanup_stale_service_unit()
     branch_name = _get_branch_name()
 
-    if branch_name in ("202411", "202412", "202505"):
-        # For 202411/202412/202505 branches, use the branch-specific container_checker
-        container_checker_src = f"/usr/share/sonic/systemd_scripts/container_checker_{branch_name}"
-        # For 202411/202412/202505 branches, use the branch-specific service_checker
-        service_checker_src = f"/usr/share/sonic/systemd_scripts/service_checker.py_{branch_name}"
-    else:
-        # For other branches, use the default container_checker
-        container_checker_src = "/usr/share/sonic/systemd_scripts/container_checker"
-        # For other branches, use the default service_checker
-        service_checker_src = "/usr/share/sonic/systemd_scripts/service_checker.py"
+    if branch_name not in ("202411", "202412", "202505"):
+        logger.log_error(f"Unsupported branch '{branch_name}'; aborting sync to trigger rollback")
+        return False
 
+    # For supported branches, use the branch-specific container_checker and service_checker
+    container_checker_src = f"/usr/share/sonic/systemd_scripts/container_checker_{branch_name}"
+    service_checker_src = f"/usr/share/sonic/systemd_scripts/service_checker.py_{branch_name}"
     items: List[SyncItem] = SYNC_ITEMS + [
         SyncItem(container_checker_src, "/bin/container_checker"),
         SyncItem(service_checker_src, HOST_SERVICE_CHECKER),

--- a/src/sonic-py-common/sonic_py_common/sidecar_common.py
+++ b/src/sonic-py-common/sonic_py_common/sidecar_common.py
@@ -10,7 +10,7 @@ import hashlib
 import shlex
 import subprocess
 from dataclasses import dataclass
-from typing import List, Optional, Tuple, Dict
+from typing import List, Optional, Tuple, Dict, Union
 
 from swsscommon.swsscommon import ConfigDBConnector
 from sonic_py_common import logger as log
@@ -121,7 +121,7 @@ def db_hgetall(key: str) -> Dict[str, str]:
         return {}
 
 
-def db_hset(key: str, field: str, value: str) -> bool:
+def db_hset(key: str, field: str, value: Union[str, List[str]]) -> bool:
     """Set a single field value in CONFIG_DB hash."""
     db = _get_config_db()
     if db is None:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The telemetry-sidecar wrote GNMI_CLIENT_CERT role as a stringified JSON string (e.g. '["admin"]') instead of a proper YANG leaf-list, causing sonic-cfggen YANG validation to fail with "Duplicated instance of role leaf-list". Additionally, ensure_sync() would overwrite container_checker and service_checker.py with default files on unsupported SONiC branches, which could break the container and introduce rollback.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Parse role as List[str] in _parse_client_certs() and make _ensure_cname_present() overwrite stale/mismatched role values.
Add _normalize_role() to handle legacy formats (plain string, JSON-encoded string, proper list) for idempotent comparison.
Abort ensure_sync() with error for unsupported SONiC branches (not in 202411/202412/202505) to trigger Kubernetes rollback.

#### How to verify it
<img width="2076" height="145" alt="image" src="https://github.com/user-attachments/assets/cad19237-ab79-42b6-a55a-3ca20829b9aa" />

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

