### PR TITLE
fix: use list-based commands in frrcfgd to prevent shell injection

### DIFF
--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -3638,7 +3638,7 @@ class BGPConfigDaemon:
                             self.__ospf_apply_config(data, rmapoper, metricoper, metrictypeoper, alwaysoper, acclistoper)
                 else:
                     if (direction == "IMPORT"):
-                        command = ""
+                        command = []
                         if (protocol == "DEFAULT_ROUTE"):
                             command = ['vtysh', '-c', 'configure terminal',
                                        '-c', 'router ospf vrf {}'.format(vrf),
@@ -3648,7 +3648,7 @@ class BGPConfigDaemon:
                                        '-c', 'router ospf vrf {}'.format(vrf),
                                        '-c', 'no redistribute {}'.format(protocol.lower())]
 
-                        if (command != ""):
+                        if command:
                             if not self.__run_command(table, command):
                                 syslog.syslog(syslog.LOG_ERR, 'failed to delete default-info/redistribute {}'.format(protocol.lower()))
                                 continue

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -46,14 +46,14 @@ bgpd_client = None
 
 def g_run_command(table, command, use_bgpd_client, daemons, ignore_fail = False):
     syslog.syslog(syslog.LOG_DEBUG, "execute command {} for table {}.".format(command, table))
-    if not command.startswith('vtysh '):
+    if not (len(command) > 0 and command[0] == 'vtysh'):
         use_bgpd_client = False
     if use_bgpd_client:
         if not bgpd_client.run_vtysh_command(table, command, daemons) and not ignore_fail:
             syslog.syslog(syslog.LOG_ERR, 'command execution failure. Command: "{}"'.format(command))
             return False
     else:
-        p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
+        p = subprocess.Popen(command, shell=False, stdout=subprocess.PIPE)
         stdout = p.communicate()[0]
         p.wait()
         if p.returncode != 0 and not ignore_fail:
@@ -277,11 +277,18 @@ class BgpdClientMgr(threading.Thread):
             resp += reply
         return (ret_val, resp)
     def run_vtysh_command(self, table, command, daemons):
-        if not command.startswith(self.VTYSH_MARK):
+        if len(command) == 0 or command[0] != 'vtysh':
             syslog.syslog(syslog.LOG_ERR, 'command %s is not for vtysh config' % command)
             return False
-        cmd_line = command[len(self.VTYSH_MARK):]
-        cmd_list = re.findall(r"-c\s+'([^']+)'\s*", cmd_line)
+        # Extract values after each -c flag
+        cmd_list = []
+        i = 1
+        while i < len(command):
+            if command[i] == '-c' and i + 1 < len(command):
+                cmd_list.append(command[i + 1])
+                i += 2
+            else:
+                i += 1
         cmd_list.append('end')
         if daemons is None:
             daemons = self.TABLE_DAEMON.get(table, None)
@@ -746,14 +753,14 @@ class BGPKeyMapList(list):
             failed = False
             if len(cmd_list) > 0:
                 run_cmd_cnt += 1
-                cmd_prefix = 'vtysh '
+                cmd_args = ['vtysh']
                 for pfx in prefix_list:
-                    cmd_prefix += "-c '%s' " % pfx
+                    cmd_args += ['-c', pfx]
                 for cmd in cmd_list:
                     ignore_fail = False
                     if type(cmd) is tuple:
                         cmd, ignore_fail = cmd
-                    if not g_run_command(table, cmd_prefix + "-c '%s'" % cmd, True, key_map.daemons, ignore_fail):
+                    if not g_run_command(table, cmd_args + ['-c', cmd], True, key_map.daemons, ignore_fail):
                         syslog.syslog(syslog.LOG_ERR, 'failed running FRR command: %s' % cmd)
                         failed = True
                         break
@@ -2379,28 +2386,28 @@ class BGPConfigDaemon:
             cmd = cmd + ' interface ' + key_params[2]
         if not data:
             #BFD peer is deleted
-            command = "vtysh -c 'configure terminal' -c 'bfd' -c 'no {}'".format(cmd)
+            command = ['vtysh', '-c', 'configure terminal', '-c', 'bfd', '-c', 'no {}'.format(cmd)]
             self.__run_command(table, command)
         else:
             #create/update case
-            command = "vtysh -c 'configure terminal' -c 'bfd' -c '{}'".format(cmd)
+            command = ['vtysh', '-c', 'configure terminal', '-c', 'bfd', '-c', '{}'.format(cmd)]
             for param in data:
                 if param == 'transmit_interval':
-                    command = command + " -c 'transmit-interval {}'".format(data[param])
+                    command += ['-c', 'transmit-interval {}'.format(data[param])]
                 elif param == 'receive_interval':
-                    command = command + " -c 'receive-interval {}'".format(data[param])
+                    command += ['-c', 'receive-interval {}'.format(data[param])]
                 elif param == 'multiplier':
-                    command = command + " -c 'detect-multiplier {}'".format(data[param])
+                    command += ['-c', 'detect-multiplier {}'.format(data[param])]
                 elif param == 'echo_mode' and data[param] == 'true':
-                    command = command + " -c 'echo-mode'"
+                    command += ['-c', 'echo-mode']
                 elif param == 'echo_interval':
-                    command = command + " -c 'echo-interval {}'".format(data[param])
+                    command += ['-c', 'echo-interval {}'.format(data[param])]
                 elif param == 'label':
-                    command = command + " -c 'label {}'".format(data[param])
+                    command += ['-c', 'label {}'.format(data[param])]
                 elif param == 'admin_status' and data[param] == 'up':
-                    command = command + " -c 'no shutdown'"
+                    command += ['-c', 'no shutdown']
                 elif param == 'admin_status' and data[param] == 'down':
-                    command = command + " -c 'shutdown'"
+                    command += ['-c', 'shutdown']
             self.__run_command(table, command)
 
     def vrf_handler(self, table, key, data):
@@ -2410,23 +2417,23 @@ class BGPConfigDaemon:
         cmd = 'vrf {}'.format(key_params[0])
         if not data:
             #VRF is deleted
