### PR TITLE
[Mellanox] Fix CPLD update for platforms with bmc

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -52,6 +52,8 @@ try:
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
+from . import utils
+
 logger = Logger("mlnx-platform-api")
 
 class MPFAManager(object):
@@ -758,6 +760,8 @@ class ComponentCPLD(Component):
     CPLD_FIRMWARE_UPDATE_COMMAND_SPC1 = ['cpldupdate', '--dev', '', '--print-progress', '']
     CPLD_FIRMWARE_UPDATE_COMMAND = ['cpldupdate', '--gpio', '--print-progress', '']
 
+    AUX_PWR_CYCLE_FILE = '/var/run/hw-management/system/aux_pwr_cycle'
+
     def __init__(self, idx):
         super(ComponentCPLD, self).__init__()
 
@@ -901,16 +905,22 @@ class ComponentCPLD(Component):
         with MPFAManager(image_path) as mpfa:
             if not mpfa.get_metadata().has_option('firmware', 'burn'):
                 raise RuntimeError("Failed to get {} burn firmware".format(self.name))
-            if not mpfa.get_metadata().has_option('firmware', 'refresh'):
-                raise RuntimeError("Failed to get {} refresh firmware".format(self.name))
 
             burn_firmware = mpfa.get_metadata().get('firmware', 'burn')
-            refresh_firmware = mpfa.get_metadata().get('firmware', 'refresh')
-
             print("INFO: Processing {} burn file: firmware install".format(self.name))
             if not self._install_firmware(os.path.join(mpfa.get_path(), burn_firmware)):
                 return
 
+            is_platform_with_bmc = device_info.get_bmc_data() is not None
+            if is_platform_with_bmc:
+                print("INFO: Burning {} firmware completed. Running aux power cycle to complete firmware update".format(self.name))
+                utils.write_file(self.AUX_PWR_CYCLE_FILE, '1', raise_exception=True)
+                return
+
+            if not mpfa.get_metadata().has_option('firmware', 'refresh'):
+                raise RuntimeError("Failed to get {} refresh firmware".format(self.name))
+
+            refresh_firmware = mpfa.get_metadata().get('firmware', 'refresh')
             print("INFO: Processing {} refresh file: firmware update".format(self.name))
             self._install_firmware(os.path.join(mpfa.get_path(), refresh_firmware))
 

--- a/platform/mellanox/mlnx-platform-api/tests/test_component.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_component.py
@@ -214,8 +214,9 @@ class TestComponent:
     @mock.patch('sonic_platform.component.subprocess.check_call')
     @mock.patch('sonic_platform.component.MPFAManager.get_path')
     @mock.patch('sonic_platform.component.MPFAManager.get_metadata')
+    @mock.patch('sonic_platform.component.device_info.get_bmc_data', return_value=None)
     @mock.patch('sonic_platform.component.os.path.exists')
-    def test_cpld_component(self, mock_exists, mock_get_meta_data, mock_get_path, mock_check_call, mock_is_spc1):
+    def test_cpld_component(self, mock_exists, mock_get_bmc, mock_get_meta_data, mock_get_path, mock_check_call, mock_is_spc1):
         c = ComponentCPLD(1)
         mock_is_spc1.return_value = True
         c._read_generic_file = mock.MagicMock(side_effect=[None, '1', None])
@@ -286,6 +287,47 @@ class TestComponent:
         assert c.auto_update_firmware('', 'cold') == FW_AUTO_ERR_UNKNOWN
         c.install_firmware = mock.MagicMock(return_value=True)
         assert c.auto_update_firmware('', 'cold') == FW_AUTO_SCHEDULED
+
+    @mock.patch('sonic_platform.component.utils.write_file')
+    @mock.patch('sonic_platform.component.device_info.get_bmc_data', return_value={'bmc_addr': 'x'})
+    @mock.patch('sonic_platform.component.MPFAManager.cleanup', mock.MagicMock())
+    @mock.patch('sonic_platform.component.MPFAManager.extract', mock.MagicMock())
+    @mock.patch('sonic_platform.component.MPFAManager.get_path')
+    @mock.patch('sonic_platform.component.MPFAManager.get_metadata')
+    def test_cpld_update_firmware_bmc_mpfa_triggers_aux_power_cycle(self, mock_get_meta_data, mock_get_path, mock_get_bmc, mock_write):
+        c = ComponentCPLD(1)
+        c._install_firmware = mock.MagicMock(return_value=True)
+        mock_meta_data = mock.MagicMock()
+        mock_meta_data.has_option = mock.MagicMock(return_value=True)
+        mock_meta_data.get = mock.MagicMock(return_value='burn')
+        mock_get_meta_data.return_value = mock_meta_data
+        mock_get_path.return_value = '/tmp'
+
+        c.update_firmware('a.mpfa')
+
+        c._install_firmware.assert_called_once_with('/tmp/burn')
+        mock_write.assert_called_once_with(ComponentCPLD.AUX_PWR_CYCLE_FILE, '1', raise_exception=True)
+
+    @mock.patch('sonic_platform.component.utils.write_file')
+    @mock.patch('sonic_platform.component.device_info.get_bmc_data', return_value={'bmc_addr': 'x'})
+    @mock.patch('sonic_platform.component.MPFAManager.cleanup', mock.MagicMock())
+    @mock.patch('sonic_platform.component.MPFAManager.extract', mock.MagicMock())
+    @mock.patch('sonic_platform.component.MPFAManager.get_path')
+    @mock.patch('sonic_platform.component.MPFAManager.get_metadata')
+    def test_cpld_update_firmware_bmc_mpfa_burn_fail_skips_aux_power_cycle(self, mock_get_meta_data, mock_get_path, mock_get_bmc, mock_write):
+        c = ComponentCPLD(1)
+        c._install_firmware = mock.MagicMock(return_value=False)
+        mock_meta_data = mock.MagicMock()
+        mock_meta_data.has_option = mock.MagicMock(return_value=True)
+        mock_meta_data.get = mock.MagicMock(return_value='burn')
+        mock_get_meta_data.return_value = mock_meta_data
+        mock_get_path.return_value = '/tmp'
+
+        c.update_firmware('a.mpfa')
+
+        c._install_firmware.assert_called_once_with('/tmp/burn')
+        mock_write.assert_not_called()
+
 
     @mock.patch('sonic_platform.component.ComponentCPLD._is_spc1_asic')
     @mock.patch('sonic_platform.component.subprocess.check_call')


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
For BMC platforms, there is no refresh file, so MPFA contains only the burn step.
Instead of the refresh step, we should power-cycle for applying the new CPLD FW.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
If the platform has BMC, we execute power-cycle instead of extract non-existing refresh file.

#### How to verify it
config platform firmware update chassis component CPLD

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

