### PR TITLE
Revert "[broadcom] Fix saibcm-modules symlink creation to be idempotent (#26450)"

### DIFF
--- a/platform/broadcom/saibcm-modules-legacy-th/debian/rules
+++ b/platform/broadcom/saibcm-modules-legacy-th/debian/rules
@@ -89,12 +89,14 @@ build-arch-stamp:
 
 	# create links
 	cd /; sudo mkdir -p /lib/modules/$(KVER_ARCH)
-	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_COMMON)/ /lib/modules/$(KVER_ARCH)/source
-	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/ /lib/modules/$(KVER_ARCH)/build
-	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/include/generated
-	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/include/generated
-	cd /; sudo ln -sf /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/module.lds /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/module.lds
-	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/include/config/ /usr/src/linux-headers-$(KVER_COMMON)/include/config
+	cd /; sudo rm /lib/modules/$(KVER_ARCH)/build
+	cd /; sudo rm /lib/modules/$(KVER_ARCH)/source
+	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_COMMON)/ /lib/modules/$(KVER_ARCH)/source
+	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/ /lib/modules/$(KVER_ARCH)/build
+	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/include/generated
+	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/include/generated
+	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/module.lds /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/module.lds
+	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/include/config/ /usr/src/linux-headers-$(KVER_COMMON)/include/config
 	cd /; sudo cp /usr/src/linux-headers-$(KVER_ARCH)/Module.symvers /usr/src/linux-headers-$(KVER_COMMON)/Module.symvers
 
 	# Add here command to compile/build the package.

--- a/platform/broadcom/saibcm-modules/debian/rules
+++ b/platform/broadcom/saibcm-modules/debian/rules
@@ -89,12 +89,14 @@ build-arch-stamp:
 
 	# create links
 	cd /; sudo mkdir -p /lib/modules/$(KVER_ARCH)
-	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_COMMON)/ /lib/modules/$(KVER_ARCH)/source
-	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/ /lib/modules/$(KVER_ARCH)/build
-	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/include/generated
-	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/include/generated
-	cd /; sudo ln -sf /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/module.lds /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/module.lds
-	cd /; sudo ln -sfn /usr/src/linux-headers-$(KVER_ARCH)/include/config/ /usr/src/linux-headers-$(KVER_COMMON)/include/config
+	cd /; sudo rm /lib/modules/$(KVER_ARCH)/build
+	cd /; sudo rm /lib/modules/$(KVER_ARCH)/source
+	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_COMMON)/ /lib/modules/$(KVER_ARCH)/source
+	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/ /lib/modules/$(KVER_ARCH)/build
+	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/include/generated
+	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/include/generated/ /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/include/generated
+	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/arch/x86/module.lds /usr/src/linux-headers-$(KVER_COMMON)/arch/x86/module.lds
+	cd /; sudo ln -s /usr/src/linux-headers-$(KVER_ARCH)/include/config/ /usr/src/linux-headers-$(KVER_COMMON)/include/config
 	cd /; sudo cp /usr/src/linux-headers-$(KVER_ARCH)/Module.symvers /usr/src/linux-headers-$(KVER_COMMON)/Module.symvers
 
 	# Add here command to compile/build the package.


### PR DESCRIPTION
Revert PR #26450 based on PR binary search result.

Binary search identified commit ab081eedf9ea as the bad commit causing test_counterpoll_queue_watermark_pg_drop failure on t1-multi-asic_checker.

SearchRunId: 0d1e6853-9db9-40b9-95d7-615c094e4518