### PR TITLE
[yang][tacacs]: reject unsupported mschap auth_type

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/tacacs.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/tacacs.json
@@ -6,6 +6,10 @@
         "desc": "Tacplus global configuration with invalid timeout value in TACPLUS table.",
         "eStr": "TACACS timeout must be 1..60"
     },
+    "TACPLUS_INVALID_AUTH_TYPE_TEST": {
+        "desc": "Tacplus global configuration with invalid auth type in TACPLUS table.",
+        "eStrKey": "InvalidValue"
+    },
     "TACPLUS_NOT_PRESENT_SRC_INTF_TEST": {
         "desc": "Tacplus global configuration with a non existent port in TACPLUS table.",
         "eStrKey": "InvalidValue"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/tacacs.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/tacacs.json
@@ -38,6 +38,15 @@
             }
         }
     },
+    "TACPLUS_INVALID_AUTH_TYPE_TEST": {
+        "sonic-system-tacacs:sonic-system-tacacs": {
+            "sonic-system-tacacs:TACPLUS": {
+                "global": {
+                        "auth_type": "mschap"
+                }
+            }
+        }
+    },
 
     "TACPLUS_NOT_PRESENT_SRC_INTF_TEST": {
         "sonic-system-tacacs:sonic-system-tacacs": {
@@ -109,7 +118,7 @@
                 "TACPLUS_SERVER_LIST": [
                 {
                     "ipaddress": "192.168.1.1",
-                    "auth_type": "123"
+                    "auth_type": "mschap"
                 }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-system-tacacs.yang
+++ b/src/sonic-yang-models/yang-models/sonic-system-tacacs.yang
@@ -37,7 +37,6 @@ module sonic-system-tacacs {
         type enumeration {
             enum pap;
             enum chap;
-            enum mschap;
             enum login;
         }
     }


### PR DESCRIPTION
#### Why I did it
SONiC TACACS currently accepts `auth_type=mschap`, but TACACS auth runtime falls back to PAP. This is misleading and can create security/configuration confusion.

Closes #26540.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it
- Removed `mschap` from TACACS auth type enum in:
  - `src/sonic-yang-models/yang-models/sonic-system-tacacs.yang`
- Added/updated YANG validation tests to ensure `mschap` is rejected in both:
  - TACPLUS global auth type
  - TACPLUS_SERVER auth type

#### How to verify it
1. Try configuring TACACS auth type as `mschap` (global or server-specific).
2. Verify config is rejected by YANG validation (`InvalidValue`) instead of being accepted and silently behaving as PAP.
3. Verify existing valid TACACS auth types (`pap`, `chap`, `login`) still work.

#### Which release branch to backport (provide reason below if selected)
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)
- [x] master (schema + json test updates)
- [ ] <!-- image version 2 -->

#### Description for the changelog
Reject unsupported TACACS `mschap` auth_type in YANG to prevent misleading PAP fallback behavior.

#### Link to config_db schema for YANG module changes
N/A (YANG enum tightening only; no new table/schema section).

#### A picture of a cute animal (not mandatory but encouraged)