### PR TITLE
Update fw-manager to support firmware upgrades for the new ASIC

### DIFF
--- a/platform/mellanox/files/mlnx-fw-manager.service
+++ b/platform/mellanox/files/mlnx-fw-manager.service
@@ -25,7 +25,8 @@ RemainAfterExit=yes
 ExecStartPre=/usr/bin/mst start --with_i2cdev
 ExecStart=/usr/local/bin/mlnx-fw-manager --clear-semaphore --verbose
 ExecStop=/usr/bin/mst stop
-TimeoutSec=300
+# Firmware burn (mlxfwmanager -u) can take 10+ minutes on SPC6; 5min was causing start timeout
+TimeoutSec=900
 User=root
 
 [Install]

--- a/platform/mellanox/fw-manager/mellanox_fw_manager/firmware_coordinator.py
+++ b/platform/mellanox/fw-manager/mellanox_fw_manager/firmware_coordinator.py
@@ -123,9 +123,9 @@ class FirmwareCoordinator:
         failure_count = 0
         timeout_failures = set()
 
-        # Wait for all processes with timeout (10 minutes per ASIC)
-        # Firmware upgrades typically take 1-3 minutes, so 10 minutes provides a safe margin
-        timeout_per_asic = 600  # seconds
+        # Wait for all processes with timeout per ASIC
+        # SPC6 and similar can take 10+ minutes; use 15 min to allow burn to complete (align with mlnx-fw-manager.service TimeoutSec=900)
+        timeout_per_asic = 900  # seconds
         for process in processes:
             process.join(timeout=timeout_per_asic)
             if process.is_alive():

--- a/platform/mellanox/fw-manager/mellanox_fw_manager/spectrum_manager.py
+++ b/platform/mellanox/fw-manager/mellanox_fw_manager/spectrum_manager.py
@@ -30,6 +30,9 @@ from .firmware_base import FirmwareManagerBase, FW_ALREADY_UPDATED_FAILURE
 class SpectrumFirmwareManager(FirmwareManagerBase):
     """Firmware manager for Spectrum ASICs."""
 
