### PR TITLE
[iccpd]: Add bounds check in mlacp_fsm_update_ndisc/arp_info functions

### DIFF
--- a/src/iccpd/include/system.h
+++ b/src/iccpd/include/system.h
@@ -46,6 +46,7 @@
 #define WARM_REBOOT 1
 
 #define MCLAG_ERROR -1
+#define MCLAG_ERROR_INVALID_TLV -2
 
 struct CSM;
 

--- a/src/iccpd/src/mlacp_sync_update.c
+++ b/src/iccpd/src/mlacp_sync_update.c
@@ -904,18 +904,24 @@ int mlacp_fsm_update_arp_entry(struct CSM* csm, struct ARPMsg *arp_entry)
 
 int mlacp_fsm_update_arp_info(struct CSM* csm, struct mLACPARPInfoTLV* tlv)
 {
-    int count = 0;
+    uint16_t count = 0;
     int i;
 
     if (!csm || !tlv)
         return MCLAG_ERROR;
+
     count = ntohs(tlv->num_of_entry);
+    /* Validate num_of_entry against TLV length to prevent OOB heap read */
+    if (ntohs(tlv->icc_parameter.len) < sizeof(tlv->num_of_entry) + count * sizeof(struct ARPMsg))
+        return MCLAG_ERROR_INVALID_TLV;
     ICCPD_LOG_DEBUG(__FUNCTION__, "Received ARP Info count  %d ", count );
 
     for (i = 0; i < count; i++)
     {
         mlacp_fsm_update_arp_entry(csm, &(tlv->ArpEntry[i]));
     }
+
+    return 0;
 }
 
 /*****************************************
@@ -1226,18 +1232,24 @@ int mlacp_fsm_update_ndisc_entry(struct CSM *csm, struct NDISCMsg *ndisc_entry)
 
 int mlacp_fsm_update_ndisc_info(struct CSM *csm, struct mLACPNDISCInfoTLV *tlv)
 {
-    int count = 0;
+    uint16_t count = 0;
     int i;
 
     if (!csm || !tlv)
         return MCLAG_ERROR;
+
     count = ntohs(tlv->num_of_entry);
+    /* Validate num_of_entry against TLV length to prevent OOB heap read */
+    if (ntohs(tlv->icc_parameter.len) < sizeof(tlv->num_of_entry) + count * sizeof(struct NDISCMsg))
+        return MCLAG_ERROR_INVALID_TLV;
     ICCPD_LOG_INFO(__FUNCTION__, "Received NDISC Info count  %d ", count);
 
     for (i = 0; i < count; i++)
     {
         mlacp_fsm_update_ndisc_entry(csm, &(tlv->NdiscEntry[i]));
     }
+
+    return 0;
 }
 
 /*****************************************


### PR DESCRIPTION
#### Why I did it

The peer-supplied `num_of_entry` field in ICCP mLACP ARP/NDISC TLV handlers was only validated in the outer receive functions. Adding the same check inside `mlacp_fsm_update_arp_info` and `mlacp_fsm_update_ndisc_info` provides defense-in-depth for any future callers that bypass the outer validation.

##### Work item tracking
- Microsoft ADO:

#### How I did it

Added bounds validation for `num_of_entry` against `icc_parameter.len` at the top of both update functions. Returns new error code `MCLAG_ERROR_INVALID_TLV` (added to `system.h`) if the value exceeds what the TLV payload can hold. The outer caller's check fires first in normal flow; the internal check is a safety net.

#### How to verify it

Send a crafted ICCP message with `num_of_entry` exceeding the TLV payload length. Both the outer caller check and the internal function check will reject it before any loop iteration.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] master

#### Description for the changelog

Add bounds check for num_of_entry in mLACP ARP/NDISC TLV update functions.

#### Link to config_db schema for YANG module changes

N/A