### PR TITLE
[sonic-slave-trixie]: Upgrade Rust toolchain to 1.95.0

### DIFF
--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -777,7 +777,7 @@ RUN curl -fsSL -o /usr/local/bin/bazel ${bazelisk_url} && chmod 755 /usr/local/b
 
 # Install Rust
 ARG RUST_ROOT=/usr/.cargo
-RUN RUSTUP_HOME=$RUST_ROOT CARGO_HOME=$RUST_ROOT bash -c 'curl --proto "=https" -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.88.0 -y'
+RUN RUSTUP_HOME=$RUST_ROOT CARGO_HOME=$RUST_ROOT bash -c 'curl --proto "=https" -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.95.0 -y'
 {% if CROSS_BUILD_ENVIRON == "y" and CONFIGURED_ARCH == "armhf" %}
 RUN mkdir -p /.cargo && $RUST_ROOT/bin/rustup target add armv7-unknown-linux-gnueabihf && echo "[target.armv7-unknown-linux-gnueabihf]\nlinker = \"arm-linux-gnueabihf-gcc\"" >> /.cargo/config.toml
 {% endif -%}

--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -777,7 +777,7 @@ RUN curl -fsSL -o /usr/local/bin/bazel ${bazelisk_url} && chmod 755 /usr/local/b
 
 # Install Rust
 ARG RUST_ROOT=/usr/.cargo
-RUN RUSTUP_HOME=$RUST_ROOT CARGO_HOME=$RUST_ROOT bash -c 'curl --proto "=https" -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.86.0 -y'
+RUN RUSTUP_HOME=$RUST_ROOT CARGO_HOME=$RUST_ROOT bash -c 'curl --proto "=https" -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.88.0 -y'
 {% if CROSS_BUILD_ENVIRON == "y" and CONFIGURED_ARCH == "armhf" %}
 RUN mkdir -p /.cargo && $RUST_ROOT/bin/rustup target add armv7-unknown-linux-gnueabihf && echo "[target.armv7-unknown-linux-gnueabihf]\nlinker = \"arm-linux-gnueabihf-gcc\"" >> /.cargo/config.toml
 {% endif -%}
@@ -788,9 +788,7 @@ ENV RUSTUP_HOME=$RUST_ROOT
 ENV PATH=$PATH:$RUST_ROOT/bin
 
 # Install cargo-tarpaulin for code coverage
-# Pin version to avoid dependency conflicts with Rust 1.86.0
-# (cargo-tarpaulin v0.35.2 pulled in gimli 0.33.0 which needs Rust 1.88+)
-RUN $RUST_ROOT/bin/cargo install --locked cargo-tarpaulin@0.35.1
+RUN $RUST_ROOT/bin/cargo install --locked cargo-tarpaulin
 
 {# Include vendor-defined rules for slave container if it exists.  Contained in ../files #}
 {% with DEBIAN_VERSION='trixie' %}

--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -788,7 +788,8 @@ ENV RUSTUP_HOME=$RUST_ROOT
 ENV PATH=$PATH:$RUST_ROOT/bin
 
 # Install cargo-tarpaulin for code coverage
-RUN $RUST_ROOT/bin/cargo install --locked cargo-tarpaulin
+# Pin version for reproducible builds; bump deliberately when newer releases are validated.
+RUN $RUST_ROOT/bin/cargo install --locked cargo-tarpaulin@0.35.2
 
 {# Include vendor-defined rules for slave container if it exists.  Contained in ../files #}
 {% with DEBIAN_VERSION='trixie' %}


### PR DESCRIPTION
## Why I did it

The trixie build slave currently installs Rust 1.86.0. Some Rust crates used by SONiC's tooling have started requiring newer toolchains — most recently `gimli 0.33.0` (pulled in by `cargo-tarpaulin >= 0.35.2`) which needs Rust 1.88+.

To keep the slave aligned with what the ecosystem expects, bump the toolchain to 1.95.0 (the current stable release).

## How I did it

- `sonic-slave-trixie/Dockerfile.j2`: bump rustup `--default-toolchain` from `1.86.0` to `1.95.0`.
- Drop the `cargo-tarpaulin@0.35.1` version pin workaround and bump to `0.35.2` (now buildable with the newer toolchain).

## How to verify it

- Rebuild the trixie slave image: `make sonic-slave-trixie-build`
- Inside the slave: `rustc --version` should report 1.95.0, and `cargo tarpaulin --version` should resolve to 0.35.2.
- Run any Rust-based package builds (e.g. `sonic-nettools`, watchdog images) and confirm they still build clean.
