### PR TITLE
BGP confederation support for Regional Hub devices

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -21,6 +21,13 @@ ip prefix-list PL_LoopbackV4 permit {{ lo0_ipv4 }}/32
 {% set disagg_t2 = "true" %}
 {% endif%}
 {% endif %}
+{# Check if the device is a disaggregated Regional Hub device #}
+{% set disagg_rh = "false" %}
+{% if (DEVICE_METADATA is defined) and ('localhost' in DEVICE_METADATA) and ('type' in DEVICE_METADATA['localhost']) %}
+{% if DEVICE_METADATA['localhost']['type'].lower() in ['lowerregionalhub', 'fabricregionalhub', 'upperregionalhub']%}
+{% set disagg_rh = "true" %}
+{% endif%}
+{% endif %}
 {% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") != 'None' %}
 {% if ( ('localhost' in DEVICE_METADATA) and ('bgp_adv_lo_prefix_as_128' in  DEVICE_METADATA['localhost']) and
         (DEVICE_METADATA['localhost']['bgp_adv_lo_prefix_as_128'] == 'true') ) %}
@@ -87,7 +94,7 @@ route-map HIDE_INTERNAL permit 20
 {% if (DEVICE_METADATA is defined) and ('localhost' in DEVICE_METADATA) and ('bgp_asn' in DEVICE_METADATA['localhost']) and (DEVICE_METADATA['localhost']['bgp_asn'].lower() != 'none') and (DEVICE_METADATA['localhost']['bgp_asn'].lower() != 'null') %}
 router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 !
-{% if disagg_t2  == "true" %}
+{% if disagg_t2  == "true" or disagg_rh == "true" %}
 {% if (BGP_DEVICE_GLOBAL is defined) and ('CONFED' in BGP_DEVICE_GLOBAL) and ('asn' in BGP_DEVICE_GLOBAL['CONFED'] )  %}
   bgp confederation identifier {{ BGP_DEVICE_GLOBAL['CONFED']['asn'] }}
 {% endif %}

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_frh.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_frh.conf
@@ -1,0 +1,26 @@
+!
+! template: bgpd/bgpd.main.conf.j2
+!
+! bgp multiple-instance
+!
+! BGP configuration
+!
+! TSA configuration
+!
+ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
+!
+router bgp 65001
+!
+  bgp confederation identifier 65000
+  bgp confederation peers 65001 65002
+  bgp log-neighbor-changes
+  bgp suppress-fib-pending
+  no bgp default ipv4-unicast
+  no bgp ebgp-requires-policy
+!
+  bgp router-id 55.55.55.55
+!
+  network 55.55.55.55/32
+!
+! end of template: bgpd/bgpd.main.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_frh.json
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_frh.json
@@ -1,0 +1,25 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "bgp_asn": "65001",
+            "type": "FabricRegionalHub"
+        }
+    },
+    "BGP_DEVICE_GLOBAL": {
+        "CONFED" : {
+            "asn": "65000",
+            "peers": "65001;65002"
+        }
+    },
+    "LOOPBACK_INTERFACE": {
+        "Loopback0|55.55.55.55/32": {},
+        "Loopback1|fc00::1/128": {}
+    },
+    "constants": {
+        "bgp": {
+            "multipath_relax": {},
+            "graceful_restart": {},
+            "maximum_paths": {}
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_lrh.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_lrh.conf
@@ -1,0 +1,26 @@
+!
+! template: bgpd/bgpd.main.conf.j2
+!
+! bgp multiple-instance
+!
+! BGP configuration
+!
+! TSA configuration
+!
+ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
+!
+router bgp 65001
+!
+  bgp confederation identifier 65000
+  bgp confederation peers 65001 65002
+  bgp log-neighbor-changes
+  bgp suppress-fib-pending
+  no bgp default ipv4-unicast
+  no bgp ebgp-requires-policy
+!
+  bgp router-id 55.55.55.55
+!
+  network 55.55.55.55/32
+!
+! end of template: bgpd/bgpd.main.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_lrh.json
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_lrh.json
@@ -1,0 +1,25 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "bgp_asn": "65001",
+            "type": "LowerRegionalHub"
+        }
+    },
+    "BGP_DEVICE_GLOBAL": {
+        "CONFED" : {
+            "asn": "65000",
+            "peers": "65001;65002"
+        }
+    },
+    "LOOPBACK_INTERFACE": {
+        "Loopback0|55.55.55.55/32": {},
+        "Loopback1|fc00::1/128": {}
+    },
+    "constants": {
+        "bgp": {
+            "multipath_relax": {},
+            "graceful_restart": {},
+            "maximum_paths": {}
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_urh.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_urh.conf
@@ -1,0 +1,26 @@
+!
+! template: bgpd/bgpd.main.conf.j2
+!
+! bgp multiple-instance
+!
+! BGP configuration
+!
+! TSA configuration
+!
+ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
+!
+router bgp 65001
+!
+  bgp confederation identifier 65000
+  bgp confederation peers 65001 65002
+  bgp log-neighbor-changes
+  bgp suppress-fib-pending
+  no bgp default ipv4-unicast
+  no bgp ebgp-requires-policy
+!
+  bgp router-id 55.55.55.55
+!
+  network 55.55.55.55/32
+!
+! end of template: bgpd/bgpd.main.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_urh.json
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_urh.json
@@ -1,0 +1,25 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "bgp_asn": "65001",
+            "type": "UpperRegionalHub"
+        }
+    },
+    "BGP_DEVICE_GLOBAL": {
+        "CONFED" : {
+            "asn": "65000",
+            "peers": "65001;65002"
+        }
+    },
+    "LOOPBACK_INTERFACE": {
+        "Loopback0|55.55.55.55/32": {},
+        "Loopback1|fc00::1/128": {}
+    },
+    "constants": {
+        "bgp": {
+            "multipath_relax": {},
+            "graceful_restart": {},
+            "maximum_paths": {}
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/test_sonic-cfggen.py
+++ b/src/sonic-bgpcfgd/tests/test_sonic-cfggen.py
@@ -242,3 +242,21 @@ def test_bgp_confed_ft2_single_asic():
              "bgpd/bgpd.main.conf.j2",
              "bgpd.main.conf.j2/single_asic_ft2.json",
              "bgpd.main.conf.j2/single_asic_ft2.conf")
+
+def test_bgp_confed_lrh_single_asic():
+    run_test("BGP Confederation LowerRegionalHub Single-ASIC",
+             "bgpd/bgpd.main.conf.j2",
+             "bgpd.main.conf.j2/single_asic_lrh.json",
+             "bgpd.main.conf.j2/single_asic_lrh.conf")
+
+def test_bgp_confed_frh_single_asic():
+    run_test("BGP Confederation FabricRegionalHub Single-ASIC",
+             "bgpd/bgpd.main.conf.j2",
+             "bgpd.main.conf.j2/single_asic_frh.json",
+             "bgpd.main.conf.j2/single_asic_frh.conf")
+
+def test_bgp_confed_urh_single_asic():
+    run_test("BGP Confederation UpperRegionalHub Single-ASIC",
+             "bgpd/bgpd.main.conf.j2",
+             "bgpd.main.conf.j2/single_asic_urh.json",
+             "bgpd.main.conf.j2/single_asic_urh.conf")


### PR DESCRIPTION
## Why I did it
Extend BGP confederation support to disaggregated Regional Hub device types (LowerRegionalHub, FabricRegionalHub, UpperRegionalHub), similar to the existing support for disaggregated T2 devices (LowerSpineRouter, UpperSpineRouter, FabricSpineRouter) added in #26427.

## How I did it
- Added a new `disagg_rh` flag in `bgpd.main.conf.j2` for Regional Hub device types
- Used `disagg_rh` alongside existing `disagg_t2` flag to enable confederation identifier and peers configuration
- Added unit tests for all three new device types

## How to verify it
- Run bgpcfgd unit tests: `pytest src/sonic-bgpcfgd/tests/test_sonic-cfggen.py -v`
- Verify the new tests pass: `test_bgp_confed_lrh_single_asic`, `test_bgp_confed_frh_single_asic`, `test_bgp_confed_urh_single_asic`

## Description for the changelog
Add BGP confederation support for LowerRegionalHub, FabricRegionalHub, and UpperRegionalHub device types.