### PR TITLE
Add IOS-style ? inline help for show commands

### DIFF
--- a/files/image_config/bash/bash.bashrc
+++ b/files/image_config/bash/bash.bashrc
@@ -28,6 +28,95 @@ PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
 #    ;;
 #esac
 
+# IOS-style '?' inline help for SONiC show commands.
+# Pressing ? while typing a show command displays available completions
+# immediately (like Cisco IOS) with descriptions, without inserting the
+# character.  For non-show commands, ? inserts literally as usual.
+# Uses Click's zsh_complete protocol to get help strings alongside values.
+_cli_question_mark() {
+    # Grab the current command line text and cursor position from readline.
+    # READLINE_LINE = full text the user has typed so far
+    # READLINE_POINT = cursor position (character offset from start)
+    local line="$READLINE_LINE" point="$READLINE_POINT"
+
+    # If the command being typed is NOT "show", just insert a literal '?'
+    # at the cursor position and advance the cursor — normal typing behavior.
+    if [[ "${line%% *}" != "show" ]]; then
+        READLINE_LINE="${line:0:point}?${line:point}"
+        ((READLINE_POINT++))
+        return
+    fi
+
+    # --- From here on, the user is typing a "show" command ---
+
+    # Take the text from the start up to the cursor (ignore anything after).
+    # Split it into words, e.g. "show bgp " -> words=("show" "bgp").
+    local partial="${line:0:point}"
+    local -a words
+    read -ra words <<< "$partial"
+    # cword = index of the word being completed (Click needs this).
+    #   - If there's a trailing space, user is starting a NEW word
+    #   - If no trailing space, user is still typing the LAST word
+    local cword=${#words[@]}
+    [[ "$partial" != *" " ]] && ((cword--))
+
+    # Ask Click for completions using the zsh_complete protocol, which
+    # returns 3 lines per completion item:
+    #   line 1: type  ("plain", "dir", or "file")
+    #   line 2: value (the completion text, e.g. "neighbors")
+    #   line 3: help  (description string, or "_" if none)
+    # We pass COMP_WORDS (space-separated) and COMP_CWORD (index) as
+    # environment variables — this is how Click knows what to complete.
+    # Capture comp_words before changing IFS so words join with spaces.
+    local comp_words="${words[*]}"
+    local IFS=$'\n'
+    local -a lines
+    lines=($(COMP_WORDS="$comp_words" COMP_CWORD=$cword \
+             _SHOW_COMPLETE=zsh_complete show 2>/dev/null))
+
+    # Parse the triplets into parallel arrays: names[] and descs[].
+    # Also track the longest name for column alignment.
+    local -a names=() descs=()
+    local i maxlen=0
+    for (( i=0; i < ${#lines[@]}; i+=3 )); do
+        local ctype="${lines[i]}" cvalue="${lines[i+1]}" chelp="${lines[i+2]}"
+        [[ "$ctype" != "plain" && "$ctype" != "dir" && "$ctype" != "file" ]] && continue
+        [[ -z "$cvalue" ]] && continue
+        names+=("$cvalue")
+        [[ "$chelp" == "_" ]] && chelp=""
+        descs+=("$chelp")
+        (( ${#cvalue} > maxlen )) && maxlen=${#cvalue}
+    done
+
+    # Print a header that looks like the current prompt + what the user typed,
+    # e.g. "admin@sonic:~$ show bgp ?"
+    # PS1@P expands the prompt string, then we strip \x01/\x02 markers that
+    # readline uses for color codes — they'd show as garbled characters.
+    local prompt="${PS1@P}"
+    prompt="${prompt//[$'\x01'$'\x02']/}"
+    printf '%s%s?\n' "$prompt" "$partial"
+
+    # Print completions in IOS style: name and description in aligned columns.
+    #   neighbors  LLDP neighbor entries
+    #   table      LLDP neighbor table
+    if (( ${#names[@]} )); then
+        for (( i=0; i < ${#names[@]}; i++ )); do
+            if [[ -n "${descs[i]}" ]]; then
+                printf "  %-${maxlen}s  %s\n" "${names[i]}" "${descs[i]}"
+            else
+                printf "  %s\n" "${names[i]}"
+            fi
+        done
+    else
+        printf '  <CR>      \n'
+        printf '  >         Redirect it to a file\n'
+        printf '  >>        Redirect it to a file in append mode\n'
+        printf '  |         Pipe command output to filter\n'
+    fi
+}
+# Bind the '?' key to call our function instead of inserting the character.
+bind -x '"?": _cli_question_mark'
+
 # enable bash completion in interactive shells
 if ! shopt -oq posix; then
     if [ -f /usr/share/bash-completion/bash_completion ]; then

--- a/files/image_config/bash/bash.bashrc
+++ b/files/image_config/bash/bash.bashrc
@@ -28,6 +28,236 @@ PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
 #    ;;
 #esac
 
+# Safely introspect a Click command for the positional arguments it still
+# expects, WITHOUT running the command.  Click's shell-completion only suggests
+# subcommands and choice-typed arguments; it returns nothing for free-form
+# positional arguments (e.g. an interface name or IP address), so '?' would
+# otherwise show no useful help for commands like "config interface ip add".
+#
+# Resolution uses Click's resilient-parsing context resolver (the same path the
+# completion protocol uses), which parses the command tree but never invokes the
+# group/command callbacks -- important because callbacks such as the "config"
+# group load the DB config, require root, etc.  Output mirrors the Click 8
+# zsh_complete protocol (type / value / help triples, "_" for no help) so the
+# caller can format it with the same loop used for real completions.
+_cli_help_introspect() {
+    python3 -I - "$@" <<'PYEOF'
+import sys
+
+
+def emit(pairs):
+    out = []
+    for value, help_text in pairs:
+        value = " ".join(str(value).split())
+        if not value:
+            continue
+        help_text = " ".join(str(help_text).split()) or "_"
+        # Click 8 zsh_complete protocol: type / value / help per item.
+        out.append("plain")
+        out.append(value)
+        out.append(help_text)
+    if out:
+        sys.stdout.write("\n".join(out) + "\n")
+
+
+def run():
+    if len(sys.argv) < 2:
+        return
+    name = sys.argv[1]
+    args = sys.argv[2:]
+    # Map the supported command names to their Click entry-point objects.
+    entries = {
+        "show": ("show.main", "cli"),
+        "config": ("config.main", "config"),
+        "sonic-clear": ("clear.main", "cli"),
+    }
+    spec = entries.get(name)
+    if spec is None:
+        return
+    try:
+        import importlib
+        import click
+        from click.shell_completion import _resolve_context
+        module = importlib.import_module(spec[0])
+        cli = getattr(module, spec[1])
+        # resilient_parsing context: walks the tree, never runs callbacks.
+        ctx = _resolve_context(cli, {}, name, args)
+    except Exception:
+        return
+    if ctx is None:
+        return
+    command = ctx.command
+    # Collect, in one pass, the positional arguments not yet provided and the
+    # options the command accepts.  Options stay relevant even after every
+    # positional is supplied (e.g. "show interfaces status Ethernet0 ?" should
+    # still list --display, --namespace, ...).  Track whether any *required*
+    # parameter (positional argument or option) is still missing -- that decides
+    # if the command can run.
+    arg_pairs, opt_pairs = [], []
+    missing_required = False
+    for p in command.get_params(ctx):
+        if isinstance(p, click.Argument):
+            if ctx.params.get(p.name) not in (None, (), [], ""):
+                continue
+            missing_required = missing_required or p.required
+            # Only the first unsatisfied positional is a valid next token;
+            # later positionals can't be entered yet, so don't list them.
+            if arg_pairs:
+                continue
+            try:
+                metavar = p.make_metavar()
+            except Exception:
+                metavar = (p.name or "").upper()
+            arg_pairs.append((metavar, ""))
+        elif isinstance(p, click.Option):
+            if p.required and ctx.params.get(p.name) in (None, (), [], ""):
+                missing_required = True
+            names = list(p.opts) + list(p.secondary_opts)
+            if names:
+                opt_pairs.append((", ".join(names), p.help or ""))
+    emit(arg_pairs + opt_pairs)
+    # The command is runnable as typed when no required parameter (argument or
+    # option) is missing and it isn't a group still awaiting a subcommand.
+    # Signal that to the caller via the exit code so it can append the
+    # <CR>/redirect/pipe hints.
+    is_group = (
+        isinstance(command, click.MultiCommand)
+        and not command.invoke_without_command
+    )
+    return not missing_required and not is_group
+
+
+sys.exit(0 if run() else 1)
+PYEOF
+}
+
+# IOS-style '?' inline help for SONiC CLI commands.
+# Pressing ? while typing a supported command (show, config, sonic-clear)
+# displays available completions immediately (like Cisco IOS) with descriptions,
+# without inserting the character.  For all other commands, ? inserts literally
+# as usual.
+# Uses Click's zsh_complete protocol to get help strings alongside values.
+_cli_question_mark() {
+    # local - scopes shell-option changes to this function (restored on return).
+    # -f (noglob): completion/introspection output may contain [, ?, * which must
+    # not glob against cwd files.  +e: those commands intentionally exit nonzero
+    # (e.g. missing required arg) and must not abort the shell under errexit.
+    local -
+    set -f +e
+
+    # Grab the current command line text and cursor position from readline.
+    # READLINE_LINE = full text the user has typed so far
+    # READLINE_POINT = cursor position (character offset from start)
+    local line="$READLINE_LINE" point="$READLINE_POINT"
+
+    # Text typed up to the cursor, with leading whitespace removed.
+    local before="${line:0:point}"
+    local segment="${before#"${before%%[![:space:]]*}"}"
+
+    # First word of the segment = the command the user is typing.
+    local cmd="${segment%% *}"
+
+    # Only trigger '?' help when the cursor is still in the FIRST command
+    # segment and that segment is one of the supported Click commands.  Once the
+    # line contains a command separator (| ; & < >) the cursor is in a later
+    # segment, so insert a literal '?' — e.g. "show ... | grep ?" types '?' for
+    # grep.
+    if [[ "$before" == *[\|\;\&\<\>]* || " show config sonic-clear " != *" $cmd "* ]]; then
+        READLINE_LINE="${line:0:point}?${line:point}"
+        ((READLINE_POINT++))
+        return
+    fi
+
+    # --- From here on, the cursor is inside a supported command segment ---
+
+    # Split the segment into words, e.g. "show bgp " -> words=("show" "bgp").
+    local -a words
+    read -ra words <<< "$segment"
+    # cword = index of the word being completed (Click needs this).
+    #   - If there's a trailing space, user is starting a NEW word
+    #   - If no trailing space, user is still typing the LAST word
+    local cword=${#words[@]}
+    [[ "$segment" != *" " ]] && ((cword--))
+
+    # Ask Click for completions using the zsh_complete protocol, which
+    # returns 3 lines per completion item:
+    #   line 1: type  ("plain", "dir", or "file")
+    #   line 2: value (the completion text, e.g. "neighbors")
+    #   line 3: help  (description string, or "_" if none)
+    # We pass COMP_WORDS (space-separated) and COMP_CWORD (index) as
+    # environment variables — this is how Click knows what to complete.
+    # Click derives the activation variable from the command name by uppercasing
+    # and replacing hyphens with underscores, e.g. "show" -> _SHOW_COMPLETE,
+    # "config" -> _CONFIG_COMPLETE, "sonic-clear" -> _SONIC_CLEAR_COMPLETE.
+    # Build it dynamically and export it (local -x) so the subshell command sees
+    # it.  Capture comp_words before changing IFS so words join with spaces.
+    local comp_words="${words[*]}"
+    local cmd_var="${cmd^^}"
+    local -x "_${cmd_var//-/_}_COMPLETE=zsh_complete"
+    local IFS=$'\n'
+    local -a lines
+    lines=($(COMP_WORDS="$comp_words" COMP_CWORD=$cword \
+             "$cmd" 2>/dev/null))
+
+    # Click returned no completions.  This commonly means the command expects a
+    # free-form positional argument (e.g. "config interface ip add <name>"),
+    # which Click can't suggest.  Safely introspect the command for the
+    # arguments it still expects so '?' shows them instead of nothing.
+    local runnable=0
+    if (( ${#lines[@]} == 0 )); then
+        lines=($(_cli_help_introspect "$cmd" "${words[@]:1:cword-1}" 2>/dev/null))
+        # _cli_help_introspect exits 0 when the command can be executed as
+        # typed, so we know whether to offer the <CR>/redirect/pipe hints below.
+        (( $? == 0 )) && runnable=1
+    fi
+
+    # Parse the triplets into parallel arrays: names[] and descs[].
+    # Also track the longest name for column alignment.
+    local -a names=() descs=()
+    local i maxlen=0
+    for (( i=0; i < ${#lines[@]}; i+=3 )); do
+        local ctype="${lines[i]}" cvalue="${lines[i+1]}" chelp="${lines[i+2]}"
+        [[ "$ctype" != "plain" && "$ctype" != "dir" && "$ctype" != "file" ]] && continue
+        [[ -z "$cvalue" ]] && continue
+        names+=("$cvalue")
+        [[ "$chelp" == "_" ]] && chelp=""
+        descs+=("$chelp")
+        (( ${#cvalue} > maxlen )) && maxlen=${#cvalue}
+    done
+
+    # Print a header that looks like the current prompt + what the user typed,
+    # e.g. "admin@sonic:~$ show bgp ?"
+    # PS1@P expands the prompt string, then we strip \x01/\x02 markers that
+    # readline uses for color codes — they'd show as garbled characters.
+    local prompt="${PS1@P}"
+    prompt="${prompt//[$'\x01'$'\x02']/}"
+    printf '%s%s?\n' "$prompt" "$before"
+
+    # Print completions in IOS style: name and description in aligned columns.
+    #   neighbors  LLDP neighbor entries
+    #   table      LLDP neighbor table
+    if (( ${#names[@]} )); then
+        for (( i=0; i < ${#names[@]}; i++ )); do
+            if [[ -n "${descs[i]}" ]]; then
+                printf "  %-${maxlen}s  %s\n" "${names[i]}" "${descs[i]}"
+            else
+                printf "  %s\n" "${names[i]}"
+            fi
+        done
+    fi
+
+    # IOS-style trailing hints: show them when the command can be executed as
+    # typed (runnable), or when there was nothing else to display at all.
+    if (( runnable || ${#names[@]} == 0 )); then
+        printf '  <CR>      \n'
+        printf '  >         Redirect it to a file\n'
+        printf '  >>        Redirect it to a file in append mode\n'
+        printf '  |         Pipe command output to filter\n'
+    fi
+}
+# Bind the '?' key to call our function instead of inserting the character.
+bind -x '"?": _cli_question_mark'
+
 # enable bash completion in interactive shells
 if ! shopt -oq posix; then
     if [ -f /usr/share/bash-completion/bash_completion ]; then


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

SONiC CLI lacks the IOS-style `?` inline help that network operators expect from NOS platforms.  Today, discovering available subcommands requires Tab completion (no descriptions) or reading documentation.  This adds the familiar `?` help experience directly in the bash session for `show` commands.

Companion PR: https://github.com/sonic-net/sonic-utilities/pull/4449/ 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added a `_cli_question_mark()` bash function in `/etc/bash.bashrc` that is bound to the `?` key via `bind -x`.

- When the current line starts with `show`, the handler constructs `COMP_WORDS`/`COMP_CWORD` from the readline state and invokes Click's `zsh_complete` protocol (`_SHOW_COMPLETE=zsh_complete`), which returns completion values together with their help strings.
- Completions are printed in aligned columns with descriptions below a prompt header that mirrors the current `PS1`.
- For non-show commands, `?` inserts literally as usual (no behavior change).

**Example output:**
```
admin@sonic:~$ show lldp ?
  neighbors  LLDP neighbor entries
  table      LLDP neighbor table
```

#### How to verify it

- Login as `admin` and `root`
- `show ?` — lists all top-level show subcommands with descriptions
- `show bgp ?` — lists only BGP subcommands (not top-level)
- `show bgp ?` after `show ?` — output stays correctly scoped (no cross-contamination)
- `echo hello?` — inserts literal `?` (non-show command)
- Prompt header shows clean text without garbled characters
- Tab completion still works normally for show commands

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202511
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add IOS-style `?` inline help for `show` commands — pressing `?` displays available subcommands with descriptions, just like Cisco IOS/NX-OS.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### A picture of a cute animal (not mandatory but encouraged)