### PR TITLE
[Mgmt VRF] Start mgmt services in mgmt VRF and remove ip rule source-match hack

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -477,6 +477,7 @@ sudo cp files/image_config/logrotate/logrotateOverride.conf $FILESYSTEM_ROOT/etc
 ## Remove sshd host keys, and will regenerate on first sshd start
 sudo rm -f $FILESYSTEM_ROOT/etc/ssh/ssh_host_*_key*
 sudo cp files/sshd/host-ssh-keygen.sh $FILESYSTEM_ROOT/usr/local/bin/
+sudo cp files/sshd/sshd-starter.sh $FILESYSTEM_ROOT/usr/local/bin/
 sudo mkdir $FILESYSTEM_ROOT/etc/systemd/system/ssh.service.d
 sudo cp files/sshd/override.conf $FILESYSTEM_ROOT/etc/systemd/system/ssh.service.d/override.conf
 # Config sshd

--- a/dockers/docker-snmp/supervisord.conf.j2
+++ b/dockers/docker-snmp/supervisord.conf.j2
@@ -40,7 +40,12 @@ dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 
 [program:snmpd]
-command=/usr/sbin/snmpd -f -LS0-2d -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf,ifTable,ifXTable,inetCidrRouteTable,ipCidrRouteTable,ip,disk_hw -p /run/snmpd.pid
+{% set snmpd_cmd = '/usr/sbin/snmpd -f -LS0-2d -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf,ifTable,ifXTable,inetCidrRouteTable,ipCidrRouteTable,ip,disk_hw -p /run/snmpd.pid' %}
+{% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
+command=ip vrf exec mgmt {{ snmpd_cmd }}
+{% else %}
+command={{ snmpd_cmd }}
+{% endif %}
 priority=3
 autostart=false
 autorestart=false

--- a/dockers/docker-sonic-mgmt-framework/rest-server.sh
+++ b/dockers/docker-sonic-mgmt-framework/rest-server.sh
@@ -53,9 +53,14 @@ REST_SERVER_ARGS="-ui /rest_ui -logtostderr"
 [ ! -z $SERVER_KEY  ] && REST_SERVER_ARGS+=" -key $SERVER_KEY"
 [ ! -z $CA_CRT      ] && REST_SERVER_ARGS+=" -cacert $CA_CRT"
 
-echo "REST_SERVER_ARGS = $REST_SERVER_ARGS"
+MGMT_VRF_ENABLED=$(sonic-db-cli CONFIG_DB hget "MGMT_VRF_CONFIG|vrf_global" "mgmtVrfEnabled" 2> /dev/null)
 
+echo "REST_SERVER_ARGS = $REST_SERVER_ARGS"
 
 export CVL_SCHEMA_PATH=/usr/sbin/schema
 
-exec /usr/sbin/rest_server ${REST_SERVER_ARGS}
+if [ "$MGMT_VRF_ENABLED" = "true" ]; then
+    exec ip vrf exec mgmt /usr/sbin/rest_server ${REST_SERVER_ARGS}
+else
+    exec /usr/sbin/rest_server ${REST_SERVER_ARGS}
+fi

--- a/dockers/docker-sonic-restapi/restapi.sh
+++ b/dockers/docker-sonic-restapi/restapi.sh
@@ -37,5 +37,11 @@ else
     RESTAPI_ARGS+=" -loglevel=trace"
 fi 
 
+MGMT_VRF_ENABLED=$(sonic-db-cli CONFIG_DB hget "MGMT_VRF_CONFIG|vrf_global" "mgmtVrfEnabled" 2> /dev/null)
+
 logger "RESTAPI_ARGS: $RESTAPI_ARGS"
-exec /usr/sbin/go-server-server ${RESTAPI_ARGS}
+if [ "$MGMT_VRF_ENABLED" = "true" ]; then
+    exec ip vrf exec mgmt /usr/sbin/go-server-server ${RESTAPI_ARGS}
+else
+    exec /usr/sbin/go-server-server ${RESTAPI_ARGS}
+fi

--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -94,7 +94,9 @@ iface {{ name }} {{ 'inet' if prefix | ipv4 else 'inet6' }} static
     # management port up rules
     up ip {{ '-4' if prefix | ipv4 else '-6' }} route add {{ prefix | network }}/{{ prefix | prefixlen }} dev {{ name }} table {{ vrf_table }}
     up ip {{ '-4' if prefix | ipv4 else '-6' }} route add default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev {{ name }} table {{ vrf_table }} metric 201
+{% if vrf_table == 'default' %}
     up ip {{ '-4' if prefix | ipv4 else '-6' }} rule add pref {{ force_mgmt_route_priority + 1 }} from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }}
