### PR TITLE
[Platform][Arista] Update TM port header type of J2CP to support runtime speed change

### DIFF
--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
@@ -485,16 +485,16 @@ ucode_port_154.BCM8869X=RCY_MIRROR.27:core_1.142
 
 port_priorities.BCM8869X=8
 
-tm_port_header_type_in_0.BCM8869X=INJECTED_2_PP
+tm_port_header_type_in_0.BCM8869X=INJECTED
 tm_port_header_type_out_0.BCM8869X=CPU
 
-tm_port_header_type_in_200.BCM8869X=INJECTED_2_PP
+tm_port_header_type_in_200.BCM8869X=INJECTED
 tm_port_header_type_out_200.BCM8869X=ETH
-tm_port_header_type_in_201.BCM8869X=INJECTED_2_PP
+tm_port_header_type_in_201.BCM8869X=INJECTED
 tm_port_header_type_out_201.BCM8869X=ETH
-tm_port_header_type_in_202.BCM8869X=INJECTED_2_PP
+tm_port_header_type_in_202.BCM8869X=INJECTED
 tm_port_header_type_out_202.BCM8869X=ETH
-tm_port_header_type_in_203.BCM8869X=INJECTED_2_PP
+tm_port_header_type_in_203.BCM8869X=INJECTED
 tm_port_header_type_out_203.BCM8869X=ETH
 
 sat_enable.BCM8869X=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -240,16 +240,16 @@ stable_size=800000000
 #########################
 #########################
 
-tm_port_header_type_in_0=INJECTED_2_PP
+tm_port_header_type_in_0=INJECTED
 tm_port_header_type_out_0=CPU
 
-tm_port_header_type_in_200=INJECTED_2_PP
+tm_port_header_type_in_200=INJECTED
 tm_port_header_type_out_200=ETH
-tm_port_header_type_in_201=INJECTED_2_PP
+tm_port_header_type_in_201=INJECTED
 tm_port_header_type_out_201=ETH
-tm_port_header_type_in_202=INJECTED_2_PP
+tm_port_header_type_in_202=INJECTED
 tm_port_header_type_out_202=ETH
-tm_port_header_type_in_203=INJECTED_2_PP
+tm_port_header_type_in_203=INJECTED
 tm_port_header_type_out_203=ETH
 
 ### RCY

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -240,16 +240,16 @@ stable_size=800000000
 #########################
 #########################
 
-tm_port_header_type_in_0=INJECTED_2_PP
+tm_port_header_type_in_0=INJECTED
 tm_port_header_type_out_0=CPU
 
-tm_port_header_type_in_200=INJECTED_2_PP
+tm_port_header_type_in_200=INJECTED
 tm_port_header_type_out_200=ETH
-tm_port_header_type_in_201=INJECTED_2_PP
+tm_port_header_type_in_201=INJECTED
 tm_port_header_type_out_201=ETH
-tm_port_header_type_in_202=INJECTED_2_PP
+tm_port_header_type_in_202=INJECTED
 tm_port_header_type_out_202=ETH
-tm_port_header_type_in_203=INJECTED_2_PP
+tm_port_header_type_in_203=INJECTED
 tm_port_header_type_out_203=ETH
 
 ### RCY

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -258,16 +258,16 @@ stable_size=800000000
 #########################
 #########################
 
-tm_port_header_type_in_0=INJECTED_2_PP
+tm_port_header_type_in_0=INJECTED
 tm_port_header_type_out_0=CPU
 
-tm_port_header_type_in_200=INJECTED_2_PP
+tm_port_header_type_in_200=INJECTED
 tm_port_header_type_out_200=ETH
-tm_port_header_type_in_201=INJECTED_2_PP
+tm_port_header_type_in_201=INJECTED
 tm_port_header_type_out_201=ETH
-tm_port_header_type_in_202=INJECTED_2_PP
+tm_port_header_type_in_202=INJECTED
 tm_port_header_type_out_202=ETH
-tm_port_header_type_in_203=INJECTED_2_PP
+tm_port_header_type_in_203=INJECTED
 tm_port_header_type_out_203=ETH
 
 ### RCY

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -258,16 +258,16 @@ stable_size=800000000
 #########################
 #########################
 
-tm_port_header_type_in_0=INJECTED_2_PP
+tm_port_header_type_in_0=INJECTED
 tm_port_header_type_out_0=CPU
 
-tm_port_header_type_in_200=INJECTED_2_PP
+tm_port_header_type_in_200=INJECTED
 tm_port_header_type_out_200=ETH
-tm_port_header_type_in_201=INJECTED_2_PP
+tm_port_header_type_in_201=INJECTED
 tm_port_header_type_out_201=ETH
-tm_port_header_type_in_202=INJECTED_2_PP
+tm_port_header_type_in_202=INJECTED
 tm_port_header_type_out_202=ETH
-tm_port_header_type_in_203=INJECTED_2_PP
+tm_port_header_type_in_203=INJECTED
 tm_port_header_type_out_203=ETH
 
 ### RCY

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -240,16 +240,16 @@ stable_size=800000000
 #########################
 #########################
 
-tm_port_header_type_in_0=INJECTED_2_PP
+tm_port_header_type_in_0=INJECTED
 tm_port_header_type_out_0=CPU
 
-tm_port_header_type_in_200=INJECTED_2_PP
+tm_port_header_type_in_200=INJECTED
 tm_port_header_type_out_200=ETH
-tm_port_header_type_in_201=INJECTED_2_PP
+tm_port_header_type_in_201=INJECTED
 tm_port_header_type_out_201=ETH
-tm_port_header_type_in_202=INJECTED_2_PP
+tm_port_header_type_in_202=INJECTED
 tm_port_header_type_out_202=ETH
-tm_port_header_type_in_203=INJECTED_2_PP
+tm_port_header_type_in_203=INJECTED
 tm_port_header_type_out_203=ETH
 
 ### RCY

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -240,16 +240,16 @@ stable_size=800000000
 #########################
 #########################
 
-tm_port_header_type_in_0=INJECTED_2_PP
+tm_port_header_type_in_0=INJECTED
 tm_port_header_type_out_0=CPU
 
-tm_port_header_type_in_200=INJECTED_2_PP
+tm_port_header_type_in_200=INJECTED
 tm_port_header_type_out_200=ETH
-tm_port_header_type_in_201=INJECTED_2_PP
+tm_port_header_type_in_201=INJECTED
 tm_port_header_type_out_201=ETH
-tm_port_header_type_in_202=INJECTED_2_PP
+tm_port_header_type_in_202=INJECTED
 tm_port_header_type_out_202=ETH
-tm_port_header_type_in_203=INJECTED_2_PP
+tm_port_header_type_in_203=INJECTED
 tm_port_header_type_out_203=ETH
 
 ### RCY


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Update TM port header type to support runtime speed change.
See CSP CS00012420395 for details.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

