### PR TITLE
[202505] fix: resolve April 2026 docker-ptf security vulnerabilities (#26676)

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -102,13 +102,17 @@ RUN apt-get update          \
 # to ensure they use a patched Go stdlib (GO-2026-4337: crypto/tls)
 {% if CONFIGURED_ARCH == "armhf" %}
 RUN GO_ARCH=armv6l \
+    && GO_SHA256=7d4f0d266d871301e08ef4ac31c56e66048688893b2848392e5c600276351ee8 \
 {% elif CONFIGURED_ARCH == "arm64" %}
 RUN GO_ARCH=arm64 \
+    && GO_SHA256=ec342e7389b7f489564ed5463c63b16cf8040023dabc7861256677165a8c0e2b \
 {% else %}
 RUN GO_ARCH=amd64 \
+    && GO_SHA256=00859d7bd6defe8bf84d9db9e57b9a4467b2887c18cd93ae7460e713db774bc1 \
 {% endif %}
-    && GO_VERSION=1.25.8 \
+    && GO_VERSION=1.25.9 \
     && curl -L "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz" -o /tmp/go.tar.gz \
+    && echo "${GO_SHA256}  /tmp/go.tar.gz" | sha256sum -c - \
     && tar -C /usr/local -xzf /tmp/go.tar.gz \
     && rm /tmp/go.tar.gz
 
@@ -120,11 +124,15 @@ RUN GRPCURL_VERSION=v1.9.3 \
     && git clone --depth 1 --branch "${GRPCURL_VERSION}" https://github.com/fullstorydev/grpcurl.git /tmp/grpcurl \
     && cd /tmp/grpcurl \
     && go get google.golang.org/grpc@v1.79.3 \
+    && go get github.com/go-jose/go-jose/v4@latest \
     && go get golang.org/x/crypto@latest golang.org/x/net@latest golang.org/x/text@latest golang.org/x/sys@latest golang.org/x/oauth2@latest \
     && go mod tidy \
     && go build -o /usr/local/bin/grpcurl ./cmd/grpcurl \
     && chmod +x /usr/local/bin/grpcurl \
     && rm -rf /tmp/grpcurl
+# Security fixes: upgrade all vulnerable system packages (S360 scan remediation)
+RUN apt-get update && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
 
 {% if PTF_ENV_PY_VER == "py3" %}
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \
@@ -370,13 +378,15 @@ RUN git clone https://github.com/karimra/gnoic.git \
     && git checkout 27bc5a6 \
     && go get google.golang.org/grpc@v1.79.3 \
     && go get github.com/go-viper/mapstructure/v2@v2.4.0 \
+    && go get github.com/go-jose/go-jose/v4@latest \
     && go get golang.org/x/crypto@latest golang.org/x/net@latest golang.org/x/text@latest golang.org/x/sys@latest golang.org/x/oauth2@latest \
     && go mod tidy \
     && go build -o /usr/local/bin/gnoic . \
     && cd .. \
-    && rm -rf gnoic
+    && rm -rf gnoic /root/go/pkg/mod /root/.cache/go-build
 
 # Build gnmic from source with upgraded deps to address known CVEs
+COPY gocloud-patches/ /tmp/gocloud-patches/
 RUN GNMIC_VERSION=v0.43.0 \
     && git clone --depth 1 --branch "${GNMIC_VERSION}" https://github.com/openconfig/gnmic.git /tmp/gnmic \
     && cd /tmp/gnmic \
@@ -384,13 +394,19 @@ RUN GNMIC_VERSION=v0.43.0 \
     && go get github.com/cloudflare/circl@v1.6.3 \
     && go get github.com/go-git/go-git/v5@latest \
     && go get github.com/nats-io/nats-server/v2@latest \
-    && go get go.opentelemetry.io/otel/sdk@v1.40.0 \
+    && go get go.opentelemetry.io/otel/sdk@latest \
     && go get github.com/docker/docker@latest \
+    && go get github.com/go-jose/go-jose/v4@latest \
+    && go get github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream@latest github.com/aws/aws-sdk-go-v2/service/s3@latest github.com/aws/aws-sdk-go-v2/feature/s3/manager@latest \
     && go get golang.org/x/crypto@latest golang.org/x/net@latest golang.org/x/text@latest golang.org/x/sys@latest golang.org/x/oauth2@latest \
+    && go get gocloud.dev@v0.25.1-0.20220408200107-09b10f7359f7 \
     && go mod tidy \
+    && GOCLOUD_DIR="$(go list -m -f '{{ '{{' }}.Dir{{ '}}' }}' gocloud.dev)" \
+    && chmod -R +w "$GOCLOUD_DIR" \
+    && patch --forward -d "$GOCLOUD_DIR" -p1 < /tmp/gocloud-patches/0001-fix-aws-sdk-go-v2-pointer-api-changes.patch \
     && go build -o /usr/local/bin/gnmic . \
     && chmod +x /usr/local/bin/gnmic \
-    && rm -rf /tmp/gnmic
+    && rm -rf /tmp/gnmic /tmp/gocloud-patches /root/go/pkg/mod /root/.cache/go-build
 COPY \
 {% for deb in docker_ptf_debs.split(' ') -%}
 debs/{{ deb }}{{' '}}

--- a/dockers/docker-ptf/gocloud-patches/0001-fix-aws-sdk-go-v2-pointer-api-changes.patch
+++ b/dockers/docker-ptf/gocloud-patches/0001-fix-aws-sdk-go-v2-pointer-api-changes.patch
@@ -1,0 +1,47 @@
+--- a/blob/s3blob/s3blob.go	2026-04-09 22:48:10.700372961 +0000
++++ b/blob/s3blob/s3blob.go	2026-04-09 22:48:19.654602364 +0000
+@@ -399,7 +399,7 @@
+ 	if b.useV2 {
+ 		in := &s3v2.ListObjectsV2Input{
+ 			Bucket:  aws.String(b.name),
+-			MaxKeys: int32(pageSize),
++			MaxKeys: aws.Int32(int32(pageSize)),
+ 		}
+ 		if len(opts.PageToken) > 0 {
+ 			in.ContinuationToken = aws.String(string(opts.PageToken))
+@@ -425,7 +425,7 @@
+ 				page.Objects[i] = &driver.ListObject{
+ 					Key:     unescapeKey(aws.StringValue(obj.Key)),
+ 					ModTime: *obj.LastModified,
+-					Size:    obj.Size,
++					Size:    aws.Int64Value(obj.Size),
+ 					MD5:     eTagToMD5(obj.ETag),
+ 					AsFunc: func(i interface{}) bool {
+ 						p, ok := i.(*typesv2.Object)
+@@ -576,7 +576,7 @@
+ 	var nextContinuationToken *string
+ 	if legacyResp.NextMarker != nil {
+ 		nextContinuationToken = legacyResp.NextMarker
+-	} else if legacyResp.IsTruncated {
++	} else if aws.BoolValue(legacyResp.IsTruncated) {
+ 		nextContinuationToken = aws.String(aws.StringValue(legacyResp.Contents[len(legacyResp.Contents)-1].Key))
+ 	}
+ 	return &s3v2.ListObjectsV2Output{
+@@ -706,7 +706,7 @@
+ 			Metadata:           md,
+ 			// CreateTime not supported; left as the zero time.
+ 			ModTime: aws.TimeValue(resp.LastModified),
+-			Size:    resp.ContentLength,
++			Size:    aws.Int64Value(resp.ContentLength),
+ 			MD5:     eTagToMD5(resp.ETag),
+ 			ETag:    aws.StringValue(resp.ETag),
+ 			AsFunc: func(i interface{}) bool {
+@@ -803,7 +803,7 @@
+ 			attrs: driver.ReaderAttributes{
+ 				ContentType: aws.StringValue(resp.ContentType),
+ 				ModTime:     aws.TimeValue(resp.LastModified),
+-				Size:        getSize(resp.ContentLength, aws.StringValue(resp.ContentRange)),
++				Size:        getSize(aws.Int64Value(resp.ContentLength), aws.StringValue(resp.ContentRange)),
+ 			},
+ 			rawV2: resp,
+ 		}, nil


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Cherry-pick #26676 for security fix
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Attempt to fix new docker-ptf security vulnerability as of 04/2026

This pull request updates the `dockers/docker-ptf/Dockerfile.j2` to incorporate several dependency upgrades and security improvements. The main focus is on updating Go and related dependencies to address vulnerabilities and ensure compatibility with the latest features and fixes.

Dependency and version updates:

* Upgraded the Go version used in the Docker image from `1.25.8` to `1.25.9` for improved stability and security.
* Updated the `go.opentelemetry.io/otel/sdk` dependency from version `v1.40.0` to `v1.43.0` for the `gnmic` build process.
* Added or updated the `github.com/go-jose/go-jose/v4` dependency to version `v4.1.4` in the build steps for `grpcurl`, `gnoic`, and `gnmic` to ensure consistent cryptography support. [[1]](diffhunk://#diff-bdead431cfeb50ac3debd09da54bbc77f0b1772edf769de0cd4e30538fd012e0R128-R135) [[2]](diffhunk://#diff-bdead431cfeb50ac3debd09da54bbc77f0b1772edf769de0cd4e30538fd012e0R411) [[3]](diffhunk://#diff-bdead431cfeb50ac3debd09da54bbc77f0b1772edf769de0cd4e30538fd012e0L423-R429)
* Added the latest versions of `github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream` and `github.com/aws/aws-sdk-go-v2/service/s3` as dependencies for the `gnmic` build.

Security improvements:

* Included a system package upgrade step to address vulnerabilities such as CVE-2026-33416 and CVE-2026-33636 (affecting `libpng16-16`), among others.


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

