### PR TITLE
build: skip removable block devices in PMON docker mounts

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -32,6 +32,14 @@ get_pmon_device_mounts() {
     local devregex='i2c-[0-9]+|ipmi[0-9]+|sd[a-z]+|mmcblk[0-9].*|nvme[0-9].*|uio.*|watchdog[0-9]*'
     local devpathregex="$(echo "$devregex" | sed -E 's#(^|\|)#\1/dev/#g')"
     for device in $(find /dev/ -maxdepth 1 | grep -E "$devpathregex"); do
+        # only skip removable block device;
+        if [ -b "$device" ]; then
+            rm_flag=$(lsblk -dn -o RM "$device" 2>/dev/null | tr -d '[:space:]')
+            if [ "$rm_flag" = "1" ]; then
+                continue
+            fi
+        fi
+
         if [ ! -L "$device" ] && [ -b "$device" -o -c "$device" ]; then
             echo "--device=$device"
         else


### PR DESCRIPTION
get_pmon_device_mounts() walks block devices under /dev for Docker --device pass-through to the PMON container. Skip devices where lsblk reports RM=1 so removable media (e.g. USB) are not mounted into PMON by mistake.

On first PMON container creation, if a USB stick was plugged in, it was picked up as a device bind-mount. If the USB was later unplugged, a subsequent system restart could fail because the container still referenced a device path that no longer existed.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

