### PR TITLE
Fix input validation for syslog filter_regex field

### DIFF
--- a/files/image_config/rsyslog/rsyslog.conf.j2
+++ b/files/image_config/rsyslog/rsyslog.conf.j2
@@ -118,7 +118,7 @@ template(name="WelfRemoteFormat" type="string" string="%TIMESTAMP% id=firewall t
 {% endif -%}
 
 {% if filter %}
-:msg, {{ fmodifier }}ereregex, "{{ regex }}"
+:msg, {{ fmodifier }}ereregex, "{{ regex | replace('\n', '') | replace('\r', '') | replace('"', '\\"') }}"
 {% endif %}
 *.{{ severity }}
 action(type="omfwd" Target="{{ server }}" Port="{{ port }}" Protocol="{{ proto }}" Template="{{ template }}" action.resumeRetryCount="60" queue.type="LinkedList" queue.size="20000"{{ options }})

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/syslog.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/syslog.json
@@ -76,6 +76,10 @@
     "SYSLOG_SERVER_FILTER_REGEX": {
         "desc": "Valid filter regex"
     },
+    "SYSLOG_SERVER_FILTER_REGEX_NEWLINE_NEG_TEST": {
+        "desc": "Filter regex with newline character should be rejected",
+        "eStrKey": "Pattern"
+    },
     "SYSLOG_SERVER_PROTOCOL": {
         "desc": "Valid syslog server protocol"
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/syslog.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/syslog.json
@@ -256,6 +256,18 @@
             }
         }
     },
+    "SYSLOG_SERVER_FILTER_REGEX_NEWLINE_NEG_TEST" : {
+        "sonic-syslog:sonic-syslog": {
+            "sonic-syslog:SYSLOG_SERVER": {
+                "SYSLOG_SERVER_LIST": [
+                    {
+                        "server_address": "1.2.3.4",
+                        "filter_regex": "^expeliarmus.*\nruleset(name=injected)"
+                    }
+                ]
+            }
+        }
+    },
     "SYSLOG_CONFIG_FEATURE_INVALID_SERVICE_NAME": {
         "sonic-syslog:sonic-syslog": {
             "sonic-syslog:SYSLOG_CONFIG_FEATURE": {

--- a/src/sonic-yang-models/yang-models/sonic-syslog.yang
+++ b/src/sonic-yang-models/yang-models/sonic-syslog.yang
@@ -133,7 +133,9 @@ module sonic-syslog {
 
                 leaf filter_regex {
                     description "Filter regex";
-                    type string;
+                    type string {
+                        pattern '[^\n\r]+';
+                    }
                 }
 
                 leaf protocol {


### PR DESCRIPTION
#### Why I did it

The `filter_regex` field in the `SYSLOG_SERVER` CONFIG_DB table had no input validation in the YANG model (`type string` with no pattern constraint). The value is rendered verbatim into rsyslog.conf via Jinja2, allowing values with newline or quote characters to inject additional rsyslog directives.

##### Work item tracking
- Microsoft ADO:

#### How I did it

- `sonic-syslog.yang`: added `pattern '[^\n\r]+'` to the `filter_regex` leaf to reject values containing newline or carriage return characters at the CONFIG_DB write layer
- `rsyslog.conf.j2`: added `replace` filters to strip `\n`/`\r` and escape `"` as `\"` in template output, providing defense-in-depth if the YANG constraint is bypassed via direct redis-cli or gNMI write

#### How to verify it

YANG model unit test added: `SYSLOG_SERVER_FILTER_REGEX_NEWLINE_NEG_TEST` in `tests/yang_model_tests/`. Run with:

```
cd src/sonic-yang-models && python3 -m pytest tests/yang_model_tests/test_yang_model.py -k syslog -v
```

The new test verifies that a `filter_regex` value containing `\n` fails YANG validation with a pattern error. The existing `SYSLOG_SERVER_FILTER_REGEX` test confirms a valid regex still passes.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] master (unit test only; no image build)

#### Description for the changelog

Add input validation for syslog filter_regex field to reject values containing newline or carriage return characters.

#### Link to config_db schema for YANG module changes

https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#syslog-servers