### PR TITLE
[Mellanox] Enable ThermalUpdater to get ASIC temperature from redis

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2010-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn2010-r0/platform.json
@@ -48,7 +48,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient Fan Side Temp"

--- a/device/mellanox/x86_64-mlnx_msn2100-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn2100-r0/platform.json
@@ -48,7 +48,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient Fan Side Temp"

--- a/device/mellanox/x86_64-mlnx_msn2410-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn2410-r0/platform.json
@@ -98,7 +98,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient Fan Side Temp"

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/platform.json
@@ -98,7 +98,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient Fan Side Temp"

--- a/device/mellanox/x86_64-mlnx_msn2700a1-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn2700a1-r0/platform.json
@@ -101,7 +101,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient Fan Side Temp"

--- a/device/mellanox/x86_64-mlnx_msn2740-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn2740-r0/platform.json
@@ -83,7 +83,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient Fan Side Temp"

--- a/device/mellanox/x86_64-mlnx_msn3420-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn3420-r0/platform.json
@@ -109,7 +109,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient Fan Side Temp"

--- a/device/mellanox/x86_64-mlnx_msn3700-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn3700-r0/platform.json
@@ -120,7 +120,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient COMEX Temp"

--- a/device/mellanox/x86_64-mlnx_msn3700c-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn3700c-r0/platform.json
@@ -98,7 +98,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient COMEX Temp"

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/platform.json
@@ -81,7 +81,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient COMEX Temp"

--- a/device/mellanox/x86_64-mlnx_msn4410-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn4410-r0/platform.json
@@ -120,7 +120,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient COMEX Temp"

--- a/device/mellanox/x86_64-mlnx_msn4600-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn4600-r0/platform.json
@@ -78,7 +78,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient COMEX Temp"

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/platform.json
@@ -78,7 +78,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient COMEX Temp"

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/platform.json
@@ -120,7 +120,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient COMEX Temp"

--- a/device/mellanox/x86_64-mlnx_msn4700_simx-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn4700_simx-r0/platform.json
@@ -120,7 +120,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient COMEX Temp"

--- a/device/mellanox/x86_64-nvidia_sn2201-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn2201-r0/platform.json
@@ -100,7 +100,8 @@
                 "name": "CPU Core 1 Temp"
             },
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "SODIMM 1 Temp"

--- a/device/mellanox/x86_64-nvidia_sn4280-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/platform.json
@@ -86,7 +86,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient Fan Side Temp"

--- a/device/mellanox/x86_64-nvidia_sn4280_simx-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn4280_simx-r0/platform.json
@@ -86,7 +86,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient Fan Side Temp"

--- a/device/mellanox/x86_64-nvidia_sn4800-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn4800-r0/platform.json
@@ -131,7 +131,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient Fan Side Temp"

--- a/device/mellanox/x86_64-nvidia_sn5400-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn5400-r0/platform.json
@@ -104,7 +104,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient Fan Side Temp"

--- a/device/mellanox/x86_64-nvidia_sn5400_simx-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn5400_simx-r0/platform.json
@@ -107,7 +107,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient Fan Side Temp"

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/platform.json
@@ -107,7 +107,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient Fan Side Temp"

--- a/device/mellanox/x86_64-nvidia_sn5600_simx-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn5600_simx-r0/platform.json
@@ -95,7 +95,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient COMEX Temp"

--- a/device/mellanox/x86_64-nvidia_sn5610n-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn5610n-r0/platform.json
@@ -138,7 +138,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient Fan Side Temp"

--- a/device/mellanox/x86_64-nvidia_sn5640-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn5640-r0/platform.json
@@ -138,7 +138,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient Fan Side Temp"

--- a/device/mellanox/x86_64-nvidia_sn5640_simx-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn5640_simx-r0/platform.json
@@ -138,7 +138,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient Fan Side Temp"

--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/platform.json
@@ -40,7 +40,8 @@
         ],        
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "CPU Pack Temp"

--- a/device/mellanox/x86_64-nvidia_sn6600_simx-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn6600_simx-r0/platform.json
@@ -26,7 +26,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "Ambient COMEX Temp"

--- a/device/mellanox/x86_64-nvidia_sn6810_ld-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn6810_ld-r0/platform.json
@@ -40,7 +40,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "CPU Pack Temp"

