### PR TITLE
[pensando]: Remove leading '/' from loop= kernel cmdline parameter

### DIFF
--- a/files/dsc/install_debian.j2
+++ b/files/dsc/install_debian.j2
@@ -251,7 +251,7 @@ label main
     kernel /$image_dir/boot/vmlinuz-6.12.41+deb13-sonic-arm64
     initrd /$image_dir/boot/initrd.img-6.12.41+deb13-sonic-arm64
     devicetree /$image_dir/boot/elba-asic-psci.dtb
-    append softdog.soft_panic=1 FW_NAME=mainfwa root=/dev/mmcblk0p10 rw rootwait rootfstype=ext4 loopfstype=squashfs loop=/$image_dir/fs.squashfs
+    append softdog.soft_panic=1 FW_NAME=mainfwa root=/dev/mmcblk0p10 rw rootwait rootfstype=ext4 loopfstype=squashfs loop=$image_dir/fs.squashfs
 }
 EOF
 }

--- a/platform/pensando/platform.conf
+++ b/platform/pensando/platform.conf
@@ -127,7 +127,7 @@ label main
 	kernel /$image_dir/boot/vmlinuz-$KVER
 	initrd /$image_dir/boot/initrd.img-$KVER
 	devicetree /$image_dir/boot/elba-asic-psci.dtb
-	append softdog.soft_panic=1 FW_NAME=mainfwa root=/dev/mmcblk0p10 rw rootwait rootfstype=ext4 loopfstype=squashfs loop=/$image_dir/fs.squashfs isolcpus=1,2,3,5,6,7,9,10,11,13,14,15 nohz_full=1,2,3,5,6,7,9,10,11,13,14,15 rcu_nocbs=1,2,3,5,6,7,9,10,11,13,14,15 rcu_nocb_poll irqaffinity=0
+	append softdog.soft_panic=1 FW_NAME=mainfwa root=/dev/mmcblk0p10 rw rootwait rootfstype=ext4 loopfstype=squashfs loop=$image_dir/fs.squashfs isolcpus=1,2,3,5,6,7,9,10,11,13,14,15 nohz_full=1,2,3,5,6,7,9,10,11,13,14,15 rcu_nocbs=1,2,3,5,6,7,9,10,11,13,14,15 rcu_nocb_poll irqaffinity=0
 }
 EOF
 }
@@ -143,7 +143,7 @@ label main
 	kernel /$image_dir/boot/vmlinuz-$KVER
 	initrd /$image_dir/boot/initrd.img-$KVER
 	devicetree /$image_dir/boot/elba-asic-psci-mtfuji.dtb
-	append softdog.soft_panic=1 FW_NAME=mainfwa root=/dev/mmcblk0p10 rw rootwait rootfstype=ext4 loopfstype=squashfs loop=/$image_dir/fs.squashfs isolcpus=1,2,3,5,6,7,9,10,11,13,14,15 nohz_full=1,2,3,5,6,7,9,10,11,13,14,15 rcu_nocbs=1,2,3,5,6,7,9,10,11,13,14,15 rcu_nocb_poll irqaffinity=0 varlog_size=256
+	append softdog.soft_panic=1 FW_NAME=mainfwa root=/dev/mmcblk0p10 rw rootwait rootfstype=ext4 loopfstype=squashfs loop=$image_dir/fs.squashfs isolcpus=1,2,3,5,6,7,9,10,11,13,14,15 nohz_full=1,2,3,5,6,7,9,10,11,13,14,15 rcu_nocbs=1,2,3,5,6,7,9,10,11,13,14,15 rcu_nocb_poll irqaffinity=0 varlog_size=256
 }
 EOF
 }
@@ -159,7 +159,7 @@ label main
 	kernel /$image_dir/boot/vmlinuz-$KVER
 	initrd /$image_dir/boot/initrd.img-$KVER
 	devicetree /$image_dir/boot/elba-asic-psci-lipari.dtb
-	append softdog.soft_panic=1 FW_NAME=mainfwa root=/dev/mmcblk0p10 rw rootwait rootfstype=ext4 loopfstype=squashfs loop=/$image_dir/fs.squashfs isolcpus=1,2,3,5,6,7,9,10,11,13,14,15 nohz_full=1,2,3,5,6,7,9,10,11,13,14,15 rcu_nocbs=1,2,3,5,6,7,9,10,11,13,14,15 rcu_nocb_poll irqaffinity=0
+	append softdog.soft_panic=1 FW_NAME=mainfwa root=/dev/mmcblk0p10 rw rootwait rootfstype=ext4 loopfstype=squashfs loop=$image_dir/fs.squashfs isolcpus=1,2,3,5,6,7,9,10,11,13,14,15 nohz_full=1,2,3,5,6,7,9,10,11,13,14,15 rcu_nocbs=1,2,3,5,6,7,9,10,11,13,14,15 rcu_nocb_poll irqaffinity=0
 }
 EOF
 }


### PR DESCRIPTION
#### What I did
Remove the unnecessary leading `/` from the `loop=` kernel command line parameter in the Pensando bootloader config for all platform variants (base, mtfuji, lipari) and the DSC install script.

#### How I did it
Changed `loop=/$image_dir/fs.squashfs` to `loop=$image_dir/fs.squashfs` in:
- `platform/pensando/platform.conf` — `create_bootloader_conf()`, `create_bootloader_mtfuji_conf()`, `create_bootloader_lipari_conf()`
- `files/dsc/install_debian.j2` — bootloader config generation

#### Why I did it
The leading `/` causes `sonic-installer list` to display incorrect version information. The `get_current_image()` method in `sonic_installer/bootloader/onie.py` parses the current image from `/proc/cmdline` using the regex `loop=(\S+)/fs.squashfs`. With the leading `/`, it captures `/image-<version>` instead of `image-<version>`, which propagates through `IMAGE_DIR_PREFIX` → `IMAGE_PREFIX` replacement to produce `/SONiC-OS-<version>` — with a spurious leading `/` in the version string.

Additionally, the grub-based platforms in `installer/default_platform.conf` already use `loop=$image_dir/...` without a leading slash, and the initramfs `union-mount` script strips any leading slash via `${LOOP#/}`, so both forms resolve to the same mount path. This change aligns Pensando platforms with the rest of the codebase.

#### How to verify it
Boot a Pensando platform (base/mtfuji/lipari) with the new image and verify:
1. The `boot-image-*.conf` file contains `loop=image-<version>/fs.squashfs` (no leading `/`)
2. The system boots successfully and the squashfs root filesystem is mounted correctly
3. `cat /proc/cmdline` shows the updated `loop=` parameter without the leading `/`
4. `sonic-installer list` shows the current image version without a leading `/`