### PR TITLE
[build] Fix FRR build failure involved by migrating to trixie.

### DIFF
--- a/src/sonic-frr/Makefile
+++ b/src/sonic-frr/Makefile
@@ -50,6 +50,11 @@ endif
 	# Clean artifacts in frr/debian directory from previous run.
 	fakeroot debian/rules clean
 
+	# Also remove the cmake/autoconf build directory to prevent stale compiled
+	# binaries (e.g. lib/clippy) from a previous build against a different Python
+	# version (e.g. bookworm/3.11 vs trixie/3.13) from being reused.
+	rm -rf build/
+
 	# Build the package.
 
 ifeq ($(CROSS_BUILD_ENVIRON), y)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Building FRR on trixie started failing at the clippy stage with:
`lib/clippy: error while loading shared libraries: libpython3.11.so.1.0`
This happens when an old FRR build directory is reused across distro transitions (bookworm to trixie), so clippy can remain linked against an older Python shared library version. During the build for bookworm, it was compiled linked against Python 3.11, but the trixie build slave has Python 3.13.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
delete the FRR build directory before building the package
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

