### PR TITLE
[yang] Add sample_rate and truncate_size to sonic-mirror-session

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
@@ -125,6 +125,14 @@
         "desc": "Configuring ERSPAN entry with sample_rate below minimum (100).",
         "eStr": "Sample rate must be 0 (no sampling/full mirroring) or 256-8388608"
     },
+    "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_ONE": {
+        "desc": "Configuring ERSPAN entry with sample_rate=1 (in the invalid 1-255 gap).",
+        "eStr": "Sample rate must be 0 (no sampling/full mirroring) or 256-8388608"
+    },
+    "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_255": {
+        "desc": "Configuring ERSPAN entry with sample_rate=255 (boundary of invalid 1-255 gap).",
+        "eStr": "Sample rate must be 0 (no sampling/full mirroring) or 256-8388608"
+    },
     "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_TOO_HIGH": {
         "desc": "Configuring ERSPAN entry with sample_rate above maximum (8388609).",
         "eStr": "Sample rate must be 0 (no sampling/full mirroring) or 256-8388608"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
@@ -123,19 +123,19 @@
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_TOO_LOW": {
         "desc": "Configuring ERSPAN entry with sample_rate below minimum (100).",
-        "eStr": "Sample rate must be 0 (disabled) or 256-8388608"
+        "eStr": "Sample rate must be 0 (no sampling/full mirroring) or 256-8388608"
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_TOO_HIGH": {
         "desc": "Configuring ERSPAN entry with sample_rate above maximum (8388609).",
-        "eStr": "Sample rate must be 0 (disabled) or 256-8388608"
+        "eStr": "Sample rate must be 0 (no sampling/full mirroring) or 256-8388608"
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_TRUNCATE_SIZE_TOO_LOW": {
         "desc": "Configuring ERSPAN entry with truncate_size below minimum (32).",
-        "eStr": "Truncate size must be 0 (disabled) or 64-9216 bytes"
+        "eStr": "Truncate size must be 0 (no truncation) or 64-9216 bytes"
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_TRUNCATE_SIZE_TOO_HIGH": {
         "desc": "Configuring ERSPAN entry with truncate_size above maximum (9217).",
-        "eStr": "Truncate size must be 0 (disabled) or 64-9216 bytes"
+        "eStr": "Truncate size must be 0 (no truncation) or 64-9216 bytes"
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_TYPE": {
         "desc": "Configuring SPAN entry with sample_rate (ERSPAN only).",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
@@ -152,5 +152,8 @@
     "MIRROR_ERSPAN_ENTRY_WRONG_TRUNCATE_SIZE_TYPE": {
         "desc": "Configuring SPAN entry with truncate_size (ERSPAN only).",
         "eStrKey": "When"
+    },
+    "MIRROR_ERSPAN_ENTRY_WITH_ZERO_SAMPLE_RATE_AND_TRUNCATE": {
+        "desc": "Configuring ERSPAN entry with sample_rate=0 and truncate_size=0 (disabled/full mirroring)."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
@@ -99,5 +99,50 @@
     "MIRROR_ERSPAN_ENTRY_WITH_INVALID_POLICER": {
         "desc": "Configuring SPAN entry with invalid policer",
         "eStrKey": "LeafRef"
+    },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_SAMPLE_RATE": {
+        "desc": "Configuring ERSPAN entry with valid sample_rate (50000)."
+    },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_SAMPLE_RATE_MIN": {
+        "desc": "Configuring ERSPAN entry with minimum valid sample_rate (256)."
+    },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_SAMPLE_RATE_MAX": {
+        "desc": "Configuring ERSPAN entry with maximum valid sample_rate (8388608)."
+    },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_TRUNCATE_SIZE": {
+        "desc": "Configuring ERSPAN entry with valid truncate_size (128)."
+    },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_TRUNCATE_SIZE_MIN": {
+        "desc": "Configuring ERSPAN entry with minimum valid truncate_size (64)."
+    },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_TRUNCATE_SIZE_MAX": {
+        "desc": "Configuring ERSPAN entry with maximum valid truncate_size (9216)."
+    },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_SAMPLE_RATE_AND_TRUNCATE": {
+        "desc": "Configuring ERSPAN entry with both sample_rate and truncate_size."
+    },
+    "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_TOO_LOW": {
+        "desc": "Configuring ERSPAN entry with sample_rate below minimum (100).",
+        "eStr": "Sample rate must be 0 (disabled) or 256-8388608"
+    },
+    "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_TOO_HIGH": {
+        "desc": "Configuring ERSPAN entry with sample_rate above maximum (8388609).",
+        "eStr": "Sample rate must be 0 (disabled) or 256-8388608"
+    },
+    "MIRROR_ERSPAN_ENTRY_WRONG_TRUNCATE_SIZE_TOO_LOW": {
+        "desc": "Configuring ERSPAN entry with truncate_size below minimum (32).",
+        "eStr": "Truncate size must be 0 (disabled) or 64-9216 bytes"
+    },
+    "MIRROR_ERSPAN_ENTRY_WRONG_TRUNCATE_SIZE_TOO_HIGH": {
+        "desc": "Configuring ERSPAN entry with truncate_size above maximum (9217).",
+        "eStr": "Truncate size must be 0 (disabled) or 64-9216 bytes"
+    },
+    "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_TYPE": {
+        "desc": "Configuring SPAN entry with sample_rate (ERSPAN only).",
+        "eStrKey": "When"
+    },
+    "MIRROR_ERSPAN_ENTRY_WRONG_TRUNCATE_SIZE_TYPE": {
+        "desc": "Configuring SPAN entry with truncate_size (ERSPAN only).",
+        "eStrKey": "When"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
@@ -123,27 +123,19 @@
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_TOO_LOW": {
         "desc": "Configuring ERSPAN entry with sample_rate below minimum (100).",
-        "eStr": "Sample rate must be 0 (no sampling/full mirroring) or 256-8388608"
-    },
-    "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_ONE": {
-        "desc": "Configuring ERSPAN entry with sample_rate=1 (in the invalid 1-255 gap).",
-        "eStr": "Sample rate must be 0 (no sampling/full mirroring) or 256-8388608"
-    },
-    "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_255": {
-        "desc": "Configuring ERSPAN entry with sample_rate=255 (boundary of invalid 1-255 gap).",
-        "eStr": "Sample rate must be 0 (no sampling/full mirroring) or 256-8388608"
+        "eStr": "Sample rate must be 256..8388608"
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_TOO_HIGH": {
         "desc": "Configuring ERSPAN entry with sample_rate above maximum (8388609).",
-        "eStr": "Sample rate must be 0 (no sampling/full mirroring) or 256-8388608"
+        "eStr": "Sample rate must be 256..8388608"
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_TRUNCATE_SIZE_TOO_LOW": {
         "desc": "Configuring ERSPAN entry with truncate_size below minimum (32).",
-        "eStr": "Truncate size must be 0 (no truncation) or 64-9216 bytes"
+        "eStr": "Truncate size must be 64..9216"
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_TRUNCATE_SIZE_TOO_HIGH": {
         "desc": "Configuring ERSPAN entry with truncate_size above maximum (9217).",
-        "eStr": "Truncate size must be 0 (no truncation) or 64-9216 bytes"
+        "eStr": "Truncate size must be 64..9216"
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_TYPE": {
         "desc": "Configuring SPAN entry with sample_rate (ERSPAN only).",
@@ -152,8 +144,5 @@
     "MIRROR_ERSPAN_ENTRY_WRONG_TRUNCATE_SIZE_TYPE": {
         "desc": "Configuring SPAN entry with truncate_size (ERSPAN only).",
         "eStrKey": "When"
-    },
-    "MIRROR_ERSPAN_ENTRY_WITH_ZERO_SAMPLE_RATE_AND_TRUNCATE": {
-        "desc": "Configuring ERSPAN entry with sample_rate=0 and truncate_size=0 (disabled/full mirroring)."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
@@ -101,40 +101,40 @@
         "eStrKey": "LeafRef"
     },
     "MIRROR_ERSPAN_ENTRY_WITH_VALID_SAMPLE_RATE": {
-        "desc": "Configuring ERSPAN entry with valid sample_rate (50000)."
+        "desc": "Configuring ERSPAN entry with a valid sample_rate."
     },
     "MIRROR_ERSPAN_ENTRY_WITH_VALID_SAMPLE_RATE_MIN": {
-        "desc": "Configuring ERSPAN entry with minimum valid sample_rate (256)."
+        "desc": "Configuring ERSPAN entry with the minimum valid sample_rate."
     },
     "MIRROR_ERSPAN_ENTRY_WITH_VALID_SAMPLE_RATE_MAX": {
-        "desc": "Configuring ERSPAN entry with maximum valid sample_rate (8388608)."
+        "desc": "Configuring ERSPAN entry with the maximum valid sample_rate."
     },
     "MIRROR_ERSPAN_ENTRY_WITH_VALID_TRUNCATE_SIZE": {
-        "desc": "Configuring ERSPAN entry with valid truncate_size (128)."
+        "desc": "Configuring ERSPAN entry with a valid truncate_size."
     },
     "MIRROR_ERSPAN_ENTRY_WITH_VALID_TRUNCATE_SIZE_MIN": {
-        "desc": "Configuring ERSPAN entry with minimum valid truncate_size (64)."
+        "desc": "Configuring ERSPAN entry with the minimum valid truncate_size."
     },
     "MIRROR_ERSPAN_ENTRY_WITH_VALID_TRUNCATE_SIZE_MAX": {
-        "desc": "Configuring ERSPAN entry with maximum valid truncate_size (9216)."
+        "desc": "Configuring ERSPAN entry with the maximum valid truncate_size."
     },
     "MIRROR_ERSPAN_ENTRY_WITH_VALID_SAMPLE_RATE_AND_TRUNCATE": {
         "desc": "Configuring ERSPAN entry with both sample_rate and truncate_size."
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_TOO_LOW": {
-        "desc": "Configuring ERSPAN entry with sample_rate below minimum (100).",
+        "desc": "Configuring ERSPAN entry with a sample_rate below the allowed range.",
         "eStr": "Sample rate must be 256..8388608"
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_TOO_HIGH": {
-        "desc": "Configuring ERSPAN entry with sample_rate above maximum (8388609).",
+        "desc": "Configuring ERSPAN entry with a sample_rate above the allowed range.",
         "eStr": "Sample rate must be 256..8388608"
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_TRUNCATE_SIZE_TOO_LOW": {
-        "desc": "Configuring ERSPAN entry with truncate_size below minimum (32).",
+        "desc": "Configuring ERSPAN entry with a truncate_size below the allowed range.",
         "eStr": "Truncate size must be 64..9216"
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_TRUNCATE_SIZE_TOO_HIGH": {
-        "desc": "Configuring ERSPAN entry with truncate_size above maximum (9217).",
+        "desc": "Configuring ERSPAN entry with a truncate_size above the allowed range.",
         "eStr": "Truncate size must be 64..9216"
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_TYPE": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/mirror_session.json
@@ -106,9 +106,6 @@
     "MIRROR_ERSPAN_ENTRY_WITH_VALID_SAMPLE_RATE_MIN": {
         "desc": "Configuring ERSPAN entry with the minimum valid sample_rate."
     },
-    "MIRROR_ERSPAN_ENTRY_WITH_VALID_SAMPLE_RATE_MAX": {
-        "desc": "Configuring ERSPAN entry with the maximum valid sample_rate."
-    },
     "MIRROR_ERSPAN_ENTRY_WITH_VALID_TRUNCATE_SIZE": {
         "desc": "Configuring ERSPAN entry with a valid truncate_size."
     },
@@ -123,11 +120,7 @@
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_TOO_LOW": {
         "desc": "Configuring ERSPAN entry with a sample_rate below the allowed range.",
-        "eStr": "Sample rate must be 256..8388608"
-    },
-    "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_TOO_HIGH": {
-        "desc": "Configuring ERSPAN entry with a sample_rate above the allowed range.",
-        "eStr": "Sample rate must be 256..8388608"
+        "eStr": "Sample rate must be in range 2..max"
     },
     "MIRROR_ERSPAN_ENTRY_WRONG_TRUNCATE_SIZE_TOO_LOW": {
         "desc": "Configuring ERSPAN entry with a truncate_size below the allowed range.",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
@@ -798,5 +798,23 @@
                 ]
             }
         }