+    # Same path as sx-kernel.service ExecStart (sonic_debian_extension installs to /usr/bin).
+    _SX_KERNEL_SH = '/usr/bin/sx-kernel.sh'
+
     # PCI ID to ASIC type mapping for Spectrum devices
     ASIC_TYPE_MAP = {
         '15b3:cb84': 'SPC',
@@ -52,6 +55,37 @@ class SpectrumFirmwareManager(FirmwareManagerBase):
     def _get_mst_device_type(self) -> str:
         """Get MST device type for Spectrum ASICs."""
         return "Spectrum"
+
+    def _run_sx_kernel(self, action: str) -> bool:
+        """
+        Run sx-kernel.sh start or stop.
+
+        Loading the Spectrum driver before mlxfwmanager can reduce burn time (e.g. DMA vs
+        register-only access). Unloading after burn lets sx-kernel.service bring the driver up
+        cleanly for syncd, avoiding a stuck or failed reactivation when the driver stayed loaded.
+
+        Args:
+            action: 'start' or 'stop'
+
+        Returns:
+            True if the script exited 0, else False.
+        """
+        if action not in ('start', 'stop'):
+            raise ValueError(f'invalid sx-kernel action: {action!r}')
+        cmd = [self._SX_KERNEL_SH, action]
+        try:
+            result = self._run_command(cmd, capture_output=True, text=True)
+            if result.returncode != 0:
+                err = (result.stderr or result.stdout or '').strip()
+                self.logger.warning(
+                    f'sx-kernel.sh {action} failed (exit {result.returncode}){": " + err if err else ""}'
+                )
+                return False
+            self.logger.info(f'sx-kernel.sh {action} completed successfully')
+            return True
+        except Exception as e:
+            self.logger.warning(f'sx-kernel.sh {action} failed: {e}')
+            return False
 
     def _get_available_firmware_version(self, psid: str) -> Optional[str]:
         """Get available firmware version for Spectrum ASICs using mlxfwmanager."""
@@ -77,15 +111,26 @@ class SpectrumFirmwareManager(FirmwareManagerBase):
 
     def run_firmware_update(self) -> bool:
         """Run the actual firmware update command for Spectrum ASICs."""
+        # MST device for mlxfwmanager/flint is intentionally fixed to mt53124_pciconf0 (PCI config
+        # access). Product/MFT require this path for SPC6 burn (see RM4953771). A plain
+        # `mlxfwmanager` query may list PCI Device Name as mt53124_pci_cr0; that is not a signal to
+        # change the burn device here without explicit MFT/product approval.
+        sx_loaded = False
         try:
-            cmd = ['mlxfwmanager', '-u', '-f', '-y', '-d', self.pci_id, '-i', self.fw_file]
+            sx_loaded = self._run_sx_kernel('start')
+            if not sx_loaded:
+                self.logger.warning(
+                    'Continuing firmware burn without sx-kernel start (slower path or already loaded)'
+                )
+
+            cmd = ['mlxfwmanager', '-u', '-f', '-y', '-d', '/dev/mst/mt53124_pciconf0', '-i', self.fw_file]
             env = self._get_env()
 
             result = self._run_command(cmd, env=env, capture_output=True, text=True)
 
             if result.returncode == FW_ALREADY_UPDATED_FAILURE:
                 self.logger.info("FW reactivation is required. Reactivating and updating FW ...")
-                reactivate_cmd = ['flint', '-d', self.pci_id, 'ir']
+                reactivate_cmd = ['flint', '-d', '/dev/mst/mt53124_pciconf0', 'ir']
                 reactivate_result = self._run_command(reactivate_cmd, capture_output=True, text=True)
                 if reactivate_result.returncode != 0:
                     self.logger.warning(f"FW reactivation failed with return code {reactivate_result.returncode}: {reactivate_result.stderr}")
@@ -100,3 +145,6 @@ class SpectrumFirmwareManager(FirmwareManagerBase):
         except Exception as e:
             self.logger.error(f"Failed to run firmware update for Spectrum ASICs: {e}")
             return False
+        finally:
+            if sx_loaded:
+                self._run_sx_kernel('stop')

--- a/platform/mellanox/fw-manager/mellanox_fw_manager/spectrum_manager.py
+++ b/platform/mellanox/fw-manager/mellanox_fw_manager/spectrum_manager.py
@@ -112,7 +112,7 @@ class SpectrumFirmwareManager(FirmwareManagerBase):
     def run_firmware_update(self) -> bool:
         """Run the actual firmware update command for Spectrum ASICs."""
         # MST device for mlxfwmanager/flint is intentionally fixed to mt53124_pciconf0 (PCI config
-        # access). Product/MFT require this path for SPC6 burn (see RM4953771). A plain
+        # access). Product/MFT require this path for SPC6 burn. A plain
         # `mlxfwmanager` query may list PCI Device Name as mt53124_pci_cr0; that is not a signal to
         # change the burn device here without explicit MFT/product approval.
         sx_loaded = False

--- a/platform/mellanox/fw-manager/tests/test_firmware_upgrade.py
+++ b/platform/mellanox/fw-manager/tests/test_firmware_upgrade.py
@@ -119,7 +119,8 @@ class TestFirmwareUpgrade(unittest.TestCase):
 
     @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._initialize_asic')
     @patch('mellanox_fw_manager.spectrum_manager.subprocess.run')
-    def test_spectrum_firmware_upgrade_success(self, mock_run, mock_init_asic):
+    @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._run_sx_kernel', return_value=True)
+    def test_spectrum_firmware_upgrade_success(self, mock_sx_kernel, mock_run, mock_init_asic):
         """Test successful firmware upgrade for Spectrum ASIC"""
         mock_init_asic.return_value = None
 
@@ -150,7 +151,7 @@ class TestFirmwareUpgrade(unittest.TestCase):
             self.assertIn('-f', upgrade_call[0][0])
             self.assertIn('-y', upgrade_call[0][0])
             self.assertIn('-d', upgrade_call[0][0])
-            self.assertIn('01:00.0', upgrade_call[0][0])
+            self.assertIn('/dev/mst/mt53124_pciconf0', upgrade_call[0][0])
             self.assertIn('-i', upgrade_call[0][0])
             self.assertIn('/test/fw/fw-SPC3.mfa', upgrade_call[0][0])
 
@@ -207,7 +208,8 @@ class TestFirmwareUpgrade(unittest.TestCase):
 
     @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._initialize_asic')
     @patch('mellanox_fw_manager.spectrum_manager.subprocess.run')
-    def test_firmware_upgrade_failure(self, mock_run, mock_init_asic):
+    @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._run_sx_kernel', return_value=True)
+    def test_firmware_upgrade_failure(self, mock_sx_kernel, mock_run, mock_init_asic):
         """Test firmware upgrade failure handling"""
         mock_init_asic.return_value = None
 
@@ -223,7 +225,8 @@ class TestFirmwareUpgrade(unittest.TestCase):
 
     @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._initialize_asic')
     @patch('mellanox_fw_manager.spectrum_manager.subprocess.run')
-    def test_spectrum_firmware_reactivation_scenario(self, mock_run, mock_init_asic):
+    @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._run_sx_kernel', return_value=True)
+    def test_spectrum_firmware_reactivation_scenario(self, mock_sx_kernel, mock_run, mock_init_asic):
         """Test firmware upgrade with reactivation required (return code 2)"""
         mock_init_asic.return_value = None
 
@@ -244,7 +247,7 @@ class TestFirmwareUpgrade(unittest.TestCase):
             reactivate_call = mock_run.call_args_list[1]
             self.assertIn('flint', reactivate_call[0][0])
             self.assertIn('-d', reactivate_call[0][0])
-            self.assertIn('01:00.0', reactivate_call[0][0])
+            self.assertIn('/dev/mst/mt53124_pciconf0', reactivate_call[0][0])
             self.assertIn('ir', reactivate_call[0][0])
 
             retry_call = mock_run.call_args_list[2]
@@ -299,7 +302,8 @@ class TestFirmwareUpgrade(unittest.TestCase):
 
     @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._initialize_asic')
     @patch('mellanox_fw_manager.spectrum_manager.subprocess.run')
-    def test_clear_semaphore_functionality(self, mock_run, mock_init_asic):
+    @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._run_sx_kernel', return_value=True)
+    def test_clear_semaphore_functionality(self, mock_sx_kernel, mock_run, mock_init_asic):
         """Test clear semaphore functionality"""
         mock_init_asic.return_value = None
 
@@ -328,7 +332,8 @@ class TestFirmwareUpgrade(unittest.TestCase):
 
     @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._initialize_asic')
     @patch('mellanox_fw_manager.spectrum_manager.subprocess.run')
-    def test_verbose_mode_commands(self, mock_run, mock_init_asic):
+    @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._run_sx_kernel', return_value=True)
+    def test_verbose_mode_commands(self, mock_sx_kernel, mock_run, mock_init_asic):
         """Test that verbose mode affects mlxfwmanager commands"""
         mock_init_asic.return_value = None
 

--- a/platform/mellanox/fw-manager/tests/test_spectrum_manager.py
+++ b/platform/mellanox/fw-manager/tests/test_spectrum_manager.py
@@ -189,8 +189,9 @@ Device Info:
 
         self.assertIsNone(result)
 
+    @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._run_sx_kernel', return_value=True)
     @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._run_command')
-    def test_run_firmware_update_success(self, mock_run_cmd):
+    def test_run_firmware_update_success(self, mock_run_cmd, mock_sx_kernel):
         """Test run_firmware_update when successful"""
         manager = self._create_manager()
 
@@ -207,9 +208,12 @@ Device Info:
         call_args = mock_run_cmd.call_args[0][0]
         self.assertIn('mlxfwmanager', call_args)
         self.assertIn('-u', call_args)
+        mock_sx_kernel.assert_any_call('start')
+        mock_sx_kernel.assert_any_call('stop')
 
+    @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._run_sx_kernel', return_value=True)
     @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._run_command')
-    def test_run_firmware_update_failure(self, mock_run_cmd):
+    def test_run_firmware_update_failure(self, mock_run_cmd, mock_sx_kernel):
         """Test run_firmware_update when firmware update fails"""
         manager = self._create_manager()
 
@@ -222,9 +226,12 @@ Device Info:
         result = manager.run_firmware_update()
 
         self.assertFalse(result)
+        mock_sx_kernel.assert_any_call('start')
+        mock_sx_kernel.assert_any_call('stop')
 
+    @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._run_sx_kernel', return_value=True)
     @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._run_command')
-    def test_run_firmware_update_reactivation_required(self, mock_run_cmd):
+    def test_run_firmware_update_reactivation_required(self, mock_run_cmd, mock_sx_kernel):
         """Test run_firmware_update when reactivation is required"""
         manager = self._create_manager()
 
@@ -242,9 +249,12 @@ Device Info:
         reactivate_call = mock_run_cmd.call_args_list[1][0][0]
         self.assertIn('flint', reactivate_call)
         self.assertIn('ir', reactivate_call)
+        mock_sx_kernel.assert_any_call('start')
+        mock_sx_kernel.assert_any_call('stop')
 
+    @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._run_sx_kernel', return_value=True)
     @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._run_command')
-    def test_run_firmware_update_reactivation_fails_but_continues(self, mock_run_cmd):
+    def test_run_firmware_update_reactivation_fails_but_continues(self, mock_run_cmd, mock_sx_kernel):
         """Test run_firmware_update when reactivation fails but continues with retry"""
         manager = self._create_manager()
 
@@ -259,8 +269,9 @@ Device Info:
         self.assertTrue(result)
         self.assertEqual(mock_run_cmd.call_count, 3)
 
+    @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._run_sx_kernel', return_value=True)
     @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._run_command')
-    def test_run_firmware_update_reactivation_required_retry_fails(self, mock_run_cmd):
+    def test_run_firmware_update_reactivation_required_retry_fails(self, mock_run_cmd, mock_sx_kernel):
         """Test run_firmware_update when reactivation required but retry fails"""
         manager = self._create_manager()
 
@@ -275,8 +286,9 @@ Device Info:
         self.assertFalse(result)
         self.assertEqual(mock_run_cmd.call_count, 3)
 
+    @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._run_sx_kernel', return_value=True)
     @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._run_command')
-    def test_run_firmware_update_exception(self, mock_run_cmd):
+    def test_run_firmware_update_exception(self, mock_run_cmd, mock_sx_kernel):
         """Test run_firmware_update when exception occurs"""
         manager = self._create_manager()
 
@@ -285,9 +297,11 @@ Device Info:
         result = manager.run_firmware_update()
 
         self.assertFalse(result)
+        mock_sx_kernel.assert_any_call('stop')
 
+    @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._run_sx_kernel', return_value=True)
     @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._run_command')
-    def test_run_firmware_update_with_verbose_mode(self, mock_run_cmd):
+    def test_run_firmware_update_with_verbose_mode(self, mock_run_cmd, mock_sx_kernel):
         """Test run_firmware_update passes correct environment in verbose mode"""
         manager = self._create_manager(verbose=True)
 
@@ -306,6 +320,23 @@ Device Info:
         env = call_kwargs['env']
         self.assertIn('FLASH_ACCESS_DEBUG', env)
         self.assertIn('FW_COMPS_DEBUG', env)
+
+    @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._run_sx_kernel', return_value=False)
+    @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._run_command')
+    def test_run_firmware_update_sx_kernel_start_fails_still_burns(self, mock_run_cmd, mock_sx_kernel):
+        """If sx-kernel start fails, burn continues and stop is not invoked (sx_loaded was False)."""
+        manager = self._create_manager()
+        mock_run_cmd.return_value = MagicMock(
+            returncode=0,
+            stdout="ok",
+            stderr=""
+        )
+
+        result = manager.run_firmware_update()
+
+        self.assertTrue(result)
+        mock_sx_kernel.assert_called_once_with('start')
+        mock_run_cmd.assert_called_once()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The existing fw-manager does not support firmware upgrades for SPC6 ASICs.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

1. Extended SpectrumFirmwareManager.run_firmware_update() to load the Spectrum kernel driver via sx-kernel.sh start before invoking mlxfwmanager, and unload it via sx-kernel.sh stop in a finally block after the burn completes. Loading the driver enables DMA-based flash access, which reduces burn time. Unloading after burn lets sx-kernel.service bring the driver up cleanly for syncd.
2. Changed the mlxfwmanager/flint device argument from self.pci_id (PCI BDF, e.g. 01:00.0) to the fixed MST path /dev/mst/mt53124_pciconf0 (PCI config access).  This is required for SPC6 firmware burn per MFT/product specification.                                                                              
3. Increased TimeoutSec in mlnx-fw-manager.service from 300 s to 900 s to accommodate SPC6 burn time, which can exceed 10 minutes.
4. Increased timeout_per_asic in firmware_coordinator.py from 600 s to 900 s to align with the service-level timeout.                                           
5. Updated unit tests to mock _run_sx_kernel and added test_run_firmware_update_sx_kernel_start_fails_still_burns to verify graceful degradation when the driver load fails. 

#### How to verify it

1. Run unit tests:                                                                                                                                              
2. On SPC6 device, trigger firmware upgrade and confirm:
- Service completes without timeout                                                                                                                           
- Logs show sx-kernel.sh start before burn and sx-kernel.sh stop after
- syncd comes up cleanly after reboot

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

