### PR TITLE
Arista 7280dr3a SKUs: Update platform.json to match the correct component ordering

### DIFF
--- a/device/arista/x86_64-arista_7280dr3a_36/platform.json
+++ b/device/arista/x86_64-arista_7280dr3a_36/platform.json
@@ -9,6 +9,9 @@
                 "name": "Scd(addr=0000:00:18.7)"
             },
             {
+                "name": "CormorantSysCpld(addr=13-0023)"
+            },
+            {
                 "name": "Adm1266(addr=10-004f)"
             },
             {
@@ -16,9 +19,6 @@
             },
             {
                 "name": "Scd(addr=0000:01:00.0)"
-            },
-            {
-                "name": "CormorantSysCpld(addr=13-0023)"
             }
         ],
         "fans": [],

--- a/device/arista/x86_64-arista_7280dr3ak_36/platform.json
+++ b/device/arista/x86_64-arista_7280dr3ak_36/platform.json
@@ -9,6 +9,9 @@
                 "name": "Scd(addr=0000:00:18.7)"
             },
             {
+                "name": "CormorantSysCpld(addr=13-0023)"
+            },
+            {
                 "name": "Adm1266(addr=10-004f)"
             },
             {
@@ -16,9 +19,6 @@
             },
             {
                 "name": "Scd(addr=0000:01:00.0)"
-            },
-            {
-                "name": "CormorantSysCpld(addr=13-0023)"
             }
         ],
         "fans": [],

--- a/device/arista/x86_64-arista_7280dr3ak_36s/platform.json
+++ b/device/arista/x86_64-arista_7280dr3ak_36s/platform.json
@@ -9,6 +9,9 @@
                 "name": "Scd(addr=0000:00:18.7)"
             },
             {
+                "name": "CormorantSysCpld(addr=13-0023)"
+            },
+            {
                 "name": "Adm1266(addr=10-004f)"
             },
             {
@@ -16,9 +19,6 @@
             },
             {
                 "name": "Scd(addr=0000:01:00.0)"
-            },
-            {
-                "name": "CormorantSysCpld(addr=13-0023)"
             }
         ],
         "fans": [],

--- a/device/arista/x86_64-arista_7280dr3am_36/platform.json
+++ b/device/arista/x86_64-arista_7280dr3am_36/platform.json
@@ -9,6 +9,9 @@
                 "name": "Scd(addr=0000:00:18.7)"
             },
             {
+                "name": "CormorantSysCpld(addr=13-0023)"
+            },
+            {
                 "name": "Adm1266(addr=10-004f)"
             },
             {
@@ -16,9 +19,6 @@
             },
             {
                 "name": "Scd(addr=0000:01:00.0)"
-            },
-            {
-                "name": "CormorantSysCpld(addr=13-0023)"
             }
         ],
         "fans": [],


### PR DESCRIPTION
Needed due to arista sonic-platform-module changes.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The platform.json is out of date, this change fixes the component ordering.

#### How to verify it
Run `platform_tests/api/test_component.py::TestComponentApi::test_get_name` on the updated skus to see it pass.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)
202511

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