+    },
+    "MIRROR_ERSPAN_ENTRY_WITH_ZERO_SAMPLE_RATE_AND_TRUNCATE": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "erspan",
+                        "type": "ERSPAN",
+                        "dst_ip": "11.1.1.1",
+                        "src_ip": "10.1.1.1",
+                        "gre_type": "0x1234",
+                        "dscp": "10",
+                        "sample_rate": "0",
+                        "truncate_size": "0"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
@@ -688,40 +688,6 @@
             }
         }
     },
-    "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_ONE": {
-        "sonic-mirror-session:sonic-mirror-session": {
-            "MIRROR_SESSION": {
-                "MIRROR_SESSION_LIST": [
-                    {
-                        "name": "erspan",
-                        "type": "ERSPAN",
-                        "dst_ip": "11.1.1.1",
-                        "src_ip": "10.1.1.1",
-                        "gre_type": "0x1234",
-                        "dscp": "10",
-                        "sample_rate": "1"
-                    }
-                ]
-            }
-        }
-    },
-    "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_255": {
-        "sonic-mirror-session:sonic-mirror-session": {
-            "MIRROR_SESSION": {
-                "MIRROR_SESSION_LIST": [
-                    {
-                        "name": "erspan",
-                        "type": "ERSPAN",
-                        "dst_ip": "11.1.1.1",
-                        "src_ip": "10.1.1.1",
-                        "gre_type": "0x1234",
-                        "dscp": "10",
-                        "sample_rate": "255"
-                    }
-                ]
-            }
-        }
-    },
     "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_TOO_HIGH": {
         "sonic-mirror-session:sonic-mirror-session": {
             "MIRROR_SESSION": {
@@ -794,24 +760,6 @@
                         "name": "span",
                         "type": "SPAN",
                         "truncate_size": "128"
-                    }
-                ]
-            }
-        }
-    },
-    "MIRROR_ERSPAN_ENTRY_WITH_ZERO_SAMPLE_RATE_AND_TRUNCATE": {
-        "sonic-mirror-session:sonic-mirror-session": {
-            "MIRROR_SESSION": {
-                "MIRROR_SESSION_LIST": [
-                    {
-                        "name": "erspan",
-                        "type": "ERSPAN",
-                        "dst_ip": "11.1.1.1",
-                        "src_ip": "10.1.1.1",
-                        "gre_type": "0x1234",
-                        "dscp": "10",
-                        "sample_rate": "0",
-                        "truncate_size": "0"
                     }
                 ]
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
@@ -562,7 +562,7 @@
                         "src_ip": "10.1.1.1",
                         "gre_type": "0x1234",
                         "dscp": "10",
-                        "sample_rate": 50000
+                        "sample_rate": "50000"
                     }
                 ]
             }
