### PR TITLE
[yang-model] Yang model for route state async publish knob

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -19,6 +19,10 @@ module sonic-device_metadata {
 
     description "DEVICE_METADATA YANG Module for SONiC OS";
 
+    revision 2026-04-11 {
+        description "Added route_state_async_publish to control async route state publishing.";
+    }
+
     revision 2021-02-27 {
         description "Added frr_mgmt_framework_config field to handle BGP
             config DB schema events to configure FRR protocols.";
@@ -229,6 +233,17 @@ module sonic-device_metadata {
                         error-message "ASIC synchronous mode must be enabled in order to enable suppress FIB pending feature";
                     }
                 }
+
+                leaf route_state_async_publish {
+                    description "When enabled, routeorch publishes route states asynchronously in state update thread.
+                                 When disabled, route state is published on the orch task path (synchronous).";
+                    type enumeration {
+                        enum enabled;
+                        enum disabled;
+                    }
+                    default enabled;
+                }
+
                 leaf rack_mgmt_map {
                     type string {
                         length 0..128 {

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -19,6 +19,10 @@ module sonic-device_metadata {
 
     description "DEVICE_METADATA YANG Module for SONiC OS";
 
+    revision 2026-04-11 {
+        description "Added route_state_async_publish to control async route state publishing.";
+    }
+
     revision 2026-04-10 {
         description "Added async_swss_rec field to control async swss recorder.";
     }
@@ -260,6 +264,17 @@ module sonic-device_metadata {
                     }
                     default disabled;
                 }
+
+                leaf route_state_async_publish {
+                    description "When enabled, routeorch publishes route states asynchronously in state update thread.
+                                 When disabled, route state is published on the orch task path (synchronous).";
+                    type enumeration {
+                        enum enabled;
+                        enum disabled;
+                    }
+                    default enabled;
+                }
+
                 leaf rack_mgmt_map {
                     type string {
                         length 0..128 {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Adding yang leaf in DEVICE_METADATA|localhost for route_state_async_publish enable/disable knob.
Ref:  sonic-swss PR https://github.com/sonic-net/sonic-swss/pull/4437

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added a leaf "route_state_async_publish" with value "enabled/disabled" under the container DEVICE_METADATA|localhost

#### How to verify it

Configuration validation sanity passes with presence of "DEVICE_METADATA|localhost:route_state_async_publish" field having values either "enabled" or "disabled" in the config_db.json/config db.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

Yang leaf for route_state_async_publish config knob in config db DEVICE_METADATA

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

