### PR TITLE
[202511][yang] Add MseeRouter device type to DEVICE_METADATA

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -108,6 +108,9 @@
     "DEVICE_METADATA_TYPE_FILTER_LEAF_PATTERN": {
         "desc": "DEVICE_METADATA value as FilterLeaf for Type field"
     },
+    "DEVICE_METADATA_TYPE_MSEE_ROUTER_PATTERN": {
+        "desc": "DEVICE_METADATA value as MseeRouter for Type field"
+    },
     "DEVICE_METADATA_TYPE_NOT_PROVISIONED_PATTERN": {
         "desc": "DEVICE_METADATA value as not-provisioned for Type field"
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
@@ -312,6 +312,16 @@
             }
         }
     },
+    "DEVICE_METADATA_TYPE_MSEE_ROUTER_PATTERN": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "bgp_asn": "65002",
+                    "type": "MseeRouter"
+                }
+            }
+        }
+    },
     "DEVICE_METADATA_TYPE_NOT_PROVISIONED_PATTERN": {
         "sonic-device_metadata:sonic-device_metadata": {
             "sonic-device_metadata:DEVICE_METADATA": {

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -100,7 +100,7 @@ module sonic-device_metadata {
                 leaf type {
                     type string {
                         length 1..255;
-                        pattern "ToRRouter|LeafRouter|SpineChassisFrontendRouter|ChassisBackendRouter|ASIC|MgmtToRRouter|MgmtLeafRouter|MgmtSpineRouter|MgmtAccessRouter|LowerMgmtAggregator|UpperMgmtAggregator|SpineRouter|UpperSpineRouter|FabricSpineRouter|LowerSpineRouter|BackEndToRRouter|BackEndLeafRouter|EPMS|MgmtTsToR|BmcMgmtToRRouter|MiniTs|LeafTs|SpineTs|CoreTs|ConsoleServer|TerminalServer|SonicHost|SmartSwitchDPU|FilterLeaf|not-provisioned|LowerRegionalHub|FabricRegionalHub|UpperRegionalHub";
+                        pattern "ToRRouter|LeafRouter|SpineChassisFrontendRouter|ChassisBackendRouter|ASIC|MgmtToRRouter|MgmtLeafRouter|MgmtSpineRouter|MgmtAccessRouter|LowerMgmtAggregator|UpperMgmtAggregator|SpineRouter|UpperSpineRouter|FabricSpineRouter|LowerSpineRouter|BackEndToRRouter|BackEndLeafRouter|EPMS|MgmtTsToR|BmcMgmtToRRouter|MiniTs|LeafTs|SpineTs|CoreTs|ConsoleServer|TerminalServer|SonicHost|SmartSwitchDPU|FilterLeaf|MseeRouter|not-provisioned|LowerRegionalHub|FabricRegionalHub|UpperRegionalHub";
                     }
                 }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add MseeRouter as a valid device type in sonic-device_metadata.yang
to support MSEE deployment scenarios.

Cherry-pick of #26847 (master) to 202511 with conflict resolution
(202511 pattern doesn't include NetworkBmc/RegionalHub types).

#### How I did it
Add MseeRouter to the type pattern in sonic-device_metadata.yang and
add corresponding YANG model test entries (positive validation test).

#### How to verify it
YANG model unit tests validate MseeRouter is accepted as a valid type value.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version 1 -->

#### Description for the changelog
Add MseeRouter as a valid device type in YANG model.

#### Link to config_db schema for YANG module changes
https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#device_metadata
