### PR TITLE
Skip optional vpp test in baseline test to save cpu

### DIFF
--- a/.azure-pipelines/baseline_test/baseline.test.buildimage.yml
+++ b/.azure-pipelines/baseline_test/baseline.test.buildimage.yml
@@ -47,7 +47,7 @@ parameters:
 
   - name: INCLUDE_JOBS
     type: string
-    default: "all"
+    default: "t0_job,t1_job,t2_job,t0_2vlans_job,t0_sonic_job,dualtor_job,dpu_job,t1_multi_asic_job"
 
 variables:
 - template: ../azure-pipelines-repd-build-variables.yml


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Vpp test is optional and in onboarding status, no need to use baseline test to find regression and flaky tests.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Skip vpp test in baseline test to save cpu.
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