-            command = "vtysh -c 'configure terminal' -c '{}'".format(cmd)
+            command = ['vtysh', '-c', 'configure terminal', '-c', '{}'.format(cmd)]
             if key_params[0] in self.vrf_vni_map:
-                command = command + " -c 'no vni {}'".format(self.vrf_vni_map[key_params[0]])
+                command += ['-c', 'no vni {}'.format(self.vrf_vni_map[key_params[0]])]
                 del self.vrf_vni_map[key_params[0]]
                 self.__run_command(table, command)
         else:
             #create/update case
-            command = "vtysh -c 'configure terminal' -c '{}'".format(cmd)
+            command = ['vtysh', '-c', 'configure terminal', '-c', '{}'.format(cmd)]
             positive_execute = False
             for param in data:
                 if param == 'vni':
                     if data[param] != '0':
-                        command = command + " -c 'vni {}'".format(data[param])
+                        command += ['-c', 'vni {}'.format(data[param])]
                         self.vrf_vni_map[key_params[0]] = data[param]
                         positive_execute = True
                     elif key_params[0] in self.vrf_vni_map:
-                        command = command + " -c 'no vni {}'".format(self.vrf_vni_map[key_params[0]])
+                        command += ['-c', 'no vni {}'.format(self.vrf_vni_map[key_params[0]])]
                         del self.vrf_vni_map[key_params[0]]
                         positive_execute = True
             if positive_execute == True:
@@ -2447,11 +2454,10 @@ class BGPConfigDaemon:
         if local_asn is None:
             syslog.syslog(syslog.LOG_ERR, 'failed to get local ASN of VRF {} for delete'.format(vrf))
             return False
-        command = "vtysh -c 'configure terminal' -c 'no router bgp {}".format(local_asn)
         if vrf != self.DEFAULT_VRF:
-            command += " vrf {}'".format(vrf)
+            command = ['vtysh', '-c', 'configure terminal', '-c', 'no router bgp {} vrf {}'.format(local_asn, vrf)]
         else:
-            command += "'"
+            command = ['vtysh', '-c', 'configure terminal', '-c', 'no router bgp {}'.format(local_asn)]
         if not self.__run_command(table, command):
             syslog.syslog(syslog.LOG_ERR, 'failed to delete local_asn for VRF %s' % vrf)
             return False
@@ -2691,7 +2697,7 @@ class BGPConfigDaemon:
                         if dval.op == CachedDataWithOp.OP_NONE:
                             prog_asn = False
                         if prog_asn:
-                            command = "vtysh -c 'configure terminal' -c 'router bgp {} vrf {}' -c 'no bgp default ipv4-unicast'".format(dval.data, vrf)
+                            command = ['vtysh', '-c', 'configure terminal', '-c', 'router bgp {} vrf {}'.format(dval.data, vrf), '-c', 'no bgp default ipv4-unicast']
                             if self.__run_command(table, command):
                                 syslog.syslog(syslog.LOG_DEBUG, 'set local_asn %s to VRF %s, re-apply all VRF related tables' % (dval.data, vrf))
                                 self.bgp_asn[vrf] = dval.data
@@ -2709,10 +2715,10 @@ class BGPConfigDaemon:
                         continue
                     cmd_prefix = ['configure terminal', 'router bgp {} vrf {}'.format(local_asn, vrf)]
                     if 'srv6_locator' in data:
-                        cmd =  "vtysh -c 'configure terminal' "
-                        cmd += " -c 'router bgp {} vrf {}' ".format(local_asn, vrf)
-                        cmd += " -c 'segment-routing srv6' "
-                        cmd += " -c 'locator {}' ".format(data['srv6_locator'].data)
+                        cmd = ['vtysh', '-c', 'configure terminal',
+                               '-c', 'router bgp {} vrf {}'.format(local_asn, vrf),
+                               '-c', 'segment-routing srv6',
+                               '-c', 'locator {}'.format(data['srv6_locator'].data)]
                         if not self.__run_command(table, cmd):
                             syslog.syslog(syslog.LOG_ERR, 'failed running SRV6 POLICY config command')
                             continue
@@ -2727,16 +2733,18 @@ class BGPConfigDaemon:
                 if not del_table:
                     locator_name = prefix
                     prefix = data['prefix']
-                    cmd = "vtysh -c 'configure terminal' -c 'segment-routing' -c 'srv6' -c 'locators' "
-                    cmd += " -c 'locator {}' ".format(locator_name)
-                    cmd += " -c 'prefix {} block-len {} node-len {} func-bits {}' ".format(prefix.data, data['block_len'].data, data['node_len'].data, data['func_len'].data)
+                    cmd = ['vtysh', '-c', 'configure terminal',
+                           '-c', 'segment-routing', '-c', 'srv6', '-c', 'locators',
+                           '-c', 'locator {}'.format(locator_name),
+                           '-c', 'prefix {} block-len {} node-len {} func-bits {}'.format(prefix.data, data['block_len'].data, data['node_len'].data, data['func_len'].data)]
                     if not self.__run_command(table, cmd):
                         syslog.syslog(syslog.LOG_ERR, 'failed running SRV6 LOCATORS config command')
                         continue
             elif table == 'SRV6_MY_SOURCE':
                 source = data['source-address']
-                cmd =  "vtysh -c 'configure terminal' -c 'segment-routing' -c 'srv6' -c 'encapsulation' "
-                cmd += " -c 'source-address {}' ".format(source.data)
+                cmd = ['vtysh', '-c', 'configure terminal',
+                       '-c', 'segment-routing', '-c', 'srv6', '-c', 'encapsulation',
+                       '-c', 'source-address {}'.format(source.data)]
                 if not self.__run_command(table, cmd):
                     syslog.syslog(syslog.LOG_ERR, 'failed running SRV6 encap config command {}'.format(cmd))
                     continue
@@ -2745,13 +2753,14 @@ class BGPConfigDaemon:
                     syslog.syslog(syslog.LOG_ERR, 'invalid key for SRV6_MY_SIDS table')
                     continue
                 if not del_table:
-                    cmd = "vtysh -c 'configure terminal' -c 'segment-routing' -c 'srv6' "
-                    cmd +="-c 'static-sids' "
+                    cmd = ['vtysh', '-c', 'configure terminal',
+                           '-c', 'segment-routing', '-c', 'srv6',
+                           '-c', 'static-sids']
                     uDTAction = ["uDT46", "uDT4", "uDT6"]
                     if data['action'].data in uDTAction:
