### PR TITLE
gbsyncd: use RESTORE REPLACE when cloning FEATURE entries

### DIFF
--- a/files/scripts/gbsyncd.sh
+++ b/files/scripts/gbsyncd.sh
@@ -8,7 +8,7 @@ function startplatform() {
     for DB_CLI in "${DbCliArray[@]}"; do
         # Add gbsyncd to FEATURE table, if not in. It did have same config as syncd.
         if [ -z $($DB_CLI CONFIG_DB HGET 'FEATURE|gbsyncd' state) ]; then
-            local CMD="local r=redis.call('DUMP', KEYS[1]); redis.call('RESTORE', KEYS[2], 0, r)"
+            local CMD="local r=redis.call('DUMP', KEYS[1]); redis.call('RESTORE', KEYS[2], 0, r, 'REPLACE')"
             $DB_CLI CONFIG_DB EVAL "$CMD" 2 'FEATURE|syncd' 'FEATURE|gbsyncd'
             $DB_CLI CONFIG_DB EVAL "$CMD" 2 'SYSLOG_CONFIG_FEATURE|syncd' 'SYSLOG_CONFIG_FEATURE|gbsyncd'
         fi


### PR DESCRIPTION
Signed-off-by: Anand Mehra (anamehra) anamehra@cisco.com

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixes: #26670 

gbsyncd seeds FEATURE and SYSLOG_CONFIG_FEATURE rows for gbsyncd by cloning
the syncd entries through Redis DUMP/RESTORE.
RESTORE without REPLACE fails when destination key exists. In current runtime, featured and gbsyncd can touch the same feature keys during bootstrap, causing intermittent BUSYKEY failures and incomplete seeding.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Use RESTORE with REPLACE so initialization succeeds even when destination keys
already exist (for example when featured updates the same keys first). This
removes bootstrap failures caused by BUSYKEY races while preserving current
design intent: gbsyncd starts with syncd-equivalent config.

#### How to verify it
Bringup sonic-mgmt T2 configuration with deploy-mg.
To repro easily, delay the gbsyncd.sh updating the featured table.
With fix, REPLACE should fix the issue.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

