### PR TITLE
[sonic-yang-models] Add short-form values to relay-agent-mode typedef

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2196,7 +2196,7 @@
                 "link_selection": "enable",
                 "vrf_selection": "enable",
                 "server_id_override": "enable",
-                "agent_relay_mode": "forward_untouched",
+                "agent_relay_mode": "discard",
                 "max_hop_count": "4"
             },
             "Vlan222": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/dhcpv4_relay.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/dhcpv4_relay.json
@@ -36,5 +36,15 @@
     "DHCPv4_RELAY_WITH_SERVER_VRF_AND_MISSING_SOURCE_INTERFACE_OPTION": {
         "desc": "Add dhcpv4 relay with server_vrf and missing source-interface option.",
         "eStrKey": "Must"
+    },
+    "DHCPv4_RELAY_WITH_AGENT_RELAY_MODE_APPEND": {
+        "desc": "Add dhcpv4 relay with agent_relay_mode=append (short-form value used by CLI/daemon)."
+    },
+    "DHCPv4_RELAY_WITH_AGENT_RELAY_MODE_REPLACE": {
+        "desc": "Add dhcpv4 relay with agent_relay_mode=replace (short-form value used by CLI/daemon)."
+    },
+    "DHCPv4_RELAY_WITH_AGENT_RELAY_MODE_LEGACY_FORWARD_UNTOUCHED": {
+        "desc": "Add dhcpv4 relay with legacy long-form agent_relay_mode=forward_untouched (now removed; should fail validation).",
+        "eStrKey": "InvalidValue"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/dhcpv4_relay.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/dhcpv4_relay.json
@@ -289,5 +289,50 @@
                 ]
             }
         }
+    },
+    "DHCPv4_RELAY_WITH_AGENT_RELAY_MODE_APPEND": {
+        "sonic-dhcpv4-relay:sonic-dhcpv4-relay": {
+            "sonic-dhcpv4-relay:DHCPV4_RELAY": {
+                "DHCPV4_RELAY_LIST": [
+                    {
+                        "name": "Vlan777",
+                        "dhcpv4_servers": [
+                            "192.168.20.100"
+                        ],
+                        "agent_relay_mode": "append"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCPv4_RELAY_WITH_AGENT_RELAY_MODE_REPLACE": {
+        "sonic-dhcpv4-relay:sonic-dhcpv4-relay": {
+            "sonic-dhcpv4-relay:DHCPV4_RELAY": {
+                "DHCPV4_RELAY_LIST": [
+                    {
+                        "name": "Vlan777",
+                        "dhcpv4_servers": [
+                            "192.168.20.100"
+                        ],
+                        "agent_relay_mode": "replace"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCPv4_RELAY_WITH_AGENT_RELAY_MODE_LEGACY_FORWARD_UNTOUCHED": {
+        "sonic-dhcpv4-relay:sonic-dhcpv4-relay": {
+            "sonic-dhcpv4-relay:DHCPV4_RELAY": {
+                "DHCPV4_RELAY_LIST": [
+                    {
+                        "name": "Vlan777",
+                        "dhcpv4_servers": [
+                            "192.168.20.100"
+                        ],
+                        "agent_relay_mode": "forward_untouched"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-dhcpv4-relay.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dhcpv4-relay.yang
@@ -118,7 +118,7 @@ module sonic-dhcpv4-relay {
                 leaf agent_relay_mode {
                     description "How to forward packets that already have a relay option";
                     type stypes:relay-agent-mode;
-                    default forward_untouched;
+                    default discard;
                 }
 
                 leaf max_hop_count {

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -503,20 +503,17 @@ module sonic-types {
     
     typedef relay-agent-mode {
         type enumeration {
-            enum forward_and_append {
-                description "Forward and append our own relay option";
-            }
-            enum forward_and_replace {
-                description "Forward, but replace theirs with ours";
-            }
-            enum forward_untouched {
-                description "Forward without changes";
-            }
             enum discard {
-                description "Discard the packet";
+                description "Discard the packet (default).";
+            }
+            enum append {
+                description "Forward the packet and append our own relay-agent option (option 82).";
+            }
+            enum replace {
+                description "Forward the packet, replacing any existing relay-agent option with our own.";
             }
         }
-        description "This enumeration type defines what to do about a dhcp packets that already has a relay option.";
+        description "This enumeration type defines what to do about DHCP packets that already have a relay-agent option. Values match what the dhcp_relay CLI accepts and what the dhcp4relay daemon implements.";
     }    
 
     {% if yang_model_type == "cvl" %}


### PR DESCRIPTION
The agent_relay_mode leaf in sonic-dhcpv4-relay.yang uses typedef 'relay-agent-mode' which only defines long-form enums:
  forward_and_append, forward_and_replace, forward_untouched, discard.

However, both the CLI (config/plugins/dhcp-relay.py uses click.Choice(["discard", "append", "replace"])) and the dhcp4relay daemon (dhcp4relay.cpp hardcodes string compares for "append" and "replace") use short-form values. This three-way mismatch causes YANG validation to reject any real-world CONFIG_DB value, producing errors during config save/reload such as:

    libyang[0]: Invalid value "append" in "agent_relay_mode" element.

which were observed during dhcp_relay teardown on 720dt testbeds.

Fix (minimal, additive, behavior-preserving): add 'append' and 'replace' enums to the existing relay-agent-mode typedef. The default (forward_untouched) is unchanged. The legacy long-form values remain valid for any existing configs. Verified on a 720dt DUT: test_dhcp_relay_agent_mode[discard|replace|append] all pass, and config save/reload with agent_relay_mode=append now succeeds.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

 Fixes a YANG validation failure that breaks `config save`/`config reload` whenever a
 DHCPv4 relay is configured with `agent_relay_mode` via the CLI. Surfaces as test
 teardown ERRORs in dhcp_relay regression on 720dt testbeds.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

 Minimal, additive, behavior-preserving change: added `append` and `replace` enums to
 the existing `relay-agent-mode` typedef in `sonic-types.yang.j2`. The default
 (`forward_untouched`) is unchanged — runtime behavior is preserved because the
 daemon does not recognize the long-form strings, so anything not equal to `append`
 or `replace` already takes the discard else-branch. Legacy long-form values remain
 valid for any existing configs.
 
 Also added two positive YANG unit tests (`DHCPv4_RELAY_WITH_AGENT_RELAY_MODE_APPEND`,
 `DHCPv4_RELAY_WITH_AGENT_RELAY_MODE_REPLACE`).

#### How to verify it

 On a 720dt DUT after applying the patched YANG files at `/usr/local/yang-models/`
 and `/usr/local/cvlyang-models/`:
 
 1. `sonic_yang.SonicYang(...).validate_data_tree()` accepts `append`, `replace`,
    `discard`, plus the three legacy long-form values; rejects unknown values.
 2. `sonic-db-cli CONFIG_DB HSET "DHCPV4_RELAY|Vlan1000" agent_relay_mode append` →
    `sudo config save -y` → `sudo config reload -y -f` succeeds (previously failed
    with the libyang error above).
 3. `tests/dhcp_relay/test_dhcpv4_relay.py::test_dhcp_relay_agent_mode[discard|replace|append]`
    — 3/3 PASSED in 10:05.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

