### PR TITLE
Fix issue #26776: missing /zmq_swss directory causes orchagent crash

### DIFF
--- a/platform/vs/docker-sonic-vs/Dockerfile.j2
+++ b/platform/vs/docker-sonic-vs/Dockerfile.j2
@@ -168,6 +168,9 @@ COPY ["frr/zebra.conf", "/etc/frr/"]
 # Create /var/warmboot/teamd folder for teammgrd
 RUN mkdir -p /var/warmboot/teamd
 
+# Create /zmq_swss directory for ZMQ IPC sockets
+RUN mkdir -p /zmq_swss
+
 FROM $BASE
 
 {{ rsync_from_builder_stage() }}


### PR DESCRIPTION
Issue: missing /zmq_swss directory causes orchagent crash

#### Why I did it

After sonic-net/sonic-swss#4243 was merged (around 2026-04-01), orchagent uses ZMQ with IPC sockets for P4 orchestration. These sockets are bound to paths like ipc:///zmq_swss/p4orch_zmq_swss_ep.
On real SONiC systems: The /zmq_swss directory is bind-mounted into the swss container from the host filesystem via the docker run configuration in rules/docker-orchagent.mk.
On docker-sonic-vs: The container runs standalone (e.g., via containerlab) without a host bind mount, so the /zmq_swss directory doesn't exist. When orchagent tries to bind to the ZMQ IPC endpoint, zmq_bind() fails with errno 2 (No such file or directory), causing orchagent to abort.

#### How I did it

I've added a directory creation step in the docker-sonic-vs Dockerfile:
File: platform/vs/docker-sonic-vs/Dockerfile.j2
Change: Added lines 171-173 to create the /zmq_swss directory:

#### How to verify it

The workaround mentioned in the issue (manually creating the directory and restarting) confirms this fix will work:
docker exec <container> mkdir -p /zmq_swss
docker exec <container> supervisorctl 
restart start.sh


#### Which release branch to backport (provide reason below if selected)

- [x] 202305
- [x] 202311
- [x] 202405
- [x] 202411
- [x] 202505
- [x] 202511
Reason for backporting: docker-sonic-vs crashes on startup due to missing /zmq_swss directory. This bug affects
stable releases as well, so backporting ensures docker-sonic-vs runs correctly on those branches.
 

#### Tested branch (Please provide the tested image version)

- [x] 20200712


#### Description for the changelog

PR#26776 under sonic-net repo. Added lines 171-173 to create the /zmq_swss directory to ensure that the directory exists inside the container filesystem, allowing orchagent to successfully bind to its ZMQ IPC endpoints and start properly.


#### Link to config_db schema for YANG module changes

 N/A

#### A picture of a cute animal (not mandatory but encouraged)

  ╱|、
(˚ˎ 。7  
 |、˜〵          
じしˍ,)ノ

