### PR TITLE
Trim Image - Fit Only Boot

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -817,6 +817,12 @@ if [[ $TARGET_BOOTLOADER == uboot ]]; then
             fi
 
             sudo LANG=C chroot $FILESYSTEM_ROOT mkimage -f /boot/sonic_fit.its /boot/sonic_${CONFIGURED_ARCH}.fit
+
+            ## vmlinuz and initrd are already bundled inside the FIT image, remove standalone copies
+            if [ "$BUILD_FIT_ONLY_BOOT" = "y" ]; then
+                sudo rm -f $FILESYSTEM_ROOT/boot/vmlinuz-${LINUX_KERNEL_VERSION}-sonic-${CONFIGURED_ARCH}
+                sudo rm -f $FILESYSTEM_ROOT/boot/initrd.img-${LINUX_KERNEL_VERSION}-sonic-${CONFIGURED_ARCH}
+            fi
         fi
     fi
 

--- a/rules/config
+++ b/rules/config
@@ -384,6 +384,9 @@ PIP_HTTP_TIMEOUT ?= 60
 # BUILD_REDUCE_IMAGE_SIZE - reduce the image size as much as possbible
 BUILD_REDUCE_IMAGE_SIZE = n
 
+# BUILD_FIT_ONLY_BOOT - remove standalone vmlinuz/initrd from boot/ (already bundled in FIT image)
+BUILD_FIT_ONLY_BOOT = n
+
 # SONIC_PTF_ENV_PY_VER - SONiC PTF test Python version. Set to 'mixed' to build the
 # image with both Python 2 and 3. Set to 'py3' to build a Python 3 only image
 SONIC_PTF_ENV_PY_VER = py3

--- a/slave.mk
+++ b/slave.mk
@@ -1251,6 +1251,7 @@ $(addprefix $(TARGET_PATH)/, $(DOCKER_IMAGES)) : $(TARGET_PATH)/%.gz : .platform
 		# Export variables for j2. Use path for unique variable names, e.g. docker_orchagent_debs
 		export include_system_eventd="$(INCLUDE_SYSTEM_EVENTD)"
 		export build_reduce_image_size="$(BUILD_REDUCE_IMAGE_SIZE)"
+		export build_fit_only_boot="$(BUILD_FIT_ONLY_BOOT)"
 		export sonic_asic_platform="$(patsubst %-$(CONFIGURED_ARCH),%,$(CONFIGURED_PLATFORM))"
 		$(eval export $(subst -,_,$(notdir $($*.gz_PATH)))_debs=$(shell printf "$(subst $(SPACE),\n,$(call expand,$($*.gz_DEPENDS),RDEPENDS))\n" | awk '!a[$$0]++'))
 		$(eval export $(subst -,_,$(notdir $($*.gz_PATH)))_pydebs=$(shell printf "$(subst $(SPACE),\n,$(call expand,$($*.gz_PYTHON_DEBS)))\n" | awk '!a[$$0]++'))
@@ -1551,6 +1552,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 	export include_system_bmp="$(INCLUDE_SYSTEM_BMP)"
 	export include_system_eventd="$(INCLUDE_SYSTEM_EVENTD)"
 	export build_reduce_image_size="$(BUILD_REDUCE_IMAGE_SIZE)"
+	export build_fit_only_boot="$(BUILD_FIT_ONLY_BOOT)"
 	export include_restapi="$(INCLUDE_RESTAPI)"
 	export include_nat="$(INCLUDE_NAT)"
 	export include_p4rt="$(INCLUDE_P4RT)"
@@ -1719,6 +1721,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 		MULTIARCH_QEMU_ENVIRON=$(MULTIARCH_QEMU_ENVIRON) \
 		CROSS_BUILD_ENVIRON=$(CROSS_BUILD_ENVIRON) \
 		BUILD_REDUCE_IMAGE_SIZE=$(BUILD_REDUCE_IMAGE_SIZE) \
