### PR TITLE
[202511] Update chrony.conf.j2 to bind Chrony to addresses instead of devices

### DIFF
--- a/files/image_config/chrony/chrony.conf.j2
+++ b/files/image_config/chrony/chrony.conf.j2
@@ -63,50 +63,56 @@ binddevice bridge-midplane
 {% endif -%}
 {% endif -%}
 
-{# use source interface if configured to send NTP requests, else use eth0 if running in mgmt
-vrf (default is not to listen on anything) -#}
-
-{# Set interface to listen on:
-     * Set global variable for configured source interface name.
-     * Set global boolean to indicate if the ip of the configured source
-       interface is configured.
-     * If the source interface is configured but no ip on that
-       interface, then listen on another interface based on existing logic. -#}
-{%- macro check_ip_on_interface(interface_name, table_name) %}
-    {%- set ns = namespace(valid_intf = 'false') %}
+{# Get interface address to listen on. Return the last IPv4 or IPv6 address on
+an interface, depending on the order it is traversed in CONFIG_DB. -#}
+{%- macro get_ip_on_interface(interface_name, table_name, use_ipv4) %}
+    {%- set ns = namespace(ip_address = 'false') %}
     {%- if table_name %}
         {%- for (name, source_prefix) in table_name|pfx_filter %}
             {%- if source_prefix and name == interface_name %}
-                {%- set ns.valid_intf = 'true' %}
+                {%- if ":" in source_prefix and not use_ipv4 %}
+                    {%- set ns.ip_address = source_prefix.split('/')[0] %}
+                {%- elif ":" not in source_prefix and use_ipv4 %}
+                    {%- set ns.ip_address = source_prefix.split('/')[0] %}
+                {%- endif %}
             {%- endif %}
         {%- endfor %}
     {%- endif %}
-{{ ns.valid_intf }}
+{{ ns.ip_address }}
 {%- endmacro %}
 
-{% set ns = namespace(source_intf = "") %}
-{%- set ns = namespace(source_intf_ip = 'false') %}
+{# use source interface if configured to send NTP requests; otherwise, rely on
+the kernel to route packets as needed. -#}
+{% set ns = namespace(source_intf = "", source_intf_ipv4 = 'false', source_intf_ipv6 = 'false') %}
 {%- if global.src_intf  %}
     {%- set ns.source_intf = global.src_intf %}
     {%- if ns.source_intf != "" %}
         {%- if ns.source_intf == "eth0" %}
-            {%- set ns.source_intf_ip = check_ip_on_interface(ns.source_intf, MGMT_INTERFACE) %}
+            {%- set ns.source_intf_ipv4 = get_ip_on_interface(ns.source_intf, MGMT_INTERFACE, true) %}
+            {%- set ns.source_intf_ipv6 = get_ip_on_interface(ns.source_intf, MGMT_INTERFACE, false) %}
         {%- elif ns.source_intf.startswith('Vlan') %}
-            {%- set ns.source_intf_ip = check_ip_on_interface(ns.source_intf, VLAN_INTERFACE) %}
+            {%- set ns.source_intf_ipv4 = get_ip_on_interface(ns.source_intf, VLAN_INTERFACE, true) %}
+            {%- set ns.source_intf_ipv6 = get_ip_on_interface(ns.source_intf, VLAN_INTERFACE, false) %}
         {%- elif ns.source_intf.startswith('Ethernet') %}
-            {%- set ns.source_intf_ip = check_ip_on_interface(ns.source_intf, INTERFACE) %}
+            {%- set ns.source_intf_ipv4 = get_ip_on_interface(ns.source_intf, INTERFACE, true) %}
+            {%- set ns.source_intf_ipv6 = get_ip_on_interface(ns.source_intf, INTERFACE, false) %}
         {%- elif ns.source_intf.startswith('PortChannel') %}
-            {%- set ns.source_intf_ip = check_ip_on_interface(ns.source_intf, PORTCHANNEL_INTERFACE) %}
+            {%- set ns.source_intf_ipv4 = get_ip_on_interface(ns.source_intf, PORTCHANNEL_INTERFACE, true) %}
+            {%- set ns.source_intf_ipv6 = get_ip_on_interface(ns.source_intf, PORTCHANNEL_INTERFACE, false) %}
         {%- elif ns.source_intf.startswith('Loopback') %}
-            {%- set ns.source_intf_ip = check_ip_on_interface(ns.source_intf, LOOPBACK_INTERFACE) %}
+            {%- set ns.source_intf_ipv4 = get_ip_on_interface(ns.source_intf, LOOPBACK_INTERFACE, true) %}
+            {%- set ns.source_intf_ipv6 = get_ip_on_interface(ns.source_intf, LOOPBACK_INTERFACE, false) %}
         {%- endif %}
     {%- endif %}
 {% endif %}
 
-{% if ns.source_intf_ip == 'true' -%}
-bindacqdevice {{ns.source_intf}}
-{% elif (NTP) and NTP['global']['vrf'] == 'mgmt' -%}
-bindacqdevice eth0
+{% if not ((NTP) and NTP['global']['vrf'] == 'mgmt') -%}
+{% if ns.source_intf_ipv4 != 'false' -%}
+bindacqaddress {{ns.source_intf_ipv4}}
+{% endif %}
+{% if ns.source_intf_ipv6 != 'false' -%}
+bindacqaddress {{ns.source_intf_ipv6}}
+{% endif %}
 {% endif %}
 
 # Use time sources from DHCP.


### PR DESCRIPTION
Cherry pick of #26160 to 202511

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

When SONiC is configured to use Loopback0 as the source interface for NTP requests, this will cause Chrony to bind to Loopback0 literally to send NTP requests. However, Loopback0 is just a loopback interface, and packets sent directly to that interface won't actually go anywhere.

What instead needs to happen is that Chrony needs to use the addresses assigned to Loopback0 instead of binding to the Loopback0 device; the routing rules and routing table that then gets set up will handle the routing correctly then.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Change the template file to get the IPv4 and IPv6 addresses (or just one, if only one is configured) on the interface, and use `bindacqaddress` to tell Chrony to use those source addresses. This does have the downside that if some setup has multiple IPv4 or multiple IPv6 addresses configured, only one will be used.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

After loading some config that has `src_intf` set, verify that `/etc/chrony.conf` contains one or two `bindacqaddress` lines, and contains no `bindacqdevice` lines.

Also verify that (assuming valid NTP servers have been specified), NTP is established using either `show ntp` or `chronyc -n` tracking, and that `tcpdump` shows NTP packets being sent and received.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

