### PR TITLE
[build] Fix parallel RFS build race condition on shared fsroot

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -32,7 +32,6 @@ CONTAINERD_IO_VERSION=1.7.28-2~debian.13~$IMAGE_DISTRO
 LINUX_KERNEL_VERSION=6.12.41+deb13
 
 ## Working directory to prepare the file system
-FILESYSTEM_ROOT=./fsroot
 PLATFORM_DIR=platform
 ## Hostname for the linux image
 HOSTNAME=sonic


### PR DESCRIPTION
Fixes #26733. Removed dead code in build_debian.sh that hardcoded FILESYSTEM_ROOT=./fsroot, which caused parallel dependent RFS builds to clobber each other's directories.