@@ -579,7 +579,7 @@
                         "src_ip": "10.1.1.1",
                         "gre_type": "0x1234",
                         "dscp": "10",
-                        "sample_rate": 256
+                        "sample_rate": "256"
                     }
                 ]
             }
@@ -596,7 +596,7 @@
                         "src_ip": "10.1.1.1",
                         "gre_type": "0x1234",
                         "dscp": "10",
-                        "sample_rate": 8388608
+                        "sample_rate": "8388608"
                     }
                 ]
             }
@@ -613,7 +613,7 @@
                         "src_ip": "10.1.1.1",
                         "gre_type": "0x1234",
                         "dscp": "10",
-                        "truncate_size": 128
+                        "truncate_size": "128"
                     }
                 ]
             }
@@ -630,7 +630,7 @@
                         "src_ip": "10.1.1.1",
                         "gre_type": "0x1234",
                         "dscp": "10",
-                        "truncate_size": 64
+                        "truncate_size": "64"
                     }
                 ]
             }
@@ -647,7 +647,7 @@
                         "src_ip": "10.1.1.1",
                         "gre_type": "0x1234",
                         "dscp": "10",
-                        "truncate_size": 9216
+                        "truncate_size": "9216"
                     }
                 ]
             }
@@ -664,8 +664,8 @@
                         "src_ip": "10.1.1.1",
                         "gre_type": "0x1234",
                         "dscp": "10",