+{% endif %}
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
     up ip {{ '-4' if prefix | ipv4 else '-6' }} rule add pref {{ force_mgmt_route_priority }} to {{ route }} table {{ vrf_table }}
 {% endfor %}
@@ -118,7 +120,9 @@ iface {{ name }} {{ 'inet' if prefix | ipv4 else 'inet6' }} static
     # management port down rules
     pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev {{ name }} table {{ vrf_table }}
     pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete {{ prefix | network }}/{{ prefix | prefixlen }} dev {{ name }} table {{ vrf_table }}
+{% if vrf_table == 'default' %}
     pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} rule delete pref {{ force_mgmt_route_priority + 1 }} from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }}
+{% endif %}
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
     pre-down ip {{ '-4' if route | ipv4 else '-6' }} rule delete pref {{ force_mgmt_route_priority }} to {{ route }} table {{ vrf_table }}
 {% endfor %}

--- a/files/sshd/override.conf
+++ b/files/sshd/override.conf
@@ -1,4 +1,9 @@
+[Unit]
+After=interfaces-config.service
+
 [Service]
 ExecStartPre=
 ExecStartPre=/usr/local/bin/host-ssh-keygen.sh
 ExecStartPre=/usr/sbin/sshd -t
+ExecStart=
+ExecStart=/usr/local/bin/sshd-starter.sh

--- a/files/sshd/sshd-starter.sh
+++ b/files/sshd/sshd-starter.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Start sshd in mgmt VRF if mgmt VRF is enabled, otherwise start in default VRF.
+# This ensures sshd binds its listening socket inside the correct VRF namespace
+# so that management traffic is routed through the mgmt VRF table without
+# needing ip rule hacks based on source address matching.
+
+VRF_ENABLED=$(sonic-db-cli CONFIG_DB hget "MGMT_VRF_CONFIG|vrf_global" "mgmtVrfEnabled" 2> /dev/null)
+if [ "$VRF_ENABLED" = "true" ]; then
+    echo "Starting sshd in mgmt-vrf"
+    exec ip vrf exec mgmt /usr/sbin/sshd -D $SSHD_OPTS
+else
+    echo "Starting sshd in default-vrf"
+    exec /usr/sbin/sshd -D $SSHD_OPTS
+fi

--- a/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
@@ -33,14 +33,12 @@ iface eth0 inet static
     # management port up rules
     up ip -4 route add 10.0.0.0/24 dev eth0 table 6000
     up ip -4 route add default via 10.0.0.1 dev eth0 table 6000 metric 201
-    up ip -4 rule add pref 32765 from 10.0.0.100/32 table 6000
     up ip -4 rule add pref 32764 to 11.11.11.11 table 6000
     up ip -4 rule add pref 32764 to 22.22.22.0/23 table 6000
     up ip rule add pref 32764 to 10.20.6.16/32 table 6000
     # management port down rules
     pre-down ip -4 route delete default via 10.0.0.1 dev eth0 table 6000
     pre-down ip -4 route delete 10.0.0.0/24 dev eth0 table 6000
-    pre-down ip -4 rule delete pref 32765 from 10.0.0.100/32 table 6000
     pre-down ip -4 rule delete pref 32764 to 11.11.11.11 table 6000
     pre-down ip -4 rule delete pref 32764 to 22.22.22.0/23 table 6000
     down ip rule delete pref 32764 to 10.20.6.16/32 table 6000
@@ -54,12 +52,10 @@ iface eth0 inet6 static
     # management port up rules
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table 6000
     up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table 6000 metric 201
-    up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table 6000
     up ip -6 rule add pref 32764 to 33:33:33::0/64 table 6000
     # management port down rules
     pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table 6000
     pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table 6000
