### PR TITLE
Add vendor specific hook to populate management port status in STATE_DB

### DIFF
--- a/files/image_config/monit/mgmt_oper_status.py
+++ b/files/image_config/monit/mgmt_oper_status.py
@@ -2,11 +2,64 @@
 
 """
 """
+import os
 import sys
-import subprocess
 import syslog
 
+import sonic_platform.platform
 from swsscommon.swsscommon import SonicV2Connector
+
+
+def _get_kernel_operstate(intf):
+    """!
+    Read the kernel-reported operstate for a network interface.
+
+    @return 'up', 'down', or other kernel operstate string.
+    """
+    path = "/sys/class/net/{}/operstate".format(intf)
+    if not os.path.exists(path):
+        syslog.syslog(syslog.LOG_ERR,
+                      "operstate path does not exist: {}".format(path))
+        return "unknown"
+    with open(path, "r") as fh:
+        return fh.readline().strip().lower()
+
+
+def _has_platform_mgmt_link_check():
+    """!
+    Check whether this platform overrides the kernel-reported management port
+    link status via the platform API (get_management_port_link_status_override).
+    """
+    try:
+        chassis = sonic_platform.platform.Platform().get_chassis()
+    except Exception:
+        return False
+    return hasattr(chassis, "get_management_port_link_status_override")
+
+
+def _platform_mgmt_link_check(intf):
+    """!
+    Query the platform for the real management port link status via the
+    platform API. If the platform provides an override (returns True/False),
+    use it instead of the kernel operstate. If not implemented (returns None)
+    or on error, return None to fall back to the kernel operstate.
+
+    @return 'up' if the platform reports link up;
+            'down' if the platform reports link down;
+            None if the platform does not override or on error.
+    """
+    try:
+        chassis = sonic_platform.platform.Platform().get_chassis()
+        is_up = chassis.get_management_port_link_status_override(intf)
+    except Exception as e:
+        syslog.syslog(syslog.LOG_WARNING,
+                      "get_management_port_link_status_override failed: %s" % str(e))
+        return None
+    if is_up is None:
+        return None
+    syslog.syslog(syslog.LOG_DEBUG,
+                  "Platform mgmt link check: %s" % ("up" if is_up else "down"))
+    return "up" if is_up else "down"
 
 
 def main():
@@ -38,9 +91,8 @@ def main():
 
                 # Update oper status if modified
                 prev_oper_status = state_db_mgmt.get('oper_status', 'unknown')
-                port_operstate_path = '/sys/class/net/{}/operstate'.format(port)
-                oper_status = subprocess.run(['cat', port_operstate_path], capture_output=True, text=True)
-                current_oper_status = oper_status.stdout.strip()
+                override = _platform_mgmt_link_check(port) if _has_platform_mgmt_link_check() else None
+                current_oper_status = override if override is not None else _get_kernel_operstate(port)
                 if current_oper_status != prev_oper_status:
                     db.set(db.STATE_DB, state_db_key, 'oper_status', current_oper_status)
                     log_level = syslog.LOG_INFO if current_oper_status == 'up' else syslog.LOG_WARNING


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Nexthop's platforms have an unmanaged switch sitting between the front panel rj45 and the CPU's eth0.
As a result eth0's link state as advertised by the kernel (`/sys/class/net/eth0/operstate`), does not reflect the state of the rj45.

e.g.
```
Front Panel RJ45 (Management Port)
         |
        A
         |
    BCM53134 Switch (management switch running in unmanaged mode)
       /    \
      B      C
     /        \
    BMC    CPU (eth0)
```
Link `A` may be down (if RJ45 for example is unplugged), but link `C` (`/sys/class/net/eth0/operstate`) still says up.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Use `get_management_port_link_status_override` from sonic platform API introduced by https://github.com/sonic-net/sonic-platform-common/pull/654 to populate the management port link state to STATE_DB. This will reflect the correct link state in SNMP (or any future consumers of this state).

#### How to verify it
Note this requires https://github.com/sonic-net/sonic-platform-common/pull/654 and the platform dependent implementation of it.
```
admin@gold230:~$ sonic-db-cli CONFIG_DB HSET 'MGMT_PORT|eth0' admin_status up
0
admin@gold230:~$ sudo sonic-db-cli STATE_DB HGET 'MGMT_PORT_TABLE|eth0' oper_status
up
```
Now I log into management switch to bring the port down. After a minute when monit runs we see on the console:
```
admin@gold230:~$ sudo sonic-db-cli STATE_DB HGET 'MGMT_PORT_TABLE|eth0' oper_status
down
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

