### PR TITLE
Restart pmon in syncd.sh to clean up invalid fd

### DIFF
--- a/files/build_templates/pmon.service.j2
+++ b/files/build_templates/pmon.service.j2
@@ -2,6 +2,9 @@
 Description=Platform monitor container
 Requires=database.service config-setup.service
 After=database.service config-setup.service
+{% if sonic_asic_platform == 'mellanox' %}
+After=syncd.service
+{% endif %}
 BindsTo=sonic.target
 After=sonic.target
 StartLimitIntervalSec=1200

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -66,6 +66,13 @@ function startplatform() {
             export FAST_BOOT=1
         fi
 
+        if [[ x"$WARM_BOOT" != x"true" ]]; then
+            if [[ x"$(/bin/systemctl is-active pmon)" == x"active" ]]; then
+                /bin/systemctl stop pmon
+                debug "pmon is active while syncd starting, stop it first (single-ASIC)"
+            fi
+        fi
+
         # Clear container's temporary directory before starting
         rm -rf /tmp/nv-syncd-shared/$DEV/* 2>/dev/null
 
@@ -146,6 +153,12 @@ function stopplatform1() {
     if [[ x$sonic_asic_platform == x"mellanox" ]]; then
         local mlx_dev=$(get_mellanox_dev)
         echo "health_check_trigger del_dev 1" > $mlx_dev
+    fi
+
+    if [[ x$sonic_asic_platform == x"mellanox" ]] && [[ x$TYPE == x"cold" ]]; then
+        debug "Stopping pmon service ahead of syncd..."
+        /bin/systemctl stop pmon
+        debug "Stopped pmon service"
     fi
 
     if [[ x$sonic_asic_platform != x"mellanox" ]] || [[ x$TYPE != x"cold" ]]; then


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

pmon holds file descriptors that become invalid when syncd restarts, causing pmon to malfunction. Stopping pmon before syncd starts/stops ensures pmon always restarts with clean state after syncd is ready.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

1. In syncd.sh startplatform(): stop pmon before syncd starts (non-warm-boot only), so pmon restarts cleanly after syncd is ready and invalid fds are cleared.  
2. In syncd.sh stopplatform1(): stop pmon ahead of syncd on Mellanox cold reboot, ensuring pmon does not hold stale fds during the shutdown sequence.           
3. In pmon.service.j2: added After=syncd.service for Mellanox, so systemd starts pmon only after syncd is up.  

#### How to verify it

On a Mellanox device, perform a cold reboot and confirm:                                                                                                        
- pmon stops before syncd during shutdown                                                                                                                       
- pmon starts after syncd comes up                                                                                                                              
- No invalid fd errors in syslog after reboot

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

