### PR TITLE
sonic-yang-mgmt: add quiet= kwarg to SonicYangExtMixin.loadData

### DIFF
--- a/src/sonic-yang-mgmt/sonic_yang_ext.py
+++ b/src/sonic-yang-mgmt/sonic_yang_ext.py
@@ -1229,9 +1229,19 @@ class SonicYangExtMixin(SonicYangPathMixin):
     load_data: load Config DB, crop, xlate and create data tree from it. (Public)
     input:    configdbJson - will NOT be modified
               debug Flag
-    returns:  True - success   False - failed
+              quiet  - when True, suppress the informational "Try to load Data"
+                       syslog line and the "Data Loading Failed" syslog LOG_ERR
+                       line on failure. The SonicYangException is still raised
+                       so callers that want to recover silently (e.g. tools that
+                       speculatively validate many candidate configs, like the
+                       generic_config_updater patch sorter) can do so without
+                       polluting /var/log/syslog with transient errors they are
+                       already handling via the exception. Default False keeps
+                       existing behavior for all current callers.
+    returns:  True on success
+    raises:   SonicYangException on failure
     """
-    def loadData(self, configdbJson, debug=False):
+    def loadData(self, configdbJson, debug=False, quiet=False):
 
        try:
           # write Translated config in file if debug enabled
@@ -1248,14 +1258,16 @@ class SonicYangExtMixin(SonicYangPathMixin):
           # xlated result will be in self.xlateJson
           self._xlateConfigDB(xlateFile=xlateFile)
           #print(self.xlateJson)
-          self.sysLog(msg="Try to load Data in the tree")
+          if not quiet:
+              self.sysLog(msg="Try to load Data in the tree")
           self.root = self.ctx.parse_data_mem(dumps(self.xlateJson), \
                         ly.LYD_JSON, ly.LYD_OPT_CONFIG|ly.LYD_OPT_STRICT)
 
        except Exception as e:
            self.root = None
-           self.sysLog(msg="Data Loading Failed:{}".format(str(e)), \
-            debug=syslog.LOG_ERR, doPrint=True)
+           if not quiet:
+               self.sysLog(msg="Data Loading Failed:{}".format(str(e)), \
+                debug=syslog.LOG_ERR, doPrint=True)
            raise SonicYangException("Data Loading Failed\n{}".format(str(e)))
 
        return True

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/test_sonic_yang.py
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/test_sonic_yang.py
@@ -607,5 +607,85 @@ class Test_SonicYang(object):
 
         return
 
+    def test_loaddata_quiet_suppresses_syslog_on_success(self, sonic_yang_data, monkeypatch):
+        # With quiet=True, the informational "Try to load Data" sysLog
+        # call must not be emitted. Exception path is covered below.
+        # monkeypatch.setattr cleanly reverts the instance-level override
+        # on teardown so state does not leak across tests.
+        test_file = sonic_yang_data['test_file']
+        syc = sonic_yang_data['syc']
+        jIn = json.loads(self.readIjsonInput(test_file, 'SAMPLE_CONFIG_DB_JSON'))
+
+        calls = []
+        monkeypatch.setattr(syc, 'sysLog',
+                            lambda *a, **kw: calls.append((a, kw)))
+
+        syc.loadData(jIn, quiet=True)
+
+        msgs = [kw.get('msg', '') for (_a, kw) in calls] + [
+            a[0] for (a, _kw) in calls if a
+        ]
+        assert not any('Try to load Data' in str(m) for m in msgs), \
+            "quiet=True must suppress 'Try to load Data' sysLog: {}".format(msgs)
+        assert not any('Data Loading Failed' in str(m) for m in msgs), \
+            "quiet=True must suppress 'Data Loading Failed' sysLog: {}".format(msgs)
+
+        return
+
+    def test_loaddata_quiet_suppresses_syslog_on_failure(self, sonic_yang_data, monkeypatch):
+        # With quiet=True, the LOG_ERR "Data Loading Failed" sysLog call
+        # must not be emitted even when parse_data_mem raises. The
+        # SonicYangException must still be raised so the caller sees the
+        # failure. monkeypatch.setattr cleanly reverts on teardown.
+        test_file = sonic_yang_data['test_file']
+        syc = sonic_yang_data['syc']
+        jIn = json.loads(self.readIjsonInput(test_file, 'SAMPLE_CONFIG_DB_JSON'))
+
+        calls = []
+
+        def _boom(*a, **kw):
+            raise RuntimeError('forced parse failure')
+
+        monkeypatch.setattr(syc, 'sysLog',
+                            lambda *a, **kw: calls.append((a, kw)))
+        monkeypatch.setattr(syc.ctx, 'parse_data_mem', _boom)
+
+        raised = False
+        try:
+            syc.loadData(jIn, quiet=True)
+        except sy.SonicYangException:
+            raised = True
+        assert raised, "SonicYangException must still be raised even when quiet=True"
+
+        msgs = [kw.get('msg', '') for (_a, kw) in calls] + [
+            a[0] for (a, _kw) in calls if a
+        ]
+        assert not any('Data Loading Failed' in str(m) for m in msgs), \
+            "quiet=True must suppress 'Data Loading Failed' sysLog on failure: {}".format(msgs)
+
+        return
+
+    def test_loaddata_default_logs_syslog_on_success(self, sonic_yang_data, monkeypatch):
+        # Default (quiet=False) preserves existing behavior: the
+        # "Try to load Data" sysLog call must be emitted on success.
+        # monkeypatch.setattr cleanly reverts on teardown.
+        test_file = sonic_yang_data['test_file']
+        syc = sonic_yang_data['syc']
+        jIn = json.loads(self.readIjsonInput(test_file, 'SAMPLE_CONFIG_DB_JSON'))
+
+        calls = []
+        monkeypatch.setattr(syc, 'sysLog',
+                            lambda *a, **kw: calls.append((a, kw)))
+
+        syc.loadData(jIn)
+
+        msgs = [kw.get('msg', '') for (_a, kw) in calls] + [
+            a[0] for (a, _kw) in calls if a
+        ]
+        assert any('Try to load Data' in str(m) for m in msgs), \
+            "default quiet=False must log 'Try to load Data': {}".format(msgs)
+
+        return
+
     def teardown_class(self):
         pass


### PR DESCRIPTION
loadData currently logs LOG_ERR "Data Loading Failed" to syslog on every exception (log-and-throw antipattern) before raising. This is undesirable for callers that use loadData speculatively to test many candidate configs for validity, e.g. generic_config_updater patch sorter (sonic-utilities) FullConfigMoveValidator — every forward leafref during the search emits a LOG_ERR to syslog even though the caller handles the exception and uses it as a prune signal.

Add a quiet=False kwarg. When quiet=True, suppress the informational "Try to load Data" line and the LOG_ERR "Data Loading Failed" line, but still raise SonicYangException so the caller sees the failure.

Default quiet=False preserves existing behavior for all current callers (including config apply-patch final validation, db_migrator upgrades, sonic-cfggen, and unit tests).

Paired with sonic-utilities change that makes patch_sorter.FullConfigMoveValidator pass quiet=True.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

 On T0 devices, a single `config apply-patch` invocation leaks 100+ `Data Loading Failed` ERR lines to /var/log/syslog. These come from the GCU patch sorter's speculative `FullConfigMoveValidator`, which deliberately tests candidate moves that may transiently violate leafref constraints during the search — the sorter already handles the failure via the 
returned `(False, error)` tuple. The ERR lines trip `loganalyzer` in sonic-mgmt baseline tests (e.g. `test_dhcp_relay_with_non_default_vrf`, `test_dhcp_relay_with_different_non_default_vrf`) and obscure real errors in support bundles.
 
 The root cause is `loadData`'s log-and-throw antipattern: it emits a LOG_ERR *and* raises, forcing log noise on callers that are expected to recover.

##### Work item tracking
- Microsoft ADO **(number only)**: 38614135

#### How I did it

 Added a `quiet=False` kwarg to `SonicYangExtMixin.loadData`. When `True`, guard the informational `"Try to load Data"` sysLog and the `LOG_ERR "Data Loading Failed"` sysLog behind `if not quiet:`. `SonicYangException` is still raised on failure, so nothing about the control flow changes — only the syslog side-effect is suppressed. Default `quiet=False` 
preserves behavior for every current caller.

#### How to verify it

 1. Build `python3-sonic-yang-mgmt` wheel from this branch and install on a T0 DUT.
 2. Pair with the sonic-utilities PR that threads `quiet=True` from `FullConfigMoveValidator` → `validate_config_db_config` → `loadData`.
 3. Run `sonic-mgmt` generic_config_updater tests and/or `dhcp_server/test_dhcp_server_port_based_customize_options` on a T0 and count `"Data Loading Failed"` lines in `/var/log/syslog` across the window.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