-    pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 table 6000
     pre-down ip -6 rule delete pref 32764 to 33:33:33::0/64 table 6000
 #
 source /etc/network/interfaces.d/*

--- a/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
@@ -33,14 +33,12 @@ iface eth0 inet static
     # management port up rules
     up ip -4 route add 10.0.0.0/24 dev eth0 table 6000
     up ip -4 route add default via 10.0.0.1 dev eth0 table 6000 metric 201
-    up ip -4 rule add pref 32765 from 10.0.0.100/32 table 6000
     up ip -4 rule add pref 32764 to 11.11.11.11 table 6000
     up ip -4 rule add pref 32764 to 22.22.22.0/23 table 6000
     up ip rule add pref 32764 to 10.20.6.16/32 table 6000
     # management port down rules
     pre-down ip -4 route delete default via 10.0.0.1 dev eth0 table 6000
     pre-down ip -4 route delete 10.0.0.0/24 dev eth0 table 6000
-    pre-down ip -4 rule delete pref 32765 from 10.0.0.100/32 table 6000
     pre-down ip -4 rule delete pref 32764 to 11.11.11.11 table 6000
     pre-down ip -4 rule delete pref 32764 to 22.22.22.0/23 table 6000
     down ip rule delete pref 32764 to 10.20.6.16/32 table 6000
@@ -54,12 +52,10 @@ iface eth0 inet6 static
     # management port up rules
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table 6000
     up ip -6 route add default via 2603:10e2:0:2902::1 dev eth0 table 6000 metric 201
-    up ip -6 rule add pref 32765 from 2603:10e2:0:2902::8/128 table 6000
     up ip -6 rule add pref 32764 to 33:33:33::0/64 table 6000
     # management port down rules
     pre-down ip -6 route delete default via 2603:10e2:0:2902::1 dev eth0 table 6000
     pre-down ip -6 route delete 2603:10e2:0:2902::/64 dev eth0 table 6000
-    pre-down ip -6 rule delete pref 32765 from 2603:10e2:0:2902::8/128 table 6000
     pre-down ip -6 rule delete pref 32764 to 33:33:33::0/64 table 6000
 #
 source /etc/network/interfaces.d/*


### PR DESCRIPTION
interfaces.j2 adds an 'ip rule add from <mgmt_ip>' that forces all locally originated traffic matching the mgmt IP source address into the mgmt VRF routing table. This breaks when the same IP is configured on both the mgmt interface (mgmt VRF) and an Ethernet interface in another VRF — the rule blindly matches on source IP regardless of the socket's VRF binding.

closes #26904 

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The interfaces.j2 template adds an ip rule that forces all locally originated traffic matching the management IP source address into the mgmt VRF routing table. This breaks when the same IP is configured on both a management interface in mgmt VRF and an Ethernet interface in another VRF, because the rule blindly matches on source IP regardless of which VRF the socket lives in.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

When mgmt VRF is enabled, start each mgmt-plane service inside the mgmt VRF via 'ip vrf exec mgmt'. The process's sockets are then inherently bound to the correct VRF, eliminating the need for the source-IP-based rule.

- sshd: new sshd-starter.sh wrapper modeled after chronyd-starter.sh, invoked via systemd ExecStart override. After=interfaces-config.service ensures the mgmt VRF l3mdev device exists before ip vrf exec runs.
- snmpd: wrap command in supervisord.conf.j2 when mgmtVrfEnabled=true. Args extracted into a Jinja2 variable so future arg changes apply to both VRF and non-VRF command lines.
- restapi (go-server-server): wrap exec in restapi.sh.
- mgmt-framework (rest_server): wrap exec in rest-server.sh.
- Update mvrf_interfaces sample outputs to match.

#### How to verify it

Boot a device with mgmtVrfEnabled=true in CONFIG_DB
Verify ip vrf exec mgmt shows in the process tree for sshd, telemetry, restapi, rest_server
Verify ip rule show no longer contains the priority 32765 from <mgmt_ip> rule
Verify SSH, gNMI, REST API are reachable via the management interface
Configure the same IP on both mgmt interface (mgmt VRF) and an Ethernet interface (different VRF) — verify traffic routes correctly through each VRF without cross-contamination

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