-                        "sample_rate": 50000,
-                        "truncate_size": 128
+                        "sample_rate": "50000",
+                        "truncate_size": "128"
                     }
                 ]
             }
@@ -682,7 +682,7 @@
                         "src_ip": "10.1.1.1",
                         "gre_type": "0x1234",
                         "dscp": "10",
-                        "sample_rate": 100
+                        "sample_rate": "100"
                     }
                 ]
             }
@@ -699,7 +699,7 @@
                         "src_ip": "10.1.1.1",
                         "gre_type": "0x1234",
                         "dscp": "10",
-                        "sample_rate": 8388609
+                        "sample_rate": "8388609"
                     }
                 ]
             }
@@ -716,7 +716,7 @@
                         "src_ip": "10.1.1.1",
                         "gre_type": "0x1234",
                         "dscp": "10",
-                        "truncate_size": 32
+                        "truncate_size": "32"
                     }
                 ]
             }
@@ -733,7 +733,7 @@
                         "src_ip": "10.1.1.1",
                         "gre_type": "0x1234",
                         "dscp": "10",
-                        "truncate_size": 9217
+                        "truncate_size": "9217"
                     }
                 ]
             }
@@ -746,7 +746,7 @@
                     {
                         "name": "span",
                         "type": "SPAN",
-                        "sample_rate": 50000
+                        "sample_rate": "50000"
                     }
                 ]
             }