-                        cmd +="-c 'sid {} locator {} behavior {} vrf {}' ".format(key, prefix, data['action'].data, data['decap_vrf'].data)
+                        cmd += ['-c', 'sid {} locator {} behavior {} vrf {}'.format(key, prefix, data['action'].data, data['decap_vrf'].data)]
                     elif data['action'].data == 'uN':
-                        cmd +="-c 'sid {} locator {} behavior {} ' ".format(key, prefix, data['action'].data)
+                        cmd += ['-c', 'sid {} locator {} behavior {} '.format(key, prefix, data['action'].data)]
                     else:
                         syslog.syslog(syslog.LOG_ERR, 'failed running SRV6 POLICY config command, not support action %s'.format(data['action'].data))
                         continue
@@ -2784,16 +2793,18 @@ class BGPConfigDaemon:
                     if is_peer_group:
                         # if peer group is not created, create it before setting other attributes
                         if key not in self.bgp_peer_group.setdefault(vrf, {}):
-                            command = "vtysh -c 'configure terminal' -c 'router bgp {} vrf {}' ".format(local_asn, vrf)
-                            command += "-c 'neighbor {} peer-group'".format(key)
+                            command = ['vtysh', '-c', 'configure terminal',
+                                       '-c', 'router bgp {} vrf {}'.format(local_asn, vrf),
+                                       '-c', 'neighbor {} peer-group'.format(key)]
                             if not self.__run_command(table, command):
                                 syslog.syslog(syslog.LOG_ERR, 'failed to create peer-group %s for VRF %s' % (key, vrf))
                                 continue
                             self.bgp_peer_group[vrf][key] = BGPPeerGroup(vrf)
                     elif not self.__peer_is_ip(key):
                         if key not in self.bgp_intf_nbr.setdefault(vrf, set()):
-                            command = "vtysh -c 'configure terminal' -c 'router bgp {} vrf {}' ".format(local_asn, vrf)
-                            command += "-c 'neighbor {} interface'".format(key)
+                            command = ['vtysh', '-c', 'configure terminal',
+                                       '-c', 'router bgp {} vrf {}'.format(local_asn, vrf),
+                                       '-c', 'neighbor {} interface'.format(key)]
                             if not self.__run_command(table, command):
                                 syslog.syslog(syslog.LOG_ERR, 'failed to create neighbor of interface %s for VRF %s' % (key, vrf))
                                 continue
@@ -2845,8 +2856,9 @@ class BGPConfigDaemon:
                     if is_peer_group:
                         # clear associated neighbor list in cache
                         self.__delete_pg_neighbors(vrf, key)
-                    command = "vtysh -c 'configure terminal' -c 'router bgp {} vrf {}' -c 'no neighbor {}'".\
-                        format(local_asn, vrf, key)
+                    command = ['vtysh', '-c', 'configure terminal',
+                               '-c', 'router bgp {} vrf {}'.format(local_asn, vrf),
+                               '-c', 'no neighbor {}'.format(key)]
                     if not self.__run_command(table, command):
                         syslog.syslog(syslog.LOG_ERR, 'failed to delete VRF %s bgp neigbor %s' % (vrf, key))
                     self.__delete_vrf_neighbor(vrf, key, data, is_peer_group)
@@ -2929,8 +2941,8 @@ class BGPConfigDaemon:
                             syslog.syslog(syslog.LOG_ERR, 'prefix of {} with range {} not found from prefix-set {}'.\
                                             format(ip_pfx, len_range, pfx_set_name))
                             continue
-                        command = "vtysh -c 'configure terminal' -c 'no {} prefix-list {} {}'".\
-                                    format(('ip' if af == socket.AF_INET else 'ipv6'), pfx_set_name, str(del_pfx))
+                        command = ['vtysh', '-c', 'configure terminal',
+                                   '-c', 'no {} prefix-list {} {}'.format(('ip' if af == socket.AF_INET else 'ipv6'), pfx_set_name, str(del_pfx))]
                         if not self.__run_command(table, command, daemons):
                             syslog.syslog(syslog.LOG_ERR, 'failed to delete prefix %s with range %s from set %s' %
                                           (ip_pfx, len_range, pfx_set_name))
@@ -2944,8 +2956,8 @@ class BGPConfigDaemon:
                             syslog.syslog(syslog.LOG_ERR, 'failed to update prefix-set %s in cache with prefix %s range %s' %
                                     (pfx_set_name, ip_pfx, len_range))
                             continue
-                        command = "vtysh -c 'configure terminal' -c '{} prefix-list {} {}'".\
-                                    format(('ip' if af == socket.AF_INET else 'ipv6'), pfx_set_name, str(add_pfx))
+                        command = ['vtysh', '-c', 'configure terminal',
+                                   '-c', '{} prefix-list {} {}'.format(('ip' if af == socket.AF_INET else 'ipv6'), pfx_set_name, str(add_pfx))]
                         if not self.__run_command(table, command, daemons):
                             syslog.syslog(syslog.LOG_ERR, 'failed to add prefix %s with range %s to set %s' %
                                           (ip_pfx, len_range, pfx_set_name))
@@ -2961,8 +2973,8 @@ class BGPConfigDaemon:
                     ip_addr_list = data['address'].data
                     if pfx_set_name in self.prefix_set_list:
                         af = self.prefix_set_list[pfx_set_name].af
-                        command = "vtysh -c 'configure terminal' -c 'no {} prefix-list {}'".\
-                                   format(('ip' if af == socket.AF_INET else 'ipv6'), pfx_set_name)
+                        command = ['vtysh', '-c', 'configure terminal',
+                                   '-c', 'no {} prefix-list {}'.format(('ip' if af == socket.AF_INET else 'ipv6'), pfx_set_name)]
                         if not self.__run_command(table, command):
                             syslog.syslog(syslog.LOG_ERR, 'failed to delete existing prefix-set {}'.format(pfx_set_name))
                             continue
@@ -2975,8 +2987,8 @@ class BGPConfigDaemon:
                             except ValueError:
                                 continue
                         for prefix in prefix_set:
