### PR TITLE
[dhcp-relay] Add "Malformed" to SUPPORTED_DHCP_TYPE so sonic-clear ze…

### DIFF
--- a/dockers/docker-dhcp-relay/cli/clear/plugins/clear_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli/clear/plugins/clear_dhcp_relay.py
@@ -14,7 +14,7 @@ import utilities_common.cli as clicommon
 
 DHCPV4_CLEAR_COUNTER_LOCK_FILE = "/tmp/clear_dhcpv4_counter.lock"
 SUPPORTED_DHCP_TYPE = [
-    "Unknown", "Discover", "Offer", "Request", "Decline", "Ack", "Nak", "Release", "Inform", "Bootp"
+    "Unknown", "Discover", "Offer", "Request", "Decline", "Ack", "Nak", "Release", "Inform", "Bootp", "Malformed"
 ]
 SUPPORTED_DIR = ["TX", "RX"]
 DHCPV4_COUNTER_TABLE_PREFIX = "DHCPV4_COUNTER_TABLE"


### PR DESCRIPTION
…roes the Malformed counter

Without this, sonic-clear dhcp_relay ipv4 counters iterates SUPPORTED_DHCP_TYPE and zeroes only those entries in COUNTERS_DB. Because "Malformed" was missing, its DB value was never reset; dhcpmons SIGUSR2 handler then synced the stale DB value back into its in-memory cache, and the periodic 20s cache writeback restored the stale value to DB indefinitely.

Symptom: test_dhcpmon_relay_counters_stress fails with
  RX Malformed: actual value <N>, expected value 0

Master already includes "Malformed" (and "Ignored") in this list as part of a larger refactor; this is a minimal back-port to 202511.

Tested on bjw2-can-720dt-4: after the patch,
test_dhcpmon_relay_counters_stress[discover-isc-relay-agent] passes.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

 `sonic-clear dhcp_relay ipv4 counters` iterates `SUPPORTED_DHCP_TYPE` and zeroes only those entries in `COUNTERS_DB`. Because `"Malformed"` was missing from the list, its DB value was never reset; dhcpmon's SIGUSR2 handler then synced the stale DB value back into its in-memory cache, and the periodic 20s cache writeback restored the stale value to DB 
indefinitely.
 
 Symptom: `test_dhcpmon_relay_counters_stress` fails with

RX Malformed: actual value <N>, expected value 0

##### Work item tracking
- Microsoft ADO **(number only)**: 38614127

 ##### Why this fix lives only on 202511 (no master change)
 Master already includes `"Malformed"` (and `"Ignored"`) in `SUPPORTED_DHCP_TYPE` — but only as a side effect of a much larger refactor of `clear_dhcp_relay.py` (restructured into shared v4/v6 helpers, new `clear_dhcpmon_counters` entry point, renamed lock file, etc.). That refactor is **feature-related** rather than a bug fix, so it is not eligible for 
back-port to 202511 under the release-branch policy.
 
 This PR therefore contains only the minimal one-line addition needed to fix the bug on 202511, without dragging the unrelated refactor along with it. Master needs no change because the larger PR there already covers it.

#### How I did it

 Added `"Malformed"` to `SUPPORTED_DHCP_TYPE` in `dockers/docker-dhcp-relay/cli/clear/plugins/clear_dhcp_relay.py` (one-line change).

#### How to verify it

 On `bjw2-can-720dt-4` (202511 image) after applying the patched plugin to the host's installed copy at `/usr/local/lib/python3.13/dist-packages/clear/plugins/dhcp-relay.py`:
 
 1. **Manual injection test** — set the counter to a non-zero value, then clear:

sudo sonic-db-cli COUNTERS_DB HSET DHCPV4_COUNTER_TABLE:Vlan1000:PortChannel101 RX 
"{'Unknown':'0',...,'Bootp':'0','Malformed':'99'}"  sudo sonic-clear dhcp_relay ipv4 counters

 Result: `Malformed:'0'` immediately after the clear, and **stays 0** across dhcpmon's 20-second cache-writeback cycles (verified at t+0/+25/+50s). Without the patch, `Malformed:'99'` persists indefinitely.
 
 2. **Full pytest re-run**:

tests/dhcp_relay/test_dhcp_counter_stress.py::test_dhcpmon_relay_counters_stress[discover-isc-relay-agent]

 **PASSED** (was failing with `RX Malformed: actual value 5, expected value 0` before the patch).

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

