### PR TITLE
frr-mgmt-framework, YANG: add IPv6 ND/RA support for VLAN_INTERFACE

### DIFF
--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -120,7 +120,8 @@ class BgpdClientMgr(threading.Thread):
             'IGMP_INTERFACE_QUERY': ['pimd'],
             'SRV6_MY_LOCATORS': ['zebra'],
             'SRV6_MY_SOURCE': ['zebra'],
-            'SRV6_MY_SIDS': ['mgmtd']
+            'SRV6_MY_SIDS': ['mgmtd'],
+            'VLAN_INTERFACE': ['mgmtd']
 
     }
     VTYSH_CMD_DAEMON = [(r'show (ip|ipv6) route($|\s+\S+)', ['zebra']),
@@ -1254,6 +1255,53 @@ def handle_igmp_if_enable(daemon, cmd_str, op, st_idx, args, data):
     syslog.syslog(syslog.LOG_INFO, 'handle_igmp_if_enable param {}, cmd_list {}'.format(param_value, cmd_list))
     return cmd_list
 
+def _hdl_nd_bool(daemon, cmd_str, op, st_idx, args, data, default_on):
+    """Translate a boolean IPv6 ND/RA ConfigDB field to a vtysh command.
+
+    cmd_str contains a ``{no:no-prefix}`` token; CommandArgument(daemon, True)
+    renders it as an empty string (command enabled), and CommandArgument(daemon,
+    False) renders it as the literal ``no `` (command disabled).
+
+    On DELETE we restore the FRR default for this flag so the interface is left
+    in the same state as if the ConfigDB entry had never existed. ``default_on``
+    is True for flags whose FRR default is "enabled" (e.g. suppress-ra), and
+    False for flags whose FRR default is "disabled" (e.g. managed-config-flag).
+    """
+    if len(args) != 1:
+        return None
+
+    value = str(args[st_idx]).lower()
+    if value == 'true':
+        flag_on = True
+    elif value == 'false':
+        flag_on = False
+    else:
+        syslog.syslog(syslog.LOG_ERR,
+                      '_hdl_nd_bool: unexpected value {!r} for cmd {!r}'.format(
+                          value, cmd_str))
+        return None
+
+    if op == CachedDataWithOp.OP_DELETE:
+        flag_on = default_on
+
+    return [cmd_str.format(no=CommandArgument(daemon, flag_on))]
+
+
+def hdl_nd_flag_default_off(daemon, cmd_str, op, st_idx, args, data):
+    """Handle a boolean IPv6 ND flag whose FRR default is "disabled"
+    (e.g. managed-config-flag, other-config-flag). On DELETE we emit
+    ``no <cmd>`` so the interface reverts to the FRR default."""
+    return _hdl_nd_bool(daemon, cmd_str, op, st_idx, args, data, default_on=False)
+
+
+def hdl_nd_flag_default_on(daemon, cmd_str, op, st_idx, args, data):
+    """Handle a boolean IPv6 ND flag whose FRR default is "enabled"
+    (e.g. suppress-ra, which FRR enables by default on non-P2P interfaces).
+    On DELETE we emit the bare command (no ``no`` prefix) so the interface
+    reverts to the FRR default."""
+    return _hdl_nd_bool(daemon, cmd_str, op, st_idx, args, data, default_on=True)
+
+
 def handle_ip_sla_common(daemon, cmd_str, op, st_idx, args, data):
     cmd_list = []
 
@@ -2073,6 +2121,18 @@ class BGPConfigDaemon:
                              ('last-member-query-count', 'ip igmp last-member-query-count {}', handle_igmp_if_common),
                              ('last-member-query-interval', 'ip igmp last-member-query-interval {}', handle_igmp_if_common),
                            ]