-                            command = "vtysh -c 'configure terminal' -c '{} prefix-list {} {}'".\
-                                       format(('ip' if prefix_set.af == socket.AF_INET else 'ipv6'), pfx_set_name, str(prefix))
+                            command = ['vtysh', '-c', 'configure terminal',
+                                       '-c', '{} prefix-list {} {}'.format(('ip' if prefix_set.af == socket.AF_INET else 'ipv6'), pfx_set_name, str(prefix))]
                             if not self.__run_command(table, command):
                                 syslog.syslog(syslog.LOG_ERR, 'failed to delete existing prefix-set {}'.format(pfx_set_name))
                                 continue
@@ -3025,19 +3037,19 @@ class BGPConfigDaemon:
                     continue
                 self.tmp_cache_key = ''
                 if del_table:
-                    cmd = "vtysh -c 'configure terminal'"
-                    cmd += " -c 'router bgp {} vrf {}'".format(local_asn, vrf)
-                    cmd += " -c 'address-family {} {}'".format(af, ip_type)
-                    cmd += " -c 'no vni {}'".format(vni)
+                    cmd = ['vtysh', '-c', 'configure terminal',
+                           '-c', 'router bgp {} vrf {}'.format(local_asn, vrf),
+                           '-c', 'address-family {} {}'.format(af, ip_type),
+                           '-c', 'no vni {}'.format(vni)]
                     if not self.__run_command(table, cmd):
                         syslog.syslog(syslog.LOG_ERR, 'failed running BGP L2VPN_EVPN VNI unconfig command')
                         continue
                 else:
                     if not data:
-                        cmd = "vtysh -c 'configure terminal'"
-                        cmd += " -c 'router bgp {} vrf {}'".format(local_asn, vrf)
-                        cmd += " -c 'address-family {} {}'".format(af, ip_type)
-                        cmd += " -c 'vni {}'".format(vni)
+                        cmd = ['vtysh', '-c', 'configure terminal',
+                               '-c', 'router bgp {} vrf {}'.format(local_asn, vrf),
+                               '-c', 'address-family {} {}'.format(af, ip_type),
+                               '-c', 'vni {}'.format(vni)]
                         if not self.__run_command(table, cmd):
                             syslog.syslog(syslog.LOG_ERR, 'failed running BGP L2VPN_EVPN VNI config command')
                             continue
@@ -3046,10 +3058,10 @@ class BGPConfigDaemon:
                 af, ip_type = af_type.lower().split('_')
                 nostr = "no " if del_table else ""
                 syslog.syslog(syslog.LOG_INFO, 'Set address family for RT {} to {} {}'.format(rt, af, ip_type))
-                cmd = "vtysh -c 'configure terminal'"
-                cmd += " -c 'router bgp {} vrf {}'".format(local_asn, vrf)
-                cmd += " -c 'address-family {} {}'".format(af, ip_type)
-                cmd += " -c '{}route-target {} {}'".format(nostr,data['route-target-type'].data, rt)
+                cmd = ['vtysh', '-c', 'configure terminal',
+                       '-c', 'router bgp {} vrf {}'.format(local_asn, vrf),
+                       '-c', 'address-family {} {}'.format(af, ip_type),
+                       '-c', '{}route-target {} {}'.format(nostr, data['route-target-type'].data, rt)]
                 cache_tbl_key = 'BGP_GLOBALS_EVPN_RT&&{}|L2VPN_EVPN|{}'.format(vrf, rt)
                 if not del_table and cache_tbl_key in self.table_data_cache.keys():
                     new_rttype = data['route-target-type'].data
@@ -3058,10 +3070,10 @@ class BGPConfigDaemon:
                         old_rttype = cache_tbl_data['route-target-type']
                         if new_rttype == "export":
                             if old_rttype == "import" or old_rttype == "both":
-                                cmd += " -c 'no route-target import {}'".format(rt)
+                                cmd += ['-c', 'no route-target import {}'.format(rt)]
                         if new_rttype == "import":
                             if old_rttype == "export" or old_rttype == "both":
-                                cmd += " -c 'no route-target export {}'".format(rt)
+                                cmd += ['-c', 'no route-target export {}'.format(rt)]
                 if not self.__run_command(table, cmd):
                     syslog.syslog(syslog.LOG_ERR, 'failed running BGP L2VPN_EVPN RT config command')
                     continue
@@ -3072,11 +3084,11 @@ class BGPConfigDaemon:
                 af, ip_type = af_type.lower().split('_')
                 nostr = "no " if del_table else ""
                 syslog.syslog(syslog.LOG_INFO, 'Set address family for VNI {} RT {} to {} {}'.format(vni, rt, af, ip_type))
-                cmd = "vtysh -c 'configure terminal'"
-                cmd += " -c 'router bgp {} vrf {}'".format(local_asn, vrf)
-                cmd += " -c 'address-family {} {}'".format(af, ip_type)
-                cmd += " -c 'vni {}'".format(vni)
-                cmd += " -c '{}route-target {} {}'".format(nostr,data['route-target-type'].data, rt)
+                cmd = ['vtysh', '-c', 'configure terminal',
+                       '-c', 'router bgp {} vrf {}'.format(local_asn, vrf),
+                       '-c', 'address-family {} {}'.format(af, ip_type),
+                       '-c', 'vni {}'.format(vni),
+                       '-c', '{}route-target {} {}'.format(nostr, data['route-target-type'].data, rt)]
                 cache_tbl_key = 'BGP_GLOBALS_EVPN_VNI_RT&&{}|L2VPN_EVPN|{}|{}'.format(vrf, vni, rt)
                 if not del_table and cache_tbl_key in self.table_data_cache.keys():
                     new_rttype = data['route-target-type'].data
@@ -3085,10 +3097,10 @@ class BGPConfigDaemon:
                         old_rttype = cache_tbl_data['route-target-type']
                         if new_rttype == "export":
                             if old_rttype == "import" or old_rttype == "both":
-                                cmd += " -c 'no route-target import {}'".format(rt)
+                                cmd += ['-c', 'no route-target import {}'.format(rt)]
                         if new_rttype == "import":
                             if old_rttype == "export" or old_rttype == "both":
