### PR TITLE
[ci] Include version file changes in PTF_MODIFIED detection

### DIFF
--- a/.azure-pipelines/azure-pipelines-image-template.yml
+++ b/.azure-pipelines/azure-pipelines-image-template.yml
@@ -81,21 +81,21 @@ jobs:
           echo "Build.Reason = $BUILD_REASON"
           echo "Build.DefinitionName = $BUILD_DEFINITIONNAME"
           if [[ "$BUILD_REASON" == "PullRequest" ]]; then
-            echo "Checking for changes to dockers/docker-ptf/Dockerfile.j2 in PR..."
-            # Get the target branch and check for changes
-            TARGET_BRANCH="origin/$(System.PullRequest.TargetBranch)"
-            echo "Comparing against target branch: $TARGET_BRANCH"
-            # Fetch target branch to ensure we have the latest
-            git fetch origin $(System.PullRequest.TargetBranch)
-            # Check if docker-ptf Dockerfile.j2 has changes
+            echo "Checking for changes to docker-ptf in PR..."
+            # Set PTF_MODIFIED to True if docker-ptf was not built from cache, otherwise set it to False
             # NOTE: The PTF_MODIFIED template parameter is of type string
             # Ensure to set it to "True" or "False" (not boolean true/false)
-            if git diff --name-only $TARGET_BRANCH...HEAD | grep -q "dockers/docker-ptf/Dockerfile.j2"; then
-              echo "docker-ptf/Dockerfile.j2 has been modified in this PR"
-              echo "##vso[task.setvariable variable=PTF_MODIFIED;isOutput=true]True"
-            else
-              echo "docker-ptf/Dockerfile.j2 has not been modified in this PR"
+            if [ ! -f "target/docker-ptf.gz.log" ]; then
+              echo "docker-ptf was not built in this PR, setting PTF_MODIFIED to False"
               echo "##vso[task.setvariable variable=PTF_MODIFIED;isOutput=true]False"
+            else
+              if grep -q "CACHE::LOADED" target/docker-ptf.gz.log; then
+                echo "docker-ptf was built from cache in this PR, setting PTF_MODIFIED to False"
+                echo "##vso[task.setvariable variable=PTF_MODIFIED;isOutput=true]False"
+              else
+                echo "docker-ptf was not built from cache in this PR, setting PTF_MODIFIED to True"
+                echo "##vso[task.setvariable variable=PTF_MODIFIED;isOutput=true]True"
+              fi
             fi
           else
             echo "Not a PR build, setting PTF_MODIFIED to false"


### PR DESCRIPTION
…ified

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The previous check only looked at docker-ptf/Dockerfile.j2 to detect if the docker-ptf image was modified. Changes to version files under files/build/versions-public/default and files/build/versions-public/dockers/docker-ptf also affect the built PTF image but were not being detected, causing PTF_MODIFIED to be incorrectly set to False.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

