### PR TITLE
installer: fix NVMe partition umount and partprobe retry in create_de…

### DIFF
--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -111,6 +111,8 @@ legacy_volume_label="ACS-OS"
 create_demo_gpt_partition()
 {
     blk_dev="$1"
+    blk_suffix=
+    echo $blk_dev | grep -q nvme0 && blk_suffix="p"
 
     # Create a temp fifo and store string in variable
     tmpfifo=$(mktemp -u)
@@ -147,16 +149,18 @@ create_demo_gpt_partition()
             # that event and return EBUSY.  udevadm settle would be ideal but is
             # not available in ONIE, so retry until udev finishes.
             partprobe_ok=0
-            for i in 1 2 3 4 5 6 7 8 9 10; do
-                if partprobe 2>/dev/null; then
+            i=1
+            while [ $i -le 10 ]; do
+                if partprobe_err=$(partprobe 2>&1); then
                     partprobe_ok=1
                     break
                 fi
-                echo "partprobe attempt $i failed, retrying in 1s..."
+                echo "partprobe attempt $i failed: $partprobe_err (retrying in 1s...)"
                 sleep 1
+                i=$((i + 1))
             done
             [ $partprobe_ok -eq 1 ] || {
-                echo "Error: Unable to partprobe"
+                echo "Error: partprobe failed after 10 attempts, last error: $partprobe_err"
                 exit 1
             }
         done < $tmpfifo

--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -125,12 +125,16 @@ create_demo_gpt_partition()
         # Note: You can use any character as a separator for sed, not just '/'
         echo "$demo_part" > $tmpfifo &
         while read -r part_index; do
-            if [ "$blk_dev$part_index" = "$cur_part" ]; then continue; fi
+            if [ "${blk_dev}${blk_suffix}$part_index" = "$cur_part" ]; then continue; fi
             echo "deleting partition $part_index ..."
             # if the partition is already mounted, umount first
-            df $blk_dev$part_index 2>/dev/null && {
-                umount $blk_dev$part_index || {
-                    echo "Error: Unable to umount $blk_dev$part_index"
+            # Note: NVMe partitions require the 'p' suffix (e.g. /dev/nvme0n1p3),
+            # so use ${blk_dev}${blk_suffix}$part_index instead of $blk_dev$part_index.
+            # ONIE does not mount the SONiC partition normally, but if a previous
+            # install was interrupted this ensures umount is not silently skipped.
+            df ${blk_dev}${blk_suffix}$part_index 2>/dev/null && {
+                umount ${blk_dev}${blk_suffix}$part_index || {
+                    echo "Error: Unable to umount ${blk_dev}${blk_suffix}$part_index"
                     exit 1
                 }
             }
@@ -138,7 +142,20 @@ create_demo_gpt_partition()
                 echo "Error: Unable to delete partition $part_index on $blk_dev"
                 exit 1
             }
-            partprobe || {
+            # Retry partprobe for up to 10 seconds.  sgdisk -d triggers a udev
+            # event; on fast NVMe devices partprobe may race with udev processing
+            # that event and return EBUSY.  udevadm settle would be ideal but is
+            # not available in ONIE, so retry until udev finishes.
+            partprobe_ok=0
+            for i in 1 2 3 4 5 6 7 8 9 10; do
+                if partprobe 2>/dev/null; then
+                    partprobe_ok=1
+                    break
+                fi
+                echo "partprobe attempt $i failed, retrying in 1s..."
+                sleep 1
+            done
+            [ $partprobe_ok -eq 1 ] || {
                 echo "Error: Unable to partprobe"
                 exit 1
             }

--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -112,7 +112,7 @@ create_demo_gpt_partition()
 {
     blk_dev="$1"
     blk_suffix=
-    echo $blk_dev | grep -q nvme0 && blk_suffix="p"
+    echo $blk_dev | grep -q '^/dev/nvme' && blk_suffix="p"
 
     # Create a temp fifo and store string in variable
     tmpfifo=$(mktemp -u)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
SONiC installation failed on NVMe devices when reinstalling in the same ONIE session due to two bugs in create_demo_gpt_partition in installer/default_platform.conf:

1. The partition delete loop used $blk_dev$part_index (e.g. /dev/nvme0n13) instead of ${blk_dev}${blk_suffix}$part_index (e.g. /dev/nvme0n1p3). The device /dev/nvme0n13 does not exist, so df exits non-zero, the && never fires, and umount is silently skipped on every NVMe partition - leaving it referenced and causing partprobe to fail.
2. After rebooting from SONiC into ONIE, udev or blkid may transiently hold a SONiC partition open during ONIE boot-time scanning, causing partprobe to fail with EBUSY. The hard exit on failure aborted the install immediately.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Fixed the device path in the partition delete loop and cur_part skip check to use ${blk_dev}${blk_suffix}$part_index, consistent with the rest of the script. blk_suffix is "p" for NVMe and empty for all other block devices, so non-NVMe behavior is unchanged.
- Replaced the single partprobe call with a retry loop (up to 10 attempts, 1-second sleep between retries) so the installer waits for transient partition references to be released before giving up.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

- NVMe: Boot into ONIE on an NVMe-based device, install SONiC, reboot back into ONIE, and reinstall SONiC in the same session. Verify the installation completes successfully without umount or partprobe errors.
- Non-NVMe (SATA/SSD): Perform the same reinstall flow on a non-NVMe device and confirm no regression in partition deletion or partprobe behavior.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