-                                cmd += " -c 'no route-target export {}'".format(rt)
+                                cmd += ['-c', 'no route-target export {}'.format(rt)]
                 if not self.__run_command(table, cmd):
                     syslog.syslog(syslog.LOG_ERR, 'failed running BGP L2VPN_EVPN VNI RT config command')
                     continue
@@ -3103,8 +3115,8 @@ class BGPConfigDaemon:
                         if dval.op != CachedDataWithOp.OP_NONE:
                             enable = (dval.op != CachedDataWithOp.OP_DELETE)
                             no_arg = CommandArgument(self, enable)
-                            command = "vtysh -c 'configure terminal' -c '{:no-prefix}route-map {} {} {}'".\
-                                       format(no_arg, map_name, dval.data, seq_no)
+                            command = ['vtysh', '-c', 'configure terminal',
+                                       '-c', '{:no-prefix}route-map {} {} {}'.format(no_arg, map_name, dval.data, seq_no)]
                             if not self.__run_command(table, command):
                                 syslog.syslog(syslog.LOG_ERR, 'failed to configure route-map {} seq {}'.format(map_name, seq_no))
                                 continue
@@ -3128,8 +3140,8 @@ class BGPConfigDaemon:
                     if map_name not in self.route_map or seq_no not in self.route_map[map_name]:
                         syslog.syslog(syslog.LOG_ERR, 'route-map {} seq {} not found for delete'.format(map_name, seq_no))
                         continue
-                    command = "vtysh -c 'configure terminal' -c 'no route-map {} {} {}'".\
-                               format(map_name, self.route_map[map_name][seq_no], seq_no)
+                    command = ['vtysh', '-c', 'configure terminal',
+                               '-c', 'no route-map {} {} {}'.format(map_name, self.route_map[map_name][seq_no], seq_no)]
                     if not self.__run_command(table, command):
                         syslog.syslog(syslog.LOG_ERR, 'failed running route-map delete command')
                         continue
@@ -3192,8 +3204,9 @@ class BGPConfigDaemon:
 
                         suffix_cmd, oper = self.__bfd_handle_delete (data)
                         if suffix_cmd and oper == CachedDataWithOp.OP_DELETE:
-                            command = "vtysh -c 'configure terminal' -c 'bfd' -c 'peer {} local-address {} vrf {} interface {}' -c '{}'".\
-                            format(remoteaddr, localaddr, vrf, interface, suffix_cmd)
+                            command = ['vtysh', '-c', 'configure terminal', '-c', 'bfd',
+                                       '-c', 'peer {} local-address {} vrf {} interface {}'.format(remoteaddr, localaddr, vrf, interface),
+                                       '-c', suffix_cmd]
 
                             if not self.__run_command(table, command):
                                 syslog.syslog(syslog.LOG_ERR, 'failed to delete single-hop peer {}'.format(key))
@@ -3212,8 +3225,9 @@ class BGPConfigDaemon:
                         suffix_cmd, oper = self.__bfd_handle_delete (data)
 
                         if suffix_cmd and oper == CachedDataWithOp.OP_DELETE:
-                            command = "vtysh -c 'configure terminal' -c 'bfd' -c 'peer {} vrf {} interface {}' -c '{}'".\
-                            format(remoteaddr, vrf, interface, suffix_cmd)
+                            command = ['vtysh', '-c', 'configure terminal', '-c', 'bfd',
+                                       '-c', 'peer {} vrf {} interface {}'.format(remoteaddr, vrf, interface),
+                                       '-c', suffix_cmd]
 
                             if not self.__run_command(table, command):
                                 syslog.syslog(syslog.LOG_ERR, 'failed to delete single-hop peer {}'.format(key))
@@ -3231,12 +3245,12 @@ class BGPConfigDaemon:
                         dval = data['local-address']
                         localaddr = dval.data
                         syslog.syslog(syslog.LOG_INFO, 'Delete BFD single hop to {} {} {}'.format(remoteaddr, vrf, interface, localaddr))
-                        command = "vtysh -c 'configure terminal' -c 'bfd' -c 'no peer {} local-address {} vrf {} interface {}'".\
-                            format(remoteaddr, localaddr, vrf, interface)
+                        command = ['vtysh', '-c', 'configure terminal', '-c', 'bfd',
+                                   '-c', 'no peer {} local-address {} vrf {} interface {}'.format(remoteaddr, localaddr, vrf, interface)]
                     else:
                         syslog.syslog(syslog.LOG_INFO, 'Delete BFD single hop to {} {} {}'.format(remoteaddr, vrf, interface))
-                        command = "vtysh -c 'configure terminal' -c 'bfd' -c 'no peer {} vrf {} interface {}'".\
-                            format(remoteaddr, vrf, interface)
+                        command = ['vtysh', '-c', 'configure terminal', '-c', 'bfd',
+                                   '-c', 'no peer {} vrf {} interface {}'.format(remoteaddr, vrf, interface)]
                     if not self.__run_command(table, command):
                         syslog.syslog(syslog.LOG_ERR, 'failed to delete single-hop peer {}'.format(key))
                         continue
@@ -3249,11 +3263,13 @@ class BGPConfigDaemon:
                     suffix_cmd, oper = self.__bfd_handle_delete (data)
                     if suffix_cmd and oper == CachedDataWithOp.OP_DELETE:
                         if not 'null' in interface:
-                            command = "vtysh -c 'configure terminal' -c 'bfd' -c 'peer {} local-address {} vrf {} interface {}' -c '{}'".\
-                            format(remoteaddr, localaddr, vrf, interface, suffix_cmd)
+                            command = ['vtysh', '-c', 'configure terminal', '-c', 'bfd',
+                                       '-c', 'peer {} local-address {} vrf {} interface {}'.format(remoteaddr, localaddr, vrf, interface),
+                                       '-c', suffix_cmd]
                         else:
