### PR TITLE
aspeed: TFTP net installer and eMMC imaging

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -365,6 +365,7 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     locales                 \
     cgroup-tools            \
     ipmitool                \
+    freeipmi-tools          \
     ndisc6                  \
     conntrack               \
     python3                 \

--- a/platform/aspeed/build-emmc-image-installer.sh
+++ b/platform/aspeed/build-emmc-image-installer.sh
@@ -2,16 +2,20 @@
 # Build Complete SONiC eMMC Image for AST2700 Using SONiC Installer
 # This creates a ready-to-flash disk image by leveraging the built-in SONiC installer
 #
-# Usage: ./build-emmc-image-installer.sh <sonic-aspeed-arm64.bin> [output-image-name]
+# Usage: ./build-emmc-image-installer.sh <sonic-aspeed-arm64.bin> [output-image-name] [emmc_size_mb]
+#        Sources platform/aspeed/onie-image-arm64.conf for EMMC_SIZE_MB and other platform variables.
+#        EMMC_SIZE_MB is required in onie-image-arm64.conf. Optional: third argument or env overrides it.
 #
 # This script uses the SONiC installer's "build" mode to create a raw ext4 image,
 # then embeds it into a full GPT-partitioned eMMC image with a single SONiC-OS partition.
 #
 # Partition Layout (Standard SONiC Approach):
-#   /dev/mmcblk0p1 - SONiC-OS (entire disk 10 GB - assumes pSLC on a 32G eMMC)
+#   /dev/mmcblk0p1 - SONiC-OS (single partition; size = emmc_size_mb - 100 MB for GPT)
 #     ├── image-SONiC-OS-<version1>/
 #     ├── image-SONiC-OS-<version2>/
 #     └── machine.conf
+#
+# For 10 GB (pSLC) set EMMC_SIZE_MB=10240 in onie-image-arm64.conf (or override with the third argument).
 #
 # Requirements:
 #   - Root privileges (for loop device mounting)
@@ -21,11 +25,25 @@
 
 set -e  # Exit on error
 
-# Configuration
-# We use 10GB as the 32G eMMC card in chipmunk will be 10G post pSLC partitioning
-EMMC_SIZE_MB=10240
-PARTITION_LABEL="SONiC-OS"  # Single partition for all SONiC images
-ROOT_PART_SIZE_MB=$((EMMC_SIZE_MB - 100))  # SONiC-OS partition size (leave 100MB for GPT overhead)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ONIE_IMAGE_ARM64_CONF="$SCRIPT_DIR/onie-image-arm64.conf"
+if [ -n "${EMMC_SIZE_MB+x}" ]; then
+    _emmc_size_mb_override=$EMMC_SIZE_MB
+fi
+if [ ! -r "$ONIE_IMAGE_ARM64_CONF" ]; then
+    echo "Error: cannot read $ONIE_IMAGE_ARM64_CONF" >&2
+    exit 1
+fi
+. "$ONIE_IMAGE_ARM64_CONF"
+if [ -n "${_emmc_size_mb_override+x}" ]; then
+    EMMC_SIZE_MB="$_emmc_size_mb_override"
+fi
+unset _emmc_size_mb_override
+if [ -z "${EMMC_SIZE_MB:-}" ]; then
+    echo "Error: EMMC_SIZE_MB must be set in $ONIE_IMAGE_ARM64_CONF" >&2
+    exit 1
+fi
+PARTITION_LABEL="SONiC-OS"
 
 # Colors
 RED='\033[0;31m'
@@ -58,18 +76,23 @@ cleanup() {
 }
 
 # Parse arguments
