### PR TITLE
Add PDB support for system-health

### DIFF
--- a/src/system-health/health_checker/hardware_checker.py
+++ b/src/system-health/health_checker/hardware_checker.py
@@ -9,7 +9,7 @@ EVENTS_PUBLISHER_TAG = "liquid-cooling-leak"
 
 class HardwareChecker(HealthChecker):
     """
-    Check system hardware status. For now, it checks ASIC, PSU and fan status.
+    Check system hardware status. For now, it checks ASIC, PSU, PDB and fan status.
     """
 
     ASIC_TEMPERATURE_KEY = 'TEMPERATURE_INFO|ASIC'
@@ -165,15 +165,13 @@ class HardwareChecker(HealthChecker):
 
     def _check_psu_status(self, config):
         """
-        Check PSU status including:
-            1. Check all PSUs are present
-            2. Check all PSUs are power on
-            3. Check PSU temperature is in valid range
-            4. Check PSU voltage is in valid range
+        Check PSU and PDB status from STATE_DB PSU_INFO (PDB keys look like PDB 1, PDB 2).
+        PSUs: presence, status, optional temperature/voltage/power_threshold checks.
+        PDBs: presence and status only (for system-health Type column).
         :param config: Health checker configuration
         :return:
         """
-        if config.ignore_devices and 'psu' in config.ignore_devices:
+        if config.ignore_devices and 'psu' in config.ignore_devices and 'pdb' in config.ignore_devices:
             return
 
         keys = self._db.keys(self._db.STATE_DB, HardwareChecker.PSU_TABLE_NAME + '*')
@@ -211,7 +209,7 @@ class HardwareChecker(HealthChecker):
                 elif temperature_threshold is None:
                     self.set_object_not_ok('PSU', name, 'Failed to get temperature threshold data for {}'.format(name))
                     continue
-                else:
+                elif temperature_threshold != 'N/A':
                     try:
                         temperature = float(temperature)
                         temperature_threshold = float(temperature_threshold)
@@ -243,7 +241,7 @@ class HardwareChecker(HealthChecker):
                     self.set_object_not_ok('PSU', name,
                                            'Failed to get voltage maximum threshold data for {}'.format(name))
                     continue
-                else:
+                elif voltage_min_th != 'N/A' and voltage_max_th != 'N/A':
                     try:
                         voltage = float(voltage)
                         voltage_min_th = float(voltage_min_th)

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -623,7 +623,24 @@ def test_hardware_checker():
             'voltage_max_threshold': '15',
             'power_overload': 'True',
             'power': '101.0'
-        }
+        },
+        'PSU_INFO|PDB 1': {
+            'presence': 'True',
+            'status': 'True',
+            'temp': '55',
+            'temp_threshold': '100',
+            'voltage': '10',
+            'voltage_min_threshold': '8',
+            'voltage_max_threshold': '15',
+        },
+        'PSU_INFO|PDB 2': {
+            'presence': 'True',
+            'status': 'False',
+        },
+        'PSU_INFO|PDB 3': {
+            'presence': 'False',
+            'status': 'True',
+        },
     })
 
     MockConnector.data.update({
@@ -721,6 +738,62 @@ def test_hardware_checker():
 
     assert 'liquid_cooling_6' in checker._info
     assert checker._info['liquid_cooling_6'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_OK
+
+    assert 'PDB 1' in checker._info
+    assert checker._info['PDB 1'][HealthChecker.INFO_FIELD_OBJECT_TYPE] == 'PSU'
+    assert checker._info['PDB 1'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_OK
+
+    assert 'PDB 2' in checker._info
+    assert checker._info['PDB 2'][HealthChecker.INFO_FIELD_OBJECT_TYPE] == 'PSU'
+    assert checker._info['PDB 2'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_NOT_OK
+    assert 'out of power' in checker._info['PDB 2'][HealthChecker.INFO_FIELD_OBJECT_MSG]
+
+    assert 'PDB 3' in checker._info
+    assert checker._info['PDB 3'][HealthChecker.INFO_FIELD_OBJECT_TYPE] == 'PSU'
+    assert checker._info['PDB 3'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_NOT_OK
+    assert 'missing' in checker._info['PDB 3'][HealthChecker.INFO_FIELD_OBJECT_MSG].lower()
+
+
+def test_hardware_checker_pdb_ignore():
+    """PSU_INFO rows are skipped when the key name is listed in ignore_devices."""
+    MockConnector.data.clear()
+    MockConnector.data.update({
+        'PSU_INFO|PDB 1': {
+            'presence': 'True',
+            'status': 'True',
+            'temp': '55',
+            'temp_threshold': '100',
+            'voltage': '10',
+            'voltage_min_threshold': '8',
+            'voltage_max_threshold': '15',
+        },
+    })
+    config = Config()
+    config.ignore_devices = ['PDB 1']
+    checker = HardwareChecker()
+    checker.check(config)
+    assert 'PDB 1' not in checker._info
+
+
+def test_hardware_checker_psu_pdb_ignore_both_skips_psu_check():
+    """When both 'psu' and 'pdb' are in ignore_devices, _check_psu_status returns without entries."""
+    MockConnector.data.clear()
+    MockConnector.data.update({
+        'PSU_INFO|PSU 1': {
+            'presence': 'True',
+            'status': 'True',
+            'temp': '55',
+            'temp_threshold': '100',
+            'voltage': '10',
+            'voltage_min_threshold': '8',
+            'voltage_max_threshold': '15',
+        },
+    })
+    config = Config()
+    config.ignore_devices = ['psu', 'pdb']
+    checker = HardwareChecker()
+    checker.check(config)
+    assert 'PSU 1' not in checker._info
 
 
 def test_config():


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This pr is part of the design [Support PDB flows](https://github.com/sonic-net/SONiC/pull/2219)
- Extended hardware_checker PSU status logic to also process PDB entries from STATE_DB PSU_INFO (e.g., PDB 1, PDB 2) so PDB power/presence failures are reported in health output.
- Adjusted check behavior so threshold validations are skipped when values are N/A, preventing false parsing failures for PDB-style rows that only expose presence/status.


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
extend current psu checkers to cover the pdb object

#### How to verify it
both manually test on pdb installed hardware and unit test
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x]202511
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