-                            command = "vtysh -c 'configure terminal' -c 'bfd' -c 'peer {} local-address {} vrf {}' -c '{}'".\
-                            format(remoteaddr, localaddr, vrf, suffix_cmd)
+                            command = ['vtysh', '-c', 'configure terminal', '-c', 'bfd',
+                                       '-c', 'peer {} local-address {} vrf {}'.format(remoteaddr, localaddr, vrf),
+                                       '-c', suffix_cmd]
 
                         if not self.__run_command(table, command):
                             syslog.syslog(syslog.LOG_ERR, 'failed to delete single-hop peer {}'.format(key))
@@ -3274,11 +3290,11 @@ class BGPConfigDaemon:
                 else:
                     syslog.syslog(syslog.LOG_INFO, 'Delete BFD multi hop to {} {} {} {}'.format(remoteaddr, vrf, localaddr, interface))
                     if not 'null' in interface:
-                        command = "vtysh -c 'configure terminal' -c 'bfd' -c 'no peer {} vrf {} multihop local-address {} interface {}'".\
-                        format(remoteaddr, vrf, localaddr, interface)
+                        command = ['vtysh', '-c', 'configure terminal', '-c', 'bfd',
+                                   '-c', 'no peer {} vrf {} multihop local-address {} interface {}'.format(remoteaddr, vrf, localaddr, interface)]
                     else:
-                        command = "vtysh -c 'configure terminal' -c 'bfd' -c 'no peer {} vrf {} multihop local-address {}'".\
-                        format(remoteaddr, vrf, localaddr)
+                        command = ['vtysh', '-c', 'configure terminal', '-c', 'bfd',
+                                   '-c', 'no peer {} vrf {} multihop local-address {}'.format(remoteaddr, vrf, localaddr)]
 
                     if not self.__run_command(table, command):
                         syslog.syslog(syslog.LOG_ERR, 'failed to delete multihop peer {}'.format(key))
@@ -3315,8 +3331,10 @@ class BGPConfigDaemon:
                                 chk_icmp_attrs_dict = {'icmp_source_interface':'source-interface ', 'icmp_source_ip':'source-address ', 'icmp_size':'request-data-size ', 'icmp_vrf':'source-vrf ', 'icmp_tos':'tos ', 'icmp_ttl':'ttl '}
                                 for attr in chk_icmp_attrs:
                                     if attr in data and data[attr].op != CachedDataWithOp.OP_DELETE:
-                                        command = "vtysh -c 'configure terminal' -c 'ip sla {}' -c '{}' -c '{} {}'".\
-                                        format(sla_id, icmp_cmd_mode, chk_icmp_attrs_dict[attr], data[attr].data)
+                                        command = ['vtysh', '-c', 'configure terminal',
+                                               '-c', 'ip sla {}'.format(sla_id),
+                                               '-c', icmp_cmd_mode,
+                                               '-c', '{} {}'.format(chk_icmp_attrs_dict[attr], data[attr].data)]
                                         syslog.syslog(syslog.LOG_INFO, 'Execute Icmp Cmd {}'.format(command))
                                         if not self.__run_command(table, command):
                                             syslog.syslog(syslog.LOG_ERR, 'failed to add icmp config for  ip sla {}'.format(sla_id))
@@ -3342,8 +3360,10 @@ class BGPConfigDaemon:
                                 chk_tcp_attrs_dict = {'tcp_source_interface':'source-interface ', 'tcp_source_ip':'source-address ', 'tcp_source_port':'source-port ', 'tcp_vrf':'source-vrf ', 'tcp_tos':'tos ', 'tcp_ttl':'ttl '}
                                 for attr in chk_tcp_attrs:
                                     if attr in data and data[attr].op != CachedDataWithOp.OP_DELETE:
-                                        command = "vtysh -c 'configure terminal' -c 'ip sla {}' -c '{}' -c '{} {}'".\
-                                        format(sla_id, tcp_cmd_mode, chk_tcp_attrs_dict[attr], data[attr].data)
+                                        command = ['vtysh', '-c', 'configure terminal',
+                                               '-c', 'ip sla {}'.format(sla_id),
+                                               '-c', tcp_cmd_mode,
+                                               '-c', '{} {}'.format(chk_tcp_attrs_dict[attr], data[attr].data)]
                                         syslog.syslog(syslog.LOG_INFO, 'Execute Tcp Cmd {}'.format(command))
                                         if not self.__run_command(table, command):
                                             syslog.syslog(syslog.LOG_ERR, 'failed to add Tcp config for  ip sla {}'.format(sla_id))
@@ -3366,7 +3386,7 @@ class BGPConfigDaemon:
 
                 # Always delete ip sla if it is not found in configdb
                 if not found_in_configdb:
-                    command = "vtysh -c 'configure terminal' -c 'no ip sla {}'".format(sla_id)
+                    command = ['vtysh', '-c', 'configure terminal', '-c', 'no ip sla {}'.format(sla_id)]
                     syslog.syslog(syslog.LOG_ERR, 'Entry deleted in ip sla config db')
                     if not self.__run_command(table, command):
                         syslog.syslog(syslog.LOG_ERR, 'failed to delete router ip sla {}'.format(sla_id))
@@ -3387,7 +3407,7 @@ class BGPConfigDaemon:
                         syslog.syslog(syslog.LOG_ERR, 'failed running ospf config command')
                         continue
                 else:
-                    command = "vtysh -c 'configure terminal' -c 'no router ospf vrf {}'".format(vrf)
+                    command = ['vtysh', '-c', 'configure terminal', '-c', 'no router ospf vrf {}'.format(vrf)]
 
                     if not self.__run_command(table, command):
                         syslog.syslog(syslog.LOG_ERR, 'failed to delete router ospf vrf {}'.format(vrf))
@@ -3415,8 +3435,9 @@ class BGPConfigDaemon:
                 syslog.syslog(syslog.LOG_INFO, 'Create router ospf vrf {}, Vlink: {}, tableop {}'.format(vrf, data, del_table))
 
                 if data == {}:
-                    command = "vtysh -c 'configure terminal' -c 'router ospf vrf {}' -c 'no area {} virtual-link {}'".\
-                    format(vrf, area, vlinkid)
+                    command = ['vtysh', '-c', 'configure terminal',
+                               '-c', 'router ospf vrf {}'.format(vrf),
+                               '-c', 'no area {} virtual-link {}'.format(area, vlinkid)]
 
                     if not self.__run_command(table, command):
                         syslog.syslog(syslog.LOG_ERR, 'failed to delete vlink {} {}'.format(area, vlinkid))
