### PR TITLE
Enable ECC/parity checking for NH5010

### DIFF
--- a/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/sai_postinit_cmd.soc
+++ b/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/sai_postinit_cmd.soc
@@ -1,0 +1,227 @@
+setreg MSU_MACSEC_INTERRUPT_MASK_REGISTER.MSU13 0x0
+setreg MSU_MACSEC_INTERRUPT_MASK_REGISTER.MSU16 0x0
+
+# Core=0
+INTeRrupt ENAble id=2249 p=0
+INTeRrupt ENAble id=2250 p=0
+INTeRrupt ENAble id=2251 p=0
+INTeRrupt ENAble id=2252 p=0
+INTeRrupt ENAble id=2253 p=0
+INTeRrupt ENAble id=2254 p=0
+INTeRrupt ENAble id=2255 p=0
+INTeRrupt ENAble id=2256 p=0
+INTeRrupt ENAble id=2257 p=0
+INTeRrupt ENAble id=2258 p=0
+INTeRrupt ENAble id=2259 p=0
+INTeRrupt ENAble id=2260 p=0
+INTeRrupt ENAble id=2261 p=0
+INTeRrupt ENAble id=2262 p=0
+INTeRrupt ENAble id=2263 p=0
+
+INTeRrupt ENAble id=540 p=0
+INTeRrupt ENAble id=541 p=0
+INTeRrupt ENAble id=542 p=0
+INTeRrupt ENAble id=543 p=0
+INTeRrupt ENAble id=544 p=0
+INTeRrupt ENAble id=545 p=0
+INTeRrupt ENAble id=546 p=0
+
+INTeRrupt ENAble id=1529 p=0
+
+# Core=1
+INTeRrupt ENAble id=2249 p=1
+INTeRrupt ENAble id=2250 p=1
+INTeRrupt ENAble id=2251 p=1
+INTeRrupt ENAble id=2252 p=1
+INTeRrupt ENAble id=2253 p=1
+INTeRrupt ENAble id=2254 p=1
+INTeRrupt ENAble id=2255 p=1
+INTeRrupt ENAble id=2256 p=1
+INTeRrupt ENAble id=2257 p=1
+INTeRrupt ENAble id=2258 p=1
+INTeRrupt ENAble id=2259 p=1
+INTeRrupt ENAble id=2260 p=1
+INTeRrupt ENAble id=2261 p=1
+INTeRrupt ENAble id=2262 p=1
+INTeRrupt ENAble id=2263 p=1
+
+
+INTeRrupt ENAble id=541 p=1
+INTeRrupt ENAble id=542 p=1
+INTeRrupt ENAble id=543 p=1
+INTeRrupt ENAble id=544 p=1
+INTeRrupt ENAble id=545 p=1
+INTeRrupt ENAble id=546 p=1
+
+INTeRrupt ENAble id=1529 p=1
+
+
+# Core=2
+INTeRrupt ENAble id=2249 p=2
+INTeRrupt ENAble id=2250 p=2
+INTeRrupt ENAble id=2251 p=2
+INTeRrupt ENAble id=2252 p=2
+INTeRrupt ENAble id=2253 p=2
+INTeRrupt ENAble id=2254 p=2
+INTeRrupt ENAble id=2255 p=2
+INTeRrupt ENAble id=2256 p=2
+INTeRrupt ENAble id=2257 p=2
+INTeRrupt ENAble id=2258 p=2
+INTeRrupt ENAble id=2259 p=2
+INTeRrupt ENAble id=2260 p=2
+INTeRrupt ENAble id=2261 p=2
+INTeRrupt ENAble id=2262 p=2
+INTeRrupt ENAble id=2263 p=2
+
+
+INTeRrupt ENAble id=541 p=2
+INTeRrupt ENAble id=542 p=2
+INTeRrupt ENAble id=543 p=2
+INTeRrupt ENAble id=544 p=2
+INTeRrupt ENAble id=545 p=2
+INTeRrupt ENAble id=546 p=2
+
+INTeRrupt ENAble id=1529 p=2
+
+
+# Core=3
+INTeRrupt ENAble id=2249 p=3
+INTeRrupt ENAble id=2250 p=3
+INTeRrupt ENAble id=2251 p=3
+INTeRrupt ENAble id=2252 p=3
+INTeRrupt ENAble id=2253 p=3
+INTeRrupt ENAble id=2254 p=3
+INTeRrupt ENAble id=2255 p=3
+INTeRrupt ENAble id=2256 p=3
+INTeRrupt ENAble id=2257 p=3
+INTeRrupt ENAble id=2258 p=3
+INTeRrupt ENAble id=2259 p=3
+INTeRrupt ENAble id=2260 p=3
+INTeRrupt ENAble id=2261 p=3
+INTeRrupt ENAble id=2262 p=3
+INTeRrupt ENAble id=2263 p=3
+
+
+INTeRrupt ENAble id=541 p=3
+INTeRrupt ENAble id=542 p=3
+INTeRrupt ENAble id=543 p=3
+INTeRrupt ENAble id=544 p=3
+INTeRrupt ENAble id=545 p=3
+INTeRrupt ENAble id=546 p=3
+
+INTeRrupt ENAble id=1529 p=3
+
+
+# Core=4
+INTeRrupt ENAble id=2249 p=4
+INTeRrupt ENAble id=2250 p=4
+INTeRrupt ENAble id=2251 p=4
+INTeRrupt ENAble id=2252 p=4
+INTeRrupt ENAble id=2253 p=4
+INTeRrupt ENAble id=2254 p=4
+INTeRrupt ENAble id=2255 p=4
+INTeRrupt ENAble id=2256 p=4
+INTeRrupt ENAble id=2257 p=4
+INTeRrupt ENAble id=2258 p=4
+INTeRrupt ENAble id=2259 p=4
+INTeRrupt ENAble id=2260 p=4
+INTeRrupt ENAble id=2261 p=4
+INTeRrupt ENAble id=2262 p=4
+INTeRrupt ENAble id=2263 p=4
+
+
+INTeRrupt ENAble id=541 p=4
+INTeRrupt ENAble id=542 p=4
+INTeRrupt ENAble id=543 p=4
+INTeRrupt ENAble id=544 p=4
+INTeRrupt ENAble id=545 p=4
+INTeRrupt ENAble id=546 p=4
+
+INTeRrupt ENAble id=1529 p=4
+
+
+# Core=5
+INTeRrupt ENAble id=2249 p=5
+INTeRrupt ENAble id=2250 p=5
+INTeRrupt ENAble id=2251 p=5
+INTeRrupt ENAble id=2252 p=5
+INTeRrupt ENAble id=2253 p=5
+INTeRrupt ENAble id=2254 p=5
+INTeRrupt ENAble id=2255 p=5
+INTeRrupt ENAble id=2256 p=5
+INTeRrupt ENAble id=2257 p=5
+INTeRrupt ENAble id=2258 p=5
+INTeRrupt ENAble id=2259 p=5
+INTeRrupt ENAble id=2260 p=5
+INTeRrupt ENAble id=2261 p=5
+INTeRrupt ENAble id=2262 p=5
+INTeRrupt ENAble id=2263 p=5
+
+
+INTeRrupt ENAble id=541 p=5
+INTeRrupt ENAble id=542 p=5
+INTeRrupt ENAble id=543 p=5
+INTeRrupt ENAble id=544 p=5
+INTeRrupt ENAble id=545 p=5
+INTeRrupt ENAble id=546 p=5
+
+INTeRrupt ENAble id=1529 p=5
+
+
+# Core=6
+INTeRrupt ENAble id=2249 p=6
+INTeRrupt ENAble id=2250 p=6
+INTeRrupt ENAble id=2251 p=6
+INTeRrupt ENAble id=2252 p=6
+INTeRrupt ENAble id=2253 p=6
+INTeRrupt ENAble id=2254 p=6
+INTeRrupt ENAble id=2255 p=6
+INTeRrupt ENAble id=2256 p=6
+INTeRrupt ENAble id=2257 p=6
+INTeRrupt ENAble id=2258 p=6
+INTeRrupt ENAble id=2259 p=6
+INTeRrupt ENAble id=2260 p=6
+INTeRrupt ENAble id=2261 p=6
+INTeRrupt ENAble id=2262 p=6
+INTeRrupt ENAble id=2263 p=6
+
+
+INTeRrupt ENAble id=541 p=6
+INTeRrupt ENAble id=542 p=6
+INTeRrupt ENAble id=543 p=6
+INTeRrupt ENAble id=544 p=6
+INTeRrupt ENAble id=545 p=6
+INTeRrupt ENAble id=546 p=6
+
+INTeRrupt ENAble id=1529 p=6
+
+
+# Core=7
+INTeRrupt ENAble id=2249 p=7
+INTeRrupt ENAble id=2250 p=7
+INTeRrupt ENAble id=2251 p=7
+INTeRrupt ENAble id=2252 p=7
+INTeRrupt ENAble id=2253 p=7
+INTeRrupt ENAble id=2254 p=7
+INTeRrupt ENAble id=2255 p=7
+INTeRrupt ENAble id=2256 p=7
+INTeRrupt ENAble id=2257 p=7
+INTeRrupt ENAble id=2258 p=7
+INTeRrupt ENAble id=2259 p=7
+INTeRrupt ENAble id=2260 p=7
+INTeRrupt ENAble id=2261 p=7
+INTeRrupt ENAble id=2262 p=7
+INTeRrupt ENAble id=2263 p=7
+
+INTeRrupt ENAble id=541 p=7
+INTeRrupt ENAble id=542 p=7
+INTeRrupt ENAble id=543 p=7
+INTeRrupt ENAble id=544 p=7
+INTeRrupt ENAble id=545 p=7
+INTeRrupt ENAble id=546 p=7
+
+INTeRrupt ENAble id=1529 p=7
+
+
+debug intr error
+

--- a/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/templates/nh5010.bcm.j2
+++ b/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/templates/nh5010.bcm.j2
@@ -1601,6 +1601,7 @@ appl_param_rcy_mirror_ports_range.BCM8887X=500-1000
 #                                     -----------------------------------------------
 
 dpp_db_path=/usr/share/bcm/db
+sai_postinit_cmd_file=/usr/share/sonic/hwsku/sai_postinit_cmd.soc
 rif_id_max=8192
 trunk_group_max_members=128
 custom_feature_ts_pll_internal_clock_reference.BCM8887X=1


### PR DESCRIPTION
#### Why I did it

This PR is to add the NH5010 sai_postinit_cmd.soc with the interrupt-ids

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Enabled it by adding those in the platform file sai_postinit_cmd.soc

#### How to verify it

Run bcmcmd "show int all" to check if those interrupts are enabled.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

