### PR TITLE
[lldp] Replace per-port portidsubtype loop with global ifname directive

### DIFF
--- a/dockers/docker-lldp/lldpd.conf.j2
+++ b/dockers/docker-lldp/lldpd.conf.j2
@@ -27,24 +27,15 @@ configure system ip management pattern {{ mgmt_if.ipv6 }}
 {% endif %}
 {% endif %}
 configure system hostname {{ DEVICE_METADATA['localhost']['hostname'] }}
-{# Configure port ID subtype for front-panel ports at startup.
-   Without this, lldpd uses MAC address as default Port ID. When lldpd
-   auto-resumes after config processing, the first LLDP frame would carry
-   MAC-based Port IDs. Peers see a transient MSAP change when lldpmgrd
-   later reconfigures portidsubtype, causing unnecessary neighbor flaps.
-   Special ports (inband/recirculation/backplane) are excluded to match
-   lldpmgrd behavior which skips these port types. #}
-{% if PORT %}
-{% for port_name in PORT|sort %}
-{% if not port_name.startswith('Ethernet-IB') and not port_name.startswith('Ethernet-Rec') and not port_name.startswith('Ethernet-BP') %}
-{% set port_alias = PORT[port_name].alias|default('') %}
-{% if port_alias %}
-configure ports {{ port_name }} lldp portidsubtype local {{ port_alias }}
-{% else %}
-configure ports {{ port_name }} lldp portidsubtype local {{ port_name }}
-{% endif %}
-{% endif %}
-{% endfor %}
-{% endif %}
+{# Set global portidsubtype to ifname so the first LLDP frame after startup
+   uses the Linux interface name (e.g. Ethernet0) instead of MAC address.
+   This avoids the per-port loop from PR #26144 which added N config lines
+   (one per front-panel port). On high-port-count platforms (e.g. 512 ports),
+   processing 512 lines delays lldpd startup by ~11 seconds, causing LLDP
+   neighbor churn and cascading force-repopulate storms in lldp_syncd.
+   The single global directive achieves the same goal (no MAC-as-Port-ID)
+   with O(1) config processing time. lldpmgrd still runs later to set the
+   final portidsubtype to local+alias per port. #}
+configure lldp portidsubtype ifname
 {# pause lldpd operations until all interfaces are well configured, resume command will run in lldpmgrd #}
 pause

--- a/dockers/docker-lldp/lldpd.conf.j2
+++ b/dockers/docker-lldp/lldpd.conf.j2
@@ -27,15 +27,7 @@ configure system ip management pattern {{ mgmt_if.ipv6 }}
 {% endif %}
 {% endif %}
 configure system hostname {{ DEVICE_METADATA['localhost']['hostname'] }}
-{# Set global portidsubtype to ifname so the first LLDP frame after startup
-   uses the Linux interface name (e.g. Ethernet0) instead of MAC address.
-   This avoids the per-port loop from PR #26144 which added N config lines
-   (one per front-panel port). On high-port-count platforms (e.g. 512 ports),
-   processing 512 lines delays lldpd startup by ~11 seconds, causing LLDP
-   neighbor churn and cascading force-repopulate storms in lldp_syncd.
-   The single global directive achieves the same goal (no MAC-as-Port-ID)
-   with O(1) config processing time. lldpmgrd still runs later to set the
-   final portidsubtype to local+alias per port. #}
+{# Use ifname globally to avoid MAC-as-Port-ID; lldpmgrd sets alias per port later. #}
 configure lldp portidsubtype ifname
 {# pause lldpd operations until all interfaces are well configured, resume command will run in lldpmgrd #}
 pause

--- a/src/sonic-config-engine/tests/sample_output/py3/lldp_conf/lldpd-ipv4-iface-with-ports.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/lldp_conf/lldpd-ipv4-iface-with-ports.conf
@@ -1,8 +1,5 @@
 configure ports eth0 lldp portidsubtype local eth0
 configure system ip management pattern 10.0.0.100
 configure system hostname switch-t0
-configure ports Ethernet0 lldp portidsubtype local Ethernet1/1
-configure ports Ethernet12 lldp portidsubtype local Ethernet12
-configure ports Ethernet4 lldp portidsubtype local Ethernet2/1
-configure ports Ethernet8 lldp portidsubtype local Ethernet8
+configure lldp portidsubtype ifname
 pause

--- a/src/sonic-config-engine/tests/sample_output/py3/lldp_conf/lldpd-ipv4-iface.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/lldp_conf/lldpd-ipv4-iface.conf
@@ -1,4 +1,5 @@
 configure ports eth0 lldp portidsubtype local eth0
 configure system ip management pattern 10.0.0.100
 configure system hostname switch-t0
+configure lldp portidsubtype ifname
 pause

--- a/src/sonic-config-engine/tests/sample_output/py3/lldp_conf/lldpd-ipv6-iface.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/lldp_conf/lldpd-ipv6-iface.conf
@@ -1,4 +1,5 @@
 configure ports eth0 lldp portidsubtype local eth0
 configure system ip management pattern 2603:10e2:0:2902::8
 configure system hostname switch-t0
+configure lldp portidsubtype ifname
 pause


### PR DESCRIPTION
### Description of PR

Summary:
Replace the per-port portidsubtype configuration loop from PR #26144 with a single global `configure lldp portidsubtype ifname` directive.

Fixes https://github.com/sonic-net/sonic-buildimage/issues/26568

#### Background: Why portidsubtype matters

Without any portidsubtype configuration, lldpd uses MAC address as the default Port ID. When lldpd auto-resumes after config processing, the first LLDP frame carries MAC-based Port IDs. Peers then see a transient MSAP change when `lldpmgrd` later reconfigures portidsubtype to `local` (alias), causing unnecessary neighbor flaps.

PR #26144 solved this by adding a Jinja2 loop generating per-port `configure ports <name> lldp portidsubtype local <alias>` lines in `lldpd.conf`. This worked fine on low-port-count platforms.

#### The problem on high-port-count platforms

On platforms with many ports (e.g., Mellanox SN5640 with 512 ports), PR #26144 generates 512+ config lines. Processing these lines blocks lldpd for **11+ seconds** at startup. During this blackout:
- Neighbors with 30-second TTL begin timing out
- When lldpd resumes, it sends frames with new MSAPs, causing neighbor table churn
- The churn cascades through lldp_syncd, creating a feedback loop that never stabilizes
- Result: LLDP neighbor count oscillates indefinitely (observed 161→166→163→171 after 4+ minutes)

#### The fix: global `portidsubtype ifname`

The single global directive `configure lldp portidsubtype ifname` tells lldpd to use the Linux interface name (e.g., `Ethernet0`) as Port ID for **all** ports, instead of MAC address. This achieves the same goal as the per-port loop (no MAC-as-Port-ID) with O(1) config processing time.

`lldpmgrd` still runs later to set the final `portidsubtype` to `local` + alias (e.g., `etp1a`) per port — this is the existing designed behavior and works correctly.

**Key trade-off:** The first LLDP frame after restart uses the interface name (`Ethernet0`) instead of the alias (`etp9a`). When lldpmgrd starts and reconfigures, there is a one-time MSAP transition per port. This is acceptable because:
1. LLDP is an informational protocol — no data plane impact
2. The transition is atomic and completes within seconds
3. The alternative (batch per-port config) causes the same 512-line processing blackout

### Type of change

- [x] Bug fix

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
On high-port-count platforms (SN5640, 512 ports), the per-port portidsubtype loop from PR #26144 blocks lldpd startup for 11+ seconds, causing LLDP neighbor churn and cascading instability that never converges.

#### How did you do it?
Replaced the per-port Jinja2 loop (N lines) with a single global directive (1 line):
```
configure lldp portidsubtype ifname
```

#### How did you verify/test it?
A/B tested on Mellanox SN5640 (str5-sn5640-6, topology t0-isolated-d256u256s2, 259 VM neighbors):

| Configuration | Config Lines | Convergence | Stable at 259? | Deletes |
|--------------|-------------|-------------|----------------|---------|
| PR #26144 (per-port loop) | 519 | never stable | ❌ | 74+ ongoing |
| No PR #26144 (baseline) | 5 | 14s | ✅ | 0 |
| **This PR (global ifname)** | **6** | **~30s** | **✅** | **0** |
| Batch per-port in waitfor_lldp_ready.sh | 6 + 512 batch | never stable | ❌ | oscillating |

The global ifname approach was tested across multiple restart cycles with zero neighbor drops.

#### Any platform specific information?
Primarily affects high-port-count platforms (SN5640 with 512 ports). Lower port count platforms were not affected by the original issue but benefit from the simpler config.

#### Supported testbed topology if it's a new test case?
N/A (not a new test case)

### Documentation
N/A