+    # VLAN_INTERFACE IPv6 Neighbor Discovery / Router Advertisement parameters.
+    # Only three interface-level ND flags + one RA interval are handled here.
+    # Each flag uses the default-aware handler variant so that a ConfigDB DELETE
+    # restores FRR's per-flag default (suppress-ra defaults to ON; managed- and
+    # other-config-flag default to OFF).
+    vlan_intf_nd_key_map = [
+        ('nd_suppress_ra',         '{no:no-prefix}ipv6 nd suppress-ra',         hdl_nd_flag_default_on),
+        ('nd_managed_config_flag', '{no:no-prefix}ipv6 nd managed-config-flag', hdl_nd_flag_default_off),
+        ('nd_other_config_flag',   '{no:no-prefix}ipv6 nd other-config-flag',   hdl_nd_flag_default_off),
+        ('nd_ra_interval',         '{no:no-prefix}ipv6 nd ra-interval {}'),
+    ]
+
     ip_sla_key_map = [
                              ('sla_id', '{no:no-prefix}ip sla {}'),
                              ('frequency', 'frequency {}', handle_ip_sla_common),
@@ -2124,6 +2184,7 @@ class BGPConfigDaemon:
                       'PIM_INTERFACE':                  pim_interface_key_map,
                       'IGMP_INTERFACE':                 igmp_mcast_grp_key_map,
                       'IGMP_INTERFACE_QUERY':           igmp_interface_config_key_map,
+                      'VLAN_INTERFACE':                 vlan_intf_nd_key_map,
     }
 
     vrf_tables = {'BGP_GLOBALS', 'BGP_GLOBALS_AF',
@@ -2325,6 +2386,7 @@ class BGPConfigDaemon:
             ('PIM_INTERFACE', self.bgp_table_handler_common),
             ('IGMP_INTERFACE', self.bgp_table_handler_common),
             ('IGMP_INTERFACE_QUERY', self.bgp_table_handler_common),
+            ('VLAN_INTERFACE', self.bgp_table_handler_common),
             ('SRV6_MY_LOCATORS', self.bgp_table_handler_common),
             ('SRV6_MY_SOURCE', self.bgp_table_handler_common),
             ('SRV6_MY_SIDS', self.bgp_table_handler_common),
@@ -3819,6 +3881,26 @@ class BGPConfigDaemon:
                     syslog.syslog(syslog.LOG_ERR, 'failed running ip igmp interface config command')
                     continue
 
+
+
+            elif table == 'VLAN_INTERFACE':
+                # VLAN_INTERFACE has two key shapes in ConfigDB:
+                #   VLAN_INTERFACE|VlanX                   - interface-level (ND fields live here)
+                #   VLAN_INTERFACE|VlanX|<ip-prefix>       - address assignment (no ND fields)
+                # We only process the interface-level entries. __update_bgp
+                # splits key on '|' once, so for the 2-part form `key` will be
+                # non-empty (the ip-prefix); skip those.
+                if key:
+                    continue
+                ifname = prefix
+                syslog.syslog(syslog.LOG_INFO,
+                              'VLAN_INTERFACE ND update for interface {}'.format(ifname))
+                cmd_prefix = ['configure terminal',
+                              'interface {}'.format(ifname)]
+                if not key_map.run_command(self, table, data, cmd_prefix):
+                    syslog.syslog(syslog.LOG_ERR,
+                                  'failed running VLAN_INTERFACE ND config command for {}'.format(ifname))
+                    continue
 
     def __add_op_to_data(self, table_key, data, comb_attr_list):
         cached_data = self.table_data_cache.setdefault(table_key, {})

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -159,7 +159,11 @@
                 "nat_zone": "0",
                 "loopback_action": "forward",
                 "ipv6_use_link_local_only": "disable",
-                "mac_addr": "02:ab:cd:ef:12:34"
+                "mac_addr": "02:ab:cd:ef:12:34",
+                "nd_suppress_ra": "false",
+                "nd_managed_config_flag": "true",
+                "nd_other_config_flag": "false",
+                "nd_ra_interval": "30"
             },
             "Vlan777": {},
             "Vlan111|2a04:5555:45:6709::1/64": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vlan_interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vlan_interface.json