@@ -3432,8 +3453,9 @@ class BGPConfigDaemon:
                         continue
 
                     if del_table:
-                        command = "vtysh -c 'configure terminal' -c 'router ospf vrf {}' -c 'no area {} virtual-link {}'".\
-                        format(vrf, area, vlinkid)
+                        command = ['vtysh', '-c', 'configure terminal',
+                                   '-c', 'router ospf vrf {}'.format(vrf),
+                                   '-c', 'no area {} virtual-link {}'.format(area, vlinkid)]
 
                         if not self.__run_command(table, command):
                             syslog.syslog(syslog.LOG_ERR, 'failed to delete vlink {} {}'.format(area, vlinkid))
@@ -3450,15 +3472,17 @@ class BGPConfigDaemon:
                 network = keyvals[1]
 
                 if not del_table:
-                    command = "vtysh -c 'configure terminal' -c 'router ospf vrf {}' -c 'network {} area {}'".\
-                    format(vrf, network, area)
+                    command = ['vtysh', '-c', 'configure terminal',
+                               '-c', 'router ospf vrf {}'.format(vrf),
+                               '-c', 'network {} area {}'.format(network, area)]
 
                     if not self.__run_command(table, command):
                         syslog.syslog(syslog.LOG_ERR, 'failed to create network {} {}'.format(area, network))
                         continue
                 else:
-                    command = "vtysh -c 'configure terminal' -c 'router ospf vrf {}' -c 'no network {} area {}'".\
-                    format(vrf, network, area)
+                    command = ['vtysh', '-c', 'configure terminal',
+                               '-c', 'router ospf vrf {}'.format(vrf),
+                               '-c', 'no network {} area {}'.format(network, area)]
 
                     if not self.__run_command(table, command):
                         syslog.syslog(syslog.LOG_ERR, 'failed to delete network {} {}'.format(area, network))
@@ -3477,15 +3501,17 @@ class BGPConfigDaemon:
 
                 if data == {}:
                    if not del_table:
-                        command = "vtysh -c 'configure terminal' -c 'router ospf vrf {}' -c 'area {} range {}'".\
-                        format(vrf, area, range)
+                        command = ['vtysh', '-c', 'configure terminal',
+                                   '-c', 'router ospf vrf {}'.format(vrf),
+                                   '-c', 'area {} range {}'.format(area, range)]
 
                         if not self.__run_command(table, command):
                             syslog.syslog(syslog.LOG_ERR, 'failed to create range {} {}'.format(area, range))
                             continue
                    else:
-                        command = "vtysh -c 'configure terminal' -c 'router ospf vrf {}' -c 'no area {} range {}'".\
-                        format(vrf, area, range)
+                        command = ['vtysh', '-c', 'configure terminal',
+                                   '-c', 'router ospf vrf {}'.format(vrf),
+                                   '-c', 'no area {} range {}'.format(area, range)]
 
                         if not self.__run_command(table, command):
                             syslog.syslog(syslog.LOG_ERR, 'failed to delete range {} {}'.format(area, range))
@@ -3580,8 +3606,9 @@ class BGPConfigDaemon:
                         else:
                             cmd_suffix = "no distribute-list {} out {}".format(acclistname, protocol.lower())
 
-                        command = "vtysh -c 'configure terminal' -c 'router ospf vrf {}' -c '{}'".\
-                            format(vrf, cmd_suffix)
+                        command = ['vtysh', '-c', 'configure terminal',
+                                   '-c', 'router ospf vrf {}'.format(vrf),
+                                   '-c', cmd_suffix]
 
                         if not self.__run_command(table, command):
                             syslog.syslog(syslog.LOG_ERR, 'failed to create distribute-list {} {}'.format(protocol, direction))
@@ -3600,8 +3627,9 @@ class BGPConfigDaemon:
                             else:
                                 cmd_suffix = "no redistribute {}".format(protocol.lower()) + del_cmd_suffix
 
-                        command = "vtysh -c 'configure terminal' -c 'router ospf vrf {}' -c '{}'".\
-                            format(vrf, cmd_suffix)
+                        command = ['vtysh', '-c', 'configure terminal',
+                                   '-c', 'router ospf vrf {}'.format(vrf),
+                                   '-c', cmd_suffix]
 
                         if not self.__run_command(table, command):
                             syslog.syslog(syslog.LOG_ERR, 'failed to create default-info/redistribute {} {}'.format(protocol, direction))
@@ -3612,11 +3640,13 @@ class BGPConfigDaemon:
                     if (direction == "IMPORT"):
                         command = ""
                         if (protocol == "DEFAULT_ROUTE"):
-                            command = "vtysh -c 'configure terminal' -c 'router ospf vrf {}' -c 'no default-information originate'".\
-                            format(vrf)
+                            command = ['vtysh', '-c', 'configure terminal',
+                                       '-c', 'router ospf vrf {}'.format(vrf),
+                                       '-c', 'no default-information originate']
                         else:
-                            command = "vtysh -c 'configure terminal' -c 'router ospf vrf {}' -c 'no redistribute {}'".\
-                            format(vrf, protocol.lower())
+                            command = ['vtysh', '-c', 'configure terminal',
+                                       '-c', 'router ospf vrf {}'.format(vrf),
+                                       '-c', 'no redistribute {}'.format(protocol.lower())]
 
                         if (command != ""):
                             if not self.__run_command(table, command):
@@ -3626,8 +3656,9 @@ class BGPConfigDaemon:
                                 self.__ospf_delete(data)
                     else:
                         if (acclistname != ""):
-                            command = "vtysh -c 'configure terminal' -c 'router ospf vrf {}' -c 'no distribute-list {} out {}'".\
-                            format(vrf, acclistname, protocol.lower())
+                            command = ['vtysh', '-c', 'configure terminal',
+                                       '-c', 'router ospf vrf {}'.format(vrf),
+                                       '-c', 'no distribute-list {} out {}'.format(acclistname, protocol.lower())]
 
                             if not self.__run_command(table, command):
                                 syslog.syslog(syslog.LOG_ERR, 'failed to delete distribute-list {} {}'.format(protocol, direction))
