### PR TITLE
Add VXLAN source port security support

### DIFF
--- a/dockers/docker-orchagent/vxlan.json.j2
+++ b/dockers/docker-orchagent/vxlan.json.j2
@@ -3,7 +3,8 @@
         "SWITCH_TABLE:switch": {
 {% if DEVICE_METADATA.localhost.vxlan_port_range == 'enable' %}
             "vxlan_sport": "0xFF00",
-            "vxlan_mask": "8"
+            "vxlan_mask": "8",
+            "vxlan_security": "false"
 {% endif %}
         },
         "OP": "SET"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
Related to https://github.com/sonic-net/sonic-swss/pull/4483
#### Why I did it

update `dockers/docker-orchagent/vxlan.json.j2` for new attribute which is supported 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Updated `dockers/docker-orchagent/vxlan.json.j2` to add `vxlan_security` attribute newly supported

#### How to verify it
Test that the attribute is being applied without issues

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