-[ $# -lt 1 ] && { echo "Usage: $0 <sonic-aspeed-arm64.bin> [output-image-name]"; exit 1; }
+[ $# -lt 1 ] && { echo "Usage: $0 <sonic-aspeed-arm64.bin> [output-image-name] [emmc_size_mb]"; exit 1; }
 
 SONIC_BIN="$(realpath "$1")"
-OUTPUT_IMAGE="${2:-sonic-aspeed-arm64-emmc.img}"
+OUTPUT_IMAGE="${2:-target/sonic-aspeed-arm64-emmc.img}"
+[ -n "${3:-}" ] && EMMC_SIZE_MB="$3"
+
+ROOT_PART_SIZE_MB=$((EMMC_SIZE_MB - 100))
 
 [ ! -f "$SONIC_BIN" ] && { log_error "SONiC binary not found: $SONIC_BIN"; exit 1; }
+[ "$EMMC_SIZE_MB" -lt 1024 ] && { log_error "EMMC_SIZE_MB must be >= 1024 (1 GB)"; exit 1; }
 
 check_requirements
 trap cleanup EXIT
 
 ORIG_DIR=$(pwd)
 LOOP_DEV=""
+# Must match OUTPUT_RAW_IMAGE embedded in the .bin (this build uses target/sonic-aspeed.raw)
 RAW_IMAGE="target/sonic-aspeed.raw"
 
 # Create target directory if it doesn't exist
@@ -77,6 +100,7 @@ mkdir -p target
 
 log_info "Building eMMC image from: $SONIC_BIN"
 log_info "Output image: $OUTPUT_IMAGE"
+log_info "eMMC size: ${EMMC_SIZE_MB} MB (SONiC-OS partition: ${ROOT_PART_SIZE_MB} MB)"
 
 # Step 1: Use SONiC installer in "build" mode to create raw ext4 image
 log_info "Running SONiC installer in 'build' mode..."
@@ -95,11 +119,9 @@ fallocate -l "${ROOT_PART_SIZE_MB}M" "$RAW_IMAGE" || {
     exit 1
 }
 
-# Run the installer directly
-# It will detect install_env="build" and use the pre-created raw image
-# The installer already has the correct path: target/sonic-aspeed.raw
+# Run the installer from ORIG_DIR so cur_wd matches where we created the raw image
 log_info "Running installer (this may take a few minutes)..."
-bash "$SONIC_BIN" || {
+(cd "$ORIG_DIR" && bash "$SONIC_BIN") || {
     log_error "Installer failed"
     exit 1
 }
@@ -119,6 +141,8 @@ TEMP_MOUNT=$(mktemp -d)
 mount -o loop "$RAW_IMAGE" "$TEMP_MOUNT"
 
 touch "$TEMP_MOUNT/.first_boot_from_prebuilt_image"
+IMAGE_DIR_NAME=$(ls -d "$TEMP_MOUNT"/image-* 2>/dev/null | head -1 | xargs basename)
+[ -n "$IMAGE_DIR_NAME" ] && log_info "U-Boot image directory on eMMC (use in ext4load): $IMAGE_DIR_NAME"
 
 umount "$TEMP_MOUNT"
 rmdir "$TEMP_MOUNT"
@@ -136,19 +160,13 @@ sgdisk -o "$DISK_IMAGE"
 log_info "Creating single SONiC-OS partition using entire disk..."
 sgdisk -n 1:0:0 -t 1:8300 -c 1:"$PARTITION_LABEL" "$DISK_IMAGE"
 
-log_info "Setting up loop device..."
-LOOP_DEV=$(losetup -f --show -P "$DISK_IMAGE")
-log_info "Loop device: $LOOP_DEV"
-sleep 1
-partprobe "$LOOP_DEV" || true
-sleep 1
+PART_START_SECTOR=$(sgdisk -i 1 "$DISK_IMAGE" | sed -n 's/^First sector: *\([0-9]*\).*/\1/p')
+[ -z "$PART_START_SECTOR" ] && { log_error "Could not get partition start sector"; exit 1; }
+log_info "Partition 1 starts at sector $PART_START_SECTOR"
 
 log_info "Copying SONiC installation to SONiC-OS partition..."
-dd if="$RAW_IMAGE" of="${LOOP_DEV}p1" bs=128M conv=sparse oflag=direct status=progress
+dd if="$RAW_IMAGE" of="$DISK_IMAGE" bs=512 seek="$PART_START_SECTOR" conv=sparse status=progress
 
-log_info "Cleaning up..."
-losetup -d "$LOOP_DEV"
-LOOP_DEV=""
 rm -f "$RAW_IMAGE"
 RAW_IMAGE=""
 

--- a/platform/aspeed/installer/create_tftp_image.sh
+++ b/platform/aspeed/installer/create_tftp_image.sh
@@ -1,0 +1,394 @@
+#!/bin/bash
+#
+# Build the Aspeed U-Boot / TFTP install bundle (FIT + initramfs + optional raw eMMC image).
+#
+# Platform-local installer orchestration under platform/<name>/installer/ (same structural role as
+# other platforms' installer scripts). Differences: output is a FIT for TFTP boot, and second-stage
+# logic lives in ../tftp-installer-init/.
+#
+# This script is not wired as a second SONIC_INSTALLERS entry: that would create a second RFS
+# squashfs target (see slave.mk rfs_define_target). The TFTP bundle reuses the rootfs built for
+# sonic-aspeed-arm64.bin (see recipes/installer-tftp.mk).
+#
+# Usage (from sonic-buildimage root):
+#   ./platform/aspeed/installer/create_tftp_image.sh [output_dir]
+#   OUTPUT_TFTP_INSTALL_TAR=target/sonic-aspeed-arm64-tftp-install.tar \
+#     ./platform/aspeed/installer/create_tftp_image.sh target/aspeed-tftp
+#
+# Environment (see also platform/aspeed/onie-image-arm64.conf):
+#   FILESYSTEM_ROOT, EMMC_RAW_IMAGE, OUTPUT_TFTP_INSTALL_TAR, TFTP_EMMC_IMAGE_NAME
+
+set -e
+
+unpack_initrd_to_dir() {
+    local img="$1" dir="$2"
+    local decom=zcat mime magic
+    mime=$(file --brief --mime-type "$img" 2>/dev/null) || mime=""
+    case "$mime" in
+        application/zstd)   decom=zstdcat ;;
+        application/x-lz4)  decom=lz4cat ;;
+        application/x-lzma) decom=xzcat ;;
+        application/gzip|application/x-gzip) decom=zcat ;;
+        application/octet-stream)
+            magic=$(head -c 6 "$img" | xxd -p 2>/dev/null | tr -d '\n')
+            case "$magic" in
+                28b52ffd*) decom=zstdcat ;;
+                1f8b*)     decom=zcat ;;
+                fd377a585a00) decom=xzcat ;;
+            esac
+            ;;
+    esac
+    mkdir -p "$dir"
+    $decom "$img" | (cd "$dir" && cpio -id 2>/dev/null) || true
+}
+
+repack_initrd_cpio_gz() {
+    local dir="$1" out="$2"
+    (cd "$dir" && find . | cpio -o -H newc) | gzip -9 > "$out"
+}
+
+# Walk DT_NEEDED from readelf and copy matching SONAMEs from FILESYSTEM_ROOT (transitive). Used when
+# chroot ldd / host ldd yield nothing for the target arch during cross-builds.
+copy_elf_needed_closure_into() {
+    local seed="$1"
+    local dest_root="$2"
+    local fs="$FILESYSTEM_ROOT"
+    local pending scanned work s f rel
+
+    [ -f "$seed" ] || return 0
+    pending=$(mktemp)
+    scanned=$(mktemp)
+    echo "$seed" >> "$pending"
+    while [ -s "$pending" ]; do
+        work=$(head -n1 "$pending")
+        tail -n +2 "$pending" > "$pending.new" && mv "$pending.new" "$pending"
+        if grep -qxF "$work" "$scanned" 2>/dev/null; then
+            continue
+        fi
+        echo "$work" >> "$scanned"
+        for s in $(readelf -d "$work" 2>/dev/null | sed -n 's/.*Shared library: \[\([^]]*\)\]/\1/p'); do
+            [ -z "$s" ] && continue
+            f=$(find "$fs/lib" "$fs/usr/lib" -name "$s" 2>/dev/null | head -n1)
+            [ -n "$f" ] && [ -f "$f" ] || continue
+            rel="${f#$fs}"
+            rel="/${rel#/}"
+            mkdir -p "$dest_root$(dirname "$rel")"
+            cp -L "$f" "$dest_root$rel" 2>/dev/null || true
+            echo "$f" >> "$pending"
+        done
+    done
+    rm -f "$pending" "$scanned"
+}
+
+copy_fsroot_binary_to_initrd() {
+    local abs="$1" dir="$2"
+    local root="${dir%/}"
+    local real="$abs"
+    [ -L "$abs" ] && real=$(readlink -f "$abs")
+    local rel="${abs#$FILESYSTEM_ROOT}"
+    rel="/${rel#/}"
+    local dest="$root$rel"
+    mkdir -p "$(dirname "$dest")"
+    rm -f "$dest"
+    cp -L "$abs" "$dest"
+    chmod 755 "$dest"
+    local interp idest ldest chpath
+    interp=$(readelf -l "$real" 2>/dev/null | sed -n 's/.*Requesting program interpreter: *\[\([^]]*\)\].*/\1/p')
+    if [ -n "$interp" ] && [ -f "$FILESYSTEM_ROOT$interp" ]; then
+        idest="$root$interp"
+        mkdir -p "$(dirname "$idest")"
+        rm -f "$idest"
+        cp -L "$FILESYSTEM_ROOT$interp" "$idest" 2>/dev/null || true
+    fi
+    chpath="/${rel#/}"
+    (chroot "$FILESYSTEM_ROOT" ldd "$chpath" 2>/dev/null || ldd "$abs" 2>/dev/null) | awk '/=>/ {print $3}' | while read -r path; do
+        [ -z "$path" ] || [ "$path" = "not" ] && continue
+        [ -f "$FILESYSTEM_ROOT$path" ] || continue
+        ldest="$root$path"
+        mkdir -p "$(dirname "$ldest")"
+        rm -f "$ldest"
+        cp -L "$FILESYSTEM_ROOT$path" "$ldest" 2>/dev/null || true
+    done
+    copy_elf_needed_closure_into "$real" "$root"
+}
+
+inject_fsroot_extras_into_initrd() {
+    local dir="$1"
+    local p
+    for p in \
+        /usr/sbin/sgdisk /sbin/sgdisk \
+        /usr/sbin/gdisk /sbin/gdisk \
+        /usr/sbin/cgdisk /sbin/cgdisk \
+        /usr/sbin/fixparts /sbin/fixparts \
+        /sbin/e2fsck /usr/sbin/e2fsck \
+        /sbin/fsck.ext2 /sbin/fsck.ext3 /sbin/fsck.ext4 \
+        /sbin/mke2fs /usr/sbin/mke2fs \
+        /sbin/mkfs.ext2 /sbin/mkfs.ext3 /sbin/mkfs.ext4 \
+        /sbin/resize2fs \
+        /sbin/tune2fs \
+        /sbin/dumpe2fs \
+        /usr/sbin/badblocks \
+        /sbin/debugfs \
+        /sbin/e4defrag \
+        /usr/sbin/filefrag \
+        /usr/sbin/logsave \
+        /sbin/mkfs.vfat /usr/sbin/mkfs.vfat /sbin/mkfs.fat \
+        /sbin/fsck.vfat /usr/sbin/fsck.vfat /sbin/fsck.fat \
+        /usr/sbin/fatlabel /sbin/fatlabel \
+        /sbin/parted /usr/sbin/parted \
+        /usr/sbin/partprobe /sbin/partprobe \
+        /sbin/blkid /usr/sbin/blkid \
+        /sbin/blockdev /usr/sbin/blockdev \
+        /sbin/wipefs /usr/sbin/wipefs \
+        /usr/sbin/sfdisk /sbin/sfdisk \
+        /usr/bin/fw_printenv /usr/sbin/fw_printenv \
+        /usr/bin/fw_setenv /usr/sbin/fw_setenv \
+        /usr/bin/fw_getenv /usr/sbin/fw_getenv; do
+        [ -e "$FILESYSTEM_ROOT/$p" ] || continue
+        copy_fsroot_binary_to_initrd "$FILESYSTEM_ROOT/$p" "$dir"
+    done
+}
+
+repack_sonic_initrd_for_tftp_installer() {
+    local in="$1" out="$2"
+    local d ko
+    d=$(mktemp -d)
+    unpack_initrd_to_dir "$in" "$d"
+    rm -f "$d/init-options" "$d/init-options-base"
+    cp "$d/init" "$d/init.stock"
+    cp "$PLATFORM_ASPEED/tftp-installer-init/init" "$d/init"
+    chmod 755 "$d/init"
+    mkdir -p "$d/sbin"
+    cp "$PLATFORM_ASPEED/tftp-installer-init/install-to-emmc.sh" "$d/sbin/install-to-emmc.sh"
+    chmod 755 "$d/sbin/install-to-emmc.sh"
+    cp "$PLATFORM_ASPEED/tftp-installer-init/udhcpc.script" "$d/sbin/udhcpc.script"
+    chmod 755 "$d/sbin/udhcpc.script"
+    cp "$PLATFORM_ASPEED/scripts/sonic-uboot-env-init.sh" "$d/sbin/sonic-uboot-env-init.sh"
+    chmod 755 "$d/sbin/sonic-uboot-env-init.sh"
+    cp "$PLATFORM_ASPEED/scripts/sonic-machine-conf-init.sh" "$d/sbin/sonic-machine-conf-init.sh"
+    chmod 755 "$d/sbin/sonic-machine-conf-init.sh"
+    cp "$PLATFORM_ASPEED/scripts/sonic-fw-env-config.sh" "$d/sbin/sonic-fw-env-config.sh"
+    chmod 755 "$d/sbin/sonic-fw-env-config.sh"
+    cp "$PLATFORM_ASPEED/scripts/sonic-program-uboot-env.sh" "$d/sbin/sonic-program-uboot-env.sh"
+    chmod 755 "$d/sbin/sonic-program-uboot-env.sh"
+    _aspeed_repo_root="$(cd "$PLATFORM_ASPEED/../.." && pwd)"
+    if [ -d "$_aspeed_repo_root/device/aspeed" ]; then
+        mkdir -p "$d/device/aspeed"
+        cp -a "$_aspeed_repo_root/device/aspeed/." "$d/device/aspeed/"
+    fi
+    unset _aspeed_repo_root
+    inject_fsroot_extras_into_initrd "$d"
+    if [ ! -f "$d/lib/modules/ftgmac100.ko" ] && [ -d "$d/lib/modules" ]; then
+        ko=$(find "$d/lib/modules" -name ftgmac100.ko 2>/dev/null | head -1)
+        if [ -n "$ko" ]; then
+            mkdir -p "$d/lib/modules"
+            cp "$ko" "$d/lib/modules/ftgmac100.ko"
+        fi
+    fi
+    repack_initrd_cpio_gz "$d" "$out"
+    rm -rf "$d"
+}
+
+# Populates globals: KERNEL, KERNEL_VERSION_FULL, SONIC_INITRD. May set BOOT_FALLBACK_TMP for unzip cleanup.
+resolve_kernel_and_initrd() {
+    local root="$1"
+    local k ver ir payload zpath
+    KERNEL=""
+    KERNEL_VERSION_FULL=""
+    SONIC_INITRD=""
+    payload="${INSTALLER_PAYLOAD:-fs.zip}"
+    zpath="$REPO_ROOT/$payload"
+
+    for k in "$root/boot"/vmlinuz-*; do
+        [ -f "$k" ] || continue
+        KERNEL="$k"
+        break
+    done
+    if [ -z "$KERNEL" ]; then
+        KERNEL=$(find "$root/usr/lib" -path '*/linux-image-*/vmlinuz-*' -type f 2>/dev/null | head -1)
+    fi
+    if [ -z "$KERNEL" ] || [ ! -f "$KERNEL" ]; then
+        if [ -f "$zpath" ] && command -v unzip >/dev/null 2>&1; then
+            BOOT_FALLBACK_TMP=$(mktemp -d)
+            if unzip -qq -j -o "$zpath" "boot/vmlinuz-*" -d "$BOOT_FALLBACK_TMP" 2>/dev/null; then
+                KERNEL=$(ls -1 "$BOOT_FALLBACK_TMP"/vmlinuz-* 2>/dev/null | head -1)
+            fi
+            if [ -z "$KERNEL" ] || [ ! -f "$KERNEL" ]; then
+                rm -rf "$BOOT_FALLBACK_TMP"
+                BOOT_FALLBACK_TMP=""
+            fi
+        fi
+    fi
+    if [ -z "$KERNEL" ] || [ ! -f "$KERNEL" ]; then
+        echo "Error: No kernel found (checked $root/boot/, usr/lib/linux-image-*/vmlinuz-*, and $zpath boot/)."
+        echo "Build target/sonic-aspeed-arm64.bin first so fs.zip or fsroot contains /boot."
+        return 1
+    fi
+    ver=$(basename "$KERNEL" | sed 's/^vmlinuz-//')
+    KERNEL_VERSION_FULL="$ver"
+
+    SONIC_INITRD="$root/boot/initrd.img-$ver"
+    if [ ! -f "$SONIC_INITRD" ]; then
+        SONIC_INITRD=$(find "$root/usr/lib" -path "*/linux-image-$ver/initrd.img*" -type f 2>/dev/null | head -1)
+    fi
+    if [ -n "$BOOT_FALLBACK_TMP" ] && [ -d "$BOOT_FALLBACK_TMP" ]; then
+        ir=$(ls -1 "$BOOT_FALLBACK_TMP"/initrd.img-* 2>/dev/null | head -1)
+        if [ -n "$ir" ] && [ -f "$ir" ]; then
+            SONIC_INITRD="$ir"
+        fi
+    fi
+    if [ -z "$SONIC_INITRD" ] || [ ! -f "$SONIC_INITRD" ]; then
+        if [ -f "$zpath" ] && command -v unzip >/dev/null 2>&1; then
+            [ -z "$BOOT_FALLBACK_TMP" ] && BOOT_FALLBACK_TMP=$(mktemp -d)
+            unzip -qq -j -o "$zpath" "boot/initrd.img-*" -d "$BOOT_FALLBACK_TMP" 2>/dev/null || true
+            ir=$(ls -1 "$BOOT_FALLBACK_TMP"/initrd.img-* 2>/dev/null | head -1)
+            [ -n "$ir" ] && [ -f "$ir" ] && SONIC_INITRD="$ir"
+        fi
+    fi
+    if [ -z "$SONIC_INITRD" ] || [ ! -f "$SONIC_INITRD" ]; then
+        echo "Error: No initrd for kernel $ver (expected boot/initrd.img-$ver, usr/lib/linux-image-$ver/, or $zpath boot/)."
+        return 1
+    fi
+    return 0
+}
+
+INSTALLER_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLATFORM_ASPEED="$(cd "$INSTALLER_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$PLATFORM_ASPEED/../.." && pwd)"
+cd "$REPO_ROOT"
+
+OUTPUT_DIR="${1:-target/aspeed-tftp}"
+FIT_NAME="sonic_tftp_install.fit"
+
+if [ -r "./platform/aspeed/onie-image-arm64.conf" ]; then
+    . ./platform/aspeed/onie-image-arm64.conf
+fi
+FILESYSTEM_ROOT="${FILESYSTEM_ROOT:-./fsroot-aspeed}"
+
+if [ ! -d "$FILESYSTEM_ROOT" ]; then
+    echo "Error: $FILESYSTEM_ROOT not found. Build the Aspeed image first:"
+    echo "  make target/sonic-aspeed-arm64.bin"
+    exit 1
+fi
+FILESYSTEM_ROOT="$(cd "$FILESYSTEM_ROOT" && pwd)"
+
+INSTALLER_PAYLOAD="${INSTALLER_PAYLOAD:-fs.zip}"
+BOOT_FALLBACK_TMP=""
+FIT_STAGING=""
+
+cleanup_all() {
+    sudo umount "$FILESYSTEM_ROOT/tmp/tftp-fit" 2>/dev/null || true
+    rm -rf "${FIT_STAGING:-}" 2>/dev/null || true
+    rm -rf "${BOOT_FALLBACK_TMP:-}" 2>/dev/null || true
+}
+trap cleanup_all EXIT
+
+if ! resolve_kernel_and_initrd "$FILESYSTEM_ROOT"; then
+    exit 1
+fi
+
+DTB_DIR=$(ls -d "$FILESYSTEM_ROOT/usr/lib/linux-image-"*/aspeed 2>/dev/null | head -1)
+if [ -z "$DTB_DIR" ] || [ ! -d "$DTB_DIR" ]; then
+    DTB_DIR=$(ls -d "$FILESYSTEM_ROOT/usr/lib/linux-image-${KERNEL_VERSION_FULL}/aspeed" 2>/dev/null | head -1)
+fi
+
+EMMC_RAW_IMAGE="${EMMC_RAW_IMAGE:-target/sonic-aspeed-arm64-emmc.img.gz}"
+[ -n "$EMMC_RAW_IMAGE" ] || EMMC_RAW_IMAGE="target/sonic-aspeed-arm64-emmc.img.gz"
+if [ -n "${TFTP_EMMC_IMAGE_NAME:-}" ]; then
+    TFTP_IMAGE_NAME="$TFTP_EMMC_IMAGE_NAME"
+else
+    TFTP_IMAGE_NAME=$(basename "$EMMC_RAW_IMAGE")
+fi
+
+if [ -z "$DTB_DIR" ] || [ ! -d "$DTB_DIR" ]; then
+    echo "Error: No DTB dir under $FILESYSTEM_ROOT/usr/lib/linux-image-*/aspeed"
+    exit 1
+fi
+if [ ! -f "$EMMC_RAW_IMAGE" ]; then
+    echo "Error: Raw eMMC image not found: $EMMC_RAW_IMAGE"
+    echo "Build it first: make aspeed-emmc-image"
+    echo "Or manually: sudo ./platform/aspeed/build-emmc-image-installer.sh target/sonic-aspeed-arm64.bin"
+    exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+INITRD_DEST="$OUTPUT_DIR/initrd-tftp-net-install.img"
+echo "Repacking production initrd $SONIC_INITRD (strip init-options; installer /init)..."
+repack_sonic_initrd_for_tftp_installer "$SONIC_INITRD" "$INITRD_DEST"
+INITRAMFS="$INITRD_DEST"
+
+echo "Using kernel: $KERNEL"
+echo "Using initramfs (source): $SONIC_INITRD"
+echo "Using repacked initramfs: $INITRAMFS"
+
+echo "Building FIT image..."
+FIT_STAGING=$(mktemp -d)
+cp "$KERNEL" "$FIT_STAGING/kernel"
+cp "$OUTPUT_DIR/initrd-tftp-net-install.img" "$FIT_STAGING/initrd"
+mkdir -p "$FIT_STAGING/dtb"
+cp "$DTB_DIR"/*.dtb "$FIT_STAGING/dtb/" 2>/dev/null || true
+sed -e "s|__KERNEL_PATH__|/tmp/tftp-fit/kernel|g" \
+    -e "s|__INITRD_PATH__|/tmp/tftp-fit/initrd|g" \
+    -e "s|__DTB_PATH_ASPEED__|/tmp/tftp-fit/dtb|g" \
+    "$PLATFORM_ASPEED/sonic_fit.its" > "$FIT_STAGING/sonic.its"
+
+sudo mkdir -p "$FILESYSTEM_ROOT/tmp/tftp-fit"
+sudo mount --bind "$FIT_STAGING" "$FILESYSTEM_ROOT/tmp/tftp-fit"
+sudo chroot "$FILESYSTEM_ROOT" mkimage -f /tmp/tftp-fit/sonic.its /tmp/tftp-fit/out.fit
+sudo cp "$FILESYSTEM_ROOT/tmp/tftp-fit/out.fit" "$OUTPUT_DIR/$FIT_NAME"
+sudo chown "$(id -u):$(id -g)" "$OUTPUT_DIR/$FIT_NAME"
+sudo umount "$FILESYSTEM_ROOT/tmp/tftp-fit"
+rm -rf "$FIT_STAGING"
+FIT_STAGING=""
+
+cp -v "$EMMC_RAW_IMAGE" "$OUTPUT_DIR/$TFTP_IMAGE_NAME"
+
+fit_addr=0x432000000
+
+cat > "$OUTPUT_DIR/uboot-tftp-commands.txt" << EOF
+# Aspeed TFTP initramfs: /init brings up network, can TFTP the eMMC image and run install-to-emmc.sh.
+#
+# 1. On TFTP server: sonic_tftp_install.fit and $TFTP_IMAGE_NAME (same directory as FIT is typical).
+#
+# 2. In U-Boot — auto install to eMMC (DHCP + TFTP from serverip):
+dhcp
+setenv serverip <tftp-server-ip>
+setenv loadaddr $fit_addr
+setenv bootargs "console=ttyS12,115200n8 earlycon=uart8250,mmio32,0x14c33b00 root=/dev/ram0 rw sonic_install.tftp_server=\${serverip} sonic_install.tftp_image=$TFTP_IMAGE_NAME"
+tftp \$loadaddr sonic_tftp_install.fit
+# bootconf must match a "configurations" entry in platform/aspeed/sonic_fit.its (name without conf- prefix).
+setenv bootconf <fit-configuration>
+bootm \$loadaddr#conf-\$bootconf
+#
+#    Optional bootargs: sonic_install.reboot=1  (reboot after flash; network is always eth0)
+#    Static IP instead of DHCP: add e.g. ip=192.168.1.50::192.168.1.1:255.255.255.0::eth0:off
+#
+# 3. Manual install (no sonic_install.tftp_server in bootargs): shell then
+#      /sbin/install-to-emmc.sh /tmp/$TFTP_IMAGE_NAME
+#    If you use gunzip|dd manually, run sync (and blockdev --flushbufs /dev/mmcblk0) before reboot
+#    or the eMMC root fs may be corrupt (EXT4 journal / I/O errors on first boot).
+EOF
+
+if [ -n "${OUTPUT_TFTP_INSTALL_TAR:-}" ]; then
+    mkdir -p "$(dirname "$OUTPUT_TFTP_INSTALL_TAR")"
+    rm -f "$OUTPUT_TFTP_INSTALL_TAR"
+    tar -chf "$OUTPUT_TFTP_INSTALL_TAR" -C "$OUTPUT_DIR" \
+        "$FIT_NAME" uboot-tftp-commands.txt "$TFTP_IMAGE_NAME"
+    echo "TFTP install archive: $OUTPUT_TFTP_INSTALL_TAR"
+fi
+
+echo ""
+echo "TFTP initramfs image ready in: $OUTPUT_DIR"
+echo "  - $FIT_NAME (boot from TFTP → initramfs shell)"
+echo "  - $TFTP_IMAGE_NAME (optional on TFTP if you pull it manually from the shell)"
+echo "  - uboot-tftp-commands.txt (U-Boot commands)"
+echo ""
+echo "Put $FIT_NAME and $TFTP_IMAGE_NAME on your TFTP server, then in U-Boot:"
+echo "  setenv serverip <tftp-server-ip>"
+echo "  setenv bootargs \"console=... root=/dev/ram0 rw sonic_install.tftp_server=\${serverip} sonic_install.tftp_image=$TFTP_IMAGE_NAME\""
+echo "  tftp $fit_addr sonic_tftp_install.fit"
+echo "  setenv bootconf <fit-configuration>   # see configurations in platform/aspeed/sonic_fit.its (no conf- prefix)"
+echo "  bootm $fit_addr#conf-\$bootconf"
+echo ""
+echo "Without sonic_install.tftp_server=: shell, then /sbin/install-to-emmc.sh /tmp/$TFTP_IMAGE_NAME"

--- a/platform/aspeed/onie-image-arm64.conf
+++ b/platform/aspeed/onie-image-arm64.conf
@@ -35,3 +35,15 @@ OUTPUT_ONIE_IMAGE=target/sonic-$TARGET_MACHINE-$CONFIGURED_ARCH.bin
 ## Output file name for raw image (referenced in installer script even if not building raw image)
 OUTPUT_RAW_IMAGE=target/sonic-$TARGET_MACHINE-$CONFIGURED_ARCH.raw
 
+## Optional: tar of TFTP install bundle (FIT + U-Boot cheat sheet + raw eMMC image), see installer/create_tftp_image.sh
+OUTPUT_TFTP_INSTALL_TAR=target/sonic-$TARGET_MACHINE-$CONFIGURED_ARCH-tftp-install.tar
+
+## eMMC disk image size in MiB (required by build-emmc-image-installer.sh; optional env or third script arg overrides)
+EMMC_SIZE_MB=7168
+
+## Raw eMMC image path for TFTP bundle (build: make aspeed-emmc-image; see build-emmc-image-installer.sh)
+EMMC_RAW_IMAGE=target/sonic-$TARGET_MACHINE-$CONFIGURED_ARCH-emmc.img.gz
+
+## Basename of that file inside the TFTP output directory / tar archive
+TFTP_EMMC_IMAGE_NAME=sonic-$TARGET_MACHINE-$CONFIGURED_ARCH-emmc.img.gz
+

--- a/platform/aspeed/recipes/installer-tftp.mk
+++ b/platform/aspeed/recipes/installer-tftp.mk
@@ -1,0 +1,36 @@
+# Aspeed TFTP / U-Boot netboot installer bundle (FIT + payload).
+#
+# Platform-local installer recipes and scripts live under platform/aspeed/installer/.
+#
+# This is not added as a second SONIC_INSTALLERS target: that would register another RFS squashfs
+# name and rebuild the same rootfs (slave.mk rfs_define_target). The bundle reuses fsroot-aspeed
+# produced for sonic-aspeed-arm64.bin.
+
+SONIC_ASPEED_TFTP_TAR = sonic-aspeed-arm64-tftp-install.tar
+
+ASPEED_EMMC_IMAGE_STEM = sonic-aspeed-arm64-emmc
+ASPEED_EMMC_IMAGE_GZ = $(TARGET_PATH)/$(ASPEED_EMMC_IMAGE_STEM).img.gz
+ASPEED_TFTP_BUILD_DIR = $(TARGET_PATH)/aspeed-tftp
+
+$(ASPEED_EMMC_IMAGE_GZ): $(TARGET_PATH)/$(SONIC_ONE_IMAGE) $(PLATFORM_PATH)/onie-image-arm64.conf
+	@echo "=== Building $(ASPEED_EMMC_IMAGE_GZ) (sudo required) ==="
+	sudo $(PLATFORM_PATH)/build-emmc-image-installer.sh \
+		$(abspath $(TARGET_PATH)/$(SONIC_ONE_IMAGE)) \
+		$(abspath $(TARGET_PATH)/$(ASPEED_EMMC_IMAGE_STEM).img)
+	@test -f $@ || { echo "Error: expected $@ after build-emmc-image-installer.sh"; exit 1; }
+
+.PHONY: aspeed-emmc-image
+aspeed-emmc-image: $(ASPEED_EMMC_IMAGE_GZ)
+
+$(ASPEED_TFTP_BUILD_DIR)/.stamp: $(TARGET_PATH)/$(SONIC_ONE_IMAGE) $(ASPEED_EMMC_IMAGE_GZ)
+	$(PLATFORM_PATH)/installer/create_tftp_image.sh $(abspath $(ASPEED_TFTP_BUILD_DIR))
+	@touch $@
+
+aspeed-tftp: $(ASPEED_TFTP_BUILD_DIR)/.stamp
+.PHONY: aspeed-tftp
+
+$(TARGET_PATH)/$(SONIC_ASPEED_TFTP_TAR): $(TARGET_PATH)/$(SONIC_ONE_IMAGE) $(ASPEED_EMMC_IMAGE_GZ)
+	OUTPUT_TFTP_INSTALL_TAR=$(abspath $@) $(PLATFORM_PATH)/installer/create_tftp_image.sh $(abspath $(ASPEED_TFTP_BUILD_DIR))
+
+aspeed-tftp-tar: $(TARGET_PATH)/$(SONIC_ASPEED_TFTP_TAR)
+.PHONY: aspeed-tftp-tar

--- a/platform/aspeed/rules.mk
+++ b/platform/aspeed/rules.mk
@@ -1,5 +1,6 @@
 include $(PLATFORM_PATH)/platform-modules-ast-evb.mk
 include $(PLATFORM_PATH)/platform-modules-nexthop.mk
 include $(PLATFORM_PATH)/one-image.mk
+include $(PLATFORM_PATH)/recipes/installer-tftp.mk
 
 SONIC_ALL += $(SONIC_ONE_IMAGE)

--- a/platform/aspeed/scripts/sonic-fw-env-config.sh
+++ b/platform/aspeed/scripts/sonic-fw-env-config.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+# Generate /etc/fw_env.config for fw_printenv/fw_setenv.
+# Order: device data (per onie_platform), then /proc/mtd, then device-tree hints, then eMMC default.
+# SONIC_MACHINE_CONF: path to machine.conf (default /host/machine.conf). Override for initramfs
+# (e.g. /tmp/machine.conf). If onie_platform is unset, that file is sourced when resolving device fw_env.
+# Optional: SONIC_FW_ENV_LOG_FILE — if set, each message is appended there (same timestamped format as
+# sonic-uboot-env-init log); messages always go to stderr as well.
+
+FW_ENV_MSG_PREFIX="${FW_ENV_MSG_PREFIX:-sonic-fw-env-config}"
+SONIC_MACHINE_CONF="${SONIC_MACHINE_CONF:-/host/machine.conf}"
+
+fw_env_msg() {
+    line="[$(date '+%Y-%m-%d %H:%M:%S')] [$FW_ENV_MSG_PREFIX] $*"
+    echo "$line" >&2
+    if [ -n "${SONIC_FW_ENV_LOG_FILE:-}" ]; then
+        echo "$line" >> "$SONIC_FW_ENV_LOG_FILE"
+    fi
+}
+
+sonic_fw_env_resolve_onie_platform() {
+    if [ -n "${onie_platform:-}" ]; then
+        return 0
+    fi
+    if [ ! -f "$SONIC_MACHINE_CONF" ]; then
+        fw_env_msg "ERROR: machine.conf not found: $SONIC_MACHINE_CONF"
+        exit 1
+    fi
+    . "$SONIC_MACHINE_CONF"
+    if [ -z "${onie_platform:-}" ]; then
+        fw_env_msg "ERROR: onie_platform not set after sourcing $SONIC_MACHINE_CONF"
+        exit 1
+    fi
+    return 0
+}
+
+sonic_fw_env_wait_for_mtd() {
+    WAIT_COUNT=0
+    MAX_WAIT="${SONIC_FW_ENV_MTD_WAIT:-10}"
+    while [ ! -f /proc/mtd ] && [ "$WAIT_COUNT" -lt "$MAX_WAIT" ]; do
+        fw_env_msg "Waiting for /proc/mtd ($WAIT_COUNT/$MAX_WAIT)..."
+        sleep 1
+        WAIT_COUNT=$((WAIT_COUNT + 1))
+    done
+    if [ ! -f /proc/mtd ]; then
+        fw_env_msg "WARNING: /proc/mtd not available after ${MAX_WAIT}s"
+    fi
+}
+
+sonic_fw_env_install_from_path() {
+    src="$1"
+    changed=1
+    if [ -f /etc/fw_env.config ]; then
+        if command -v cmp >/dev/null 2>&1 && cmp -s "$src" /etc/fw_env.config; then
+            changed=0
+        elif [ "$(cat "$src")" = "$(cat /etc/fw_env.config)" ]; then
+            changed=0
+        fi
+    fi
+    if [ "$changed" -eq 1 ]; then
+        cp "$src" /etc/fw_env.config
+        fw_env_msg "Updated /etc/fw_env.config from $src"
+    else
+        fw_env_msg "Keeping /etc/fw_env.config (matches $src)"
+    fi
+}
+
+sonic_fw_env_install_from_content() {
+    content="$1"
+    mkdir -p /etc
+    if [ -f /etc/fw_env.config ]; then
+        CURRENT_CONFIG=$(cat /etc/fw_env.config)
+        if [ "$CURRENT_CONFIG" != "$content" ]; then
+            fw_env_msg "Updating /etc/fw_env.config"
+            printf '%s\n' "$content" > /etc/fw_env.config
+        else
+            fw_env_msg "Keeping /etc/fw_env.config (unchanged)"
+        fi
+    else
+        printf '%s\n' "$content" > /etc/fw_env.config
+        fw_env_msg "Created /etc/fw_env.config"
+    fi
+}
+
+sonic_fw_env_try_device_data() {
+    sonic_fw_env_resolve_onie_platform
+    if [ -z "${onie_platform:-}" ]; then
+        return 1
+    fi
+    for p in \
+        "/usr/share/sonic/device/${onie_platform}/fw_env" \
+        "/device/aspeed/${onie_platform}/fw_env"
+    do
+        if [ -f "$p" ]; then
+            mkdir -p /etc
+            sonic_fw_env_install_from_path "$p"
+            return 0
+        fi
+    done
+    return 1
+}
+
+sonic_fw_env_from_mtd_or_fallback() {
+    sonic_fw_env_wait_for_mtd
+
+    MTD_ENV_LINE=$(grep -E '"u-boot-env"|"uboot-env"' /proc/mtd 2>/dev/null || true)
+    if [ -n "$MTD_ENV_LINE" ]; then
+        MTD_DEV=$(echo "$MTD_ENV_LINE" | awk -F: '{print $1}')
+        MTD_SIZE=$(echo "$MTD_ENV_LINE" | awk '{print "0x" $2}')
+        MTD_ERASESIZE=$(echo "$MTD_ENV_LINE" | awk '{print "0x" $3}')
+        if [ -c "/dev/$MTD_DEV" ]; then
+            FW_ENV_CONFIG="/dev/$MTD_DEV 0x0 $MTD_SIZE $MTD_ERASESIZE"
+            fw_env_msg "Detected U-Boot env from /proc/mtd: $FW_ENV_CONFIG"
+            sonic_fw_env_install_from_content "$FW_ENV_CONFIG"
+            return 0
+        fi
+    fi
+
+    DTB_HAS_ENV_BLK=$(grep -E "uboot-env|u-boot-env" /proc/mtd 2>/dev/null | sed -e 's/:.*$//' || true)
+    if [ -n "$DTB_HAS_ENV_BLK" ] && [ -c "/dev/$DTB_HAS_ENV_BLK" ]; then
+        PROC_ENV_FILE=$(find /proc/device-tree/ -name env_size 2>/dev/null | head -1 || true)
+        if [ -n "$PROC_ENV_FILE" ] && command -v hd >/dev/null 2>&1; then
+            UBOOT_ENV_SIZ="0x$(hd "$PROC_ENV_FILE" | awk 'FNR==1 {print $2 $3 $4 $5}')"
+            UBOOT_ENV_ERASE_SIZ="0x$(grep -E "uboot-env|u-boot-env" /proc/mtd | awk '{print $3}')"
+            if [ -n "$UBOOT_ENV_SIZ" ] && [ -n "$UBOOT_ENV_ERASE_SIZ" ]; then
+                FW_ENV_CONFIG="/dev/$DTB_HAS_ENV_BLK 0x00000000 $UBOOT_ENV_SIZ $UBOOT_ENV_ERASE_SIZ"
+                fw_env_msg "Detected U-Boot env from device tree: $FW_ENV_CONFIG"
+                sonic_fw_env_install_from_content "$FW_ENV_CONFIG"
+                return 0
+            fi
+        fi
+    fi
+
+    FW_ENV_CONFIG="/dev/mmcblk0 0x1F40000 0x20000 0x1000"
+    fw_env_msg "Using default eMMC U-Boot env location: $FW_ENV_CONFIG"
+    sonic_fw_env_install_from_content "$FW_ENV_CONFIG"
+    return 0
+}
+
+mkdir -p /etc
+
+if sonic_fw_env_try_device_data; then
+    exit 0
+fi
+
+sonic_fw_env_from_mtd_or_fallback
+
+exit 0

--- a/platform/aspeed/scripts/sonic-machine-conf-init.sh
+++ b/platform/aspeed/scripts/sonic-machine-conf-init.sh
@@ -1,11 +1,18 @@
-#!/bin/bash
+#!/bin/sh
 # SONiC Machine Configuration Initialization Script
-# This script creates /host/machine.conf on first boot by detecting hardware from DTB
+# This script creates machine.conf on first boot by detecting hardware from DTB.
+# Override paths for initramfs: MACHINE_CONF=/tmp/machine.conf LOG_FILE=/dev/null
 
 set -e
 
-LOG_FILE="/var/log/sonic-machine-conf-init.log"
-MACHINE_CONF="/host/machine.conf"
+MACHINE_CONF="${MACHINE_CONF:-/host/machine.conf}"
+LOG_FILE="${LOG_FILE:-/var/log/sonic-machine-conf-init.log}"
+
+mkdir -p "$(dirname "$MACHINE_CONF")"
+case "$LOG_FILE" in
+/dev/fd/*|/dev/null) ;;
+*) mkdir -p "$(dirname "$LOG_FILE")" ;;
+esac
 
 log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
@@ -19,18 +26,16 @@ if [ -f "$MACHINE_CONF" ]; then
     exit 0
 fi
 
-# Detect hardware from device tree compatible string
+# Detect hardware from device tree (compatible and model)
 if [ ! -f /proc/device-tree/compatible ]; then
     log "ERROR: /proc/device-tree/compatible not found. Cannot detect hardware."
     exit 1
 fi
 
-# Read compatible string (null-separated values)
 COMPATIBLE=$(cat /proc/device-tree/compatible | tr '\0' ' ')
-log "Detected compatible string: $COMPATIBLE"
+MODEL=$(cat /proc/device-tree/model 2>/dev/null || echo "")
+log "Detected compatible: $COMPATIBLE, model: $MODEL"
 
-# Map compatible string to platform name
-# The compatible string contains multiple values, we check for specific vendor strings
 PLATFORM=""
 MACHINE=""
 
@@ -38,15 +43,17 @@ if echo "$COMPATIBLE" | grep -q "nexthop,nexthop-b27-r0"; then
     PLATFORM="arm64-nexthop_b27-r0"
     MACHINE="aspeed_ast2700"
     log "Detected NextHop B27 BMC platform"
+elif echo "$MODEL" | grep -qi "AST2700-A1 Spc6"; then
+    PLATFORM="arm64-aspeed_nvidia_ast2700_a1_bmc-r0"
+    MACHINE="aspeed_ast2700"
+    log "Detected NVIDIA SPC6 BMC platform"
 elif echo "$COMPATIBLE" | grep -q "aspeed,ast2700-evb"; then
     PLATFORM="arm64-aspeed_ast2700_evb-r0"
     MACHINE="aspeed_ast2700"
     log "Detected Aspeed AST2700 EVB platform"
 else
-    log "ERROR: Unknown hardware. Compatible string: $COMPATIBLE"
-    log "Supported platforms:"
-    log "  - nexthop,nexthop-b27-r0 -> arm64-nexthop_b27-r0"
-    log "  - aspeed,ast2700-evb -> arm64-aspeed_ast2700_evb-r0"
+    log "ERROR: Unknown hardware. Compatible: $COMPATIBLE, model: $MODEL"
+    log "Supported platforms: nexthop-b27-r0, nvidia-spc6-bmc, aspeed_ast2700_evb"
     exit 1
 fi
 

--- a/platform/aspeed/scripts/sonic-machine-conf-init.sh
+++ b/platform/aspeed/scripts/sonic-machine-conf-init.sh
@@ -43,10 +43,6 @@ if echo "$COMPATIBLE" | grep -q "nexthop,nexthop-b27-r0"; then
     PLATFORM="arm64-nexthop_b27-r0"
     MACHINE="aspeed_ast2700"
     log "Detected NextHop B27 BMC platform"
-elif echo "$MODEL" | grep -qi "AST2700-A1 Spc6"; then
-    PLATFORM="arm64-aspeed_nvidia_ast2700_a1_bmc-r0"
-    MACHINE="aspeed_ast2700"
-    log "Detected NVIDIA SPC6 BMC platform"
 elif echo "$COMPATIBLE" | grep -q "aspeed,ast2700-evb"; then
     PLATFORM="arm64-aspeed_ast2700_evb-r0"
     MACHINE="aspeed_ast2700"

--- a/platform/aspeed/scripts/sonic-program-uboot-env.sh
+++ b/platform/aspeed/scripts/sonic-program-uboot-env.sh
@@ -1,0 +1,110 @@
+#!/bin/sh
+# Program U-Boot variables for SONiC ext4 + FIT boot. Used by sonic-uboot-env-init (host first boot and
+# TFTP initrd with SONIC_UBOOT_ENV_INSTALLER=1).
+#
+# Required environment:
+#   UBOOT_ENV_BOOT_DEVICE     root block device (e.g. /dev/mmcblk0p1) for blkid UUID
+#   UBOOT_ENV_DEMO_DEV       whole-disk device (e.g. /dev/mmcblk0)
+#   UBOOT_ENV_DEMO_PART      partition index for U-Boot ext4load (e.g. 1)
+#   UBOOT_ENV_DISK_INTERFACE  mmc | scsi
+#   UBOOT_ENV_IMAGE_DIR       e.g. image-<version>
+# Optional:
+#   UBOOT_ENV_INSTALLER_CONF  if set and exists, sourced before applying defaults
+#   SONIC_UBOOT_ENV_LOG_FILE  append timestamped lines (same style as other SONiC logs)
+
+sonic_uboot_env_log() {
+    msg="$*"
+    echo "$msg" >&2
+    if [ -n "${SONIC_UBOOT_ENV_LOG_FILE:-}" ]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] $msg" >> "$SONIC_UBOOT_ENV_LOG_FILE"
+    fi
+}
+
+for v in UBOOT_ENV_BOOT_DEVICE UBOOT_ENV_DEMO_DEV UBOOT_ENV_DEMO_PART UBOOT_ENV_DISK_INTERFACE UBOOT_ENV_IMAGE_DIR; do
+    eval "sonic_uboot_chk=\${$v-}"
+    if [ -z "$sonic_uboot_chk" ]; then
+        sonic_uboot_env_log "ERROR: $v is not set"
+        exit 1
+    fi
+done
+
+if ! command -v fw_setenv >/dev/null 2>&1 || ! command -v fw_printenv >/dev/null 2>&1; then
+    sonic_uboot_env_log "ERROR: fw_setenv or fw_printenv not available"
+    exit 1
+fi
+
+if ! fw_printenv bootcmd >/dev/null 2>&1; then
+    sonic_uboot_env_log "ERROR: fw_printenv cannot read U-Boot env (check /etc/fw_env.config)"
+    exit 1
+fi
+
+if [ -n "${UBOOT_ENV_INSTALLER_CONF:-}" ] && [ -f "$UBOOT_ENV_INSTALLER_CONF" ]; then
+    . "$UBOOT_ENV_INSTALLER_CONF" || true
+fi
+
+CONSOLE_DEV=${CONSOLE_DEV:-12}
+CONSOLE_SPEED=${CONSOLE_SPEED:-115200}
+EARLYCON=${EARLYCON:-"earlycon=uart8250,mmio32,0x14c33b00"}
+VAR_LOG_SIZE=${VAR_LOG_SIZE:-512}
+CONSOLE_PORT="ttyS${CONSOLE_DEV}"
+
+FS_ROOT_DEV=$UBOOT_ENV_BOOT_DEVICE
+FS_UUID=$(blkid -s UUID -o value "$FS_ROOT_DEV" 2>/dev/null || true)
+if [ -z "$FS_UUID" ]; then
+    sonic_uboot_env_log "WARNING: Cannot detect filesystem UUID for $FS_ROOT_DEV; using device path for root="
+    ROOT_DEV="$FS_ROOT_DEV"
+else
+    ROOT_DEV="UUID=$FS_UUID"
+fi
+
+IMAGE_DIR=$UBOOT_ENV_IMAGE_DIR
+SONIC_VERSION=$(echo "$IMAGE_DIR" | sed 's/^image-/SONiC-OS-/')
+disk_interface=$UBOOT_ENV_DISK_INTERFACE
+demo_part=$UBOOT_ENV_DEMO_PART
+
+BOOTCONF_RAW=$(fw_printenv -n bootconf 2>/dev/null || true)
+BOOTCONF=$BOOTCONF_RAW
+if [ -z "$BOOTCONF" ]; then
+    BOOTCONF="ast2700-evb"
+elif [ "$BOOTCONF" = "ast2700-nvidia-spc6-bmc" ]; then
+    BOOTCONF="sonic-ast2700-nvidia-spc6-a1-bmc"
+fi
+if [ "$BOOTCONF_RAW" != "$BOOTCONF" ]; then
+    sonic_uboot_env_log "Adjusting bootconf for FIT: ${BOOTCONF_RAW:-empty} -> $BOOTCONF"
+    fw_setenv bootconf "$BOOTCONF" || sonic_uboot_env_log "ERROR: Failed to set bootconf"
+fi
+
+sonic_uboot_env_log "Programming U-Boot env (bootconf=$BOOTCONF, image_dir=$IMAGE_DIR, root=$ROOT_DEV)..."
+
+fw_setenv image_dir "$IMAGE_DIR" || sonic_uboot_env_log "ERROR: Failed to set image_dir"
+fw_setenv fit_name "$IMAGE_DIR/boot/sonic_arm64.fit" || sonic_uboot_env_log "ERROR: Failed to set fit_name"
+fw_setenv sonic_version_1 "$SONIC_VERSION" || sonic_uboot_env_log "ERROR: Failed to set sonic_version_1"
+fw_setenv image_dir_old "" || sonic_uboot_env_log "ERROR: Failed to set image_dir_old"
+fw_setenv fit_name_old "" || sonic_uboot_env_log "ERROR: Failed to set fit_name_old"
+fw_setenv sonic_version_2 "None" || sonic_uboot_env_log "ERROR: Failed to set sonic_version_2"
+fw_setenv linuxargs_old "" || sonic_uboot_env_log "ERROR: Failed to set linuxargs_old"
+
+LINUXARGS_VAL="console=${CONSOLE_PORT},${CONSOLE_SPEED}n8 ${EARLYCON} loopfstype=squashfs loop=$IMAGE_DIR/fs.squashfs varlog_size=${VAR_LOG_SIZE}"
+fw_setenv linuxargs "$LINUXARGS_VAL" || sonic_uboot_env_log "ERROR: Failed to set linuxargs"
+BOOTARGS_VAL="root=$ROOT_DEV rw rootwait panic=1 $LINUXARGS_VAL"
+fw_setenv bootargs "$BOOTARGS_VAL" || sonic_uboot_env_log "ERROR: Failed to set bootargs"
+
+fw_setenv sonic_boot_load "ext4load ${disk_interface} 0:${demo_part} \${loadaddr} \${fit_name}" || sonic_uboot_env_log "ERROR: Failed to set sonic_boot_load"
+fw_setenv sonic_boot_load_old "ext4load ${disk_interface} 0:${demo_part} \${loadaddr} \${fit_name_old}" || sonic_uboot_env_log "ERROR: Failed to set sonic_boot_load_old"
+fw_setenv sonic_bootargs "setenv bootargs root=$ROOT_DEV rw rootwait panic=1 \${linuxargs}" || sonic_uboot_env_log "ERROR: Failed to set sonic_bootargs"
+fw_setenv sonic_bootargs_old "setenv bootargs root=$ROOT_DEV rw rootwait panic=1 \${linuxargs_old}" || sonic_uboot_env_log "ERROR: Failed to set sonic_bootargs_old"
+fw_setenv sonic_image_1 "run sonic_bootargs; run sonic_boot_load; bootm \${loadaddr}#conf-\${bootconf}" || sonic_uboot_env_log "ERROR: Failed to set sonic_image_1"
+fw_setenv sonic_image_2 "run sonic_bootargs_old; run sonic_boot_load_old; bootm \${loadaddr}#conf-\${bootconf}" || sonic_uboot_env_log "ERROR: Failed to set sonic_image_2"
+
+fw_setenv print_menu "echo ===================================================; echo SONiC Boot Menu; echo ===================================================; echo To boot \$sonic_version_1; echo   type: run sonic_image_1; echo   at the U-Boot prompt after interrupting U-Boot when it says; echo   \\\"Hit any key to stop autoboot:\\\" during boot; echo; echo To boot \$sonic_version_2; echo   type: run sonic_image_2; echo   at the U-Boot prompt after interrupting U-Boot when it says; echo   \\\"Hit any key to stop autoboot:\\\" during boot; echo; echo ===================================================" || sonic_uboot_env_log "ERROR: Failed to set print_menu"
+
+fw_setenv boot_next "run sonic_image_1" || sonic_uboot_env_log "ERROR: Failed to set boot_next"
+fw_setenv bootcmd "run print_menu; test -n \"\$boot_once\" && setenv do_boot_once \"\$boot_once\" && setenv boot_once \"\" && saveenv && run do_boot_once; run boot_next" || sonic_uboot_env_log "ERROR: Failed to set bootcmd"
+
+fw_setenv loadaddr "0x432000000" || sonic_uboot_env_log "ERROR: Failed to set loadaddr"
+fw_setenv kernel_addr "0x403000000" || sonic_uboot_env_log "ERROR: Failed to set kernel_addr"
+fw_setenv fdt_addr "0x44C000000" || sonic_uboot_env_log "ERROR: Failed to set fdt_addr"
+fw_setenv initrd_addr "0x440000000" || sonic_uboot_env_log "ERROR: Failed to set initrd_addr"
+
+sonic_uboot_env_log "U-Boot environment variables programmed successfully."
+exit 0

--- a/platform/aspeed/scripts/sonic-uboot-env-init.sh
+++ b/platform/aspeed/scripts/sonic-uboot-env-init.sh
@@ -1,110 +1,161 @@
-#!/bin/bash
+#!/bin/sh
 # SONiC U-Boot Environment Initialization Script
-# This script has two parts:
-# 1. Always create /etc/fw_env.config (runs every boot for every image)
-# 2. Set U-Boot environment variables (runs once globally, controlled by marker file)
+#
+# Host (default): systemd; /etc/fw_env.config every boot; program U-Boot once (marker on /host).
+# Installer: TFTP/raw eMMC initramfs after install; same flow with /sbin helpers. Enable with
+#   SONIC_UBOOT_ENV_INSTALLER=1 (TFTP init sets this) or pass --installer.
 
 set -e
 
-LOG_FILE="/var/log/sonic-uboot-env-init.log"
+installer_mode() {
+    case "${SONIC_UBOOT_ENV_INSTALLER:-}" in
+    1|yes|true) return 0 ;;
+    esac
+    for a in "$@"; do
+        [ "$a" = "--installer" ] && return 0
+    done
+    return 1
+}
+
+if installer_mode "$@"; then
+    INSTALLER_MODE=1
+    LOG_FILE="${SONIC_UBOOT_ENV_LOG_FILE:-/tmp/sonic-uboot-env-init.log}"
+    export FW_ENV_MSG_PREFIX="${FW_ENV_MSG_PREFIX:-sonic-uboot-env-init-installer}"
+    export SONIC_MACHINE_CONF="${SONIC_MACHINE_CONF:-/tmp/machine.conf}"
+else
+    INSTALLER_MODE=0
+    LOG_FILE="${SONIC_UBOOT_ENV_LOG_FILE:-/var/log/sonic-uboot-env-init.log}"
+    export FW_ENV_MSG_PREFIX="${FW_ENV_MSG_PREFIX:-sonic-uboot-env-init}"
+fi
+
 MARKER_FILE="/host/.uboot-env-initialized"
+EMMC="${EMMC:-/dev/mmcblk0}"
+MNT="${MNT:-/mnt}"
 
 log() {
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE" 2>/dev/null || echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >&2
 }
+
+mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
 
 log "Starting U-Boot environment configuration..."
 
-# Check if fw_setenv is available
-if ! command -v fw_setenv &> /dev/null; then
+resolve_fw_env_config_sh() {
+    if [ -x /usr/bin/sonic-fw-env-config.sh ]; then
+        SONIC_FW_ENV_CONFIG_SH=/usr/bin/sonic-fw-env-config.sh
+    elif [ -x /sbin/sonic-fw-env-config.sh ]; then
+        SONIC_FW_ENV_CONFIG_SH=/sbin/sonic-fw-env-config.sh
+    else
+        return 1
+    fi
+    return 0
+}
+
+resolve_program_uboot_sh() {
+    if [ -x /usr/bin/sonic-program-uboot-env.sh ]; then
+        SONIC_PROGRAM_UBOOT_ENV_SH=/usr/bin/sonic-program-uboot-env.sh
+    elif [ -x /sbin/sonic-program-uboot-env.sh ]; then
+        SONIC_PROGRAM_UBOOT_ENV_SH=/sbin/sonic-program-uboot-env.sh
+    else
+        return 1
+    fi
+    return 0
+}
+
+run_fw_env_config() {
+    export SONIC_FW_ENV_LOG_FILE="$LOG_FILE"
+    "$SONIC_FW_ENV_CONFIG_SH"
+}
+
+run_installer_uboot_programming() {
+    if ! resolve_program_uboot_sh; then
+        umount "$MNT" 2>/dev/null || true
+        log "ERROR: sonic-program-uboot-env.sh not found in /usr/bin or /sbin."
+        exit 1
+    fi
+
+    export UBOOT_ENV_BOOT_DEVICE="$BOOT_PART"
+    export UBOOT_ENV_DEMO_DEV="$EMMC"
+    export UBOOT_ENV_DEMO_PART=1
+    export UBOOT_ENV_DISK_INTERFACE=mmc
+    export UBOOT_ENV_IMAGE_DIR="$IMAGE_DIR"
+    export UBOOT_ENV_INSTALLER_CONF="$MNT/$IMAGE_DIR/installer.conf"
+    export SONIC_UBOOT_ENV_LOG_FILE="$LOG_FILE"
+    if "$SONIC_PROGRAM_UBOOT_ENV_SH"; then
+        log "U-Boot environment updated."
+    else
+        log "Warning: sonic-program-uboot-env.sh failed (see messages above)."
+    fi
+}
+
+if [ "$INSTALLER_MODE" = 1 ]; then
+    if ! resolve_fw_env_config_sh; then
+        log "ERROR: sonic-fw-env-config.sh not found in /usr/bin or /sbin."
+        exit 1
+    fi
+    run_fw_env_config
+
+    if ! command -v fw_setenv >/dev/null 2>&1 || ! command -v fw_printenv >/dev/null 2>&1; then
+        log "Warning: fw_setenv/fw_printenv not available; skipping U-Boot env update."
+        exit 0
+    fi
+
+    sync
+    blockdev --rereadpt "$EMMC" 2>/dev/null || true
+    command -v partprobe >/dev/null 2>&1 && partprobe "$EMMC" 2>/dev/null || true
+    sleep 1
+
+    BOOT_PART=$(blkid -L SONiC-OS 2>/dev/null || true)
+    if [ -z "$BOOT_PART" ] && [ -b "${EMMC}p1" ]; then
+        BOOT_PART="${EMMC}p1"
+    fi
+    if [ -z "$BOOT_PART" ] || [ ! -b "$BOOT_PART" ]; then
+        log "Warning: SONiC-OS partition not found; skipping U-Boot variable programming."
+        exit 0
+    fi
+
+    mkdir -p "$MNT"
+    if ! mount -t ext4 -o ro "$BOOT_PART" "$MNT" 2>/dev/null; then
+        log "Warning: could not mount $BOOT_PART; skipping U-Boot variable programming."
+        exit 0
+    fi
+
+    IMAGE_DIR=""
+    for d in "$MNT"/image-*; do
+        [ ! -e "$d" ] && continue
+        [ -d "$d" ] || continue
+        IMAGE_DIR=$(basename "$d")
+        break
+    done
+    if [ -z "$IMAGE_DIR" ]; then
+        umount "$MNT" 2>/dev/null || true
+        log "Warning: no image-* directory on $BOOT_PART; skipping U-Boot variable programming."
+        exit 0
+    fi
+
+    run_installer_uboot_programming
+    umount "$MNT" 2>/dev/null || true
+    exit 0
+fi
+
+if ! command -v fw_setenv >/dev/null 2>&1; then
     log "ERROR: fw_setenv not found. Cannot configure U-Boot environment."
     exit 1
 fi
 
-# Wait for /proc/mtd to be available (up to 10 seconds)
-# MTD devices may not be ready immediately during early boot
-WAIT_COUNT=0
-MAX_WAIT=10
-while [ ! -f /proc/mtd ] && [ $WAIT_COUNT -lt $MAX_WAIT ]; do
-    log "Waiting for /proc/mtd to be available... ($WAIT_COUNT/$MAX_WAIT)"
-    sleep 1
-    WAIT_COUNT=$((WAIT_COUNT + 1))
-done
-
-if [ ! -f /proc/mtd ]; then
-    log "WARNING: /proc/mtd not available after ${MAX_WAIT}s, will use default configuration"
+if ! resolve_fw_env_config_sh; then
+    log "ERROR: sonic-fw-env-config.sh not found in /usr/bin or /sbin."
+    exit 1
 fi
 
-#############################################################################
-# PART 1: Create /etc/fw_env.config (ALWAYS runs, every boot, every image)
-#############################################################################
 log "Configuring U-Boot environment access..."
+run_fw_env_config
 
-# Check for MTD device first by parsing /proc/mtd
-# Example line: mtd1: 00020000 00010000 "u-boot-env"
-MTD_ENV_LINE=$(grep -E '"u-boot-env"|"uboot-env"' /proc/mtd 2>/dev/null || true)
-
-if [ -n "$MTD_ENV_LINE" ]; then
-    # Parse MTD device name, size, and erasesize from /proc/mtd
-    MTD_DEV=$(echo "$MTD_ENV_LINE" | awk -F: '{print $1}')
-    MTD_SIZE=$(echo "$MTD_ENV_LINE" | awk '{print "0x" $2}')
-    MTD_ERASESIZE=$(echo "$MTD_ENV_LINE" | awk '{print "0x" $3}')
-
-    if [ -c "/dev/$MTD_DEV" ]; then
-        FW_ENV_CONFIG="/dev/$MTD_DEV 0x0 $MTD_SIZE $MTD_ERASESIZE"
-        log "Detected U-Boot env from /proc/mtd: $FW_ENV_CONFIG"
-    fi
-fi
-
-# If not found in MTD, try device tree
-if [ -z "$FW_ENV_CONFIG" ]; then
-    DTB_HAS_ENV_BLK=$(grep -E "uboot-env|u-boot-env" /proc/mtd 2>/dev/null | sed -e 's/:.*$//' || true)
-    if [ -n "$DTB_HAS_ENV_BLK" ] && [ -c "/dev/$DTB_HAS_ENV_BLK" ]; then
-        PROC_ENV_FILE=$(find /proc/device-tree/ -name env_size 2>/dev/null || true)
-        if [ -n "$PROC_ENV_FILE" ]; then
-            UBOOT_ENV_SIZ="0x$(hd $PROC_ENV_FILE | awk 'FNR==1 {print $2 $3 $4 $5}')"
-            UBOOT_ENV_ERASE_SIZ="0x$(grep -E "uboot-env|u-boot-env" /proc/mtd | awk '{print $3}')"
-            if [[ -n "$UBOOT_ENV_SIZ" && -n "$UBOOT_ENV_ERASE_SIZ" ]]; then
-                FW_ENV_CONFIG="/dev/$DTB_HAS_ENV_BLK 0x00000000 $UBOOT_ENV_SIZ $UBOOT_ENV_ERASE_SIZ"
-                log "Detected U-Boot env from device tree: $FW_ENV_CONFIG"
-            fi
-        fi
-    fi
-fi
-
-# If still not found, use eMMC default location
-if [ -z "$FW_ENV_CONFIG" ]; then
-    # AST2700 default: U-Boot environment on eMMC at 31.25 MB offset
-    FW_ENV_CONFIG="/dev/mmcblk0 0x1F40000 0x20000 0x1000"
-    log "Using default eMMC U-Boot env location: $FW_ENV_CONFIG"
-fi
-
-# Update /etc/fw_env.config if it's different from current content
-if [ -f /etc/fw_env.config ]; then
-    CURRENT_CONFIG=$(cat /etc/fw_env.config)
-    if [ "$CURRENT_CONFIG" != "$FW_ENV_CONFIG" ]; then
-        log "Updating /etc/fw_env.config (was: $CURRENT_CONFIG)"
-        echo "$FW_ENV_CONFIG" > /etc/fw_env.config
-        log "Updated /etc/fw_env.config: $FW_ENV_CONFIG"
-    else
-        log "Using existing /etc/fw_env.config: $FW_ENV_CONFIG"
-    fi
-else
-    echo "$FW_ENV_CONFIG" > /etc/fw_env.config
-    log "Created /etc/fw_env.config: $FW_ENV_CONFIG"
-fi
-
-#############################################################################
-# PART 2: Set U-Boot environment variables (runs ONCE globally)
-#############################################################################
-
-# Check if ONIE partition is mounted and skip U-Boot env setup if found
 if blkid -L "ONIE" >/dev/null 2>&1 || blkid -L "ONIE-BOOT" >/dev/null 2>&1; then
-    echo "ONIE parition found. skipping uboot environment configurations."
+    echo "ONIE partition found. Skipping U-Boot environment configurations."
     exit 0
 fi
 
-# Check if already initialized
 if [ -f "$MARKER_FILE" ]; then
     log "U-Boot environment already initialized (marker file exists). Skipping U-Boot env setup."
     log "fw_env.config configuration complete."
@@ -113,12 +164,10 @@ fi
 
 log "U-Boot environment not yet initialized. Proceeding with first-time setup..."
 
-# Detect boot device from /host mount (assumes eMMC)
 boot_device=$(findmnt -n -o SOURCE /host)
 demo_dev=$(echo "$boot_device" | sed 's/p\?[0-9]*$//')
 demo_part=$(echo "$boot_device" | grep -o '[0-9]*$')
 
-# Fallback if detection fails
 if [ -z "$boot_device" ]; then
     boot_device="/dev/mmcblk0p1"
     demo_dev="/dev/mmcblk0"
@@ -126,7 +175,6 @@ if [ -z "$boot_device" ]; then
     log "WARNING: Could not detect boot device, defaulting to $boot_device"
 fi
 
-# Determine storage interface type (mmc for eMMC, scsi for UFS)
 if echo "$demo_dev" | grep -q "mmc"; then
     disk_interface="mmc"
 else
@@ -135,12 +183,9 @@ fi
 
 log "Detected boot device: ${boot_device}, partition: ${demo_part}, interface: ${disk_interface}"
 
-# Detect current image directory from /proc/cmdline
-# The kernel command line contains "loop=image-xxx/fs.squashfs"
 IMAGE_DIR=$(grep -o 'loop=[^ ]*' /proc/cmdline | sed 's|loop=\([^/]*\)/.*|\1|')
 if [ -z "$IMAGE_DIR" ]; then
     log "WARNING: Cannot detect image from /proc/cmdline, trying fallback method"
-    # Fallback: use first image directory (may not be correct for multi-image systems)
     IMAGE_DIR=$(ls -d /host/image-* 2>/dev/null | head -1 | xargs basename)
     if [ -z "$IMAGE_DIR" ]; then
         log "ERROR: Cannot find image directory in /host/"
@@ -151,87 +196,25 @@ else
     log "Detected image directory from /proc/cmdline: $IMAGE_DIR"
 fi
 
-# Get filesystem UUID (not partition UUID)
-FS_UUID=$(blkid -s UUID -o value ${boot_device} 2>/dev/null || echo "")
-if [ -z "$FS_UUID" ]; then
-    log "WARNING: Cannot detect filesystem UUID, using device path instead"
-    ROOT_DEV="${boot_device}"
-else
-    ROOT_DEV="UUID=$FS_UUID"
+if ! resolve_program_uboot_sh; then
+    log "ERROR: sonic-program-uboot-env.sh not found in /usr/bin or /sbin."
+    exit 1
 fi
 
-# Extract version from image directory
-SONIC_VERSION=$(echo "$IMAGE_DIR" | sed 's/^image-/SONiC-OS-/')
-
-log "Setting U-Boot environment variables..."
-
-# Get DTB configuration name from U-Boot bootconf variable
-# bootconf is set by U-Boot based on hardware detection
-BOOTCONF=$(fw_printenv -n bootconf 2>/dev/null || echo "")
-if [ -z "$BOOTCONF" ]; then
-    log "WARNING: U-Boot bootconf variable not set, using default: ast2700-evb"
-    BOOTCONF="ast2700-evb"
-fi
-log "Using U-Boot bootconf: $BOOTCONF"
-
-# Set U-Boot environment variables
-
-# Image configuration
-fw_setenv image_dir "$IMAGE_DIR" || log "ERROR: Failed to set image_dir"
-fw_setenv fit_name "$IMAGE_DIR/boot/sonic_arm64.fit" || log "ERROR: Failed to set fit_name"
-fw_setenv sonic_version_1 "$SONIC_VERSION" || log "ERROR: Failed to set sonic_version_1"
-
-# Old/backup image (none for first installation)
-fw_setenv image_dir_old "" || log "ERROR: Failed to set image_dir_old"
-fw_setenv fit_name_old "" || log "ERROR: Failed to set fit_name_old"
-fw_setenv sonic_version_2 "None" || log "ERROR: Failed to set sonic_version_2"
-fw_setenv linuxargs_old "" || log "ERROR: Failed to set linuxargs_old"
-
-# Kernel command line arguments
-# Read device-specific configuration from installer.conf
-if [ -f ${IMAGE_DIR}/installer.conf ]; then
-    source ${IMAGE_DIR}/installer.conf
-fi
-
-# Set defaults if not specified in installer.conf
-CONSOLE_DEV=${CONSOLE_DEV:-12}
-CONSOLE_SPEED=${CONSOLE_SPEED:-115200}
-EARLYCON=${EARLYCON:-"earlycon=uart8250,mmio32,0x14c33b00"}
-VAR_LOG_SIZE=${VAR_LOG_SIZE:-512}
-
-# Construct console device name
-CONSOLE_PORT="ttyS${CONSOLE_DEV}"
-
-fw_setenv linuxargs "console=${CONSOLE_PORT},${CONSOLE_SPEED}n8 ${EARLYCON} loopfstype=squashfs loop=$IMAGE_DIR/fs.squashfs varlog_size=${VAR_LOG_SIZE}" || log "ERROR: Failed to set linuxargs"
-
-# Boot commands
-fw_setenv sonic_boot_load "ext4load ${disk_interface} 0:${demo_part} \${loadaddr} \${fit_name}" || log "ERROR: Failed to set sonic_boot_load"
-fw_setenv sonic_boot_load_old "ext4load ${disk_interface} 0:${demo_part} \${loadaddr} \${fit_name_old}" || log "ERROR: Failed to set sonic_boot_load_old"
-fw_setenv sonic_bootargs "setenv bootargs root=$ROOT_DEV rw rootwait panic=1 \${linuxargs}" || log "ERROR: Failed to set sonic_bootargs"
-fw_setenv sonic_bootargs_old "setenv bootargs root=$ROOT_DEV rw rootwait panic=1 \${linuxargs_old}" || log "ERROR: Failed to set sonic_bootargs_old"
-fw_setenv sonic_image_1 "run sonic_bootargs; run sonic_boot_load; bootm \${loadaddr}#conf-\${bootconf}" || log "ERROR: Failed to set sonic_image_1"
-fw_setenv sonic_image_2 "run sonic_bootargs_old; run sonic_boot_load_old; bootm \${loadaddr}#conf-\${bootconf}" || log "ERROR: Failed to set sonic_image_2"
-
-# Boot menu with instructions
-fw_setenv print_menu "echo ===================================================; echo SONiC Boot Menu; echo ===================================================; echo To boot \$sonic_version_1; echo   type: run sonic_image_1; echo   at the U-Boot prompt after interrupting U-Boot when it says; echo   \\\"Hit any key to stop autoboot:\\\" during boot; echo; echo To boot \$sonic_version_2; echo   type: run sonic_image_2; echo   at the U-Boot prompt after interrupting U-Boot when it says; echo   \\\"Hit any key to stop autoboot:\\\" during boot; echo; echo ===================================================" || log "ERROR: Failed to set print_menu"
-
-# Boot configuration
-fw_setenv boot_next "run sonic_image_1" || log "ERROR: Failed to set boot_next"
-fw_setenv bootcmd "run print_menu; test -n \"\$boot_once\" && setenv do_boot_once \"\$boot_once\" && setenv boot_once \"\" && saveenv && run do_boot_once; run boot_next" || log "ERROR: Failed to set bootcmd"
-
-# Memory addresses
-fw_setenv loadaddr "0x432000000" || log "ERROR: Failed to set loadaddr"
-fw_setenv kernel_addr "0x403000000" || log "ERROR: Failed to set kernel_addr"
-fw_setenv fdt_addr "0x44C000000" || log "ERROR: Failed to set fdt_addr"
-fw_setenv initrd_addr "0x440000000" || log "ERROR: Failed to set initrd_addr"
+export UBOOT_ENV_BOOT_DEVICE="$boot_device"
+export UBOOT_ENV_DEMO_DEV="$demo_dev"
+export UBOOT_ENV_DEMO_PART="$demo_part"
+export UBOOT_ENV_DISK_INTERFACE="$disk_interface"
+export UBOOT_ENV_IMAGE_DIR="$IMAGE_DIR"
+export UBOOT_ENV_INSTALLER_CONF="/host/${IMAGE_DIR}/installer.conf"
+export SONIC_UBOOT_ENV_LOG_FILE="$LOG_FILE"
+"$SONIC_PROGRAM_UBOOT_ENV_SH"
 
 log "U-Boot environment variables set successfully"
 
-# Create marker file to prevent re-initialization
 mkdir -p "$(dirname "$MARKER_FILE")"
 touch "$MARKER_FILE"
 
 log "U-Boot environment initialization complete"
 
 exit 0
-

--- a/platform/aspeed/systemd/sonic-uboot-env-init.service
+++ b/platform/aspeed/systemd/sonic-uboot-env-init.service
@@ -8,6 +8,7 @@ Before=sonic.target
 
 [Service]
 Type=oneshot
+Environment=SONIC_MACHINE_CONF=/host/machine.conf
 ExecStart=/usr/bin/sonic-uboot-env-init.sh
 RemainAfterExit=yes
 

--- a/platform/aspeed/tftp-installer-init/init
+++ b/platform/aspeed/tftp-installer-init/init
@@ -146,9 +146,9 @@ bringup_network() {
     esac
     modprobe ftgmac100 2>/dev/null || true
 
-    echo "Waiting for $IFACE in sysfs (up to 10s)..."
+    echo "Waiting for $IFACE in sysfs (up to 30s)..."
     n=0
-    while [ ! -d "/sys/class/net/$IFACE" ] && [ "$n" -lt 10 ]; do
+    while [ ! -d "/sys/class/net/$IFACE" ] && [ "$n" -lt 30 ]; do
         sleep 1
         n=$((n + 1))
     done

--- a/platform/aspeed/tftp-installer-init/init
+++ b/platform/aspeed/tftp-installer-init/init
@@ -1,0 +1,230 @@
+#!/bin/sh
+# TFTP installer initramfs: minimal bring-up, then same driver load path as stock SONiC initramfs
+# (init-top + /conf/modules + init-premount/udev) so MDIO/I2C/GPIO/PHY deps match full initramfs.
+# If cmdline has sonic_install.tftp_server=, DHCP (or existing ip=) + TFTP + /sbin/install-to-emmc.sh;
+# else interactive shell. Optional: sonic_install.tftp_image= sonic_install.reboot=1 (network: always eth0)
+
+export PATH=/sbin:/usr/sbin:/bin:/usr/bin
+
+mkdir -p /proc /sys /dev /tmp /run
+
+mount -t proc -o nodev,noexec,nosuid proc /proc || {
+    echo "Error: mount -t proc proc /proc failed (ifconfig/ip need /proc)."
+    exec /bin/sh
+}
+mount -t sysfs -o nodev,noexec,nosuid sysfs /sys || {
+    echo "Warning: sysfs mount failed."
+}
+mount -t devtmpfs -o nosuid,mode=0755 udev /dev 2>/dev/null || \
+    mount -t devtmpfs devtmpfs /dev || {
+    echo "Warning: devtmpfs mount failed."
+}
+
+[ ! -h /dev/fd ] && ln -sf /proc/self/fd /dev/fd 2>/dev/null || true
+[ ! -h /dev/stdin ] && ln -sf /proc/self/fd/0 /dev/stdin 2>/dev/null || true
+[ ! -h /dev/stdout ] && ln -sf /proc/self/fd/1 /dev/stdout 2>/dev/null || true
+[ ! -h /dev/stderr ] && ln -sf /proc/self/fd/2 /dev/stderr 2>/dev/null || true
+mkdir -p /dev/pts
+mount -t devpts -o noexec,nosuid,gid=5,mode=0620 devpts /dev/pts 2>/dev/null || true
+
+refresh_machine_conf_for_installer() {
+    INSTALLER_MACHINE_CONF=/tmp/machine.conf
+    rm -f "$INSTALLER_MACHINE_CONF"
+    if [ -x /sbin/sonic-machine-conf-init.sh ]; then
+        MACHINE_CONF="$INSTALLER_MACHINE_CONF" LOG_FILE=/dev/null \
+            /bin/sh /sbin/sonic-machine-conf-init.sh || true
+    fi
+    if [ -f "$INSTALLER_MACHINE_CONF" ]; then
+        . "$INSTALLER_MACHINE_CONF"
+        export onie_platform
+    fi
+}
+
+# Match Debian initramfs-tools early boot (see usr/share/initramfs-tools/init): loads modules and
+# runs udev coldplug so Ethernet/PHY/MDIO match "full" SONiC initramfs behavior.
+run_initramfs_tools_drivers() {
+    [ -f /scripts/functions ] && [ -f /conf/arch.conf ] || return 0
+    (
+        cd /
+        export DPKG_ARCH=
+        . /conf/arch.conf
+        export MODPROBE_OPTIONS="-qb"
+        export ROOT= ROOTDELAY= ROOTFLAGS= ROOTFSTYPE=
+        export LOOP= LOOPFLAGS= LOOPFSTYPE= LOOPOFFSET=
+        export IP= DEVICE= BOOT= BOOTIF= UBIMTD=
+        export init=/sbin/init readonly=y rootmnt=/root
+        export resume= resume_offset= noresume= drop_caps=
+        export fastboot=n forcefsck=n fsckfix=
+        export debug= panic= blacklist= break=
+        RUNSIZE=10%
+        quiet=n
+        netconsole=
+        for x in $(cat /proc/cmdline); do
+            case $x in
+            quiet) quiet=y ;;
+            initramfs.runsize=*) RUNSIZE="${x#initramfs.runsize=}" ;;
+            blacklist=*) blacklist=${x#blacklist=} ;;
+            panic=*) panic=${x#panic=} ;;
+            break=*) break=${x#break=} ;;
+            break) break=premount ;;
+            debug|debug=*) debug=y; quiet=n ;;
+            netconsole=*) netconsole=${x#netconsole=} ;;
+            esac
+        done
+        export quiet blacklist panic break debug netconsole
+        [ -d /root ] || mkdir -m 0700 /root
+        mkdir -p /var/lock
+        mkdir -p /run/initramfs
+        if command -v mountpoint >/dev/null 2>&1; then
+            mountpoint -q /run || mount -t tmpfs -o "nodev,noexec,nosuid,size=${RUNSIZE},mode=0755" tmpfs /run
+        else
+            mount -t tmpfs -o "nodev,noexec,nosuid,size=${RUNSIZE},mode=0755" tmpfs /run 2>/dev/null || true
+        fi
+        mkdir -m 0700 /run/initramfs
+        . /conf/initramfs.conf
+        for conf in /conf/conf.d/*; do
+            [ -f "$conf" ] && . "$conf"
+        done
+        . /scripts/functions
+        if [ -n "$netconsole" ]; then
+            /sbin/modprobe netconsole netconsole="$netconsole" 2>/dev/null || true
+        fi
+        run_scripts /scripts/init-top
+        load_modules
+        run_scripts /scripts/init-premount
+    ) || echo "Warning: initramfs-tools driver phase had errors (continuing to shell)."
+}
+
+run_initramfs_tools_drivers
+
+refresh_machine_conf_for_installer
+
+cd /tmp
+
+DEFAULT_TFTP_IMAGE=sonic-aspeed-arm64-emmc.img.gz
+TFTP_SERVER=
+TFTP_IMAGE="$DEFAULT_TFTP_IMAGE"
+INSTALL_REBOOT=
+for x in $(cat /proc/cmdline); do
+    case $x in
+    sonic_install.tftp_server=*) TFTP_SERVER="${x#sonic_install.tftp_server=}" ;;
+    sonic_install.tftp_image=*) TFTP_IMAGE="${x#sonic_install.tftp_image=}" ;;
+    sonic_install.reboot=1|sonic_install.reboot=yes|sonic_install.reboot=true)
+        INSTALL_REBOOT=y ;;
+    esac
+done
+
+drop_shell() {
+    echo "Aspeed TFTP installer: dropping to shell."
+    echo "  Manual install: /sbin/install-to-emmc.sh /tmp/<image.img.gz>"
+    echo "  Auto install: add to bootargs, e.g. sonic_install.tftp_server=<tftp-ip> [sonic_install.tftp_image=$DEFAULT_TFTP_IMAGE]"
+    echo ""
+    if [ -x /bin/bash ]; then
+        exec /bin/bash
+    fi
+    if [ -x /usr/bin/bash ]; then
+        exec /usr/bin/bash
+    fi
+    exec /bin/sh
+}
+
+iface_has_ipv4() {
+    if command -v ip >/dev/null 2>&1; then
+        ip -4 -o addr show dev "$1" 2>/dev/null | grep -q .
+        return $?
+    fi
+    ifconfig "$1" 2>/dev/null | grep -q 'inet '
+}
+
+bringup_network() {
+    IFACE=eth0
+    case "$onie_platform" in
+    arm64-aspeed_nvidia_ast2700_a1_bmc-r0)
+        # Reload ftgmac100 to ensure the driver is loaded and the interface is up
+        rmmod ftgmac100 2>/dev/null || true
+        ;;
+    esac
+    modprobe ftgmac100 2>/dev/null || true
+
+    echo "Waiting for $IFACE in sysfs (up to 10s)..."
+    n=0
+    while [ ! -d "/sys/class/net/$IFACE" ] && [ "$n" -lt 10 ]; do
+        sleep 1
+        n=$((n + 1))
+    done
+    if [ ! -d "/sys/class/net/$IFACE" ]; then
+        echo "Error: /sys/class/net/$IFACE not found."
+        return 1
+    fi
+    echo "Using interface $IFACE"
+    ip link set "$IFACE" up 2>/dev/null || ifconfig "$IFACE" up 2>/dev/null || true
+    sleep 1
+    if iface_has_ipv4 "$IFACE"; then
+        echo "Interface $IFACE already has an IPv4 address (kernel/ip=)."
+        return 0
+    fi
+    if [ ! -x /sbin/udhcpc.script ]; then
+        echo "Error: /sbin/udhcpc.script missing (TFTP initrd must ship udhcpc.script next to install-to-emmc.sh)."
+        return 1
+    fi
+    echo "Running DHCP on $IFACE..."
+    udhcpc -n -q -i "$IFACE" -s /sbin/udhcpc.script -t 10 -T 3 || true
+    if iface_has_ipv4 "$IFACE"; then
+        return 0
+    fi
+    echo "Error: no IPv4 on $IFACE (set ip=... in bootargs or fix DHCP)."
+    return 1
+}
+
+tftp_fetch_image() {
+    srv="$1"
+    img="$2"
+    dest="/tmp/$(basename "$img")"
+    rm -f "$dest"
+    echo "TFTP: $srv -> $dest ($img)"
+    if command -v tftp >/dev/null 2>&1 && tftp -g -r "$img" -l "$dest" "$srv" && [ -s "$dest" ]; then
+        return 0
+    fi
+    if command -v busybox >/dev/null 2>&1 && busybox tftp -g -r "$img" -l "$dest" "$srv" && [ -s "$dest" ]; then
+        return 0
+    fi
+    echo "Error: tftp failed or empty file (check server, filename, firewall)."
+    return 1
+}
+
+if [ -z "$TFTP_SERVER" ]; then
+    echo "Aspeed TFTP installer: no sonic_install.tftp_server= in cmdline — interactive shell."
+    echo "  eMMC helper: /sbin/install-to-emmc.sh <path-to-raw-image>"
+    echo ""
+    drop_shell
+fi
+
+if ! bringup_network; then
+    drop_shell
+fi
+
+if ! tftp_fetch_image "$TFTP_SERVER" "$TFTP_IMAGE"; then
+    drop_shell
+fi
+
+if [ ! -x /sbin/install-to-emmc.sh ]; then
+    echo "Error: /sbin/install-to-emmc.sh missing from initramfs."
+    drop_shell
+fi
+
+if ! /sbin/install-to-emmc.sh "/tmp/$(basename "$TFTP_IMAGE")"; then
+    echo "Install script failed."
+    drop_shell
+fi
+
+if [ -x /sbin/sonic-uboot-env-init.sh ]; then
+    SONIC_UBOOT_ENV_INSTALLER=1 /sbin/sonic-uboot-env-init.sh || echo "Warning: U-Boot env update failed or incomplete."
+fi
+
+if [ "$INSTALL_REBOOT" = y ]; then
+    echo "Rebooting..."
+    sync
+    reboot -f 2>/dev/null || busybox reboot -f 2>/dev/null || /sbin/reboot -f
+fi
+
+drop_shell

--- a/platform/aspeed/tftp-installer-init/install-to-emmc.sh
+++ b/platform/aspeed/tftp-installer-init/install-to-emmc.sh
@@ -35,10 +35,16 @@ partprobe "$EMMC" 2>/dev/null || true
 
 echo "Writing $IMG to $EMMC..."
 # Smaller bs + full pipe reads: fewer phys_seg per I/O on some MMC hosts than bs=1M; conv=fsync at end.
-if ! gunzip -c "$IMG" | dd of="$EMMC" bs=128k iflag=fullblock conv=fsync; then
-    echo "Error: write to $EMMC failed (see kernel log for mmcblk I/O errors)."
+# Pipeline exit status is only from dd; corrupt/truncated gzip can still yield dd exit 0, so require gunzip success.
+gz_ok=$(mktemp) || exit 1
+(gunzip -c "$IMG" && echo ok >"$gz_ok") | dd of="$EMMC" bs=128k iflag=fullblock conv=fsync
+DD_RC=$?
+if [ "$DD_RC" -ne 0 ] || [ ! -s "$gz_ok" ]; then
+    rm -f "$gz_ok"
+    echo "Error: write to $EMMC failed, or image is corrupt/truncated (see kernel log for mmcblk I/O errors)."
     exit 1
 fi
+rm -f "$gz_ok"
 echo "Syncing..."
 sync
 blockdev --flushbufs "$EMMC" 2>/dev/null || true

--- a/platform/aspeed/tftp-installer-init/install-to-emmc.sh
+++ b/platform/aspeed/tftp-installer-init/install-to-emmc.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# Write eMMC image to /dev/mmcblk0 and ensure data is persisted before reboot.
+# Usage: install-to-emmc.sh [path-to-image.img.gz]
+# Default: /tmp/sonic-aspeed-arm64-emmc.img.gz
+# After running, reboot to boot from eMMC.
+# Initramfs must provide: sgdisk, wipefs, blockdev, partprobe, e2fsck,
+# gunzip, dd, blkid, mount. (TFTP installer ramfs has no swap and no eMMC mounts.)
+
+IMG="${1:-/tmp/sonic-aspeed-arm64-emmc.img.gz}"
+EMMC="/dev/mmcblk0"
+
+if [ ! -b "$EMMC" ]; then
+    echo "Error: $EMMC not found"
+    exit 1
+fi
+if [ ! -f "$IMG" ]; then
+    echo "Error: image not found: $IMG"
+    echo "Usage: $0 [path-to-image.img.gz]"
+    exit 1
+fi
+
+rosys="/sys/block/$(basename "$EMMC")/force_ro"
+if [ -w "$rosys" ]; then
+    echo 0 > "$rosys" 2>/dev/null || true
+fi
+blockdev --setrw "$EMMC" 2>/dev/null || true
+sync
+
+echo "Clearing existing partition table on $EMMC..."
+sgdisk --zap-all "$EMMC" || echo "Warning: sgdisk --zap-all failed; continuing with full image write."
+wipefs -a "$EMMC" || echo "Warning: wipefs -a failed; continuing with full image write."
+sync
+blockdev --rereadpt "$EMMC" 2>/dev/null || true
+partprobe "$EMMC" 2>/dev/null || true
+
+echo "Writing $IMG to $EMMC..."
+# Smaller bs + full pipe reads: fewer phys_seg per I/O on some MMC hosts than bs=1M; conv=fsync at end.
+if ! gunzip -c "$IMG" | dd of="$EMMC" bs=128k iflag=fullblock conv=fsync; then
+    echo "Error: write to $EMMC failed (see kernel log for mmcblk I/O errors)."
+    exit 1
+fi
+echo "Syncing..."
+sync
+blockdev --flushbufs "$EMMC" 2>/dev/null || true
+echo "Relocating GPT backup to end of $EMMC (fixes invalid alternate GPT when image < device)..."
+sgdisk -e "$EMMC" || echo "Warning: sgdisk -e failed"
+partprobe "$EMMC" 2>/dev/null || true
+
+# SONiC mounts the SONiC-OS ext4 root at /host; machine.conf must be the file at the fs root
+# (see platform/aspeed/build-emmc-image-installer.sh). Copy from TFTP init if we generated it in initramfs.
+MACHINE_CONF_SRC=/tmp/machine.conf
+if [ -f "$MACHINE_CONF_SRC" ] && [ -s "$MACHINE_CONF_SRC" ]; then
+    sync
+    blockdev --rereadpt "$EMMC" 2>/dev/null || true
+    partprobe "$EMMC" 2>/dev/null || true
+    sleep 1
+    BOOT_PART=$(blkid -L SONiC-OS 2>/dev/null || true)
+    if [ -z "$BOOT_PART" ] && [ -b "${EMMC}p1" ]; then
+        BOOT_PART="${EMMC}p1"
+    fi
+    if [ -n "$BOOT_PART" ] && [ -b "$BOOT_PART" ]; then
+        echo "Checking ext4 on $BOOT_PART (e2fsck)..."
+        e2fsck -fy "$BOOT_PART" </dev/null 2>/dev/null || true
+        MNT=$(mktemp -d)
+        if mount -t ext4 -o rw "$BOOT_PART" "$MNT" 2>/dev/null; then
+            cp "$MACHINE_CONF_SRC" "$MNT/machine.conf"
+            chmod 644 "$MNT/machine.conf" 2>/dev/null || true
+            sync
+            umount "$MNT" 2>/dev/null || true
+            echo "Wrote machine.conf to SONiC-OS partition (visible as /host/machine.conf after boot)."
+        else
+            echo "Warning: could not mount $BOOT_PART rw; left machine.conf only in initramfs ($MACHINE_CONF_SRC)."
+        fi
+        rmdir "$MNT" 2>/dev/null || true
+    else
+        echo "Warning: SONiC-OS partition not found; could not write machine.conf to eMMC."
+    fi
+fi

--- a/platform/aspeed/tftp-installer-init/udhcpc.script
+++ b/platform/aspeed/tftp-installer-init/udhcpc.script
@@ -1,0 +1,35 @@
+#!/bin/sh
+# BusyBox udhcpc handler: apply lease (address + default route). Bundled as /sbin/udhcpc.script
+# because minimal initramfs has no /usr/share/udhcpc/default.script.
+
+case "$1" in
+deconfig)
+    if command -v ip >/dev/null 2>&1; then
+        ip -4 addr flush dev "$interface" 2>/dev/null || true
+    else
+        ifconfig "$interface" 0.0.0.0 2>/dev/null || true
+    fi
+    ;;
+renew|bound)
+    [ -n "$interface" ] && [ -n "$ip" ] || exit 1
+    if command -v ip >/dev/null 2>&1 && [ -n "$mask" ]; then
+        ip -4 addr flush dev "$interface" 2>/dev/null || true
+        ip -4 addr add "$ip/$mask" dev "$interface" || exit 1
+        ip link set "$interface" up 2>/dev/null || true
+    elif [ -n "$subnet" ]; then
+        ifconfig "$interface" "$ip" netmask "$subnet" up || exit 1
+    else
+        exit 1
+    fi
+    if [ -n "$router" ]; then
+        for gw in $router; do
+            if command -v ip >/dev/null 2>&1; then
+                ip -4 route add default via "$gw" dev "$interface" 2>/dev/null && break
+            else
+                route add default gw "$gw" dev "$interface" 2>/dev/null && break
+            fi
+        done
+    fi
+    ;;
+esac
+exit 0

--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -130,6 +130,7 @@ RUN apt-get update && apt-get install -y eatmydata && eatmydata apt-get install 
         cron \
         debootstrap \
         e2fsprogs \
+        gdisk \
 # For sonic-swss-common
         nlohmann-json3-dev \
         libhiredis-dev \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Add an Aspeed BMC path to install SONiC onto eMMC over the network: boot a small TFTP-delivered FIT (kernel + dedicated initramfs), fetch a gzipped raw eMMC image from TFTP, flash `/dev/mmcblk0` safely (partition teardown, GPT cleanup, retry on I/O quirks), optionally fix alternate GPT placement, copy `machine.conf` onto the SONiC-OS ext4 root when present, and optionally refresh U-Boot environment and reboot. This complements the existing one-image flow and supports factory/bring-up without local storage or a full installer UI.

##### Work item tracking

- Microsoft ADO **(number only)**:

#### How I did it

- **Build / packaging** — `platform/aspeed/recipes/installer-tftp.mk` defines `aspeed-emmc-image`, `aspeed-tftp`, and `aspeed-tftp-tar`. The gzipped raw image is produced from the platform one-image via `build-emmc-image-installer.sh`; the TFTP bundle is assembled by `platform/aspeed/installer/create_tftp_image.sh` (FIT, repacked initrd, staging/tar).
- **Initramfs** — `platform/aspeed/tftp-installer-init/init` mounts early filesystems, runs the same initramfs-tools driver phase as stock SONiC (`init-top`, module list, `init-premount`/udev) for consistent Ethernet/PHY/MDIO, refreshes `machine.conf` via `sonic-machine-conf-init.sh` when available, parses `sonic_install.*` kernel parameters, brings up `eth0` (DHCP via `udhcpc` or static `ip=` in cmdline), TFTPs the image to `/tmp/`, invokes `install-to-emmc.sh`, optionally runs `sonic-uboot-env-init.sh`, and optionally reboots.
- **Flash helper** — `platform/aspeed/tftp-installer-init/install-to-emmc.sh` clears kernel partition nodes, primes MMC writes, `sgdisk --zap-all` / `wipefs`, streams `gunzip | dd` with `conv=fsync`, relocates GPT with `sgdisk -e`, and mounts the SONiC-OS-labeled ext4 to write `/machine.conf` when `/tmp/machine.conf` exists.
- **U-Boot `fw_env.config` (`/etc/fw_env.config`)** — `fw_printenv` / `fw_setenv` require a single-line U-Boot-tools descriptor: device, environment offset, environment length, and flash erase size.
  - **`platform/aspeed/scripts/sonic-fw-env-config.sh`** creates or updates `/etc/fw_env.config` at runtime, in this order:
    1. **Per-platform file** — if `machine.conf` sets `onie_platform`, use the first existing path: `/usr/share/sonic/device/${onie_platform}/fw_env` or `/device/aspeed/${onie_platform}/fw_env` (for example, NVIDIA AST2700 A1 BMC can point at the eMMC boot hardware partition via `device/aspeed/.../fw_env`, e.g. `/dev/mmcblk0boot0` with length `0x20000` at offset `0x0`).
    2. **SPI / NOR** — parse `/proc/mtd` for a partition named `u-boot-env` or `uboot-env` and synthesize the `/dev/mtdN …` line.
    3. **Device tree** — when MTD and `env_size` under `/proc/device-tree` (and `hd`) allow, derive the line for the matching block device.
    4. **Fallback** — AST2700-style eMMC user-area layout: `/dev/mmcblk0 0x1F40000 0x20000 0x1000`.
  - **`platform/aspeed/scripts/sonic-uboot-env-init.sh`** runs **`sonic-fw-env-config.sh`** before any U-Boot variable programming. On the host this refreshes the config each boot; programming is guarded by `/host/.uboot-env-initialized`. In **installer / TFTP initrd** mode (`SONIC_UBOOT_ENV_INSTALLER=1`), it uses **`SONIC_MACHINE_CONF=/tmp/machine.conf`** so the same resolution runs after `sonic-machine-conf-init.sh` and before **`sonic-program-uboot-env.sh`**.
  - **TFTP initramfs** — `platform/aspeed/installer/create_tftp_image.sh` installs **`sonic-fw-env-config.sh`** into the repacked initrd as **`/sbin/sonic-fw-env-config.sh`**, with the other `/sbin` helpers.
  - **One-image / chroot build** — `platform/aspeed/platform_arm64.conf` function **`configure_uboot_env`** applies the same style of detection and fallback when preparing the target rootfs (writes `/etc/fw_env.config` during image construction and may verify with `fw_printenv bootcmd`).

#### How to verify it

1. From `sonic-buildimage` with `PLATFORM=aspeed` configured, build the bundle, for example:
   - `make aspeed-tftp` (staging under `target/aspeed-tftp/`), or
   - `make aspeed-tftp-tar` → `target/sonic-aspeed-arm64-tftp-install.tar`.
2. On a TFTP server, extract or copy **`sonic_tftp_install.fit`** and **`sonic-aspeed-arm64-emmc.img.gz`** (same directory is typical).
3. On the board, in U-Boot, use the sequence below (adjust console, `loadaddr`, and `earlycon` for your board).
4. Pass kernel command line including at least **`sonic_install.tftp_server=<tftp-server-ip>`**; optionally **`sonic_install.tftp_image=...`** and **`sonic_install.reboot=1`**.
5. Confirm: DHCP (or static IP) succeeds, TFTP completes, flash runs without mmc errors, subsequent eMMC boot reaches SONiC; optionally confirm **`/host/machine.conf`** after boot if the init path generated it.
6. **Manual path:** omit **`sonic_install.tftp_server=`**, drop to shell, run **`/sbin/install-to-emmc.sh /tmp/<image.img.gz>`**.
7. **U-Boot env access:** confirm **`cat /etc/fw_env.config`** matches the board (device, offset, length, erase size). If **`fw_printenv bootcmd`** fails, add or fix the per-platform **`fw_env`** file under `device/aspeed/<onie_platform>/` or align the fallback in **`sonic-fw-env-config.sh`** / **`configure_uboot_env`** for that hardware.

#### U-Boot commands (example)

```
dhcp
setenv serverip <tftp-server-ip>
setenv loadaddr 0x432000000
setenv bootargs "console=ttyS12,115200n8 earlycon=uart8250,mmio32,0x14c33b00 root=/dev/ram0 rw sonic_install.tftp_server=${serverip} sonic_install.tftp_image=sonic-aspeed-arm64-emmc.img.gz"
tftp $loadaddr sonic_tftp_install.fit
# bootconf must match a "configurations" entry in platform/aspeed/sonic_fit.its (name without conf- prefix).
setenv bootconf <fit-configuration>
bootm $loadaddr#conf-$bootconf
```

#### Dependency diagram

```mermaid
flowchart TB
  subgraph build["Build (sonic-buildimage)"]
    ONE[sonic-aspeed-arm64.bin / one-image]
    MK[installer-tftp.mk]
    EMMC_SH[build-emmc-image-installer.sh]
    IMG_GZ[sonic-aspeed-arm64-emmc.img.gz]
    CREAT[create_tftp_image.sh]
    FIT[sonic_tftp_install.fit]
    TAR[sonic-aspeed-arm64-tftp-install.tar]

    ONE --> MK
    MK --> EMMC_SH
    EMMC_SH --> IMG_GZ
    ONE --> CREAT
    IMG_GZ --> CREAT
    CREAT --> FIT
    CREAT --> TAR
  end

  subgraph runtime["Runtime (BMC U-Boot / RAM)"]
    UB[U-Boot TFTP + bootm FIT]
    KR[kernel + cmdline sonic_install.*]
    INIT[tftp-installer-init /init]
    ETH[eth0: ip= or udhcpc]
    TFTP_CLI[TFTP → /tmp/*.img.gz]
    FLASH[install-to-emmc.sh → /dev/mmcblk0]
    UENV[sonic-uboot-env-init.sh optional]

    UB --> KR --> INIT
    INIT --> ETH --> TFTP_CLI --> FLASH
    FLASH --> UENV
  end

  FIT --> UB
  IMG_GZ --> TFTP_CLI
```
