### PR TITLE
Adding Arista Goldfinch DTS to aspeed fit image.

### DIFF
--- a/platform/aspeed/sonic_fit.its
+++ b/platform/aspeed/sonic_fit.its
@@ -6,6 +6,7 @@
  * This FIT image contains multiple DTBs for different hardware variants:
  * - ast2700-evb: Aspeed AST2700 EVB reference platform
  * - nexthop-b27-r0: NextHop AST2700 platform
+ * - arista_goldfinch-r0: Arista AST2700 BMC platform
  *
  * U-Boot selects the appropriate DTB configuration using the 'bootconf' variable
  * which is set based on hardware detection at boot time.
@@ -74,6 +75,17 @@
 				algo = "sha256";
 			};
 		};
+		fdt-arista_goldfinch-r0 {
+			description = "Flattened Device Tree blob for Arista 2700 BMC";
+			data = /incbin/("__DTB_PATH_ASPEED__/arista_goldfinch-r0.dtb");
+			type = "flat_dt";
+			arch = "arm64";
+			compression = "none";
+			load = <0x4 0x4C000000>;
+			hash-1 {
+				algo = "sha256";
+			};
+		};
 		ramdisk-1 {
 			description = "Initramfs";
 			data = /incbin/("__INITRD_PATH__");
@@ -103,6 +115,15 @@
 			description = "SONiC for NextHop AST2700";
 			kernel = "kernel-1";
 			fdt = "fdt-nexthop-b27-r0";
+			ramdisk = "ramdisk-1";
+			hash-1 {
+				algo = "sha256";
+			};
+		};
+		conf-arista_goldfinch-r0 {
+			description = "SONiC for Arista 2700 BMC";
+			kernel = "kernel-1";
+			fdt = "fdt-arista_goldfinch-r0";
 			ramdisk = "ramdisk-1";
 			hash-1 {
 				algo = "sha256";


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Adding Arista Goldfinch DTS to aspeed fit image for ast2700.
Changes linked to PR adding of DTS file to sonic-linux-kernel : https://github.com/sonic-net/sonic-linux-kernel/pull/561


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added Arista Goldfinch dtb to aspeed fit image.

#### How to verify it
Boot ast2700 dut with arista goldfinch dtb.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

