### PR TITLE
UDF YANG model + ACL_RULE UDF-match support

### DIFF
--- a/src/sonic-yang-mgmt/sonic_yang_ext.py
+++ b/src/sonic-yang-mgmt/sonic_yang_ext.py
@@ -649,6 +649,20 @@ class SonicYangExtMixin(SonicYangPathMixin):
     are displayed only when an entry is not xlated properly from ConfigDB
     to sonic_yang.json.
     """
+    def _isAclUdfMatch(self, pkey, vKey):
+        # A field in an ACL_RULE that is not a static yang leaf is a valid
+        # UDF-group match iff its name is declared in the referencing
+        # ACL_TABLE_TYPE's MATCHES list. Group names are user-defined, so they
+        # cannot be modeled as static leaves; they are folded into the
+        # USER_DEFINED_MATCH list instead.
+        cfg = getattr(self, "_xlateFullConfig", None) or self.jIn
+        tableName = pkey.split("|")[0]
+        ttype = cfg.get("ACL_TABLE", {}).get(tableName, {}).get("type")
+        if not ttype:
+            return False
+        matches = cfg.get("ACL_TABLE_TYPE", {}).get(ttype, {}).get("MATCHES", [])
+        return vKey in matches
+
     def _xlateList(self, model, yang, config, table, exceptionList):
 
         # Type 1 lists need special handling because of inner yang list and
@@ -692,6 +706,15 @@ class SonicYangExtMixin(SonicYangPathMixin):
                                 self._xlateContainerInList(modelContainer, yangContainer, config[pkey], table)
                         if len(yangContainer):
                             keyDict[vKey] = yangContainer
+                        continue
+                    # Custom ACL table types: a rule field may be a UDF-group
+                    # match whose name is user-defined (declared in the table
+                    # type's MATCHES) and so has no static yang leaf. Fold it
+                    # into the modeled USER_DEFINED_MATCH list.
+                    if table == "ACL_RULE" and vKey not in leafDict and \
+                            self._isAclUdfMatch(pkey, vKey):
+                        keyDict.setdefault("USER_DEFINED_MATCH", []).append(
+                            {"NAME": vKey, "VALUE": config[pkey][vKey]})
                         continue
                     self.elementPath.append(vKey)
                     self.sysLog(syslog.LOG_DEBUG, "xlateList vkey {}".format(vKey))
@@ -847,6 +870,10 @@ class SonicYangExtMixin(SonicYangPathMixin):
     def _xlateConfigDB(self, xlateFile=None):
 
         jIn= self.jIn
+        # Snapshot the full config for cross-table lookups during translation
+        # (jIn entries are deleted table-by-table as they are processed, so a
+        # later table like ACL_RULE cannot rely on ACL_TABLE still being here).
+        self._xlateFullConfig = copy.deepcopy(jIn)
         yangJ = self.xlateJson
         # xlation is written in self.xlateJson
         self._xlateConfigDBtoYang(jIn, yangJ)
@@ -1018,6 +1045,12 @@ class SonicYangExtMixin(SonicYangPathMixin):
                 # fill rest of the entries
                 for key in entry:
                     if key not in pkeydict:
+                        # Flatten UDF-group matches back to top-level rule
+                        # fields (NAME -> VALUE), the inverse of the xlate hook.
+                        if key == "USER_DEFINED_MATCH":
+                            for m in entry[key]:
+                                config[pkey][m["NAME"]] = m["VALUE"]
+                            continue
                         if ccontainer and key == ccontainer['@name']:
                             self.sysLog(syslog.LOG_DEBUG, "revXlateList handle container {} in list {}".format(pkey, table))
                             # IF container has only one inner container

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -206,6 +206,7 @@ yang_files = [
     'sonic-trimming.yang',
     'sonic-tunnel.yang',
     'sonic-types.yang',
+    'sonic-udf.yang',
     'sonic-versions.yang',
     'sonic-vlan-sub-interface.yang',
     'sonic-vlan.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -3100,6 +3100,20 @@
                 "swbus_port": "23607"
             }
         },
+        "UDF": {
+            "my_udf": {
+                "field_type": "GENERIC",
+                "length": "4"
+            }
+        },
+        "UDF_SELECTOR": {
+            "my_udf|sel1": {
+                "select_base":        "L3",
+                "select_offset":      "0",
+                "match_l2_type":      "0x0800",
+                "match_l2_type_mask": "0xFFFF"
+            }
+        },
         "VDPU": {
             "vdpu0": {
                 "profile": "none",

--- a/src/sonic-yang-models/tests/yang_model_pytests/test_acl.py
+++ b/src/sonic-yang-models/tests/yang_model_pytests/test_acl.py
@@ -106,3 +106,64 @@ class TestACL:
         }
 
         yang_model.load_data(data, error_message)
+
+    def _udf_match_data(self, value):
+        # A custom ACL table type declares a UDF group ("G0") as a match, and a
+        # rule matches on it via USER_DEFINED_MATCH (NAME = group, VALUE = mask).
+        return {
+            "sonic-port:sonic-port": {
+                "sonic-port:PORT": {
+                    "PORT_LIST": [
+                        {
+                            "name": "Ethernet0",
+                            "lanes": "0,1,2,3",
+                            "speed": "100000"
+                        }
+                    ]
+                }
+            },
+            "sonic-acl:sonic-acl": {
+                "sonic-acl:ACL_TABLE_TYPE": {
+                    "ACL_TABLE_TYPE_LIST": [
+                        {
+                            "ACL_TABLE_TYPE_NAME": "UDF_TT",
+                            "BIND_POINTS": [ "PORT" ],
+                            "MATCHES": [ "IN_PORTS", "G0" ],
+                            "ACTIONS": [ "PACKET_ACTION" ]
+                        }
+                    ]
+                },
+                "sonic-acl:ACL_TABLE": {
+                    "ACL_TABLE_LIST": [
+                        {
+                            "ACL_TABLE_NAME": "UDF_TABLE",
+                            "type": "UDF_TT",
+                            "stage": "INGRESS",
+                            "ports": [ "Ethernet0" ]
+                        }
+                    ]
+                },
+                "sonic-acl:ACL_RULE": {
+                    "ACL_RULE_LIST": [
+                        {
+                            "ACL_TABLE_NAME": "UDF_TABLE",
+                            "RULE_NAME": "UDF_RULE",
+                            "PRIORITY": "999",
+                            "USER_DEFINED_MATCH": [
+                                { "NAME": "G0", "VALUE": value }
+                            ],
+                            "PACKET_ACTION": "FORWARD"
+                        }
+                    ]
+                }
+            }
+        }
+
+    def test_valid_udf_user_defined_match(self, yang_model):
+        # A UDF-group match (value/mask hex) on a custom table type is accepted.
+        yang_model.load_data(self._udf_match_data("0x1234/0xffff"))
+
+    def test_neg_udf_user_defined_match_value(self, yang_model):
+        # A non-hex UDF match value is rejected by the VALUE pattern.
+        yang_model.load_data(self._udf_match_data("nothex"),
+                             "Unsatisfied pattern")

--- a/src/sonic-yang-models/yang-models/sonic-udf.yang
+++ b/src/sonic-yang-models/yang-models/sonic-udf.yang
@@ -1,0 +1,187 @@
+/* SONiC UDF YANG model — flat-fields schema (UDF + UDF_SELECTOR) */
+module sonic-udf {
+
+    yang-version 1.1;
+
+    namespace "http://github.com/sonic-net/sonic-udf";
+    prefix udf;
+
+    description "UDF YANG Module for SONiC OS — flat-fields schema";
+
+    revision 2026-04-21 {
+        description "Replace JSON-in-string select/match with flat typed leaves";
+    }
+
+    revision 2024-03-16 {
+        description "Initial revision for UDF support";
+    }
+
+    container sonic-udf {
+
+        /* ================================================================
+         * UDF — defines the custom field (maps to SAI UDF_GROUP internally)
+         * Key: UDF|<udf_name>
+         * ================================================================ */
+        container UDF {
+
+            description "UDF field definitions";
+
+            list UDF_LIST {
+
+                key "UDF_NAME";
+
+                leaf UDF_NAME {
+                    type string {
+                        length 1..64;
+                        pattern "[a-zA-Z0-9_-]+";
+                    }
+                    description "Unique UDF field name. Referenced by ACL_TABLE_TYPE MATCHES and ACL_RULE fields.";
+                }
+
+                leaf length {
+                    mandatory true;
+                    type uint8 {
+                        range "1..255";
+                    }
+                    description "Extraction length in bytes";
+                }
+
+                leaf field_type {
+                    type enumeration {
+                        enum GENERIC {
+                            description "Generic UDF type — used for ACL matching";
+                        }
+                        enum HASH {
+                            description "Hash UDF type — used for ECMP hashing";
+                        }
+                    }
+                    default "GENERIC";
+                    description "UDF group type (default: GENERIC)";
+                }
+
+                leaf description {
+                    type string {
+                        length 0..128;
+                    }
+                    description "Optional human-readable label";
+                }
+            }
+        }
+
+        /* ================================================================
+         * UDF_SELECTOR — per-packet-type extraction definition
+         * Key: UDF_SELECTOR|<udf_name>|<selector_name>
+         * Maps to SAI UDF_MATCH + SAI UDF objects internally
+         * ================================================================ */
+        container UDF_SELECTOR {
+
+            description "UDF selector definitions";
+
+            list UDF_SELECTOR_LIST {
+
+                key "UDF_NAME SELECTOR_NAME";
+
+                leaf UDF_NAME {
+                    type leafref {
+                        path "/udf:sonic-udf/udf:UDF/udf:UDF_LIST/udf:UDF_NAME";
+                    }
+                    description "Reference to parent UDF field";
+                }
+
+                leaf SELECTOR_NAME {
+                    type string {
+                        length 1..64;
+                        pattern "[a-zA-Z0-9_-]+";
+                    }
+                    description "Selector name (e.g., roce_v1, roce_v2)";
+                }
+
+                /* ---- extraction location ---- */
+
+                leaf select_base {
+                    mandatory true;
+                    type enumeration {
+                        enum L2 { description "Offset from start of L2 (Ethernet) header"; }
+                        enum L3 { description "Offset from start of L3 (IP) header"; }
+                        enum L4 { description "Offset from start of L4 (TCP/UDP) header"; }
+                    }
+                    description "Packet layer used as the offset base";
+                }
+
+                leaf select_offset {
+                    mandatory true;
+                    type uint8 {
+                        range "0..255";
+                    }
+                    description "Byte offset from select_base";
+                }
+
+                /* ---- packet match criteria (at least one required) ---- */
+
+                leaf match_l2_type {
+                    type string {
+                        pattern "0x[0-9a-fA-F]{1,4}";
+                    }
+                    description "EtherType value to match (hex, e.g. 0x8915 for RoCEv1)";
+                }
+
+                leaf match_l2_type_mask {
+                    type string {
+                        pattern "0x[0-9a-fA-F]{1,4}";
+                    }
+                    description "EtherType mask (hex, default 0xFFFF if match_l2_type is set)";
+                }
+
+                leaf match_l3_type {
+                    type string {
+                        pattern "0x[0-9a-fA-F]{1,2}";
+                    }
+                    description "IP protocol value to match (hex, e.g. 0x11 for UDP)";
+                }
+
+                leaf match_l3_type_mask {
+                    type string {
+                        pattern "0x[0-9a-fA-F]{1,2}";
+                    }
+                    description "IP protocol mask (hex, default 0xFF if match_l3_type is set)";
+                }
+
+                leaf match_gre_type {
+                    type string {
+                        pattern "0x[0-9a-fA-F]{1,4}";
+                    }
+                    description "GRE protocol type value to match (hex)";
+                }
+
+                leaf match_gre_type_mask {
+                    type string {
+                        pattern "0x[0-9a-fA-F]{1,4}";
+                    }
+                    description "GRE protocol type mask (hex, default 0xFFFF if match_gre_type is set)";
+                }
+
+                leaf match_l4_dst_port {
+                    type string {
+                        pattern "0x[0-9a-fA-F]{1,4}";
+                    }
+                    description "L4 destination port value to match (decimal, e.g. 4791 for RoCEv2)";
+                }
+
+                leaf match_l4_dst_port_mask {
+                    type string {
+                        pattern "0x[0-9a-fA-F]{1,4}";
+                    }
+                    description "L4 destination port mask (default 0xFFFF if match_l4_dst_port is set)";
+                }
+
+                leaf match_priority {
+                    type uint8 {
+                        range "0..255";
+                    }
+                    default 0;
+                    description "Match priority (0-255). When multiple selectors match a packet, the highest priority wins.";
+                }
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
@@ -346,6 +346,23 @@ module sonic-acl {
 					description "Tunnel Termination Flag";
 					type boolean;
 				}
+
+				list USER_DEFINED_MATCH {
+					description "User-defined (UDF) match. NAME is a UDF group
+						declared in the referencing ACL_TABLE_TYPE MATCHES list;
+						VALUE is the value/mask matched on the extracted bytes.";
+					key "NAME";
+					leaf NAME {
+						type string {
+							pattern "[a-zA-Z0-9_-]+";
+						}
+					}
+					leaf VALUE {
+						type string {
+							pattern "0[xX][0-9a-fA-F]{1,16}/0[xX][0-9a-fA-F]{1,16}";
+						}
+					}
+				}
 			}
 			/* end of ACL_RULE_LIST */
 		}


### PR DESCRIPTION
Adds YANG support for the User Defined Fields (UDF) feature (HLD: sonic-net/SONiC#2299), in two parts:

1. **UDF model** — `sonic-udf.yang` modeling the CONFIG_DB `UDF` and `UDF_SELECTOR` tables (group type/length, selector base/offset, match criteria, priority), wired into `setup.py`, with sample config.

2. **ACL_RULE UDF-match support** — a `USER_DEFINED_MATCH` list in `sonic-acl.yang` plus the `sonic_yang` translation (`sonic_yang_ext.py`) so an ACL rule matching a UDF group declared in its `ACL_TABLE_TYPE`'s `MATCHES` (e.g. `{"G0": "0x1234/0xffff"}`) validates through `config apply-patch` / `config reload` / GCU instead of being rejected. Group names are user-defined, so they cannot be modeled as static leaves; an unknown ACL_RULE field is folded into `USER_DEFINED_MATCH` only when its name is in the table type's `MATCHES`, and flattened back on reverse translation. Fields not declared in `MATCHES` are still rejected, so validation is preserved. CONFIG_DB schema and orchagent are unchanged.

#### Tests
`tests/yang_model_pytests/test_acl.py`: positive (`0x1234/0xffff` accepted) and negative (non-hex value rejected) `USER_DEFINED_MATCH` cases; the yang-models suite validates the UDF model.

#### Why I did it
UDF requires a matching YANG model for `config reload` / GCU-based config to work; without part 2, no ACL rule can actually match a UDF group through the validated config path.

#### How I did it
Added the model and the ACL translation hooks; verified on a Broadcom DUT that the full UDF + ACL config (including a UDF-match rule) applies via `config apply-patch`.
