### PR TITLE
[cisco-8000]: Update platform ref to 202511.1.0.7

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202511.1.0.5
+ref=202511.1.0.7


### PR DESCRIPTION
#### Why I did it
Update Cisco 8000 platform checkout ref from 202511.1.0.5 to 202511.1.0.7.

#### How I did it
Updated ref in platform/checkout/cisco-8000.ini.

#### How to verify it
Build with Cisco 8000 platform and verify the correct platform submodule is checked out.