@@ -3710,15 +3741,17 @@ class BGPConfigDaemon:
                 if data == {}:
                    if not del_table:
 
-                        command = "vtysh -c 'configure terminal' -c 'router ospf vrf {}' -c 'passive-interface {} {}'".\
-                        format(vrf, if_name, if_addr)
+                        command = ['vtysh', '-c', 'configure terminal',
+                                   '-c', 'router ospf vrf {}'.format(vrf),
+                                   '-c', 'passive-interface {} {}'.format(if_name, if_addr)]
 
                         if not self.__run_command(table, command):
                             syslog.syslog(syslog.LOG_ERR, 'failed to create passive interface {} {}'.format(if_name, if_addr))
                             continue
                    else:
-                        command = "vtysh -c 'configure terminal' -c 'router ospf vrf {}' -c 'no passive-interface {} {}'".\
-                        format(vrf, if_name, if_addr)
+                        command = ['vtysh', '-c', 'configure terminal',
+                                   '-c', 'router ospf vrf {}'.format(vrf),
+                                   '-c', 'no passive-interface {} {}'.format(if_name, if_addr)]
 
                         if not self.__run_command(table, command):
                             syslog.syslog(syslog.LOG_ERR, 'failed to delete passive interface {} {}'.format(if_name, if_addr))

--- a/src/sonic-frr-mgmt-framework/tests/test_config.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_config.py
@@ -53,11 +53,11 @@ class CmdMapTestInfo:
         return copy.deepcopy(cls.data_buf[test.table_name][test.key])
     @staticmethod
     def compose_vtysh_cmd(cmd_list, negtive = False):
-        cmdline = 'vtysh'
+        result = ['vtysh']
         for cmd in cmd_list:
             cmd = cmd.format('no ' if negtive else '')
-            cmdline += " -c '%s'" % cmd
-        return cmdline
+            result += ['-c', cmd]
+        return result
     def check_running_cmd(self, mock, is_del):
         if is_del:
             vtysh_cmd = self.vtysh_cmd if self.vtysh_neg_cmd is None else self.vtysh_neg_cmd
@@ -82,7 +82,9 @@ def hdl_confed_peers_cmd(is_del, cmd_list, chk_data):
     if is_del:
         chk_data = list(reversed(chk_data))
     for idx, cmd in enumerate(cmd_list):
-        last_cmd = re.findall(r"-c\s+'([^']+)'\s*", cmd)[-1]
+        # cmd is now a list: ['vtysh', '-c', ..., '-c', last_cmd]
+        # Extract last -c value
+        last_cmd = cmd[-1] if isinstance(cmd, list) else re.findall(r"-c\s+'([^']+)'\s*", cmd)[-1]
         neg_cmd = False
         if last_cmd.startswith('no '):
             neg_cmd = True
@@ -266,3 +268,42 @@ def test_bgp_neighbor_shutdown():
     # The neighbor shutdown msg test cases explicitly verify delete behavior, so skip the delete
     # verification data_set_del_test (else it would try the del of 'no ' commands as well and fail)
     data_set_del_test(neighbor_shutdown_data, skip_del=True)
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_bgp_neighbor_description_injection(run_cmd):
+    """Regression test: shell metacharacters in BGP_NEIGHBOR description must be
+    passed as a literal vtysh argument, not interpreted by a shell."""
+    from frrcfgd.frrcfgd import BGPConfigDaemon
+    daemon = BGPConfigDaemon()
+
+    # Seed BGP_GLOBALS to set local ASN (reuse existing test data)
+    globals_seed = bgp_globals_data[0]  # local_asn = 100
+    CmdMapTestInfo.add_test_data(globals_seed)
+    bgp_globals_hdlr = [h for t, h in daemon.table_handler_list if t == 'BGP_GLOBALS'][0]
+    bgp_globals_hdlr('BGP_GLOBALS', globals_seed.key, CmdMapTestInfo.get_test_data(globals_seed))
+
+    # Now test BGP_NEIGHBOR description with injection payload
+    injection_payload = "'; id #"
+    run_cmd.reset_mock()
+    nbr_test = CmdMapTestInfo(
+        'BGP_NEIGHBOR', 'default|10.0.0.1',
+        {'name': injection_payload},
+        conf_bgp_cmd('default', 100) + [
+            'neighbor 10.0.0.1 description {}'.format(injection_payload)
+        ]
+    )
+    CmdMapTestInfo.add_test_data(nbr_test)
+    nbr_hdlr = [h for t, h in daemon.table_handler_list if t == 'BGP_NEIGHBOR'][0]
+    nbr_hdlr('BGP_NEIGHBOR', nbr_test.key, CmdMapTestInfo.get_test_data(nbr_test))
+
+    # Verify g_run_command was called with a list (shell=False path)
+    assert run_cmd.called, "g_run_command was not called for BGP_NEIGHBOR description"
+    for call in run_cmd.call_args_list:
+        cmd = call[0][1]
+        assert isinstance(cmd, list), \
+            "command must be a list (shell=False), got string: {}".format(cmd)
+        if any('description' in arg for arg in cmd):
+            assert any(injection_payload in arg for arg in cmd), \
+                "injection payload not found as literal arg: {}".format(cmd)


### PR DESCRIPTION
#### Why I did it

`g_run_command()` in frrcfgd passed commands to `subprocess.Popen` with `shell=True`, interpolating CONFIG_DB field values (BGP neighbor descriptions, peer-group names, prefix-set values, etc.) directly into shell command strings. Shell metacharacters in any writable CONFIG_DB field could enable command injection.

##### Work item tracking
- Microsoft ADO:

#### How I did it

Replaced `subprocess.Popen(command, shell=True)` with list-based argv and `shell=False` in `g_run_command()`. Converted all vtysh command assembly sites from string interpolation to list construction.

#### How to verify it

Set a BGP neighbor description containing shell metacharacters (e.g. `; id`) in CONFIG_DB. Verify frrcfgd passes it as a literal vtysh argument without shell execution.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] master

#### Description for the changelog

Use list-based subprocess in frrcfgd to prevent shell injection via CONFIG_DB field values.

#### Link to config_db schema for YANG module changes

N/A