--- a/device/mellanox/x86_64-nvidia_sn6810_ld_simx-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn6810_ld_simx-r0/platform.json
@@ -40,7 +40,8 @@
         ],
         "thermals": [
             {
-                "name": "ASIC"
+                "name": "ASIC",
+                "polling_interval": 3
             },
             {
                 "name": "CPU Pack Temp"

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/db_table_helper.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/db_table_helper.py
@@ -23,17 +23,19 @@ from sonic_py_common import multi_asic
 TRANSCEIVER_DOM_TEMPERATURE_TABLE = 'TRANSCEIVER_DOM_TEMPERATURE'
 TRANSCEIVER_DOM_THRESHOLD_TABLE = 'TRANSCEIVER_DOM_THRESHOLD'
 TRANSCEIVER_INFO_TABLE = 'TRANSCEIVER_INFO'
+TEMPERATURE_INFO_TABLE = 'TEMPERATURE_INFO'
 STATE_DB = 'STATE_DB'
 APPL_DB = 'APPL_DB'
 
 
-class DbTableHelper:    
+class DbTableHelper:
     def __init__(self):
         self.state_dbs = {}
         self.appl_dbs = {}
         self.module_temperature_table = None
         self.module_threshold_table = None
         self.module_info_table = None
+        self.temperature_info_table = None
         self._initialized = False
 
     def initialize(self):
@@ -47,6 +49,7 @@ class DbTableHelper:
             self.module_temperature_table = Table(self.state_dbs[default_namespace], TRANSCEIVER_DOM_TEMPERATURE_TABLE)
             self.module_threshold_table = Table(self.state_dbs[default_namespace], TRANSCEIVER_DOM_THRESHOLD_TABLE)
             self.module_info_table = Table(self.state_dbs[default_namespace], TRANSCEIVER_INFO_TABLE)
+            self.temperature_info_table = Table(self.state_dbs[default_namespace], TEMPERATURE_INFO_TABLE)
             self._initialized = True
 
     def get_module_temperature_table(self):
@@ -60,6 +63,10 @@ class DbTableHelper:
     def get_module_info_table(self):
         self.initialize()
         return self.module_info_table
+
+    def get_temperature_info_table(self):
+        self.initialize()
+        return self.temperature_info_table
 
     def get_appl_db(self, namespace):
         self.initialize()

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
@@ -17,6 +17,7 @@
 #
 
 from .device_data import DeviceDataManager
+from .db_table_helper import get_db_table_helper
 from . import utils
 from sonic_py_common import logger
 
@@ -45,8 +46,7 @@ except ImportError:
         raise
 
 
-SFP_TEMPERATURE_SCALE = 1000
-ASIC_TEMPERATURE_SCALE = 125
+TEMPERATURE_SCALE = 1000
 ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD = 105000
 ASIC_DEFAULT_TEMP_CRITICAL_THRESHOLD = 120000
 
@@ -78,6 +78,11 @@ class ThermalUpdater:
         self._sfp_list = sfp_list
         self._sfp_status = {}
         self._timer = utils.Timer()
+        asic_count = DeviceDataManager.get_asic_count()
+        if asic_count > 1:
+            self._asic_names = [f'ASIC{i}' for i in range(asic_count)]
+        else:
+            self._asic_names = ['ASIC']
         atexit.register(functools.partial(clean_thermal_data, self._sfp_list))
 
     def _find_matching_key(self, dev_parameters, pattern):
@@ -144,17 +149,19 @@ class ThermalUpdater:
         logger.log_notice(f'Set hw-management-tc to {"suspend" if suspend else "resume"}')
         utils.write_file('/run/hw-management/config/suspend', 1 if suspend else 0)
 
-    def get_asic_temp(self, asic_index=0):
-        temperature = utils.read_int_from_file(f'/sys/module/sx_core/asic{asic_index}/temperature/input', default=None)
-        return temperature * ASIC_TEMPERATURE_SCALE if temperature is not None else None
+    def get_asic_temp(self, asic_name):
+        try:
+            present, temperature = get_db_table_helper().get_temperature_info_table().hget(asic_name, 'temperature')
+            return int(float(temperature) * TEMPERATURE_SCALE) if present else 0
+        except Exception as e:
+            logger.log_error(f'Failed to read ASIC {asic_name} temperature - {temperature} - {e}')
+            return None
 
-    def get_asic_temp_warning_threshold(self, asic_index=0):
-        emergency = utils.read_int_from_file(f'/sys/module/sx_core/asic{asic_index}/temperature/emergency', default=None, log_func=None)
-        return emergency * ASIC_TEMPERATURE_SCALE if emergency is not None else ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD
+    def get_asic_temp_warning_threshold(self):
+        return ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD
 
-    def get_asic_temp_critical_threshold(self, asic_index=0):
-        critical = utils.read_int_from_file(f'/sys/module/sx_core/asic{asic_index}/temperature/critical', default=None, log_func=None)
-        return critical * ASIC_TEMPERATURE_SCALE if  critical is not None else ASIC_DEFAULT_TEMP_CRITICAL_THRESHOLD
+    def get_asic_temp_critical_threshold(self):
+        return ASIC_DEFAULT_TEMP_CRITICAL_THRESHOLD
 
     def update_single_module(self, sfp):
         try:
@@ -185,9 +192,9 @@ class ThermalUpdater:
                 hw_management_independent_mode_update.thermal_data_set_module(
                     sfp.get_asic_index(),
                     sfp.sdk_index + 1,
-                    int(temperature * SFP_TEMPERATURE_SCALE),
-                    int(critical_thresh * SFP_TEMPERATURE_SCALE),
-                    int(warning_thresh * SFP_TEMPERATURE_SCALE),
+                    int(temperature * TEMPERATURE_SCALE),
+                    int(critical_thresh * TEMPERATURE_SCALE),
+                    int(warning_thresh * TEMPERATURE_SCALE),
                     fault
                 )
                 hw_management_independent_mode_update.vendor_data_set_module(
@@ -233,9 +240,9 @@ class ThermalUpdater:
     def update_asic(self):
         try:
             for asic_index in range(DeviceDataManager.get_asic_count()):
-                asic_temp = self.get_asic_temp(asic_index)
-                warn_threshold = self.get_asic_temp_warning_threshold(asic_index)
-                critical_threshold = self.get_asic_temp_critical_threshold(asic_index)
+                asic_temp = self.get_asic_temp(self._asic_names[asic_index])
+                warn_threshold = self.get_asic_temp_warning_threshold()
+                critical_threshold = self.get_asic_temp_critical_threshold()
                 fault = 0
                 if asic_temp is None:
                     logger.log_error(f'Failed to read ASIC {asic_index} temperature, send fault to hw-management-tc')

--- a/platform/mellanox/mlnx-platform-api/tests/test_thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_thermal_updater.py
@@ -112,19 +112,30 @@ class TestThermalUpdater:
         assert not updater._timer.is_alive()
         mock_write.assert_called_once_with('/run/hw-management/config/suspend', 1)
 
-    @mock.patch('sonic_platform.utils.read_int_from_file')
-    def test_update_asic(self, mock_read):
+    @mock.patch('sonic_platform.thermal_updater.get_db_table_helper')
+    def test_update_asic(self, mock_get_db_table_helper):
         hw_management_independent_mode_update.reset_mock()
-        mock_read.return_value = 8
-        updater = ThermalUpdater(None)
-        assert updater.get_asic_temp() == 1000
-        assert updater.get_asic_temp_warning_threshold() == 1000
-        assert updater.get_asic_temp_critical_threshold() == 1000
-        updater.update_asic()
-        hw_management_independent_mode_update.thermal_data_set_asic.assert_called_once()
+        mock_temp_table = mock.MagicMock()
+        mock_db_table_helper = mock.MagicMock()
+        mock_db_table_helper.get_temperature_info_table.return_value = mock_temp_table
+        mock_get_db_table_helper.return_value = mock_db_table_helper
 
-        mock_read.return_value = None
-        assert updater.get_asic_temp() is None
+        mock_temp_table.hget.return_value = (True, 8)
+        updater = ThermalUpdater(None)
+        assert updater.get_asic_temp('ASIC') == 8000
+        assert updater.get_asic_temp_warning_threshold() == ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD
+        assert updater.get_asic_temp_critical_threshold() == ASIC_DEFAULT_TEMP_CRITICAL_THRESHOLD
+        updater.update_asic()
+        hw_management_independent_mode_update.thermal_data_set_asic.assert_called_once_with(
+            0,
+            8000,
+            ASIC_DEFAULT_TEMP_CRITICAL_THRESHOLD,
+            ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD,
+            0
+        )
+
+        mock_temp_table.hget.return_value = (False, None)
+        assert updater.get_asic_temp('ASIC') == 0
         assert updater.get_asic_temp_warning_threshold() == ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD
         assert updater.get_asic_temp_critical_threshold() == ASIC_DEFAULT_TEMP_CRITICAL_THRESHOLD
 


### PR DESCRIPTION
Dependency PR https://github.com/sonic-net/sonic-platform-daemons/pull/785 is merged, pending submodule update PR: https://github.com/sonic-net/sonic-buildimage/pull/27053
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The PR is to optimize I2C access on Nvidia platforms. Currently, there are more than 1 tasks to read ASIC temperature directly via I2C. The idea is to ensure that only one task read ASIC temperature from I2C and cache to redis, other tasks should read from redis instead of I2C.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

After this commit, Nvidia thermal/module data path is effectively:

1. enable Nvidia platform polling asic temperature data via thermalctld with polling interval 3 by adding `polling_interval` to `platform.json`
2. thermal updater thread reads ASIC temperature from Redis instead of SDK sysfs.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
sonic-mgmt regression passed on Nvidia platforms
new unit test cases passed

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