@@ -1,0 +1,40 @@
+{
+    "VLAN_INTERFACE_ND_SUPPRESS_RA_VALID": {
+        "desc": "Valid nd_suppress_ra boolean on VLAN_INTERFACE."
+    },
+    "VLAN_INTERFACE_ND_SUPPRESS_RA_INVALID": {
+        "desc": "Invalid nd_suppress_ra value - boolean expected.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["nd_suppress_ra"]
+    },
+    "VLAN_INTERFACE_ND_MANAGED_CONFIG_FLAG_VALID": {
+        "desc": "Valid nd_managed_config_flag boolean on VLAN_INTERFACE."
+    },
+    "VLAN_INTERFACE_ND_MANAGED_CONFIG_FLAG_INVALID": {
+        "desc": "Invalid nd_managed_config_flag value - boolean expected.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["nd_managed_config_flag"]
+    },
+    "VLAN_INTERFACE_ND_OTHER_CONFIG_FLAG_VALID": {
+        "desc": "Valid nd_other_config_flag boolean on VLAN_INTERFACE."
+    },
+    "VLAN_INTERFACE_ND_OTHER_CONFIG_FLAG_INVALID": {
+        "desc": "Invalid nd_other_config_flag value - boolean expected.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["nd_other_config_flag"]
+    },
+    "VLAN_INTERFACE_ND_RA_INTERVAL_VALID": {
+        "desc": "Valid nd_ra_interval (30 seconds) on VLAN_INTERFACE."
+    },
+    "VLAN_INTERFACE_ND_RA_INTERVAL_INVALID_RANGE_HIGH": {
+        "desc": "Invalid nd_ra_interval value above 1800 seconds.",
+        "eStr": ["Invalid IPv6 ND RA interval"]
+    },
+    "VLAN_INTERFACE_ND_RA_INTERVAL_INVALID_RANGE_LOW": {
+        "desc": "Invalid nd_ra_interval value below 1 second.",
+        "eStr": ["Invalid IPv6 ND RA interval"]
+    },
+    "VLAN_INTERFACE_ND_ALL_FLAGS_COMBINED": {
+        "desc": "All four ND leaves set together on a single VLAN_INTERFACE."
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan_interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan_interface.json
@@ -1,0 +1,148 @@
+{
+    "VLAN_INTERFACE_ND_SUPPRESS_RA_VALID": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    { "name": "Vlan100", "vlanid": 100 }
+                ]
+            },
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_LIST": [
+                    { "name": "Vlan100", "nd_suppress_ra": "false" }
+                ]
+            }
+        }
+    },
+    "VLAN_INTERFACE_ND_SUPPRESS_RA_INVALID": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    { "name": "Vlan100", "vlanid": 100 }
+                ]
+            },
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_LIST": [
+                    { "name": "Vlan100", "nd_suppress_ra": "maybe" }
+                ]
+            }
+        }
+    },
+    "VLAN_INTERFACE_ND_MANAGED_CONFIG_FLAG_VALID": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    { "name": "Vlan100", "vlanid": 100 }
+                ]
+            },
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_LIST": [
+                    { "name": "Vlan100", "nd_managed_config_flag": "true" }
+                ]
+            }
+        }
+    },
+    "VLAN_INTERFACE_ND_MANAGED_CONFIG_FLAG_INVALID": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    { "name": "Vlan100", "vlanid": 100 }
+                ]
+            },
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_LIST": [
+                    { "name": "Vlan100", "nd_managed_config_flag": "enable" }
+                ]
+            }
+        }
+    },
+    "VLAN_INTERFACE_ND_OTHER_CONFIG_FLAG_VALID": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    { "name": "Vlan100", "vlanid": 100 }
+                ]
+            },
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_LIST": [
+                    { "name": "Vlan100", "nd_other_config_flag": "false" }
+                ]
+            }
+        }
+    },
+    "VLAN_INTERFACE_ND_OTHER_CONFIG_FLAG_INVALID": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    { "name": "Vlan100", "vlanid": 100 }
+                ]
+            },
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_LIST": [
+                    { "name": "Vlan100", "nd_other_config_flag": 1 }
+                ]
+            }
+        }
+    },
+    "VLAN_INTERFACE_ND_RA_INTERVAL_VALID": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    { "name": "Vlan100", "vlanid": 100 }
+                ]
+            },
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_LIST": [
+                    { "name": "Vlan100", "nd_ra_interval": 30 }
+                ]
+            }
+        }
+    },
+    "VLAN_INTERFACE_ND_RA_INTERVAL_INVALID_RANGE_HIGH": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    { "name": "Vlan100", "vlanid": 100 }
+                ]
+            },
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_LIST": [
+                    { "name": "Vlan100", "nd_ra_interval": 99999 }
+                ]
+            }
+        }
+    },
+    "VLAN_INTERFACE_ND_RA_INTERVAL_INVALID_RANGE_LOW": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    { "name": "Vlan100", "vlanid": 100 }
+                ]
+            },
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_LIST": [
+                    { "name": "Vlan100", "nd_ra_interval": 0 }
+                ]
+            }
+        }
+    },
+    "VLAN_INTERFACE_ND_ALL_FLAGS_COMBINED": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    { "name": "Vlan815", "vlanid": 815 }
+                ]
+            },
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_LIST": [
+                    {
+                        "name": "Vlan815",
+                        "nd_suppress_ra": "false",
+                        "nd_managed_config_flag": "true",
+                        "nd_other_config_flag": "false",
+                        "nd_ra_interval": 30
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -43,6 +43,10 @@ module sonic-vlan {
 
 	description "VLAN yang Module for SONiC OS";
 
+	revision 2026-04-17 {
+		description "Add IPv6 Neighbor Discovery / Router Advertisement leaves to VLAN_INTERFACE_LIST";
+	}
+
 	revision 2025-03-06 {
 		description "Add leaf vnet_name";
 	}
@@ -141,6 +145,30 @@ module sonic-vlan {
 				leaf loopback_action {
 					description "Packet action when a packet ingress and gets routed on the same IP interface";
 					type stypes:loopback_action;
+				}
+
+				leaf nd_suppress_ra {
+					description "Suppress IPv6 Router Advertisements on the VLAN interface";
+					type boolean;
+				}
+
+				leaf nd_managed_config_flag {
+					description "Set M-flag in RAs directing hosts to obtain IPv6 addresses via DHCPv6";
+					type boolean;
+				}
+
+				leaf nd_other_config_flag {
+					description "Set O-flag in RAs directing hosts to obtain non-address configuration via DHCPv6";
+					type boolean;
+				}
+
+				leaf nd_ra_interval {
+					description "Interval between unsolicited IPv6 Router Advertisements, in seconds";
+					type uint32 {
+						range "1..1800" {
+							error-message "Invalid IPv6 ND RA interval (expected range: 1..1800 seconds)";
+						}
+					}
 				}
 			}
 			/* end of VLAN_INTERFACE_LIST */


### PR DESCRIPTION
#### Why I did it

There is no ConfigDB-native mechanism to configure IPv6 Neighbor Discovery / Router Advertisement parameters on VLAN interfaces in SONiC today. The only way to apply `ipv6 nd suppress-ra`, `ipv6 nd managed-config-flag`, `ipv6 nd other-config-flag`, or `ipv6 nd ra-interval <N>` to an SVI is to issue vtysh commands manually, which do not persist and are outside the frrcfgd management framework.

This change adds the 4 interface-level flag leaves to `VLAN_INTERFACE_LIST` and implementing the frrcfgd translation to zebra interface-context commands.

#### How I did it

**YANG (`sonic-vlan.yang`):** added four new leaves to `VLAN_INTERFACE_LIST`:

| Leaf | Type | OpenConfig mapping |
|---|---|---|
| `nd_suppress_ra` | `boolean` | `router-advertisement/config/suppress` |
| `nd_managed_config_flag` | `boolean` | `router-advertisement/config/managed` |
| `nd_other_config_flag` | `boolean` | `router-advertisement/config/other-config` |
| `nd_ra_interval` | `uint32` range `1..1800` | (none - extension) |

A new revision entry was added to the yang file.

**frrcfgd (`frrcfgd.py`):** subscribed to the `VLAN_INTERFACE` table, introduced a `vlan_intf_nd_key_map` using the standard `{no:no-prefix}` convention established by [PR #21697][21697] (`hdl_admin_status` style). Interface-context command dispatch follows the existing `PIM_INTERFACE` / `IGMP_INTERFACE` pattern.

DELETE semantics restore per-flag FRR defaults rather than blindly emitting `no <cmd>`. Two handler variants make this explicit:
`hdl_nd_flag_default_on` (used for `suppress-ra` whose FRR default is enabled on non-P2P interfaces) and `hdl_nd_flag_default_off` (used for the M/O flags whose FRR default is disabled). This keeps the observable behaviour symmetric: creating then deleting a `VLAN_INTERFACE` entry leaves the interface in the same state as if the entry had never existed.

[21697]: https://github.com/sonic-net/sonic-buildimage/pull/21697

#### How to verify it

```
# Apply the config via apply-patch (full yang validation)
cat > /tmp/ra.json <<JSON
[
  {"op": "add", "path": "/VLAN_INTERFACE/Vlan100/nd_suppress_ra", "value": "false"},
  {"op": "add", "path": "/VLAN_INTERFACE/Vlan100/nd_managed_config_flag", "value": "true"},
  {"op": "add", "path": "/VLAN_INTERFACE/Vlan100/nd_ra_interval", "value": "30"}
]
JSON
sudo config apply-patch /tmp/ra.json

# Verify resulting FRR configuration
docker exec bgp vtysh -c 'show running-config' | grep -A6 '^interface Vlan100$'
# interface Vlan100
#  ipv6 nd managed-config-flag
#  ipv6 nd ra-interval 30
#  no ipv6 nd suppress-ra
# exit
```

Yang validation rejects invalid input:

```
# Invalid boolean
sudo config apply-patch '[{"op":"add","path":"/VLAN_INTERFACE/Vlan100/nd_suppress_ra","value":"garbage"}]'
# libyang: Invalid value "garbage" in "nd_suppress_ra" element.

# Out-of-range interval
sudo config apply-patch '[{"op":"add","path":"/VLAN_INTERFACE/Vlan100/nd_ra_interval","value":"99999"}]'
# Invalid IPv6 ND RA interval (expected range: 1..1800 seconds)
```

DELETE restores the FRR default:

```
sudo config apply-patch '[
  {"op":"remove","path":"/VLAN_INTERFACE/Vlan100/nd_suppress_ra"},
  {"op":"remove","path":"/VLAN_INTERFACE/Vlan100/nd_managed_config_flag"},
  {"op":"remove","path":"/VLAN_INTERFACE/Vlan100/nd_ra_interval"}
]'
docker exec bgp vtysh -c 'show running-config' | grep -A3 '^interface Vlan100$' || echo "(interface reverted to default)"
```

Tested on SONiC in unified routing config mode with FRR 10.4.1 on a
top-of-rack switch. Full test matrix (19 tests: 9 direct ConfigDB writes,
3 delete-semantics checks, 7 apply-patch end-to-end) passes.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

- master (based on commit 9a40754b)

#### Description for the changelog

frr-mgmt-framework, YANG: add IPv6 ND/RA support for VLAN_INTERFACE

#### A picture of a cute animal (not mandatory but encouraged)

![cat](https://images.unsplash.com/photo-1573865526739-10659fec78a5?w=400)