### PR TITLE
[PrefixListMgr]: Refactor PrefixListMgr to support multiple prefix types via config registry

### DIFF
--- a/dockers/docker-fpm-frr/base_image_files/prefix_list
+++ b/dockers/docker-fpm-frr/base_image_files/prefix_list
@@ -32,17 +32,45 @@ check_root_privileges() {
     fi
 }
 
-# Function to check if the device is supported device with type spine routers and subtype UpstreamLC
-check_spine_router() {
-    type=$(sonic-cfggen -d -v DEVICE_METADATA.localhost.type)
-    subtype=$(sonic-cfggen -d -v DEVICE_METADATA.localhost.subtype)
+# Function to check if the device is a supported device type
+DEVICE_TYPE=""
+DEVICE_SUBTYPE=""
 
-    # only supported on UpstreamLC or UpperSpineRouter
-    if [[ ("$type" == "SpineRouter" && "$subtype" == "UpstreamLC") || "$type" == "UpperSpineRouter" ]]; then
+read_device_metadata() {
+    if [[ -z "$DEVICE_TYPE" ]]; then
+        DEVICE_TYPE=$(sonic-cfggen -d -v DEVICE_METADATA.localhost.type)
+        DEVICE_SUBTYPE=$(sonic-cfggen -d -v DEVICE_METADATA.localhost.subtype)
+    fi
+}
+
+check_supported_device() {
+    read_device_metadata
+    if [[ ("$DEVICE_TYPE" == "SpineRouter" && "$DEVICE_SUBTYPE" == "UpstreamLC") || \
+          "$DEVICE_TYPE" == "UpperSpineRouter" ]]; then
         return
     fi
+    echo "Operation is not supported on this device type." >&2
+    exit 1
+}
 
-    echo "Operation is only supported on Upstream SpineRouter." >&2
+declare -A prefix_type_devices
+prefix_type_devices=(
+    ["ANCHOR_PREFIX"]="SpineRouter:UpstreamLC UpperSpineRouter"
+)
+
+validate_device_for_type() {
+    local prefix_type=$1
+    read_device_metadata
+    local allowed="${prefix_type_devices[$prefix_type]}"
+    local device_id="$DEVICE_TYPE:$DEVICE_SUBTYPE"
+    for entry in $allowed; do
+        if [[ "$entry" == *":"* ]]; then
+            [[ "$device_id" == "$entry" ]] && return
+        else
+            [[ "$DEVICE_TYPE" == "$entry" ]] && return
+        fi
+    done
+    echo "Prefix type '$prefix_type' is not supported on device type '$DEVICE_TYPE' (subtype: '$DEVICE_SUBTYPE')." >&2
     exit 1
 }
 
@@ -156,10 +184,13 @@ fi
 if [ "$1" != "status" ]; then
     check_root_privileges
 fi
-check_spine_router
+check_supported_device
 skip_chassis_supervisor
 
 validate_operation $1 $2
+if [[ "$1" == "add" || "$1" == "remove" ]]; then
+    validate_device_for_type "$2"
+fi
 
 # Read SONiC immutable variables
 [ -f /etc/sonic/sonic-environment ] && . /etc/sonic/sonic-environment

--- a/dockers/docker-fpm-frr/base_image_files/prefix_list
+++ b/dockers/docker-fpm-frr/base_image_files/prefix_list
@@ -43,25 +43,17 @@ read_device_metadata() {
     fi
 }
 
-check_supported_device() {
-    read_device_metadata
-    if [[ ("$DEVICE_TYPE" == "SpineRouter" && "$DEVICE_SUBTYPE" == "UpstreamLC") || \
-          "$DEVICE_TYPE" == "UpperSpineRouter" ]]; then
-        return
-    fi
-    echo "Operation is not supported on this device type." >&2
-    exit 1
-}
-
 declare -A prefix_type_devices
 prefix_type_devices=(
     ["ANCHOR_PREFIX"]="SpineRouter:UpstreamLC UpperSpineRouter"
+    ["SUPPRESS_PREFIX"]=""
 )
 
 validate_device_for_type() {
     local prefix_type=$1
-    read_device_metadata
     local allowed="${prefix_type_devices[$prefix_type]}"
+    [[ -z "$allowed" ]] && return
+    read_device_metadata
     local device_id="$DEVICE_TYPE:$DEVICE_SUBTYPE"
     for entry in $allowed; do
         if [[ "$entry" == *":"* ]]; then
@@ -175,7 +167,7 @@ handle_prefix_list_single() {
 }
 
 prefix_list_operations=("add" "remove" "status")
-supported_prefix_types=("ANCHOR_PREFIX")
+supported_prefix_types=("ANCHOR_PREFIX" "SUPPRESS_PREFIX")
 # Main script execution
 if [[ "$1" == "-h" || "$1" == "--help" ]]; then
     display_help
@@ -184,7 +176,6 @@ fi
 if [ "$1" != "status" ]; then
     check_root_privileges
 fi
-check_supported_device
 skip_chassis_supervisor
 
 validate_operation $1 $2

--- a/dockers/docker-fpm-frr/frr/bgpd/suppress_prefix/add_suppress_prefix.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/suppress_prefix/add_suppress_prefix.conf.j2
@@ -1,0 +1,1 @@
+{{ data.ipv }} prefix-list {{ data.prefix_list_name }} permit {{ data.prefix }}

--- a/dockers/docker-fpm-frr/frr/bgpd/suppress_prefix/del_suppress_prefix.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/suppress_prefix/del_suppress_prefix.conf.j2
@@ -1,0 +1,1 @@
+no {{ data.ipv }} prefix-list {{ data.prefix_list_name }} permit {{ data.prefix }}

--- a/files/image_config/constants/constants.yml
+++ b/files/image_config/constants/constants.yml
@@ -72,3 +72,10 @@ constants:
         enabled: true
         db_table: "BGP_SENTINELS"
         template_dir: "sentinels"
+    prefix_list:
+      SUPPRESS_PREFIX:
+        ipv4_name: "SUPPRESS_IPV4_PREFIX"
+        ipv6_name: "SUPPRESS_IPV6_PREFIX"
+      ANCHOR_PREFIX:
+        ipv4_name: "ANCHOR_CONTRIBUTING_ROUTES"
+        ipv6_name: "ANCHOR_CONTRIBUTING_ROUTES"

--- a/files/image_config/constants/constants.yml
+++ b/files/image_config/constants/constants.yml
@@ -76,6 +76,3 @@ constants:
       SUPPRESS_PREFIX:
         ipv4_name: "SUPPRESS_IPV4_PREFIX"
         ipv6_name: "SUPPRESS_IPV6_PREFIX"
-      ANCHOR_PREFIX:
-        ipv4_name: "ANCHOR_CONTRIBUTING_ROUTES"
-        ipv6_name: "ANCHOR_CONTRIBUTING_ROUTES"

--- a/src/sonic-bgpcfgd/bgpcfgd/main.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/main.py
@@ -120,16 +120,15 @@ def do_work():
         managers.append(BfdMgr(common_objs, "STATE_DB", swsscommon.STATE_BFD_SOFTWARE_SESSION_TABLE_NAME))
 
     device_metadata = config_db.get_table("DEVICE_METADATA")
-    # Enable Prefix List Manager and AsPath Manager for UpperSpineRouter/UpstreamLC
+    managers.append(PrefixListMgr(common_objs, "CONFIG_DB", "PREFIX_LIST"))
+    # Enable AsPath Manager for UpperSpineRouter/UpstreamLC
     is_upstream_lc = ("localhost" in device_metadata and "type" in device_metadata["localhost"] and "subtype" in device_metadata["localhost"] and
                       device_metadata["localhost"]["type"] == "SpineRouter" and device_metadata["localhost"]["subtype"] == "UpstreamLC")
     is_upper_spine_router = ("localhost" in device_metadata and "type" in device_metadata["localhost"] and
                              device_metadata["localhost"]["type"] == "UpperSpineRouter")
     if is_upstream_lc or is_upper_spine_router:
-        # Prefix List Manager
-        managers.append(PrefixListMgr(common_objs, "CONFIG_DB", "PREFIX_LIST"))
         managers.append(AsPathMgr(common_objs, "CONFIG_DB", "DEVICE_METADATA"))
-        log_notice("Prefix List Manager and AsPath Manager are enabled for UpperSpineRouter/UpstreamLC")
+        log_notice("Prefix List Manager and AsPath Manager are enabled for %s" % device_metadata["localhost"]["type"])
 
     runner = Runner(common_objs['cfg_mgr'])
     for mgr in managers:

--- a/src/sonic-bgpcfgd/bgpcfgd/main.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/main.py
@@ -128,7 +128,7 @@ def do_work():
                              device_metadata["localhost"]["type"] == "UpperSpineRouter")
     if is_upstream_lc or is_upper_spine_router:
         managers.append(AsPathMgr(common_objs, "CONFIG_DB", "DEVICE_METADATA"))
-        log_notice("Prefix List Manager and AsPath Manager are enabled for %s" % device_metadata["localhost"]["type"])
+        log_notice("AsPath Manager is enabled for %s" % device_metadata["localhost"]["type"])
 
     runner = Runner(common_objs['cfg_mgr'])
     for mgr in managers:

--- a/src/sonic-bgpcfgd/bgpcfgd/main.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/main.py
@@ -120,7 +120,6 @@ def do_work():
         managers.append(BfdMgr(common_objs, "STATE_DB", swsscommon.STATE_BFD_SOFTWARE_SESSION_TABLE_NAME))
 
     device_metadata = config_db.get_table("DEVICE_METADATA")
-    managers.append(PrefixListMgr(common_objs, "CONFIG_DB", "PREFIX_LIST"))
     # Enable AsPath Manager for UpperSpineRouter/UpstreamLC
     is_upstream_lc = ("localhost" in device_metadata and "type" in device_metadata["localhost"] and "subtype" in device_metadata["localhost"] and
                       device_metadata["localhost"]["type"] == "SpineRouter" and device_metadata["localhost"]["subtype"] == "UpstreamLC")
@@ -129,6 +128,8 @@ def do_work():
     if is_upstream_lc or is_upper_spine_router:
         managers.append(AsPathMgr(common_objs, "CONFIG_DB", "DEVICE_METADATA"))
         log_notice("AsPath Manager is enabled for %s" % device_metadata["localhost"]["type"])
+
+    managers.append(PrefixListMgr(common_objs, "CONFIG_DB", "PREFIX_LIST"))
 
     runner = Runner(common_objs['cfg_mgr'])
     for mgr in managers:

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
@@ -102,6 +102,8 @@ class PrefixListMgr(Manager):
             data["prefix"] = str(prefix.cidr)
             data["prefixlen"] = prefix.prefixlen
             data["ipv"] = self.get_ip_type(prefix)
+            if not self.directory.path_exist("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost"):
+                return False
             if self.generate_prefix_list_config(prefix_type, data, add=True):
                 log_info("PrefixListMgr:: %s %s configuration generated" % (prefix_type, data["prefix"]))
                 self.directory.put(self.db_name, self.table_name, key, data)

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
@@ -38,7 +38,10 @@ class PrefixListMgr(Manager):
             self.templates[cfg["del_template"]] = common_objs['tf'].from_file(cfg["del_template"] + ".conf.j2")
         super(PrefixListMgr, self).__init__(
             common_objs,
-            [],
+            [
+                ("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost/type"),
+                ("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost/bgp_asn"),
+            ],
             db,
             table,
         )
@@ -56,6 +59,10 @@ class PrefixListMgr(Manager):
         type_cfg = PREFIX_TYPE_CONFIG.get(prefix_type)
         if type_cfg is None:
             log_warn("PrefixListMgr:: Prefix type '%s' is not supported" % prefix_type)
+            return False
+
+        if not self.directory.path_exist("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost"):
+            log_warn("PrefixListMgr:: DEVICE_METADATA not available yet")
             return False
 
         metadata = self.directory.get_slot("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)["localhost"]

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
@@ -65,6 +65,11 @@ class PrefixListMgr(Manager):
             log_info("PrefixListMgr:: Device metadata is not ready yet")
             return False
         metadata = self.directory.get_path("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost")
+        # bgp_asn is required for all prefix types: ANCHOR_PREFIX templates use it
+        # directly (router bgp <asn>), and while SUPPRESS_PREFIX templates don't
+        # reference it today, prefix-list operations are inherently BGP features —
+        # any device managing prefix lists will be running BGP with an ASN configured.
+        # Requiring bgp_asn upfront keeps templates free to use it when expanded.
         try:
             device_type = metadata["type"]
             device_subtype = metadata.get("subtype", "")

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
@@ -62,10 +62,9 @@ class PrefixListMgr(Manager):
             return False
 
         if not self.directory.path_exist("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost"):
-            log_warn("PrefixListMgr:: DEVICE_METADATA not available yet")
+            log_info("PrefixListMgr:: Device metadata is not ready yet")
             return False
-
-        metadata = self.directory.get_slot("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)["localhost"]
+        metadata = self.directory.get_path("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost")
         try:
             device_type = metadata["type"]
             device_subtype = metadata.get("subtype", "")

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
@@ -38,7 +38,7 @@ class PrefixListMgr(Manager):
             self.templates[cfg["del_template"]] = common_objs['tf'].from_file(cfg["del_template"] + ".conf.j2")
         super(PrefixListMgr, self).__init__(
             common_objs,
-            [("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost")],
+            [],
             db,
             table,
         )
@@ -58,9 +58,6 @@ class PrefixListMgr(Manager):
             log_warn("PrefixListMgr:: Prefix type '%s' is not supported" % prefix_type)
             return False
 
-        if not self.directory.path_exist("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost"):
-            log_warn("PrefixListMgr:: DEVICE_METADATA not available yet")
-            return False
         metadata = self.directory.get_slot("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)["localhost"]
         try:
             device_type = metadata["type"]
@@ -102,8 +99,6 @@ class PrefixListMgr(Manager):
             data["prefix"] = str(prefix.cidr)
             data["prefixlen"] = prefix.prefixlen
             data["ipv"] = self.get_ip_type(prefix)
-            if not self.directory.path_exist("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost"):
-                return False
             if self.generate_prefix_list_config(prefix_type, data, add=True):
                 log_info("PrefixListMgr:: %s %s configuration generated" % (prefix_type, data["prefix"]))
                 self.directory.put(self.db_name, self.table_name, key, data)

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
@@ -58,6 +58,9 @@ class PrefixListMgr(Manager):
             log_warn("PrefixListMgr:: Prefix type '%s' is not supported" % prefix_type)
             return False
 
+        if not self.directory.path_exist("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost"):
+            log_warn("PrefixListMgr:: DEVICE_METADATA not available yet")
+            return False
         metadata = self.directory.get_slot("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)["localhost"]
         try:
             device_type = metadata["type"]
@@ -68,7 +71,8 @@ class PrefixListMgr(Manager):
             return False
 
         if not self._is_device_allowed(device_type, device_subtype, type_cfg["allowed_devices"]):
-            log_warn("PrefixListMgr:: Device type %s/%s not supported for %s" % (device_type, device_subtype, prefix_type))
+            device_desc = "%s/%s" % (device_type, device_subtype) if device_subtype else device_type
+            log_warn("PrefixListMgr:: Device type %s not supported for %s" % (device_desc, prefix_type))
             return False
 
         data["bgp_asn"] = bgp_asn

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
@@ -25,7 +25,7 @@ class PrefixListMgr(Manager):
         self.cfg_mgr = common_objs['cfg_mgr']
         self.constants = common_objs['constants']
         self.templates = {}
-        for ptype, cfg in PREFIX_TYPE_CONFIG.items():
+        for cfg in PREFIX_TYPE_CONFIG.values():
             self.templates[cfg["add_template"]] = common_objs['tf'].from_file(cfg["add_template"] + ".conf.j2")
             self.templates[cfg["del_template"]] = common_objs['tf'].from_file(cfg["del_template"] + ".conf.j2")
         super(PrefixListMgr, self).__init__(
@@ -52,6 +52,7 @@ class PrefixListMgr(Manager):
         try:
             device_type = metadata["type"]
             device_subtype = metadata.get("subtype", "")
+            bgp_asn = metadata["bgp_asn"]
         except KeyError as e:
             log_warn("PrefixListMgr:: Missing metadata key: %s" % e)
             return False
@@ -60,7 +61,7 @@ class PrefixListMgr(Manager):
             log_warn("PrefixListMgr:: Device type %s/%s not supported for %s" % (device_type, device_subtype, prefix_type))
             return False
 
-        data["bgp_asn"] = metadata["bgp_asn"]
+        data["bgp_asn"] = bgp_asn
         data["prefix_list_name"] = type_cfg["prefix_list_name"](data["ipv"])
 
         template_key = type_cfg["add_template"] if add else type_cfg["del_template"]

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
@@ -38,7 +38,7 @@ class PrefixListMgr(Manager):
             self.templates[cfg["del_template"]] = common_objs['tf'].from_file(cfg["del_template"] + ".conf.j2")
         super(PrefixListMgr, self).__init__(
             common_objs,
-            [],
+            [("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost")],
             db,
             table,
         )

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
@@ -3,23 +3,31 @@ from .log import log_debug, log_warn, log_info
 from swsscommon import swsscommon
 import netaddr
 
+PREFIX_TYPE_CONFIG = {
+    "ANCHOR_PREFIX": {
+        "add_template": "bgpd/radian/add_radian",
+        "del_template": "bgpd/radian/del_radian",
+        "allowed_devices": [
+            ("SpineRouter", "UpstreamLC"),
+            ("UpperSpineRouter", None),
+        ],
+        "prefix_list_name": lambda ipv: "ANCHOR_CONTRIBUTING_ROUTES",
+        "log_label": "Anchor prefix",
+        "log_label_target": "radian",
+    },
+}
+
 class PrefixListMgr(Manager):
     """This class responds to changes in the PREFIX_LIST table"""
 
     def __init__(self, common_objs, db, table):
-        """
-        Initialize the object
-        :param common_objs: common object dictionary
-        :param db: name of the db
-        :param table: name of the table in the db
-        """
         self.directory = common_objs['directory']
         self.cfg_mgr = common_objs['cfg_mgr']
         self.constants = common_objs['constants']
-        self.templates = {
-            "add_radian": common_objs['tf'].from_file("bgpd/radian/add_radian.conf.j2"),
-            "del_radian": common_objs['tf'].from_file("bgpd/radian/del_radian.conf.j2"),
-        }
+        self.templates = {}
+        for ptype, cfg in PREFIX_TYPE_CONFIG.items():
+            self.templates[cfg["add_template"]] = common_objs['tf'].from_file(cfg["add_template"] + ".conf.j2")
+            self.templates[cfg["del_template"]] = common_objs['tf'].from_file(cfg["del_template"] + ".conf.j2")
         super(PrefixListMgr, self).__init__(
             common_objs,
             [],
@@ -27,60 +35,56 @@ class PrefixListMgr(Manager):
             table,
         )
 
-    def generate_prefix_list_config(self, data, add):
-        """
-        Generate the prefix list configuration from the template
-        :param data: data from the PREFIX_LIST table
-        :return: rendered configuration
-        """
-        cmd = "\n"
+    def _is_device_allowed(self, device_type, device_subtype, allowed_list):
+        for allowed_type, allowed_subtype in allowed_list:
+            if device_type == allowed_type:
+                if allowed_subtype is None or device_subtype == allowed_subtype:
+                    return True
+        return False
+
+    def generate_prefix_list_config(self, prefix_type, data, add):
+        type_cfg = PREFIX_TYPE_CONFIG.get(prefix_type)
+        if type_cfg is None:
+            log_warn("PrefixListMgr:: Prefix type '%s' is not supported" % prefix_type)
+            return False
+
         metadata = self.directory.get_slot("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)["localhost"]
         try:
-            bgp_asn = metadata["bgp_asn"]
-            localhost_type = metadata["type"]
-            subtype = metadata["subtype"]
+            device_type = metadata["type"]
+            device_subtype = metadata.get("subtype", "")
         except KeyError as e:
-            log_warn(f"PrefixListMgr:: Missing metadata key: {e}")
+            log_warn("PrefixListMgr:: Missing metadata key: %s" % e)
             return False
 
-        if data["prefix_list_name"] != "ANCHOR_PREFIX":
-            log_warn("PrefixListMgr:: Prefix list %s is not supported" % data["prefix_list_name"])
-            return False
-        if localhost_type not in ["UpperSpineRouter", "SpineRouter"] or (localhost_type == "SpineRouter" and subtype != "UpstreamLC"):
-            log_warn("PrefixListMgr:: Prefix list %s is only supported on Upstream SpineRouter" % data["prefix_list_name"])
+        if not self._is_device_allowed(device_type, device_subtype, type_cfg["allowed_devices"]):
+            log_warn("PrefixListMgr:: Device type %s/%s not supported for %s" % (device_type, device_subtype, prefix_type))
             return False
 
-        # Add the anchor prefix to the radian configuration
-        data["bgp_asn"] = bgp_asn
-        if add:
-            # add some way of getting this asn list from the database in the future
-            cmd += self.templates["add_radian"].render(data=data)
-            log_debug("PrefixListMgr:: Anchor prefix %s added to radian configuration" % data["prefix"])
-        else:
-            cmd += self.templates["del_radian"].render(data=data)
-            log_debug("PrefixListMgr:: Anchor prefix %s removed from radian configuration" % data["prefix"])	
+        data["bgp_asn"] = metadata["bgp_asn"]
+        data["prefix_list_name"] = type_cfg["prefix_list_name"](data["ipv"])
+
+        template_key = type_cfg["add_template"] if add else type_cfg["del_template"]
+        cmd = "\n" + self.templates[template_key].render(data=data)
         self.cfg_mgr.push(cmd)
+
+        action = "added to" if add else "removed from"
+        log_debug("PrefixListMgr:: %s %s %s %s configuration" % (type_cfg["log_label"], data["prefix"], action, type_cfg["log_label_target"]))
         return True
-            
-        
 
     def set_handler(self, key, data):
         log_debug("PrefixListMgr:: set handler")
         if '|' in key:
-            prefix_list_name, prefix_str =  key.split('|', 1)
+            prefix_type, prefix_str = key.split('|', 1)
             try:
                 prefix = netaddr.IPNetwork(str(prefix_str))
             except (netaddr.NotRegisteredError, netaddr.AddrFormatError, netaddr.AddrConversionError):
-                log_warn("PrefixListMgr:: Prefix '%s' format is wrong for prefix list '%s'" % (prefix_str, prefix_list_name))
+                log_warn("PrefixListMgr:: Prefix '%s' format is wrong for prefix list '%s'" % (prefix_str, prefix_type))
                 return True
-            data["prefix_list_name"] = prefix_list_name
             data["prefix"] = str(prefix.cidr)
             data["prefixlen"] = prefix.prefixlen
             data["ipv"] = self.get_ip_type(prefix)
-            # Generate the prefix list configuration
-            if self.generate_prefix_list_config(data, add=True):
-                log_info("PrefixListMgr:: %s %s configuration generated" % (prefix_list_name, data["prefix"]))
-
+            if self.generate_prefix_list_config(prefix_type, data, add=True):
+                log_info("PrefixListMgr:: %s %s configuration generated" % (prefix_type, data["prefix"]))
                 self.directory.put(self.db_name, self.table_name, key, data)
                 log_info("PrefixListMgr:: set %s" % key)
         return True
@@ -88,31 +92,23 @@ class PrefixListMgr(Manager):
     def del_handler(self, key):
         log_debug("PrefixListMgr:: del handler")
         if '|' in key:
-            prefix_list_name, prefix_str =  key.split('|', 1)
+            prefix_type, prefix_str = key.split('|', 1)
             try:
                 prefix = netaddr.IPNetwork(str(prefix_str))
             except (netaddr.NotRegisteredError, netaddr.AddrFormatError, netaddr.AddrConversionError):
-                log_warn("PrefixListMgr:: Prefix '%s' format is wrong for prefix list '%s'" % (prefix_str, prefix_list_name))
+                log_warn("PrefixListMgr:: Prefix '%s' format is wrong for prefix list '%s'" % (prefix_str, prefix_type))
                 return True
             data = {}
-            data["prefix_list_name"] = prefix_list_name
             data["prefix"] = str(prefix.cidr)
             data["prefixlen"] = prefix.prefixlen
             data["ipv"] = self.get_ip_type(prefix)
-            # remove the prefix list configuration
-            if self.generate_prefix_list_config(data, add=False):
-                log_info("PrefixListMgr:: %s %s configuration deleted" % (prefix_list_name, data["prefix"]))
+            if self.generate_prefix_list_config(prefix_type, data, add=False):
+                log_info("PrefixListMgr:: %s %s configuration deleted" % (prefix_type, data["prefix"]))
                 self.directory.remove(self.db_name, self.table_name, key)
                 log_info("PrefixListMgr:: deleted %s" % key)
-        # Implement deletion logic if necessary
         return True
 
     def get_ip_type(self, prefix: netaddr.IPNetwork):
-        """
-        Determine the IP type (IPv4 or IPv6) of a prefix.
-        :param prefix: The prefix to check (e.g., "192.168.1.0/24" or "2001:db8::/32")
-        :return: "ip" if the prefix is an IPv4 address, "ipv6" if it is an IPv6 address, None if invalid
-        """
         if prefix.version == 4:
             return "ip"
         elif prefix.version == 6:

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
@@ -15,6 +15,14 @@ PREFIX_TYPE_CONFIG = {
         "log_label": "Anchor prefix",
         "log_label_target": "radian",
     },
+    "SUPPRESS_PREFIX": {
+        "add_template": "bgpd/suppress_prefix/add_suppress_prefix",
+        "del_template": "bgpd/suppress_prefix/del_suppress_prefix",
+        "allowed_devices": None,
+        "prefix_list_name": lambda ipv: "SUPPRESS_IPV4_PREFIX" if ipv == "ip" else "SUPPRESS_IPV6_PREFIX",
+        "log_label": "Suppress prefix",
+        "log_label_target": "suppress_prefix",
+    },
 }
 
 class PrefixListMgr(Manager):
@@ -36,6 +44,8 @@ class PrefixListMgr(Manager):
         )
 
     def _is_device_allowed(self, device_type, device_subtype, allowed_list):
+        if allowed_list is None:
+            return True
         for allowed_type, allowed_subtype in allowed_list:
             if device_type == allowed_type:
                 if allowed_subtype is None or device_subtype == allowed_subtype:
@@ -62,6 +72,8 @@ class PrefixListMgr(Manager):
             return False
 
         data["bgp_asn"] = bgp_asn
+        data["device_type"] = device_type
+        data["device_subtype"] = device_subtype
         data["prefix_list_name"] = type_cfg["prefix_list_name"](data["ipv"])
 
         template_key = type_cfg["add_template"] if add else type_cfg["del_template"]

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
@@ -74,7 +74,9 @@ class PrefixListMgr(Manager):
         data["bgp_asn"] = bgp_asn
         data["device_type"] = device_type
         data["device_subtype"] = device_subtype
-        data["prefix_list_name"] = type_cfg["prefix_list_name"](data["ipv"])
+        pl_overrides = self.constants.get("bgp", {}).get("prefix_list", {}).get(prefix_type, {})
+        name_key = "ipv4_name" if data["ipv"] == "ip" else "ipv6_name"
+        data["prefix_list_name"] = pl_overrides.get(name_key, type_cfg["prefix_list_name"](data["ipv"]))
 
         template_key = type_cfg["add_template"] if add else type_cfg["del_template"]
         cmd = "\n" + self.templates[template_key].render(data=data)

--- a/src/sonic-bgpcfgd/tests/test_prefix_list.py
+++ b/src/sonic-bgpcfgd/tests/test_prefix_list.py
@@ -4,6 +4,10 @@ import os
 from bgpcfgd.directory import Directory
 from bgpcfgd.template import TemplateFabric
 from . import swsscommon_test
+
+import sys
+sys.modules["swsscommon"] = swsscommon_test
+
 from swsscommon import swsscommon
 
 from bgpcfgd.managers_prefix_list import PrefixListMgr
@@ -69,7 +73,7 @@ def test_del_handler_ipv6(mocked_log_debug):
     del_handler_test(m, "ANCHOR_PREFIX|fc02:100::/64")
     mocked_log_debug.assert_called_with("PrefixListMgr:: Anchor prefix fc02:100::/64 removed from radian configuration")
 
-def constructor_unsupported_device():
+def constructor_generic_device():
     cfg_mgr = MagicMock()
     common_objs = {
         'directory': Directory(),
@@ -79,17 +83,49 @@ def constructor_unsupported_device():
     }
     m = PrefixListMgr(common_objs, "CONFIG_DB", "PREFIX_LIST")
     m.directory.put("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost",
-                    {"bgp_asn": "65100", "type": "SpineRouter", "subtype": "DownstreamLC"})
+                    {"bgp_asn": "65100", "type": "ToRRouter", "subtype": ""})
     return m
 
 @patch('bgpcfgd.managers_prefix_list.log_warn')
 def test_unsupported_prefix_type(mocked_log_warn):
-    m = constructor()
+    m = constructor_generic_device()
     set_handler_test(m, "UNKNOWN_TYPE|10.0.0.0/24", {})
     mocked_log_warn.assert_called_with("PrefixListMgr:: Prefix type 'UNKNOWN_TYPE' is not supported")
 
 @patch('bgpcfgd.managers_prefix_list.log_warn')
 def test_anchor_prefix_wrong_device(mocked_log_warn):
-    m = constructor_unsupported_device()
+    m = constructor_generic_device()
     set_handler_test(m, "ANCHOR_PREFIX|192.168.0.0/24", {})
-    mocked_log_warn.assert_called_with("PrefixListMgr:: Device type SpineRouter/DownstreamLC not supported for ANCHOR_PREFIX")
+    mocked_log_warn.assert_called_with("PrefixListMgr:: Device type ToRRouter/ not supported for ANCHOR_PREFIX")
+
+@patch('bgpcfgd.managers_prefix_list.log_debug')
+def test_suppress_prefix_ipv4(mocked_log_debug):
+    m = constructor_generic_device()
+    set_handler_test(m, "SUPPRESS_PREFIX|10.0.0.0/24", {})
+    mocked_log_debug.assert_called_with("PrefixListMgr:: Suppress prefix 10.0.0.0/24 added to suppress_prefix configuration")
+
+@patch('bgpcfgd.managers_prefix_list.log_debug')
+def test_suppress_prefix_ipv6(mocked_log_debug):
+    m = constructor_generic_device()
+    set_handler_test(m, "SUPPRESS_PREFIX|fc00::/64", {})
+    mocked_log_debug.assert_called_with("PrefixListMgr:: Suppress prefix fc00::/64 added to suppress_prefix configuration")
+
+@patch('bgpcfgd.managers_prefix_list.log_debug')
+def test_suppress_prefix_del_ipv4(mocked_log_debug):
+    m = constructor_generic_device()
+    set_handler_test(m, "SUPPRESS_PREFIX|10.0.0.0/24", {})
+    del_handler_test(m, "SUPPRESS_PREFIX|10.0.0.0/24")
+    mocked_log_debug.assert_called_with("PrefixListMgr:: Suppress prefix 10.0.0.0/24 removed from suppress_prefix configuration")
+
+@patch('bgpcfgd.managers_prefix_list.log_debug')
+def test_suppress_prefix_del_ipv6(mocked_log_debug):
+    m = constructor_generic_device()
+    set_handler_test(m, "SUPPRESS_PREFIX|fc00::/64", {})
+    del_handler_test(m, "SUPPRESS_PREFIX|fc00::/64")
+    mocked_log_debug.assert_called_with("PrefixListMgr:: Suppress prefix fc00::/64 removed from suppress_prefix configuration")
+
+@patch('bgpcfgd.managers_prefix_list.log_debug')
+def test_suppress_prefix_any_device(mocked_log_debug):
+    m = constructor()
+    set_handler_test(m, "SUPPRESS_PREFIX|10.0.0.0/24", {})
+    mocked_log_debug.assert_called_with("PrefixListMgr:: Suppress prefix 10.0.0.0/24 added to suppress_prefix configuration")

--- a/src/sonic-bgpcfgd/tests/test_prefix_list.py
+++ b/src/sonic-bgpcfgd/tests/test_prefix_list.py
@@ -96,7 +96,7 @@ def test_unsupported_prefix_type(mocked_log_warn):
 def test_anchor_prefix_wrong_device(mocked_log_warn):
     m = constructor_with_constants({})
     set_handler_test(m, "ANCHOR_PREFIX|192.168.0.0/24", {})
-    mocked_log_warn.assert_called_with("PrefixListMgr:: Device type ToRRouter/ not supported for ANCHOR_PREFIX")
+    mocked_log_warn.assert_called_with("PrefixListMgr:: Device type ToRRouter not supported for ANCHOR_PREFIX")
 
 @patch('bgpcfgd.managers_prefix_list.log_debug')
 def test_suppress_prefix_ipv4(mocked_log_debug):

--- a/src/sonic-bgpcfgd/tests/test_prefix_list.py
+++ b/src/sonic-bgpcfgd/tests/test_prefix_list.py
@@ -73,13 +73,13 @@ def test_del_handler_ipv6(mocked_log_debug):
     del_handler_test(m, "ANCHOR_PREFIX|fc02:100::/64")
     mocked_log_debug.assert_called_with("PrefixListMgr:: Anchor prefix fc02:100::/64 removed from radian configuration")
 
-def constructor_generic_device():
+def constructor_with_constants(constants):
     cfg_mgr = MagicMock()
     common_objs = {
         'directory': Directory(),
         'cfg_mgr':   cfg_mgr,
         'tf':        TemplateFabric(TEMPLATE_PATH),
-        'constants': {},
+        'constants': constants,
     }
     m = PrefixListMgr(common_objs, "CONFIG_DB", "PREFIX_LIST")
     m.directory.put("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost",
@@ -88,38 +88,38 @@ def constructor_generic_device():
 
 @patch('bgpcfgd.managers_prefix_list.log_warn')
 def test_unsupported_prefix_type(mocked_log_warn):
-    m = constructor_generic_device()
+    m = constructor_with_constants({})
     set_handler_test(m, "UNKNOWN_TYPE|10.0.0.0/24", {})
     mocked_log_warn.assert_called_with("PrefixListMgr:: Prefix type 'UNKNOWN_TYPE' is not supported")
 
 @patch('bgpcfgd.managers_prefix_list.log_warn')
 def test_anchor_prefix_wrong_device(mocked_log_warn):
-    m = constructor_generic_device()
+    m = constructor_with_constants({})
     set_handler_test(m, "ANCHOR_PREFIX|192.168.0.0/24", {})
     mocked_log_warn.assert_called_with("PrefixListMgr:: Device type ToRRouter/ not supported for ANCHOR_PREFIX")
 
 @patch('bgpcfgd.managers_prefix_list.log_debug')
 def test_suppress_prefix_ipv4(mocked_log_debug):
-    m = constructor_generic_device()
+    m = constructor_with_constants({})
     set_handler_test(m, "SUPPRESS_PREFIX|10.0.0.0/24", {})
     mocked_log_debug.assert_called_with("PrefixListMgr:: Suppress prefix 10.0.0.0/24 added to suppress_prefix configuration")
 
 @patch('bgpcfgd.managers_prefix_list.log_debug')
 def test_suppress_prefix_ipv6(mocked_log_debug):
-    m = constructor_generic_device()
+    m = constructor_with_constants({})
     set_handler_test(m, "SUPPRESS_PREFIX|fc00::/64", {})
     mocked_log_debug.assert_called_with("PrefixListMgr:: Suppress prefix fc00::/64 added to suppress_prefix configuration")
 
 @patch('bgpcfgd.managers_prefix_list.log_debug')
 def test_suppress_prefix_del_ipv4(mocked_log_debug):
-    m = constructor_generic_device()
+    m = constructor_with_constants({})
     set_handler_test(m, "SUPPRESS_PREFIX|10.0.0.0/24", {})
     del_handler_test(m, "SUPPRESS_PREFIX|10.0.0.0/24")
     mocked_log_debug.assert_called_with("PrefixListMgr:: Suppress prefix 10.0.0.0/24 removed from suppress_prefix configuration")
 
 @patch('bgpcfgd.managers_prefix_list.log_debug')
 def test_suppress_prefix_del_ipv6(mocked_log_debug):
-    m = constructor_generic_device()
+    m = constructor_with_constants({})
     set_handler_test(m, "SUPPRESS_PREFIX|fc00::/64", {})
     del_handler_test(m, "SUPPRESS_PREFIX|fc00::/64")
     mocked_log_debug.assert_called_with("PrefixListMgr:: Suppress prefix fc00::/64 removed from suppress_prefix configuration")
@@ -129,3 +129,21 @@ def test_suppress_prefix_any_device(mocked_log_debug):
     m = constructor()
     set_handler_test(m, "SUPPRESS_PREFIX|10.0.0.0/24", {})
     mocked_log_debug.assert_called_with("PrefixListMgr:: Suppress prefix 10.0.0.0/24 added to suppress_prefix configuration")
+
+@patch('bgpcfgd.managers_prefix_list.log_debug')
+def test_suppress_prefix_constants_override(mocked_log_debug):
+    constants = {"bgp": {"prefix_list": {"SUPPRESS_PREFIX": {
+        "ipv4_name": "SUPPRESS_ON_T1_IPV4_PREFIX",
+        "ipv6_name": "SUPPRESS_ON_T1_IPV6_PREFIX"}}}}
+    m = constructor_with_constants(constants)
+    set_handler_test(m, "SUPPRESS_PREFIX|10.0.0.0/24", {})
+    push_call = m.cfg_mgr.push.call_args[0][0]
+    assert "SUPPRESS_ON_T1_IPV4_PREFIX" in push_call
+    assert "SUPPRESS_IPV4_PREFIX" not in push_call
+
+@patch('bgpcfgd.managers_prefix_list.log_debug')
+def test_suppress_prefix_no_constants_fallback(mocked_log_debug):
+    m = constructor_with_constants({})
+    set_handler_test(m, "SUPPRESS_PREFIX|10.0.0.0/24", {})
+    push_call = m.cfg_mgr.push.call_args[0][0]
+    assert "SUPPRESS_IPV4_PREFIX" in push_call

--- a/src/sonic-bgpcfgd/tests/test_prefix_list.py
+++ b/src/sonic-bgpcfgd/tests/test_prefix_list.py
@@ -133,12 +133,12 @@ def test_suppress_prefix_any_device(mocked_log_debug):
 @patch('bgpcfgd.managers_prefix_list.log_debug')
 def test_suppress_prefix_constants_override(mocked_log_debug):
     constants = {"bgp": {"prefix_list": {"SUPPRESS_PREFIX": {
-        "ipv4_name": "SUPPRESS_ON_T1_IPV4_PREFIX",
-        "ipv6_name": "SUPPRESS_ON_T1_IPV6_PREFIX"}}}}
+        "ipv4_name": "CUSTOM_IPV4_PREFIX",
+        "ipv6_name": "CUSTOM_IPV6_PREFIX"}}}}
     m = constructor_with_constants(constants)
     set_handler_test(m, "SUPPRESS_PREFIX|10.0.0.0/24", {})
     push_call = m.cfg_mgr.push.call_args[0][0]
-    assert "SUPPRESS_ON_T1_IPV4_PREFIX" in push_call
+    assert "CUSTOM_IPV4_PREFIX" in push_call
     assert "SUPPRESS_IPV4_PREFIX" not in push_call
 
 @patch('bgpcfgd.managers_prefix_list.log_debug')

--- a/src/sonic-bgpcfgd/tests/test_prefix_list.py
+++ b/src/sonic-bgpcfgd/tests/test_prefix_list.py
@@ -142,6 +142,17 @@ def test_suppress_prefix_constants_override(mocked_log_debug):
     assert "SUPPRESS_IPV4_PREFIX" not in push_call
 
 @patch('bgpcfgd.managers_prefix_list.log_debug')
+def test_suppress_prefix_constants_override_ipv6(mocked_log_debug):
+    constants = {"bgp": {"prefix_list": {"SUPPRESS_PREFIX": {
+        "ipv4_name": "CUSTOM_IPV4_PREFIX",
+        "ipv6_name": "CUSTOM_IPV6_PREFIX"}}}}
+    m = constructor_with_constants(constants)
+    set_handler_test(m, "SUPPRESS_PREFIX|fc00::/64", {})
+    push_call = m.cfg_mgr.push.call_args[0][0]
+    assert "CUSTOM_IPV6_PREFIX" in push_call
+    assert "SUPPRESS_IPV6_PREFIX" not in push_call
+
+@patch('bgpcfgd.managers_prefix_list.log_debug')
 def test_suppress_prefix_no_constants_fallback(mocked_log_debug):
     m = constructor_with_constants({})
     set_handler_test(m, "SUPPRESS_PREFIX|10.0.0.0/24", {})

--- a/src/sonic-bgpcfgd/tests/test_prefix_list.py
+++ b/src/sonic-bgpcfgd/tests/test_prefix_list.py
@@ -69,7 +69,6 @@ def test_del_handler_ipv6(mocked_log_debug):
     del_handler_test(m, "ANCHOR_PREFIX|fc02:100::/64")
     mocked_log_debug.assert_called_with("PrefixListMgr:: Anchor prefix fc02:100::/64 removed from radian configuration")
 
-# test unsupported prefix type
 def constructor_unsupported_device():
     cfg_mgr = MagicMock()
     common_objs = {

--- a/src/sonic-bgpcfgd/tests/test_prefix_list.py
+++ b/src/sonic-bgpcfgd/tests/test_prefix_list.py
@@ -68,3 +68,29 @@ def test_del_handler_ipv6(mocked_log_debug):
     set_handler_test(m, "ANCHOR_PREFIX|fc02:100::/64", {})
     del_handler_test(m, "ANCHOR_PREFIX|fc02:100::/64")
     mocked_log_debug.assert_called_with("PrefixListMgr:: Anchor prefix fc02:100::/64 removed from radian configuration")
+
+# test unsupported prefix type
+def constructor_unsupported_device():
+    cfg_mgr = MagicMock()
+    common_objs = {
+        'directory': Directory(),
+        'cfg_mgr':   cfg_mgr,
+        'tf':        TemplateFabric(TEMPLATE_PATH),
+        'constants': {},
+    }
+    m = PrefixListMgr(common_objs, "CONFIG_DB", "PREFIX_LIST")
+    m.directory.put("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost",
+                    {"bgp_asn": "65100", "type": "SpineRouter", "subtype": "DownstreamLC"})
+    return m
+
+@patch('bgpcfgd.managers_prefix_list.log_warn')
+def test_unsupported_prefix_type(mocked_log_warn):
+    m = constructor()
+    set_handler_test(m, "UNKNOWN_TYPE|10.0.0.0/24", {})
+    mocked_log_warn.assert_called_with("PrefixListMgr:: Prefix type 'UNKNOWN_TYPE' is not supported")
+
+@patch('bgpcfgd.managers_prefix_list.log_warn')
+def test_anchor_prefix_wrong_device(mocked_log_warn):
+    m = constructor_unsupported_device()
+    set_handler_test(m, "ANCHOR_PREFIX|192.168.0.0/24", {})
+    mocked_log_warn.assert_called_with("PrefixListMgr:: Device type SpineRouter/DownstreamLC not supported for ANCHOR_PREFIX")


### PR DESCRIPTION
#### Why I did it

Currently PrefixListMgr only supports ANCHOR_PREFIX with hardcoded device-type checks and template references. This refactor makes PrefixListMgr data-driven and extensible, and adds a generic SUPPRESS_PREFIX type for route suppression use cases.

##### Work item tracking
- Microsoft ADO **(number only)**: 37638053

#### How I did it

**Registry refactor (ANCHOR_PREFIX behavior unchanged):**
- Added `PREFIX_TYPE_CONFIG` registry mapping each prefix type to its templates, allowed device types, prefix-list naming lambda, and log labels
- Added `_is_device_allowed()` helper using `(type, subtype)` tuple matching, with `None` = unrestricted
- Refactored `generate_prefix_list_config` to use registry lookup instead of hardcoded checks
- Renamed handler local `prefix_list_name` → `prefix_type` to avoid confusion with `data["prefix_list_name"]`
- Used `metadata.get("subtype", "")` to handle devices without subtype

**SUPPRESS_PREFIX type (new):**
- Added `SUPPRESS_PREFIX` registry entry with `allowed_devices: None` (any device)
- Added `add_suppress_prefix.conf.j2` / `del_suppress_prefix.conf.j2` templates
- In CLI: replaced global `check_spine_router` with per-type `validate_device_for_type`

**constants.yml-driven prefix-list name resolution:**
- Prefix-list names resolved from `constants.yml` (`bgp.prefix_list.<type>.ipv4_name` / `ipv6_name`) with registry lambda as fallback
- Enables downstream repos to override names via `constants.yml` alone

**Backward-compatibility:**
- All 5 existing ANCHOR_PREFIX unit tests pass unchanged
- PrefixListMgr registered on all devices — ANCHOR_PREFIX on non-spine devices logs a warning (no FRR state change; doesn't occur in practice)
- CLI `status` now allowed on any device (read-only)

#### How to verify it

- All 15 unit tests pass (5 existing ANCHOR_PREFIX + 2 registry validation + 5 SUPPRESS_PREFIX + 3 constants override/fallback)
- ANCHOR_PREFIX behavior identical before and after

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [x] 202603

#### Tested branch (Please provide the tested image version)

- [x]  SONiC.20251110.19

#### Description for the changelog

Refactor PrefixListMgr to use a data-driven config registry with constants.yml-driven prefix-list name resolution, and add generic SUPPRESS_PREFIX type.

#### Link to config_db schema for YANG module changes
No YANG model changes. Uses existing PREFIX_LIST table:
[Prefix list](https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#prefix-list)

#### A picture of a cute animal (not mandatory but encouraged)

<img width="491" height="526" alt="枣" src="https://github.com/user-attachments/assets/244cb96f-1b7d-4110-8ba4-92a5a4abcee0" />