### PR TITLE
[202511][FRR][Patch]bgpd: Show all advertised paths including non best paths only if addpath is enabled

### DIFF
--- a/src/sonic-frr/patch/0105-bgpd-Show-all-advertised-paths-including-non-best-paths-only-if-addpath-is-enabled.patch
+++ b/src/sonic-frr/patch/0105-bgpd-Show-all-advertised-paths-including-non-best-paths-only-if-addpath-is-enabled.patch
@@ -1,0 +1,284 @@
+From 5ea4bfb5678c0eca9fb63543c142b6e62279dd42 Mon Sep 17 00:00:00 2001
+From: Donatas Abraitis <donatas@opensourcerouting.org>
+Date: Thu, 29 Jan 2026 09:08:16 +0200
+Subject: [PATCH] bgpd: Show all advertised paths including non-best paths only if
+ addpath is enabled
+
+If addpath is disabled (do not send additional paths), we should not show all
+paths to be advertised.
+
+Fixes: 98ca49e0ee581259903e8ab2d6306e61dfc87606 ("bgpd: Show neighbor advertised paths including addpath")
+
+Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>
+---
+ bgpd/bgp_route.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/bgpd/bgp_route.c b/bgpd/bgp_route.c
+index 6de269ea98..60ccf72e49 100644
+--- a/bgpd/bgp_route.c
++++ b/bgpd/bgp_route.c
+@@ -15607,10 +15607,16 @@ show_adj_route(struct vty *vty, struct peer *peer, struct bgp_table *table,
+ 									  json_ar, wide);
+ 						} else {
+ 							for (bpi = bgp_dest_get_bgp_path_info(dest);
+-							     bpi; bpi = bpi->next)
++							     bpi; bpi = bpi->next) {
++								if (peer->addpath_type[afi][safi] ==
++									    BGP_ADDPATH_NONE &&
++								    !CHECK_FLAG(bpi->flags,
++										BGP_PATH_SELECTED))
++									continue;
+ 								route_vty_out(vty, rn_p, bpi, 0,
+ 									      adj->attr, safi, NULL,
+ 									      wide);
++							}
+ 						}
+ 					}
+ 					(*output_count)++;
+-- 
+2.48.1
+
+
+From 67b14612b362cb0b0e240b792beacd2c86f1fafb Mon Sep 17 00:00:00 2001
+From: Donatas Abraitis <donatas@opensourcerouting.org>
+Date: Thu, 29 Jan 2026 09:44:17 +0200
+Subject: bgpd: Add total paths count in output for advertised-routes
+
+r2# show ip bgp neighbors 192.168.7.7 advertised-routes
+BGP table version is 8, local router ID is 192.168.7.2, vrf id 0
+Default local pref 100, local AS 65002
+Status codes:  s suppressed, d damped, h history, u unsorted, * valid, > best, = multipath,
+               i internal, r RIB-failure, S Stale, R Removed
+Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
+Origin codes:  i - IGP, e - EGP, ? - incomplete
+RPKI validation codes: V valid, I invalid, N Not found
+
+     Network          Next Hop            Metric LocPrf Weight Path
+ *>  172.16.16.254/32 0.0.0.0                                4 65004 ?
+ *   172.16.16.254/32 0.0.0.0                                4 65004 ?
+ *   172.16.16.254/32 0.0.0.0                                4 65004 ?
+ *   172.16.16.254/32 0.0.0.0                                4 65004 ?
+ *>  172.16.16.254/32 0.0.0.0                                5 65005 ?
+ *   172.16.16.254/32 0.0.0.0                                5 65005 ?
+ *   172.16.16.254/32 0.0.0.0                                5 65005 ?
+ *   172.16.16.254/32 0.0.0.0                                5 65005 ?
+ *>  172.16.16.254/32 0.0.0.0                                6 65006 ?
+ *   172.16.16.254/32 0.0.0.0                                6 65006 ?
+ *   172.16.16.254/32 0.0.0.0                                6 65006 ?
+ *   172.16.16.254/32 0.0.0.0                                6 65006 ?
+
+Total number of prefixes 3, total number of paths 12
+
+r2# show ip bgp neighbors 192.168.7.7 advertised-routes json
+{
+"bgpTableVersion":8,"bgpLocalRouterId":"192.168.7.2","defaultLocPrf":100,"localAS":65002,"advertisedRoutes": {"172.16.16.254/32":{"addrPrefix":"172.16.16.254","prefixLen":32,"network":"172.16.16.254/32","nextHop":"0.0.0.0","weight":6,"path":"65006","origin":"incomplete","valid":true,"best":true}}
+,"totalPrefixCounter":3,"filteredPrefixCounter":0,"totalPathsCount":12}
+r2#
+
+Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>
+---
+ bgpd/bgp_route.c | 47 ++++++++++++++++++++++++++++++-----------------
+ 1 file changed, 30 insertions(+), 17 deletions(-)
+
+diff --git a/bgpd/bgp_route.c b/bgpd/bgp_route.c
+index 60ccf72e49..8ee8c38136 100644
+--- a/bgpd/bgp_route.c
++++ b/bgpd/bgp_route.c
+@@ -15297,13 +15297,12 @@ static void show_adj_route_header(struct vty *vty, struct peer *peer,
+ 	}
+ }
+ 
+-static void
+-show_adj_route(struct vty *vty, struct peer *peer, struct bgp_table *table,
+-	       afi_t afi, safi_t safi, enum bgp_show_adj_route_type type,
+-	       const char *rmap_name, json_object *json, json_object *json_ar,
+-	       uint16_t show_flags, int *header1, int *header2, char *rd_str,
+-	       const struct prefix *match, unsigned long *output_count,
+-	       unsigned long *filtered_count)
++static void show_adj_route(struct vty *vty, struct peer *peer, struct bgp_table *table, afi_t afi,
++			   safi_t safi, enum bgp_show_adj_route_type type, const char *rmap_name,
++			   json_object *json, json_object *json_ar, uint16_t show_flags,
++			   int *header1, int *header2, char *rd_str, const struct prefix *match,
++			   unsigned long *output_count, unsigned long *filtered_count,
++			   unsigned long *paths_count)
+ {
+ 	struct bgp_adj_in *ain = NULL;
+ 	struct bgp_adj_out *adj = NULL;
+@@ -15602,6 +15601,15 @@ show_adj_route(struct vty *vty, struct peer *peer, struct bgp_table *table,
+ 						 * This is for backward compatibility.
+ 						 */
+ 						if (use_json) {
++							for (bpi = bgp_dest_get_bgp_path_info(dest);
++							     bpi; bpi = bpi->next) {
++								if (peer->addpath_type[afi][safi] ==
++									    BGP_ADDPATH_NONE &&
++								    !CHECK_FLAG(bpi->flags,
++										BGP_PATH_SELECTED))
++									continue;
++								(*paths_count)++;
++							}
+ 							route_vty_out_tmp(vty, bgp, dest, rn_p,
+ 									  adj->attr, safi, use_json,
+ 									  json_ar, wide);
+@@ -15613,6 +15621,7 @@ show_adj_route(struct vty *vty, struct peer *peer, struct bgp_table *table,
+ 								    !CHECK_FLAG(bpi->flags,
+ 										BGP_PATH_SELECTED))
+ 									continue;
++								(*paths_count)++;
+ 								route_vty_out(vty, rn_p, bpi, 0,
+ 									      adj->attr, safi, NULL,
+ 									      wide);
+@@ -15693,8 +15702,10 @@ static int peer_adj_routes(struct vty *vty, struct peer *peer, afi_t afi,
+ 	 * maintained across multiple runs of show_adj_route()
+ 	 */
+ 	unsigned long output_count_per_rd;
++	unsigned long paths_count_per_rd;
+ 	unsigned long filtered_count_per_rd;
+ 	unsigned long output_count = 0;
++	unsigned long paths_count = 0;
+ 	unsigned long filtered_count = 0;
+ 
+ 	if (use_json) {
+@@ -15802,11 +15813,10 @@ static int peer_adj_routes(struct vty *vty, struct peer *peer, afi_t afi,
+ 			prefix_rd2str(prd, rd_str, sizeof(rd_str),
+ 				      bgp->asnotation);
+ 
+-			show_adj_route(vty, peer, table, afi, safi, type,
+-				       rmap_name, json, json_routes, show_flags,
+-				       &header1, &header2, rd_str, match,
+-				       &output_count_per_rd,
+-				       &filtered_count_per_rd);
++			show_adj_route(vty, peer, table, afi, safi, type, rmap_name, json,
++				       json_routes, show_flags, &header1, &header2, rd_str, match,
++				       &output_count_per_rd, &filtered_count_per_rd,
++				       &paths_count_per_rd);
+ 
+ 			/* Don't include an empty RD in the output! */
+ 			if (json_routes && (output_count_per_rd > 0) && use_json) {
+@@ -15826,6 +15836,7 @@ static int peer_adj_routes(struct vty *vty, struct peer *peer, afi_t afi,
+ 				json_object_free(json_routes);
+ 
+ 			output_count += output_count_per_rd;
++			paths_count += paths_count_per_rd;
+ 			filtered_count += filtered_count_per_rd;
+ 		}
+ 		if (json_ar &&
+@@ -15834,9 +15845,9 @@ static int peer_adj_routes(struct vty *vty, struct peer *peer, afi_t afi,
+ 		if (first == false && json_routes)
+ 			vty_out(vty, "}");
+ 	} else {
+-		show_adj_route(vty, peer, table, afi, safi, type, rmap_name,
+-			       json, json_ar, show_flags, &header1, &header2,
+-			       rd_str, match, &output_count, &filtered_count);
++		show_adj_route(vty, peer, table, afi, safi, type, rmap_name, json, json_ar,
++			       show_flags, &header1, &header2, rd_str, match, &output_count,
++			       &filtered_count, &paths_count);
+ 
+ 		if (use_json) {
+ 			if (type == bgp_show_adj_route_advertised ||
+@@ -15850,12 +15861,14 @@ static int peer_adj_routes(struct vty *vty, struct peer *peer, afi_t afi,
+ 		if (type == bgp_show_adj_route_advertised || type == bgp_show_adj_route_received) {
+ 			vty_out(vty, ",\"totalPrefixCounter\":%lu", output_count);
+ 			vty_out(vty, ",\"filteredPrefixCounter\":%lu", filtered_count);
++			vty_out(vty, ",\"totalPathsCount\":%lu", paths_count);
+ 			json_object_free(json);
+ 		} else {
+ 			/* for bgp_show_adj_route_filtered & bgp_show_adj_route_bestpath type */
+ 			json_object_object_add(json, "receivedRoutes", json_ar);
+ 			json_object_int_add(json, "totalPrefixCounter", output_count);
+ 			json_object_int_add(json, "filteredPrefixCounter", filtered_count);
++			json_object_int_add(json, "totalPathsCount", paths_count);
+ 		}
+ 
+ 		/*
+@@ -15870,8 +15883,8 @@ static int peer_adj_routes(struct vty *vty, struct peer *peer, afi_t afi,
+ 				"\nTotal number of prefixes %ld (%ld filtered)\n",
+ 				output_count, filtered_count);
+ 		else
+-			vty_out(vty, "\nTotal number of prefixes %ld\n",
+-				output_count);
++			vty_out(vty, "\nTotal number of prefixes %ld, total number of paths %ld\n",
++				output_count, paths_count);
+ 	}
+ 
+ 	return CMD_SUCCESS;
+-- 
+2.48.1
+
+
+From a06b9e718ad96cb72eadc1ffab592da8004c990b Mon Sep 17 00:00:00 2001
+From: Donatas Abraitis <donatas@opensourcerouting.org>
+Date: Thu, 29 Jan 2026 09:50:51 +0200
+Subject: tests: Check if we show only best path as advertised if addpath is
+ disabled
+
+Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>
+---
+ .../test_bgp_addpath_paths_limit.py           | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/tests/topotests/bgp_addpath_paths_limit/test_bgp_addpath_paths_limit.py b/tests/topotests/bgp_addpath_paths_limit/test_bgp_addpath_paths_limit.py
+index 44042f449c..1e711e4dda 100644
+--- a/tests/topotests/bgp_addpath_paths_limit/test_bgp_addpath_paths_limit.py
++++ b/tests/topotests/bgp_addpath_paths_limit/test_bgp_addpath_paths_limit.py
+@@ -104,6 +104,25 @@ def test_bgp_addpath_paths_limit():
+     _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
+     assert result is None, "Can't converge initially"
+ 
++    def _bgp_check_advertised_routes(neighbor, total_prefixes, total_paths):
++        output = json.loads(
++            r2.vtysh_cmd(f"show ip bgp neighbors {neighbor} advertised-routes json")
++        )
++        expected = {
++            "totalPrefixCounter": total_prefixes,
++            "totalPathsCount": total_paths,
++        }
++
++        return topotest.json_cmp(output, expected)
++
++    test_func = functools.partial(_bgp_check_advertised_routes, "192.168.7.7", 3, 12)
++    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
++    assert result is None, "Advertised routes count for 192.168.7.7 is not as expected"
++
++    test_func = functools.partial(_bgp_check_advertised_routes, "192.168.2.6", 2, 2)
++    _, result = topotest.run_and_expect(test_func, None, count=30, wait=1)
++    assert result is None, "Advertised routes count for 192.168.2.6 is not as expected"
++
+     def _bgp_check_received_routes(router, expected):
+         output = json.loads(
+             router.vtysh_cmd("show bgp ipv4 unicast 172.16.16.254/32 json")
+-- 
+2.48.1
+
+
+From 141c2e3f9965637ece16346f3659d352d015640e Mon Sep 17 00:00:00 2001
+From: Donatas Abraitis <donatas@opensourcerouting.org>
+Date: Thu, 29 Jan 2026 09:58:11 +0200
+Subject: bgpd: Initialize paths/routes count variables related for VPN tables
+
+Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>
+---
+ bgpd/bgp_route.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/bgpd/bgp_route.c b/bgpd/bgp_route.c
+index 8ee8c38136..0862131e29 100644
+--- a/bgpd/bgp_route.c
++++ b/bgpd/bgp_route.c
+@@ -15701,9 +15701,9 @@ static int peer_adj_routes(struct vty *vty, struct peer *peer, afi_t afi,
+ 	/* For 2-tier tables, prefix counts need to be
+ 	 * maintained across multiple runs of show_adj_route()
+ 	 */
+-	unsigned long output_count_per_rd;
+-	unsigned long paths_count_per_rd;
+-	unsigned long filtered_count_per_rd;
++	unsigned long output_count_per_rd = 0;
++	unsigned long paths_count_per_rd = 0;
++	unsigned long filtered_count_per_rd = 0;
+ 	unsigned long output_count = 0;
+ 	unsigned long paths_count = 0;
+ 	unsigned long filtered_count = 0;
+-- 
+2.48.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -63,3 +63,4 @@
 0102-staticd-Fix-SRv6-SID-use-after-free-on-locator-deletion.patch
 0103-SONiC-ONLY-bgpd-reduce-suppress-fib-advertisement-delay-to-50ms.patch
 0104-SONiC-ONLY-zebra-skip-if-add-update-in-speed-timer-for-unready-ifp.patch
+0105-bgpd-Show-all-advertised-paths-including-non-best-paths-only-if-addpath-is-enabled.patch


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fix issue #26739:
Bug: vtysh show ip bgp neighbor advertised-routes output all

#### How I did it

Port from upstream FRR PR FRRouting/frr#20618:
bgpd: Show all advertised paths including non-best paths only if addpath is enabled

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### A picture of a cute animal (not mandatory but encouraged)
<img width="250" height="151" alt="image" src="https://github.com/user-attachments/assets/a842daba-28e4-4f97-821c-079db0e23905" />