@@ -759,7 +759,7 @@
                     {
                         "name": "span",
                         "type": "SPAN",
-                        "truncate_size": 128
+                        "truncate_size": "128"
                     }
                 ]
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
@@ -688,6 +688,40 @@
             }
         }
     },
+    "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_ONE": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "erspan",
+                        "type": "ERSPAN",
+                        "dst_ip": "11.1.1.1",
+                        "src_ip": "10.1.1.1",
+                        "gre_type": "0x1234",
+                        "dscp": "10",
+                        "sample_rate": "1"
+                    }
+                ]
+            }
+        }
+    },
+    "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_255": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "erspan",
+                        "type": "ERSPAN",
+                        "dst_ip": "11.1.1.1",
+                        "src_ip": "10.1.1.1",
+                        "gre_type": "0x1234",
+                        "dscp": "10",
+                        "sample_rate": "255"
+                    }
+                ]
+            }
+        }
+    },
     "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_TOO_HIGH": {
         "sonic-mirror-session:sonic-mirror-session": {
             "MIRROR_SESSION": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
@@ -550,5 +550,219 @@
                 ]
             }
         }
+    },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_SAMPLE_RATE": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "erspan",
+                        "type": "ERSPAN",
+                        "dst_ip": "11.1.1.1",
+                        "src_ip": "10.1.1.1",
+                        "gre_type": "0x1234",
+                        "dscp": "10",
+                        "sample_rate": 50000
+                    }
+                ]
+            }
+        }
+    },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_SAMPLE_RATE_MIN": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "erspan",
+                        "type": "ERSPAN",
+                        "dst_ip": "11.1.1.1",
+                        "src_ip": "10.1.1.1",
+                        "gre_type": "0x1234",
+                        "dscp": "10",
+                        "sample_rate": 256
+                    }
+                ]
+            }
+        }
+    },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_SAMPLE_RATE_MAX": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "erspan",
+                        "type": "ERSPAN",
+                        "dst_ip": "11.1.1.1",
+                        "src_ip": "10.1.1.1",
+                        "gre_type": "0x1234",
+                        "dscp": "10",
+                        "sample_rate": 8388608
+                    }
+                ]
+            }
+        }
+    },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_TRUNCATE_SIZE": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "erspan",
+                        "type": "ERSPAN",
+                        "dst_ip": "11.1.1.1",
+                        "src_ip": "10.1.1.1",
+                        "gre_type": "0x1234",
+                        "dscp": "10",
+                        "truncate_size": 128
+                    }
+                ]
+            }
+        }
+    },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_TRUNCATE_SIZE_MIN": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "erspan",
+                        "type": "ERSPAN",
+                        "dst_ip": "11.1.1.1",
+                        "src_ip": "10.1.1.1",
+                        "gre_type": "0x1234",
+                        "dscp": "10",
+                        "truncate_size": 64
+                    }
+                ]
+            }
+        }
+    },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_TRUNCATE_SIZE_MAX": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "erspan",
+                        "type": "ERSPAN",
+                        "dst_ip": "11.1.1.1",
+                        "src_ip": "10.1.1.1",
+                        "gre_type": "0x1234",
+                        "dscp": "10",
+                        "truncate_size": 9216
+                    }
+                ]
+            }
+        }
+    },
+    "MIRROR_ERSPAN_ENTRY_WITH_VALID_SAMPLE_RATE_AND_TRUNCATE": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "erspan",
+                        "type": "ERSPAN",
+                        "dst_ip": "11.1.1.1",
+                        "src_ip": "10.1.1.1",
+                        "gre_type": "0x1234",
+                        "dscp": "10",
+                        "sample_rate": 50000,
+                        "truncate_size": 128
+                    }
+                ]
+            }
+        }
+    },
+    "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_TOO_LOW": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "erspan",
+                        "type": "ERSPAN",
+                        "dst_ip": "11.1.1.1",
+                        "src_ip": "10.1.1.1",
+                        "gre_type": "0x1234",
+                        "dscp": "10",
+                        "sample_rate": 100
+                    }
+                ]
+            }
+        }
+    },
+    "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_TOO_HIGH": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "erspan",
+                        "type": "ERSPAN",
+                        "dst_ip": "11.1.1.1",
+                        "src_ip": "10.1.1.1",
+                        "gre_type": "0x1234",
+                        "dscp": "10",
+                        "sample_rate": 8388609
+                    }
+                ]
+            }
+        }
+    },
+    "MIRROR_ERSPAN_ENTRY_WRONG_TRUNCATE_SIZE_TOO_LOW": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "erspan",
+                        "type": "ERSPAN",
+                        "dst_ip": "11.1.1.1",
+                        "src_ip": "10.1.1.1",
+                        "gre_type": "0x1234",
+                        "dscp": "10",
+                        "truncate_size": 32
+                    }
+                ]
+            }
+        }
+    },
+    "MIRROR_ERSPAN_ENTRY_WRONG_TRUNCATE_SIZE_TOO_HIGH": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "erspan",
+                        "type": "ERSPAN",
+                        "dst_ip": "11.1.1.1",
+                        "src_ip": "10.1.1.1",
+                        "gre_type": "0x1234",
+                        "dscp": "10",
+                        "truncate_size": 9217
+                    }
+                ]
+            }
+        }
+    },
+    "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_TYPE": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "span",
+                        "type": "SPAN",
+                        "sample_rate": 50000
+                    }
+                ]
+            }
+        }
+    },
+    "MIRROR_ERSPAN_ENTRY_WRONG_TRUNCATE_SIZE_TYPE": {
+        "sonic-mirror-session:sonic-mirror-session": {
+            "MIRROR_SESSION": {
+                "MIRROR_SESSION_LIST": [
+                    {
+                        "name": "span",
+                        "type": "SPAN",
+                        "truncate_size": 128
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/mirror_session.json
@@ -579,24 +579,7 @@
                         "src_ip": "10.1.1.1",
                         "gre_type": "0x1234",
                         "dscp": "10",
-                        "sample_rate": "256"
-                    }
-                ]
-            }
-        }
-    },
-    "MIRROR_ERSPAN_ENTRY_WITH_VALID_SAMPLE_RATE_MAX": {
-        "sonic-mirror-session:sonic-mirror-session": {
-            "MIRROR_SESSION": {
-                "MIRROR_SESSION_LIST": [
-                    {
-                        "name": "erspan",
-                        "type": "ERSPAN",
-                        "dst_ip": "11.1.1.1",
-                        "src_ip": "10.1.1.1",
-                        "gre_type": "0x1234",
-                        "dscp": "10",
-                        "sample_rate": "8388608"
+                        "sample_rate": "2"
                     }
                 ]
             }
@@ -682,24 +665,7 @@
                         "src_ip": "10.1.1.1",
                         "gre_type": "0x1234",
                         "dscp": "10",
-                        "sample_rate": "100"
-                    }
-                ]
-            }
-        }
-    },
-    "MIRROR_ERSPAN_ENTRY_WRONG_SAMPLE_RATE_TOO_HIGH": {
-        "sonic-mirror-session:sonic-mirror-session": {
-            "MIRROR_SESSION": {
-                "MIRROR_SESSION_LIST": [
-                    {
-                        "name": "erspan",
-                        "type": "ERSPAN",
-                        "dst_ip": "11.1.1.1",
-                        "src_ip": "10.1.1.1",
-                        "gre_type": "0x1234",
-                        "dscp": "10",
-                        "sample_rate": "8388609"
+                        "sample_rate": "1"
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
@@ -20,6 +20,12 @@ module sonic-mirror-session {
     description
         "SONiC Mirror session yang model";
 
+    revision 2026-04-14 {
+        description
+            "Add sample_rate and truncate_size leaves for sampled port mirroring
+             with truncation support.";
+    }
+
     revision 2021-06-15 {
         description
             "Initial revision.";
@@ -187,7 +193,7 @@ module sonic-mirror-session {
                     when "current()/../type = 'ERSPAN'";
                     type uint32 {
                         range "0|256..8388608" {
-                            error-message "Sample rate must be 0 (disabled) or 256-8388608";
+                            error-message "Sample rate must be 0 (no sampling/full mirroring) or 256-8388608";
                             error-app-tag sample-rate-invalid;
                         }
                     }
@@ -201,7 +207,7 @@ module sonic-mirror-session {
                     when "current()/../type = 'ERSPAN'";
                     type uint32 {
                         range "0|64..9216" {
-                            error-message "Truncate size must be 0 (disabled) or 64-9216 bytes";
+                            error-message "Truncate size must be 0 (no sampling/full mirroring) or 64-9216 bytes";
                             error-app-tag truncate-size-invalid;
                         }
                     }

--- a/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
@@ -189,6 +189,7 @@ module sonic-mirror-session {
                     description
                         "Policer to be applied for the mirrored traffic.";
                 }
+                
                 leaf sample_rate {
                     when "current()/../type = 'ERSPAN'";
                     type uint32 {

--- a/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
@@ -189,7 +189,7 @@ module sonic-mirror-session {
                     description
                         "Policer to be applied for the mirrored traffic.";
                 }
-                
+
                 leaf sample_rate {
                     when "current()/../type = 'ERSPAN'";
                     type uint32 {

--- a/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
@@ -193,30 +193,29 @@ module sonic-mirror-session {
                 leaf sample_rate {
                     when "current()/../type = 'ERSPAN'";
                     type uint32 {
-                        range "0|256..8388608" {
-                            error-message "Sample rate must be 0 (no sampling/full mirroring) or 256-8388608";
+                        range "256..8388608" {
+                            error-message "Sample rate must be 256..8388608";
                             error-app-tag sample-rate-invalid;
                         }
                     }
-                    default 0;
                     description
-                        "Sampling rate for mirrored packets. 0 means full mirroring
-                         (no sampling). N means mirror 1 out of every N packets.";
+                        "Sampling rate for mirrored packets. When not configured,
+                         full mirroring is used (no sampling). N means mirror 1 out
+                         of every N packets.";
                 }
 
                 leaf truncate_size {
                     when "current()/../type = 'ERSPAN'";
                     type uint32 {
-                        range "0|64..9216" {
-                            error-message "Truncate size must be 0 (no truncation) or 64-9216 bytes";
+                        range "64..9216" {
+                            error-message "Truncate size must be 64..9216";
                             error-app-tag truncate-size-invalid;
                         }
                     }
-                    default 0;
                     description
                         "Truncation size in bytes for mirrored packets.
-                         0 means no truncation. When set, only the first N bytes
-                         of each mirrored packet are sent.";
+                         When not configured, no truncation is applied. When set,
+                         only the first N bytes of each mirrored packet are sent.";
                 }
             }
         }

--- a/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
@@ -183,6 +183,34 @@ module sonic-mirror-session {
                     description
                         "Policer to be applied for the mirrored traffic.";
                 }
+                leaf sample_rate {
+                    when "current()/../type = 'ERSPAN'";
+                    type uint32 {
+                        range "0|256..8388608" {
+                            error-message "Sample rate must be 0 (disabled) or 256-8388608";
+                            error-app-tag sample-rate-invalid;
+                        }
+                    }
+                    default 0;
+                    description
+                        "Sampling rate for mirrored packets. 0 means full mirroring
+                         (no sampling). N means mirror 1 out of every N packets.";
+                }
+
+                leaf truncate_size {
+                    when "current()/../type = 'ERSPAN'";
+                    type uint32 {
+                        range "0|64..9216" {
+                            error-message "Truncate size must be 0 (disabled) or 64-9216 bytes";
+                            error-app-tag truncate-size-invalid;
+                        }
+                    }
+                    default 0;
+                    description
+                        "Truncation size in bytes for mirrored packets.
+                         0 means no truncation. When set, only the first N bytes
+                         of each mirrored packet are sent.";
+                }
             }
         }
     }

--- a/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
@@ -207,7 +207,7 @@ module sonic-mirror-session {
                     when "current()/../type = 'ERSPAN'";
                     type uint32 {
                         range "0|64..9216" {
-                            error-message "Truncate size must be 0 (no sampling/full mirroring) or 64-9216 bytes";
+                            error-message "Truncate size must be 0 (no truncation) or 64-9216 bytes";
                             error-app-tag truncate-size-invalid;
                         }
                     }

--- a/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
@@ -193,8 +193,8 @@ module sonic-mirror-session {
                 leaf sample_rate {
                     when "current()/../type = 'ERSPAN'";
                     type uint32 {
-                        range "256..8388608" {
-                            error-message "Sample rate must be 256..8388608";
+                        range "2..max" {
+                            error-message "Sample rate must be in range 2..max";
                             error-app-tag sample-rate-invalid;
                         }
                     }


### PR DESCRIPTION
Add two new optional leaves to MIRROR_SESSION_LIST in sonic-mirror-session.yang for sampled port mirroring with truncation support:

 - sample_rate: optional, range
   2..max. When not configured, full mirroring is used (no sampling).
  - truncate_size: optional, range
   64..9216. When not configured, no truncation is applied.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
 Add YANG model support for the sampled port mirroring with truncation feature. This feature allows users to configure a sampling rate and truncation size on ERSPAN mirror sessions, reducing mirror 
bandwidth.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
 Added two new leaf definitions to the `MIRROR_SESSION_LIST` in `sonic-mirror-session.yang`, after the existing `policer` leaf. 
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
 Add `sample_rate` and `truncate_size` leaves to sonic-mirror-session YANG model for sampled port mirroring with truncation support.
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