+		BUILD_FIT_ONLY_BOOT=$(BUILD_FIT_ONLY_BOOT) \
 		MASTER_KUBERNETES_VERSION=$(MASTER_KUBERNETES_VERSION) \
 		MASTER_KUBERNETES_CONTAINER_IMAGE_VERSION=$(MASTER_KUBERNETES_CONTAINER_IMAGE_VERSION) \
 		MASTER_PAUSE_VERSION=$(MASTER_PAUSE_VERSION) \


### PR DESCRIPTION
This commit removes the extra copies of standalone initrd, and vmlinuz in the boot/ directory of the
installer archive. These initrd and vmlinuz are
already packaged in the Fit image, which is utilized by u-boot.

To Enable this feature the following build flag should be set - .`BUILD_FIT_ONLY_BOOT`

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Redundant `initrd` and `vmlinuz`

On aspeed platforms, u-boot is used as the bootloader. The build process produces a [FIT image](https://u-boot.readthedocs.io/en/latest/usage/fit/index.html) (`sonic_arm64.fit`) using `mkimage`, which is a single self-contained archive that bundles the kernel (`vmlinuz`) and the initial ramdisk (`initrd.img`) together. This is the file that u-boot actually loads and boots from.

Despite both files already being packed inside the FIT image, `build_debian.sh` also leaves their standalone copies in `boot/` — an artifact of the standard Debian build flow. The `uboot-bootloader` derives the kernel and initrd from the FIT image during boot, making these standalone files entirely redundant.

This change introduces a flag `BUILD_FIT_ONLY_BOOT` which when enabled removes the redundant copies of these files from the image. As aspeed platforms are u-boot based,  planning to enable this flag for all aspeed platform builds in subsequent PRs.

The `boot/` directory before this change looks like:

```shell
*-apoorv@vm-apoorv-arm64:/garage/apoorv/builddir/aspeed-image/boot:📟
|
*-$ ll
.rw-r--r-- apoorv apoorv 319 KB Tue Aug 12 03:28:04 2025 config-6.12.41+deb13-sonic-arm64
.rw-r--r-- apoorv apoorv  37 MB Wed Apr 15 21:59:55 2026 initrd.img-6.12.41+deb13-sonic-arm64   ← redundant
.rw-r--r-- apoorv apoorv  78 MB Wed Apr 15 21:59:56 2026 sonic_arm64.fit                        ← already contains both
.rw-r--r-- apoorv apoorv 3.1 KB Wed Apr 15 21:59:55 2026 sonic_fit.its
.rw-r--r-- apoorv apoorv  83 B  Tue Aug 12 03:28:04 2025 System.map-6.12.41+deb13-sonic-arm64
.rw-r--r-- apoorv apoorv  40 MB Tue Aug 12 03:28:04 2025 vmlinuz-6.12.41+deb13-sonic-arm64      ← redundant
```

`initrd.img` (37 MB) and `vmlinuz` (40 MB) together account for \~77 MB, while the FIT image that already contains them is only 78 MB — meaning the standalone copies are almost pure overhead.

#### How I did it

When `BUILD_FIT_ONLY_BOOT=y`, the following is added to `build_debian.sh` immediately after the FIT image is assembled:

```shell
## vmlinuz and initrd are already bundled inside the FIT image, remove standalone copies
if [ "$BUILD_FIT_ONLY_BOOT" = "y" ]; then
    sudo rm -f $FILESYSTEM_ROOT/boot/vmlinuz-${LINUX_KERNEL_VERSION}-sonic-${CONFIGURED_ARCH}
    sudo rm -f $FILESYSTEM_ROOT/boot/initrd.img-${LINUX_KERNEL_VERSION}-sonic-${CONFIGURED_ARCH}
fi
```

#### How to verify it

This results in a size reduction of \~45 MB from the final image archive (the files are compressed within the archive, hence the reduction is smaller than the raw file sizes). Post making this change we were able to boot sonic normally on aspeed platform.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

