### PR TITLE
[cisco-8000] Switch timeout for Cisco platforms

### DIFF
--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -87,13 +87,15 @@ elif [ "$platform" == "pensando" ]; then
     ORCHAGENT_ARGS+="-m $MAC_ADDRESS"
 elif [ "$platform" == "marvell-prestera" ]; then
     ORCHAGENT_ARGS+="-m $MAC_ADDRESS"
-    CREATE_SWITCH_TIMEOUT=`cat $HWSKU_DIR/sai.profile | grep "createSwitchTimeout" | cut -d'=' -f 2`
-    if [[ ! -z $CREATE_SWITCH_TIMEOUT ]]; then
-        ORCHAGENT_ARGS+=" -t $CREATE_SWITCH_TIMEOUT"
-    fi
 else
     # Should we use the fallback MAC in case it is not found in Device.Metadata
     ORCHAGENT_ARGS+="-m $MAC_ADDRESS"
+fi
+
+# Allow any platform to override the orchagent create-switch timeout from sai.profile.
+CREATE_SWITCH_TIMEOUT=$(awk -F= '$1 == "createSwitchTimeout" { print $2; exit }' "$HWSKU_DIR/sai.profile" 2>/dev/null)
+if [[ -n "$CREATE_SWITCH_TIMEOUT" ]]; then
+    ORCHAGENT_ARGS+=" -t $CREATE_SWITCH_TIMEOUT"
 fi
 
 # Enable ZMQ


### PR DESCRIPTION
#### Why I did it
Cisco platforms need a longer switch create timeout in orchagent.

#### How I did it
Add `cisco-8000` handling in `dockers/docker-orchagent/orchagent.sh` to read `createSwitchTimeout` from `sai.profile` and pass it to orchagent.

#### How to verify it
- Set `createSwitchTimeout=<value>` in a Cisco platform `sai.profile`.
- Confirm `orchagent.sh` passes `-t <value>` to orchagent.
- Local validation from this environment: `bash -n dockers/docker-orchagent/orchagent.sh`.

#### Which release branch to backport (provide reason below if selected)
- [ ] 202405

#### Tested branch (Please provide the tested image version)
- [ ] Not run on hardware from this environment

#### Description for the changelog
Cisco 8000 switch timeout for Cisco platforms.