### PR TITLE
Fix input validation for SNMP sysLocation field

### DIFF
--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -86,7 +86,7 @@ CreateUser {{ user }} {{ SNMP_USER[user]['SNMP_USER_AUTH_TYPE'] }} {{ SNMP_USER[
 #  See snmpd.conf(5) for more details
 
 {% if SNMP is defined and SNMP.LOCATION is defined %}
-sysLocation    {{ SNMP.LOCATION.Location }}
+sysLocation    {{ SNMP.LOCATION.Location | replace('\n', ' ') }}
 {% else %}
 sysLocation    public
 {% endif %}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
@@ -7,8 +7,12 @@
         "eStrKey": "Length"
     },
     "SNMP_SYSTEM_LOCATION_NEG_TEST": {
-        "desc": "Load SNMP sysContact with empty string",
+        "desc": "Load SNMP sysLocation with empty string",
         "eStrKey": "Length"
+    },
+    "SNMP_SYSTEM_LOCATION_NEWLINE_NEG_TEST": {
+        "desc": "Load SNMP sysLocation with newline character",
+        "eStrKey": "Pattern"
     },
     "SNMP_COMMUNITY_TEST": {
         "desc": "Load SNMP community string."

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
@@ -29,6 +29,15 @@
             }
         }
     },
+    "SNMP_SYSTEM_LOCATION_NEWLINE_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP": {
+                "LOCATION": {
+                        "Location": "DataCenter1\nextend test /bin/sh"
+                }
+            }
+        }
+    },
 
     "SNMP_COMMUNITY_TEST": {
         "sonic-snmp:sonic-snmp": {

--- a/src/sonic-yang-models/yang-models/sonic-snmp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-snmp.yang
@@ -39,6 +39,7 @@ module sonic-snmp {
         leaf Location {
           type string {
              length "1..255";
+             pattern '[^\n]+';
           }
           description
             "SNMP System Location.";


### PR DESCRIPTION
#### Why I did it

The `Location` field in the `SNMP|LOCATION` CONFIG_DB table had no input validation beyond a length constraint in the YANG model. The value is rendered verbatim into snmpd.conf via Jinja2, allowing values with newline characters to inject additional snmpd directives.

##### Work item tracking
- Microsoft ADO:

#### How I did it

- `sonic-snmp.yang`: added `pattern '[^\n]+'` to the `Location` leaf to reject values containing newline characters at the CONFIG_DB write layer
- `snmpd.conf.j2`: added a `replace` filter to strip `\n` in template output, providing defense-in-depth if the YANG constraint is bypassed via direct redis-cli or gNMI write

#### How to verify it

YANG model unit test added: `SNMP_SYSTEM_LOCATION_NEWLINE_NEG_TEST` in `tests/yang_model_tests/`. Run with:

```
cd src/sonic-yang-models && python3 -m pytest tests/yang_model_tests/test_yang_model.py -k snmp -v
```

The new test verifies that a `Location` value containing `\n` fails YANG validation with a pattern error. The existing `SNMP_SYSTEM_TEST` confirms a valid location string still passes.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] master (unit test only; no image build)

#### Description for the changelog

Add input validation for SNMP sysLocation field to reject values containing newline characters.

#### Link to config_db schema for YANG module changes

https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#snmp