### PR TITLE
rsyslogd: disable DNS for resolving remote IP addresses

### DIFF
--- a/files/image_config/rsyslog/rsyslog.conf.j2
+++ b/files/image_config/rsyslog/rsyslog.conf.j2
@@ -17,6 +17,8 @@
 {% set rate_limit_interval = gconf.get('rate_limit_interval') -%}
 {% set rate_limit_burst = gconf.get('rate_limit_burst') -%}
 
+global(net.enableDNS="off")
+
 module(load="imuxsock" {% if rate_limit_interval is not none %}SysSock.RateLimit.Interval="{{ rate_limit_interval }}"{% endif %} {% if rate_limit_burst is not none %}SysSock.RateLimit.Burst="{{ rate_limit_burst }}"{% endif %}) # provides support for local system logging
 module(load="imklog" ParseKernelTimestamp="off" KeepKernelTimestamp="on")   # provides kernel logging support
 #module(load="immark")  # provides --MARK-- message capability

--- a/src/sonic-config-engine/tests/sample_output/py3/rsyslog.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/rsyslog.conf
@@ -13,6 +13,8 @@
 #### MODULES ####
 #################
 
+global(net.enableDNS="off")
+
 module(load="imuxsock"  ) # provides support for local system logging
 module(load="imklog" ParseKernelTimestamp="off" KeepKernelTimestamp="on")   # provides kernel logging support
 #module(load="immark")  # provides --MARK-- message capability

--- a/src/sonic-config-engine/tests/sample_output/py3/rsyslog_same_ip.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/rsyslog_same_ip.conf
@@ -13,6 +13,8 @@
 #### MODULES ####
 #################
 
+global(net.enableDNS="off")
+
 module(load="imuxsock"  ) # provides support for local system logging
 module(load="imklog" ParseKernelTimestamp="off" KeepKernelTimestamp="on")   # provides kernel logging support
 #module(load="immark")  # provides --MARK-- message capability

--- a/src/sonic-config-engine/tests/sample_output/py3/rsyslog_with_docker0.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/rsyslog_with_docker0.conf
@@ -13,6 +13,8 @@
 #### MODULES ####
 #################
 
+global(net.enableDNS="off")
+
 module(load="imuxsock"  ) # provides support for local system logging
 module(load="imklog" ParseKernelTimestamp="off" KeepKernelTimestamp="on")   # provides kernel logging support
 #module(load="immark")  # provides --MARK-- message capability


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

When using RELP for receiving syslogs, rsyslogd will try to convert the remote IP address to a hostname using DNS. This, I think, is to make sure that there isn't someone with a fake PTR for some IP address pointing to some hostname that doesn't exist. Considering this is used only for containers running on the device itself, this is not an issue.

On multi-ASIC systems, ASIC-specific containers will be sending syslogs from a different IP address to the host rsyslogd. When this happens, the container rsyslogd will initiate a connection to the host rsyslogd. The host rsyslogd will then try to resolve the remote IP address. However, if the DNS servers are unreachable (as is the case for KVM setups), then this connection initiation will get blocked for 10 seconds (per incorrect DNS server, glibc limit of 3). This is long enough for the TCP connection initiation to be considered as failed by the container rsyslogd, and to block TCP connections from other senders, causing logs to not properly get forwarded.

##### Work item tracking
- Microsoft ADO **(number only)**: 37579636

#### How I did it

Disable reverse DNS resolution by rsyslogd, so that it doesn't use the DNS servers at all unless necessary.

#### How to verify it

Start a multi-ASIC KVM system, and verify that logs from containers are getting forwarded, and that TCP connections to port 2514 are getting established.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

