### PR TITLE
[Smartswitch][Mellanox] Updated module to initialize without connector

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
@@ -286,8 +286,13 @@ class DpuModule(ModuleBase):
         self.MLX_DPU_REBOOT_CAUSE_WARM = 0
         self.MLX_DPU_REBOOT_CAUSE_COLD = 1
         self.MLX_DPU_REBOOT_CAUSE_WATCHDOG = 2
-        self.chassis_state_db = SonicV2Connector(host="127.0.0.1")
-        self.chassis_state_db.connect(self.chassis_state_db.CHASSIS_STATE_DB)
+        self.chassis_state_db = None
+
+    def get_chassis_db_conn(self):
+        if not self.chassis_state_db:
+            self.chassis_state_db = SonicV2Connector(host="127.0.0.1")
+            self.chassis_state_db.connect(self.chassis_state_db.CHASSIS_STATE_DB)
+        return self.chassis_state_db
 
     def get_base_mac(self):
         """
@@ -553,6 +558,7 @@ class DpuModule(ModuleBase):
         """
         This function is used to obtain the TEMPERATURE INFO TABLE from CHASSIS_STATE_DB
         """
+        chassis_state_db = self.get_chassis_db_conn()
         chassis_state_db_name = "CHASSIS_STATE_DB"
         ddr = "DDR"
         nvme = "NVME"
@@ -562,10 +568,10 @@ class DpuModule(ModuleBase):
         dpu_drive_temperature_info_table = f"TEMPERATURE_INFO_{self.dpu_id}|{nvme}"
         return_dict = {}
         try:
-            return_dict[ddr] = self.chassis_state_db.get_all(chassis_state_db_name, dpu_ddr_temperature_info_table)
-            return_dict[cpu] = self.chassis_state_db.get_all(chassis_state_db_name, dpu_cpu_temperature_info_table)
-            return_dict[nvme] = self.chassis_state_db.get_all(chassis_state_db_name, dpu_drive_temperature_info_table)
+            return_dict[ddr] = chassis_state_db.get_all(chassis_state_db_name, dpu_ddr_temperature_info_table)
+            return_dict[cpu] = chassis_state_db.get_all(chassis_state_db_name, dpu_cpu_temperature_info_table)
+            return_dict[nvme] = chassis_state_db.get_all(chassis_state_db_name, dpu_drive_temperature_info_table)
         except Exception as e:
-            logger.log_error(f"Failed to check obtain DPU temperature informatoin for {self.get_name()}! {e}")
+            logger.log_error(f"Failed to check obtain DPU temperature information for {self.get_name()}! {e}")
             return {}
         return return_dict

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
@@ -572,6 +572,6 @@ class DpuModule(ModuleBase):
             return_dict[cpu] = chassis_state_db.get_all(chassis_state_db_name, dpu_cpu_temperature_info_table)
             return_dict[nvme] = chassis_state_db.get_all(chassis_state_db_name, dpu_drive_temperature_info_table)
         except Exception as e:
-            logger.log_error(f"Failed to check obtain DPU temperature information for {self.get_name()}! {e}")
+            logger.log_error(f"Failed to obtain DPU temperature information for {self.get_name()}! {e}")
             return {}
         return return_dict

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
@@ -558,7 +558,6 @@ class DpuModule(ModuleBase):
         """
         This function is used to obtain the TEMPERATURE INFO TABLE from CHASSIS_STATE_DB
         """
-        chassis_state_db = self.get_chassis_db_conn()
         chassis_state_db_name = "CHASSIS_STATE_DB"
         ddr = "DDR"
         nvme = "NVME"
@@ -568,6 +567,7 @@ class DpuModule(ModuleBase):
         dpu_drive_temperature_info_table = f"TEMPERATURE_INFO_{self.dpu_id}|{nvme}"
         return_dict = {}
         try:
+            chassis_state_db = self.get_chassis_db_conn()
             return_dict[ddr] = chassis_state_db.get_all(chassis_state_db_name, dpu_ddr_temperature_info_table)
             return_dict[cpu] = chassis_state_db.get_all(chassis_state_db_name, dpu_cpu_temperature_info_table)
             return_dict[nvme] = chassis_state_db.get_all(chassis_state_db_name, dpu_drive_temperature_info_table)

--- a/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
@@ -333,8 +333,6 @@ class TestChassis:
         content = chassis._parse_vpd_data(os.path.join(test_path, 'vpd_data_file'))
         assert content.get('REV') == 'A7'
 
-    @mock.patch('sonic_platform.module.SonicV2Connector', mock.MagicMock())
-    @mock.patch('sonic_platform.module.ConfigDBConnector', mock.MagicMock())
     def test_smartswitch(self):
         orig_dpu_count = DeviceDataManager.get_dpu_count
         DeviceDataManager.get_dpu_count = mock.MagicMock(return_value=4)

--- a/platform/mellanox/mlnx-platform-api/tests/test_module.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_module.py
@@ -59,8 +59,6 @@ class TestModule:
         chassis = ModularChassis()
         assert len(chassis.get_all_sfps()) == 4
 
-    @patch('sonic_platform.module.SonicV2Connector', mock.MagicMock())
-    @patch('sonic_platform.module.ConfigDBConnector', mock.MagicMock())
     def test_chassis_get_num_modules(self):
         chassis = SmartSwitchChassis()
         assert chassis.get_num_modules() == 4
@@ -183,8 +181,6 @@ class TestModule:
         assert len(m._sfp_list) == 0
         assert len(m._thermal_list) == 0
 
-    @patch('sonic_platform.module.SonicV2Connector', mock.MagicMock())
-    @patch('sonic_platform.module.ConfigDBConnector', mock.MagicMock())
     def test_module_vpd(self):
         m = Module(1)
         m.vpd_parser.vpd_file = os.path.join(test_path, 'mock_psu_vpd')
@@ -237,7 +233,6 @@ class TestModule:
         assert dm.get_serial() == "N/A"
         assert dm.get_revision() == "N/A"
 
-    @patch('sonic_platform.module.SonicV2Connector', mock.MagicMock())
     @patch('swsscommon.swsscommon.ConfigDBConnector.connect', mock.MagicMock())
     @mock.patch('swsscommon.swsscommon.ConfigDBConnector.get')
     @mock.patch('subprocess.call')
@@ -415,8 +410,10 @@ class TestModule:
         }
         def new_get_all(db_name, table_name):
             return temp_data[table_name]
-        
-        with patch.object(m.chassis_state_db, 'get_all', wraps=new_get_all):
+
+        mock_chassis_db = mock.MagicMock()
+        with patch.object(m, 'get_chassis_db_conn', return_value=mock_chassis_db):
+            mock_chassis_db.get_all = mock.MagicMock(wraps=new_get_all)
             output_dict = m.get_temperature_dict()
             assert output_dict['DDR'] == temp_data[f"TEMPERATURE_INFO_{m.get_dpu_id()}|DDR"]
             assert output_dict['CPU'] == temp_data[f"TEMPERATURE_INFO_{m.get_dpu_id()}|CPU"]


### PR DESCRIPTION
#### Why I did it

On SmartSwitch platforms  `parseDatabaseConfig` errors are logged to syslog during every system boot:

```
ERR python3: :- parseDatabaseConfig: Sonic database config file doesn't exist at /var/run/redis/sonic-db/database_config.json
ERR -c: :- parseDatabaseConfig: Sonic database config file doesn't exist at /var/run/redis/sonic-db/database_config.json
ERR bmc_base: :- parseDatabaseConfig: Sonic database config file doesn't exist at /var/run/redis/sonic-db/database_config.json
```

**Root cause**: During `database-chassis.service` startup, `database.sh` runs `postStartAction()` which executes `python3 -c 'import sonic_platform.platform; ...'` to detect `slot_id` and `supervisor_slot_id`. On SmartSwitch platforms, `Platform()` constructs `SmartSwitchChassis`, which calls `initialize_modules()`, creating `DpuModule` instances. Each `DpuModule.__init__()` eagerly creates a `SonicV2Connector` and connects to `CHASSIS_STATE_DB`, triggering `SonicDBConfig::initialize()` which reads `/var/run/redis/sonic-db/database_config.json`. This file is only created by the main `database` container, which has not started yet at this point (`database.service` starts after `database-chassis.service`).

##### Work item tracking
- Microsoft ADO:

#### How I did it

Changed `DpuModule.__init__()` to use lazy initialization for the `chassis_state_db` connector:

1. Replaced the eager `SonicV2Connector` construction and `.connect()` call in `__init__` with `self.chassis_state_db = None`.
2. Added a new `get_chassis_db_conn()` method that creates and connects the `SonicV2Connector` on first use.
3. Updated `get_temperature_dict()` to use `self.get_chassis_db_conn()` instead of accessing `self.chassis_state_db` directly.
4. Updated unit tests in `test_module.py` and `test_chassis.py` to remove now-unnecessary `SonicV2Connector`/`ConfigDBConnector` mock patches from test decorators, and updated the temperature dict test to mock through `get_chassis_db_conn`.

#### How to verify it

1. Boot a SmartSwitch platform (e.g. SN4280) and check syslog for `parseDatabaseConfig` errors — they should no longer appear.
2. Verify that `get_temperature_dict()` still works correctly after the database is ready by querying DPU temperature information.
3. Run the platform API unit tests:
   ```
   cd platform/mellanox/mlnx-platform-api
   pytest tests/test_module.py tests/test_chassis.py -v
   ```

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

Fix boot-time `parseDatabaseConfig` errors on SmartSwitch platforms by deferring `DpuModule` chassis state DB connection to first use.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

