### PR TITLE
scripts: bound db readiness waits to avoid boot hangs

### DIFF
--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -122,14 +122,35 @@ function wait_for_database_service()
 {
     debug "Wait for database to become ready..."
 
+    local timeout_sec=${DB_READY_TIMEOUT_SEC:-120}
+    local poll_sec=${DB_READY_POLL_INTERVAL_SEC:-1}
+    local elapsed=0
+
+    [[ "$timeout_sec" =~ ^[0-9]+$ ]] || timeout_sec=120
+    [[ "$poll_sec" =~ ^[0-9]+$ ]] || poll_sec=1
+    if (( poll_sec <= 0 )); then
+        poll_sec=1
+    fi
+
     # Wait for redis server start before database clean
-    until [[ $(sonic-db-cli -n "$NETNS" PING | grep -c PONG) -gt 0 ]]; do
-      sleep 1;
+    while [[ $(sonic-db-cli -n "$NETNS" PING | grep -c PONG) -le 0 ]]; do
+        if (( elapsed >= timeout_sec )); then
+            debug "Timed out waiting for redis PING after ${elapsed}s in namespace '${NETNS:-default}' (timeout=${timeout_sec}s)"
+            return 1
+        fi
+        sleep "$poll_sec"
+        elapsed=$((elapsed + poll_sec))
     done
 
+    elapsed=0
     # Wait for configDB initialization
-    until [[ $(sonic-db-cli -n "$NETNS" CONFIG_DB GET "CONFIG_DB_INITIALIZED") -eq 1 ]];
-        do sleep 1;
+    while [[ $(sonic-db-cli -n "$NETNS" CONFIG_DB GET "CONFIG_DB_INITIALIZED") -ne 1 ]]; do
+        if (( elapsed >= timeout_sec )); then
+            debug "Timed out waiting for CONFIG_DB_INITIALIZED after ${elapsed}s in namespace '${NETNS:-default}' (timeout=${timeout_sec}s)"
+            return 1
+        fi
+        sleep "$poll_sec"
+        elapsed=$((elapsed + poll_sec))
     done
 
     debug "Database is ready..."
@@ -258,7 +279,7 @@ function wait_for_components_to_reconcile() {
     fi
 }
 
-wait_for_database_service
+wait_for_database_service || exit 1
 check_warm_boot_and_fast_boot_or_exit
 
 if [[ (x"${WARM_BOOT}" == x"true") && (x"${FAST_REBOOT}" != x"true") ]]; then
@@ -277,7 +298,7 @@ for dev in `seq 0 $((NUM_ASIC - 1))`; do
         # For multi-ASIC devices, wait for the namespace database to be ready
         # and check if warm/fast boot is enabled.
         if [[ -n $NETNS ]]; then
-            wait_for_database_service
+            wait_for_database_service || exit 1
             check_warm_boot_and_fast_boot_or_exit
         fi
 

--- a/files/scripts/configdb-load.sh
+++ b/files/scripts/configdb-load.sh
@@ -1,8 +1,24 @@
 #!/usr/bin/env bash
 
+DB_READY_TIMEOUT_SEC=${DB_READY_TIMEOUT_SEC:-120}
+DB_READY_POLL_INTERVAL_SEC=${DB_READY_POLL_INTERVAL_SEC:-1}
+
+[[ "$DB_READY_TIMEOUT_SEC" =~ ^[0-9]+$ ]] || DB_READY_TIMEOUT_SEC=120
+[[ "$DB_READY_POLL_INTERVAL_SEC" =~ ^[0-9]+$ ]] || DB_READY_POLL_INTERVAL_SEC=1
+if (( DB_READY_POLL_INTERVAL_SEC <= 0 )); then
+    DB_READY_POLL_INTERVAL_SEC=1
+fi
+
+elapsed=0
+
 # Wait until redis starts
-until [[ $(sonic-db-cli PING | grep -c PONG) -gt 0 ]]; do
-  sleep 1;
+while [[ $(sonic-db-cli PING | grep -c PONG) -le 0 ]]; do
+    if (( elapsed >= DB_READY_TIMEOUT_SEC )); then
+        echo "Timed out waiting for redis PING after ${elapsed}s (timeout=${DB_READY_TIMEOUT_SEC}s)" >&2
+        exit 1
+    fi
+    sleep "$DB_READY_POLL_INTERVAL_SEC"
+    elapsed=$((elapsed + DB_READY_POLL_INTERVAL_SEC))
 done
 
 # If there is a config_db.json dump file, load it.

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -83,14 +83,35 @@ function validate_restore_count()
 
 function wait_for_database_service()
 {
+    local timeout_sec=${DB_READY_TIMEOUT_SEC:-120}
+    local poll_sec=${DB_READY_POLL_INTERVAL_SEC:-1}
+    local elapsed=0
+
+    [[ "$timeout_sec" =~ ^[0-9]+$ ]] || timeout_sec=120
+    [[ "$poll_sec" =~ ^[0-9]+$ ]] || poll_sec=1
+    if (( poll_sec <= 0 )); then
+        poll_sec=1
+    fi
+
     # Wait for redis server start before database clean
-    until [[ $($SONIC_DB_CLI PING | grep -c PONG) -gt 0 ]]; do
-      sleep 1;
+    while [[ $($SONIC_DB_CLI PING | grep -c PONG) -le 0 ]]; do
+        if (( elapsed >= timeout_sec )); then
+            debug "Timed out waiting for redis PING after ${elapsed}s (timeout=${timeout_sec}s)"
+            return 1
+        fi
+        sleep "$poll_sec"
+        elapsed=$((elapsed + poll_sec))
     done
 
+    elapsed=0
     # Wait for configDB initialization
-    until [[ $($SONIC_DB_CLI CONFIG_DB GET "CONFIG_DB_INITIALIZED") -eq 1 ]];
-        do sleep 1;
+    while [[ $($SONIC_DB_CLI CONFIG_DB GET "CONFIG_DB_INITIALIZED") -ne 1 ]]; do
+        if (( elapsed >= timeout_sec )); then
+            debug "Timed out waiting for CONFIG_DB_INITIALIZED after ${elapsed}s (timeout=${timeout_sec}s)"
+            return 1
+        fi
+        sleep "$poll_sec"
+        elapsed=$((elapsed + poll_sec))
     done
 }
 
@@ -392,7 +413,11 @@ start() {
 
     lock_service_state_change
 
-    wait_for_database_service
+    if ! wait_for_database_service; then
+        debug "Database readiness check failed for ${SERVICE}$DEV"
+        unlock_service_state_change
+        return 1
+    fi
     check_warm_boot
     validate_restore_count
 

--- a/files/scripts/syncd_common.sh
+++ b/files/scripts/syncd_common.sh
@@ -62,14 +62,35 @@ function check_fast_boot()
 
 function wait_for_database_service()
 {
+    local timeout_sec=${DB_READY_TIMEOUT_SEC:-120}
+    local poll_sec=${DB_READY_POLL_INTERVAL_SEC:-1}
+    local elapsed=0
+
+    [[ "$timeout_sec" =~ ^[0-9]+$ ]] || timeout_sec=120
+    [[ "$poll_sec" =~ ^[0-9]+$ ]] || poll_sec=1
+    if (( poll_sec <= 0 )); then
+        poll_sec=1
+    fi
+
     # Wait for redis server start before database clean
-    until [[ $($SONIC_DB_CLI PING | grep -c PONG) -gt 0 ]]; do
-      sleep 1;
+    while [[ $($SONIC_DB_CLI PING | grep -c PONG) -le 0 ]]; do
+        if (( elapsed >= timeout_sec )); then
+            debug "Timed out waiting for redis PING after ${elapsed}s (timeout=${timeout_sec}s)"
+            return 1
+        fi
+        sleep "$poll_sec"
+        elapsed=$((elapsed + poll_sec))
     done
 
+    elapsed=0
     # Wait for configDB initialization
-    until [[ $($SONIC_DB_CLI CONFIG_DB GET "CONFIG_DB_INITIALIZED") -eq 1 ]];
-        do sleep 1;
+    while [[ $($SONIC_DB_CLI CONFIG_DB GET "CONFIG_DB_INITIALIZED") -ne 1 ]]; do
+        if (( elapsed >= timeout_sec )); then
+            debug "Timed out waiting for CONFIG_DB_INITIALIZED after ${elapsed}s (timeout=${timeout_sec}s)"
+            return 1
+        fi
+        sleep "$poll_sec"
+        elapsed=$((elapsed + poll_sec))
     done
 }
 
@@ -108,7 +129,11 @@ start() {
 
     mkdir -p /host/warmboot$DEV
 
-    wait_for_database_service
+    if ! wait_for_database_service; then
+        debug "Database readiness check failed for ${SERVICE}$DEV"
+        unlock_service_state_change
+        return 1
+    fi
     check_warm_boot
 
     debug "Warm boot flag: ${SERVICE}$DEV ${WARM_BOOT}."


### PR DESCRIPTION
<!--
	Please make sure you've read and understood our contributing guidelines:
	https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

	** Make sure all your commits include a signature generated with `git commit -s` **

	If this is a bug fix, make sure your description includes "fixes #xxxx", or
	"closes #xxxx" or "resolves #xxxx"

	Please provide the following information:
-->

#### Why I did it

Several startup-critical scripts wait indefinitely for Redis readiness and CONFIG_DB initialization. In degraded or failure conditions, this can block startup or warmboot finalization indefinitely with weak failure signaling.

This PR makes startup behavior deterministic by bounding database-readiness waits and failing clearly on timeout.

Fixes #26910 

##### Work item tracking9
- Microsoft ADO **(number only)**: N/A

#### How I did it

Added bounded readiness checks with conservative defaults:

- DB_READY_TIMEOUT_SEC=120
- DB_READY_POLL_INTERVAL_SEC=1

Applied to the following scripts:

- files/scripts/swss.sh
- files/scripts/syncd_common.sh
- files/image_config/warmboot-finalizer/finalize-warmboot.sh
- files/scripts/configdb-load.sh

Implementation details:

- Validate timeout/poll env values and fallback to safe defaults.
- Bound Redis PING waits and CONFIG_DB_INITIALIZED waits.
- Emit explicit timeout logs with elapsed time.
- Return non-zero on timeout.
- Fail fast at call sites instead of continuing with an undefined startup state.

#### How to verify it

Static validation:

- bash parse checks pass for all modified shell scripts.
- Editor diagnostics show no errors on modified files.

Functional validation:

1. Healthy path:
- Start services/boot normally.
- Confirm behavior is unchanged under normal DB readiness.

2. Unhealthy path simulation:
- Delay or block DB readiness.
- Confirm scripts do not wait forever.
- Confirm explicit timeout logs are emitted.
- Confirm startup path exits non-zero on timeout.

3. Warmboot path:
- Trigger warm/fast recovery flow.
- Confirm warmboot finalizer exits on DB readiness timeout with clear namespace-aware logs.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

Backport reason:

Not requested in this PR. Can be backported if maintainers confirm impact on active release branches.

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Bound DB readiness waits in startup/warmboot scripts to prevent indefinite hangs and improve failure visibility.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

N/A

#### A picture of a cute animal (not mandatory but encouraged)

