### PR TITLE
[Mellanox] lazy initialize BMC

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -36,7 +36,6 @@ try:
     from . import module_host_mgmt_initializer
     from . import utils
     from .device_data import DeviceDataManager
-    from .bmc import BMC
     import re
     import select
     import threading
@@ -931,7 +930,9 @@ class Chassis(ChassisBase):
             self._component_list.extend(DeviceDataManager.get_cpld_component_list())
 
         # Initialize BMC and its components
-        self.initialize_bmc()
+        if DeviceDataManager.is_platform_with_bmc():
+            from .bmc import BMC
+            self.initialize_bmc()
 
     def get_num_components(self):
         """

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
@@ -409,6 +409,16 @@ class DeviceDataManager:
         return data.get('SAI_INDEPENDENT_MODULE_MODE') == '1'
 
     @classmethod
+    @utils.read_only_cache()
+    def is_platform_with_bmc(cls):
+        from sonic_py_common import device_info
+        platform_path = device_info.get_path_to_platform_dir()
+        bmc_json_file = os.path.join(platform_path, 'bmc.json')
+        if os.path.exists(bmc_json_file):
+            return True
+        return False
+
+    @classmethod
     def wait_platform_ready(cls):
         """
         Legacy function for backward compatibility

--- a/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
@@ -406,3 +406,23 @@ class TestChassis:
             chassis.get_dpu_id('ABC')
         DeviceDataManager.get_platform_dpus_data = orig_dpus_data
         DeviceDataManager.get_dpu_count = orig_dpu_count
+
+    @mock.patch('sonic_platform.chassis.utils.is_host', mock.MagicMock(return_value=True))
+    def test_initialize_components_bmc(self):
+        chassis = Chassis()
+        chassis._component_list = []
+
+        with mock.patch.object(DeviceDataManager, 'is_platform_with_bmc', return_value=True), \
+             mock.patch.object(DeviceDataManager, 'get_bios_component', return_value=MagicMock()), \
+             mock.patch.object(DeviceDataManager, 'get_cpld_component_list', return_value=[]), \
+             mock.patch('sonic_platform.chassis.Chassis.initialize_bmc') as mock_init_bmc:
+            chassis.initialize_components()
+            mock_init_bmc.assert_called_once()
+
+        chassis._component_list = []
+        with mock.patch.object(DeviceDataManager, 'is_platform_with_bmc', return_value=False), \
+             mock.patch.object(DeviceDataManager, 'get_bios_component', return_value=MagicMock()), \
+             mock.patch.object(DeviceDataManager, 'get_cpld_component_list', return_value=[]), \
+             mock.patch('sonic_platform.chassis.Chassis.initialize_bmc') as mock_init_bmc:
+            chassis.initialize_components()
+            mock_init_bmc.assert_not_called()

--- a/platform/mellanox/mlnx-platform-api/tests/test_component.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_component.py
@@ -1,7 +1,7 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
 # Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ from sonic_platform_base.component_base import FW_AUTO_INSTALLED,      \
 
 class TestComponent:
     @mock.patch('sonic_platform.chassis.utils.is_host')
+    @mock.patch('sonic_platform.chassis.DeviceDataManager.is_platform_with_bmc', mock.MagicMock(return_value=False))
     @mock.patch('sonic_platform.chassis.DeviceDataManager.get_cpld_component_list', mock.MagicMock(return_value=[]))
     def test_chassis_component(self, mock_is_host):
         mock_is_host.return_value = False


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The BMC module (`bmc.py`) and its dependencies (`bmc_base`, `redfish_client`) were imported eagerly at the top level of `chassis.py`. This caused all platform daemons that load the chassis object to pull in additional memory from the BMC/Redfish import chain, even on platforms without BMC or in daemons that never use BMC functionality. This change reduces RAM usage for all platform daemons on non-OpenBMC platforms.

#### How I did it

- Removed the top-level `from .bmc import BMC` import from `chassis.py`.
- Moved the BMC import inside `initialize_components()`, gated behind a `DeviceDataManager. is_platform_with_bmc()` check, so it is only loaded on platforms that actually have BMC hardware.
- The `initialize_bmc()` method retains its own local `from .bmc import BMC` import for when it is explicitly called.
- Added a unit test `test_initialize_components_bmc` to verify that `initialize_bmc()` is called only when `is_platform_with_bmc()` returns `True`, and is skipped otherwise.

#### How to verify it

- Run the existing platform API unit tests to confirm no regressions:
  ```
  cd platform/mellanox/mlnx-platform-api
  python3 -m pytest tests/test_chassis.py -v
  ```
- On a non-OpenBMC platform, verify that `bmc.py` is not imported by checking the loaded modules of any pmon daemon (e.g., psud, thermalctld):
  ```
  pid=$(pgrep -f '/usr/local/bin/psud' | head -1)
  sudo grep "bmc" /proc/$pid/maps
  ```
- On an OpenBMC platform, verify that BMC components are still correctly initialized when `get_all_components()` or `get_num_components()` is called.

#### Description for the changelog

Lazy-load BMC module in chassis.py to reduce RAM usage on non-OpenBMC platforms.


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

