### PR TITLE
Add EOPTOLINK tunings for Arista 7280R4-32QF-32DF-F

### DIFF
--- a/device/arista/x86_64-arista_7280r4_32qf_32df/media_settings.json
+++ b/device/arista/x86_64-arista_7280r4_32qf_32df/media_settings.json
@@ -133,6 +133,50 @@
                     "lane3": "0x0"
                 }
             },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x62",
+                    "lane1": "0x63",
+                    "lane2": "0x62",
+                    "lane3": "0x61"
+                },
+                "post1": {
+                    "lane0": "0xfffffff5",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff5",
+                    "lane3": "0xfffffff5"
+                },
+                "post2": {
+                    "lane0": "0xfffffff4",
+                    "lane1": "0xfffffff6",
+                    "lane2": "0xfffffff4",
+                    "lane3": "0xfffffff4"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffea",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffea",
+                    "lane3": "0xffffffec"
+                },
+                "pre2": {
+                    "lane0": "0x5",
+                    "lane1": "0x5",
+                    "lane2": "0x5",
+                    "lane3": "0x4"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff"
+                }
+            },
             "OPTICAL100": {
                 "main": {
                     "lane0": "0x78",
@@ -399,6 +443,50 @@
                     "lane3": "0x0"
                 }
             },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x67",
+                    "lane1": "0x68",
+                    "lane2": "0x63",
+                    "lane3": "0x66"
+                },
+                "post1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff4",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0xfffffff4",
+                    "lane1": "0xfffffff3",
+                    "lane2": "0xfffffff6",
+                    "lane3": "0xfffffff2"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe5"
+                },
+                "pre2": {
+                    "lane0": "0x5",
+                    "lane1": "0x4",
+                    "lane2": "0x5",
+                    "lane3": "0x6"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0x0",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff"
+                }
+            },
             "OPTICAL100": {
                 "main": {
                     "lane0": "0x78",
@@ -499,7 +587,6 @@
                     "lane1": "0x0",
                     "lane2": "0x0",
                     "lane3": "0x0"
-
                 },
                 "post2": {
                     "lane0": "0x0",
@@ -530,6 +617,7 @@
                     "lane1": "0x0",
                     "lane2": "0x0",
                     "lane3": "0x0"
+
                 }
             }
         },
@@ -663,6 +751,50 @@
                     "lane0": "0x0",
                     "lane1": "0x0",
                     "lane2": "0x0",
+                    "lane3": "0x0"
+                }
+            },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x68",
+                    "lane1": "0x67",
+                    "lane2": "0x68",
+                    "lane3": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xfffffff0",
+                    "lane1": "0xfffffff4",
+                    "lane2": "0xfffffff1",
+                    "lane3": "0xffffffeb"
+                },
+                "post2": {
+                    "lane0": "0xfffffff4",
+                    "lane1": "0xfffffff5",
+                    "lane2": "0xfffffff4",
+                    "lane3": "0xfffffff7"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe9",
+                    "lane1": "0xffffffe6",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffea"
+                },
+                "pre2": {
+                    "lane0": "0x5",
+                    "lane1": "0x5",
+                    "lane2": "0x5",
+                    "lane3": "0x4"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
                     "lane3": "0x0"
                 }
             },
@@ -932,6 +1064,50 @@
                     "lane3": "0x0"
                 }
             },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x64",
+                    "lane1": "0x61",
+                    "lane2": "0x61",
+                    "lane3": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xfffffff3",
+                    "lane1": "0xfffffff5",
+                    "lane2": "0xfffffff5",
+                    "lane3": "0xfffffff5"
+                },
+                "post2": {
+                    "lane0": "0xfffffff5",
+                    "lane1": "0xfffffff4",
+                    "lane2": "0xfffffff4",
+                    "lane3": "0xfffffff1"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffea",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffe9"
+                },
+                "pre2": {
+                    "lane0": "0x5",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x5"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff"
+                }
+            },
             "OPTICAL100": {
                 "main": {
                     "lane0": "0x78",
@@ -1198,6 +1374,50 @@
                     "lane3": "0x0"
                 }
             },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x61",
+                    "lane1": "0x61",
+                    "lane2": "0x60",
+                    "lane3": "0x5e"
+                },
+                "post1": {
+                    "lane0": "0xfffffff9",
+                    "lane1": "0xfffffff5",
+                    "lane2": "0xfffffff9",
+                    "lane3": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff4",
+                    "lane2": "0xfffffff3",
+                    "lane3": "0xfffffff5"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffea",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffe9",
+                    "lane3": "0xffffffe9"
+                },
+                "pre2": {
+                    "lane0": "0x5",
+                    "lane1": "0x4",
+                    "lane2": "0x5",
+                    "lane3": "0x5"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff"
+                }
+            },
             "OPTICAL100": {
                 "main": {
                     "lane0": "0x78",
@@ -1284,7 +1504,6 @@
                     "lane1": "0x0",
                     "lane2": "0x0",
                     "lane3": "0x0"
-
                 }
             },
             "OPTICAL50": {
@@ -1462,6 +1681,50 @@
                     "lane0": "0x0",
                     "lane1": "0x0",
                     "lane2": "0x0",
+                    "lane3": "0x0"
+                }
+            },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x67",
+                    "lane1": "0x67",
+                    "lane2": "0x63",
+                    "lane3": "0x68"
+                },
+                "post1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff5",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff4"
+                },
+                "post2": {
+                    "lane0": "0xfffffff4",
+                    "lane1": "0xfffffff1",
+                    "lane2": "0xfffffff6",
+                    "lane3": "0xfffffff3"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe9",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8"
+                },
+                "pre2": {
+                    "lane0": "0x5",
+                    "lane1": "0x5",
+                    "lane2": "0x5",
+                    "lane3": "0x4"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
                     "lane3": "0x0"
                 }
             },
@@ -1731,6 +1994,50 @@
                     "lane3": "0x0"
                 }
             },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x65",
+                    "lane1": "0x68",
+                    "lane2": "0x65",
+                    "lane3": "0x68"
+                },
+                "post1": {
+                    "lane0": "0xfffffff0",
+                    "lane1": "0xfffffff1",
+                    "lane2": "0xfffffff5",
+                    "lane3": "0xfffffff1"
+                },
+                "post2": {
+                    "lane0": "0xfffffff6",
+                    "lane1": "0xfffffff4",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff4"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe7",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe6",
+                    "lane3": "0xffffffe8"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x5",
+                    "lane2": "0x6",
+                    "lane3": "0x5"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff"
+                }
+            },
             "OPTICAL100": {
                 "main": {
                     "lane0": "0x78",
@@ -1995,6 +2302,50 @@
                     "lane1": "0x0",
                     "lane2": "0x0",
                     "lane3": "0x0"
+                }
+            },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x5e",
+                    "lane1": "0x63",
+                    "lane2": "0x5f",
+                    "lane3": "0x5e"
+                },
+                "post1": {
+                    "lane0": "0xfffffff4",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff7",
+                    "lane3": "0xfffffff7"
+                },
+                "post2": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff6",
+                    "lane2": "0xfffffff6",
+                    "lane3": "0xfffffff5"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffeb",
+                    "lane2": "0xffffffe9",
+                    "lane3": "0xffffffed"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x5",
+                    "lane3": "0x4"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff"
                 }
             },
             "OPTICAL100": {
@@ -2263,6 +2614,50 @@
                     "lane3": "0x0"
                 }
             },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x5f",
+                    "lane1": "0x5f",
+                    "lane2": "0x5c",
+                    "lane3": "0x5e"
+                },
+                "post1": {
+                    "lane0": "0xfffffff6",
+                    "lane1": "0xfffffff6",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffff4"
+                },
+                "post2": {
+                    "lane0": "0xfffffff6",
+                    "lane1": "0xfffffff6",
+                    "lane2": "0xfffffff4",
+                    "lane3": "0xfffffff8"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffeb",
+                    "lane1": "0xffffffeb",
+                    "lane2": "0xffffffea",
+                    "lane3": "0xffffffec"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x5",
+                    "lane3": "0x4"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff"
+                }
+            },
             "OPTICAL100": {
                 "main": {
                     "lane0": "0x78",
@@ -2527,6 +2922,50 @@
                     "lane1": "0x0",
                     "lane2": "0x0",
                     "lane3": "0x0"
+                }
+            },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x61",
+                    "lane1": "0x62",
+                    "lane2": "0x5e",
+                    "lane3": "0x63"
+                },
+                "post1": {
+                    "lane0": "0xfffffff5",
+                    "lane1": "0xfffffff5",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffff2"
+                },
+                "post2": {
+                    "lane0": "0xfffffff4",
+                    "lane1": "0xfffffff4",
+                    "lane2": "0xfffffff5",
+                    "lane3": "0xfffffff6"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffea",
+                    "lane2": "0xffffffe9",
+                    "lane3": "0xffffffe8"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x5",
+                    "lane2": "0x5",
+                    "lane3": "0x5"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff"
                 }
             },
             "OPTICAL100": {
@@ -2795,6 +3234,51 @@
                     "lane3": "0x0"
                 }
             },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x67",
+                    "lane1": "0x67",
+                    "lane2": "0x66",
+                    "lane3": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff4",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff4"
+                },
+                "post2": {
+                    "lane0": "0xfffffff4",
+
+                    "lane1": "0xfffffff5",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff5"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe6",
+                    "lane2": "0xffffffe5",
+                    "lane3": "0xffffffe6"
+                },
+                "pre2": {
+                    "lane0": "0x5",
+                    "lane1": "0x5",
+                    "lane2": "0x6",
+                    "lane3": "0x5"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff"
+                }
+            },
             "OPTICAL100": {
                 "main": {
                     "lane0": "0x78",
@@ -3059,6 +3543,50 @@
                     "lane1": "0x0",
                     "lane2": "0x0",
                     "lane3": "0x0"
+                }
+            },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x65",
+                    "lane1": "0x63",
+                    "lane2": "0x61",
+                    "lane3": "0x63"
+                },
+                "post1": {
+                    "lane0": "0xfffffff0",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff5",
+                    "lane3": "0xfffffff2"
+                },
+                "post2": {
+                    "lane0": "0xfffffff6",
+                    "lane1": "0xfffffff6",
+                    "lane2": "0xfffffff4",
+                    "lane3": "0xfffffff6"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe7",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffe8"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x5",
+                    "lane2": "0x4",
+                    "lane3": "0x5"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff"
                 }
             },
             "OPTICAL100": {
@@ -3327,6 +3855,50 @@
                     "lane3": "0x0"
                 }
             },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x62",
+                    "lane1": "0x65",
+                    "lane2": "0x5f",
+                    "lane3": "0x65"
+                },
+                "post1": {
+                    "lane0": "0xfffffff5",
+                    "lane1": "0xfffffff0",
+                    "lane2": "0xfffffff6",
+                    "lane3": "0xfffffff5"
+                },
+                "post2": {
+                    "lane0": "0xfffffff4",
+                    "lane1": "0xfffffff6",
+                    "lane2": "0xfffffff6",
+                    "lane3": "0xfffffff2"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffea",
+                    "lane1": "0xffffffe7",
+                    "lane2": "0xffffffeb",
+                    "lane3": "0xffffffe6"
+                },
+                "pre2": {
+                    "lane0": "0x5",
+                    "lane1": "0x6",
+                    "lane2": "0x5",
+                    "lane3": "0x6"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff"
+                }
+            },
             "OPTICAL100": {
                 "main": {
                     "lane0": "0x78",
@@ -3591,6 +4163,50 @@
                     "lane1": "0x0",
                     "lane2": "0x0",
                     "lane3": "0x0"
+                }
+            },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x68",
+                    "lane1": "0x65",
+                    "lane2": "0x65",
+                    "lane3": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xfffffff0",
+                    "lane1": "0xfffffff0",
+                    "lane2": "0xfffffff0",
+                    "lane3": "0xfffffff4"
+                },
+                "post2": {
+                    "lane0": "0xfffffff4",
+                    "lane1": "0xfffffff6",
+                    "lane2": "0xfffffff6",
+                    "lane3": "0xfffffff5"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe9",
+                    "lane1": "0xffffffe7",
+                    "lane2": "0xffffffe7",
+                    "lane3": "0xffffffe6"
+                },
+                "pre2": {
+                    "lane0": "0x5",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x5"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff"
                 }
             },
             "OPTICAL100": {
@@ -3859,6 +4475,50 @@
                     "lane3": "0x0"
                 }
             },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x65",
+                    "lane1": "0x68",
+                    "lane2": "0x61",
+                    "lane3": "0x61"
+                },
+                "post1": {
+                    "lane0": "0xfffffff5",
+                    "lane1": "0xfffffff1",
+                    "lane2": "0xfffffff5",
+                    "lane3": "0xfffffff5"
+                },
+                "post2": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff4",
+                    "lane2": "0xfffffff4",
+                    "lane3": "0xfffffff4"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe6",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x5",
+                    "lane2": "0x4",
+                    "lane3": "0x4"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff"
+                }
+            },
             "OPTICAL100": {
                 "main": {
                     "lane0": "0x78",
@@ -4123,6 +4783,50 @@
                     "lane1": "0x0",
                     "lane2": "0x0",
                     "lane3": "0x0"
+                }
+            },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x64",
+                    "lane1": "0x60",
+                    "lane2": "0x5e",
+                    "lane3": "0x62"
+                },
+                "post1": {
+                    "lane0": "0xfffffff3",
+                    "lane1": "0xfffffff5",
+                    "lane2": "0xfffffff7",
+                    "lane3": "0xfffffff5"
+                },
+                "post2": {
+                    "lane0": "0xfffffff5",
+                    "lane1": "0xfffffff7",
+                    "lane2": "0xfffffff5",
+                    "lane3": "0xfffffff4"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffea",
+                    "lane1": "0xffffffe9",
+                    "lane2": "0xffffffed",
+                    "lane3": "0xffffffea"
+                },
+                "pre2": {
+                    "lane0": "0x5",
+                    "lane1": "0x6",
+                    "lane2": "0x4",
+                    "lane3": "0x5"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff"
                 }
             },
             "OPTICAL100": {
@@ -4391,6 +5095,50 @@
                     "lane3": "0x0"
                 }
             },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x68",
+                    "lane1": "0x67",
+                    "lane2": "0x63",
+                    "lane3": "0x69"
+                },
+                "post1": {
+                    "lane0": "0xfffffff0",
+                    "lane1": "0xfffffff5",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xffffffed"
+                },
+                "post2": {
+                    "lane0": "0xfffffff4",
+                    "lane1": "0xfffffff1",
+                    "lane2": "0xfffffff6",
+                    "lane3": "0xfffffff6"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe9",
+                    "lane1": "0xffffffe9",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffea"
+                },
+                "pre2": {
+                    "lane0": "0x5",
+                    "lane1": "0x5",
+                    "lane2": "0x5",
+                    "lane3": "0x4"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff"
+                }
+            },
             "OPTICAL100": {
                 "main": {
                     "lane0": "0x78",
@@ -4476,7 +5224,6 @@
                     "lane0": "0x0",
                     "lane1": "0x0",
                     "lane2": "0x0",
-
                     "lane3": "0x0"
                 }
             },
@@ -4655,6 +5402,50 @@
                     "lane0": "0x0",
                     "lane1": "0x0",
                     "lane2": "0x0",
+                    "lane3": "0x0"
+                }
+            },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x67",
+                    "lane1": "0x67",
+                    "lane2": "0x67",
+                    "lane3": "0x68"
+                },
+                "post1": {
+                    "lane0": "0xfffffff4",
+                    "lane1": "0xffffffeb",
+                    "lane2": "0xfffffff4",
+                    "lane3": "0xfffffff4"
+                },
+                "post2": {
+                    "lane0": "0xfffffff5",
+                    "lane1": "0xfffffff7",
+                    "lane2": "0xfffffff5",
+                    "lane3": "0xfffffff3"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe6",
+                    "lane1": "0xffffffea",
+                    "lane2": "0xffffffe6",
+                    "lane3": "0xffffffe8"
+                },
+                "pre2": {
+                    "lane0": "0x5",
+                    "lane1": "0x4",
+                    "lane2": "0x5",
+                    "lane3": "0x4"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0x0",
+                    "lane2": "0xffffffff",
                     "lane3": "0x0"
                 }
             },
@@ -4916,6 +5707,50 @@
                     "lane1": "0x0",
                     "lane2": "0x0",
                     "lane3": "0x0"
+                },
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                }
+            },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x67",
+                    "lane1": "0x67",
+                    "lane2": "0x67",
+                    "lane3": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xffffffeb",
+                    "lane1": "0xffffffeb",
+                    "lane2": "0xffffffeb",
+                    "lane3": "0xffffffeb"
+                },
+                "post2": {
+                    "lane0": "0xfffffff7",
+                    "lane1": "0xfffffff7",
+                    "lane2": "0xfffffff7",
+                    "lane3": "0xfffffff7"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffea",
+                    "lane1": "0xffffffea",
+                    "lane2": "0xffffffea",
+                    "lane3": "0xffffffea"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4"
                 },
                 "pre3": {
                     "lane0": "0x0",
@@ -5190,6 +6025,50 @@
                     "lane3": "0x0"
                 }
             },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x68",
+                    "lane1": "0x66",
+                    "lane2": "0x67",
+                    "lane3": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xfffffff1",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff4"
+                },
+                "post2": {
+                    "lane0": "0xfffffff4",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff4",
+                    "lane3": "0xfffffff5"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe5",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe6"
+                },
+                "pre2": {
+                    "lane0": "0x5",
+                    "lane1": "0x6",
+                    "lane2": "0x5",
+                    "lane3": "0x5"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff"
+                }
+            },
             "OPTICAL100": {
                 "main": {
                     "lane0": "0x78",
@@ -5456,6 +6335,50 @@
                     "lane3": "0x0"
                 }
             },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x68",
+                    "lane1": "0x67",
+                    "lane2": "0x68",
+                    "lane3": "0x66"
+                },
+                "post1": {
+                    "lane0": "0xfffffff1",
+                    "lane1": "0xfffffff4",
+                    "lane2": "0xfffffff1",
+                    "lane3": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0xfffffff4",
+                    "lane1": "0xfffffff5",
+                    "lane2": "0xfffffff4",
+                    "lane3": "0xfffffff2"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe6",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe5"
+                },
+                "pre2": {
+                    "lane0": "0x5",
+                    "lane1": "0x5",
+                    "lane2": "0x5",
+                    "lane3": "0x6"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff"
+                }
+            },
             "OPTICAL100": {
                 "main": {
                     "lane0": "0x78",
@@ -5463,6 +6386,7 @@
                     "lane2": "0x78",
                     "lane3": "0x78"
                 },
+
                 "post1": {
                     "lane0": "0x0",
                     "lane1": "0x0",
@@ -5719,6 +6643,50 @@
                     "lane0": "0x0",
                     "lane1": "0x0",
                     "lane2": "0x0",
+                    "lane3": "0x0"
+                }
+            },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x67",
+                    "lane1": "0x67",
+                    "lane2": "0x67",
+                    "lane3": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xffffffeb",
+                    "lane1": "0xffffffeb",
+                    "lane2": "0xfffffff4",
+                    "lane3": "0xffffffeb"
+                },
+                "post2": {
+                    "lane0": "0xfffffff7",
+                    "lane1": "0xfffffff7",
+                    "lane2": "0xfffffff5",
+                    "lane3": "0xfffffff7"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffea",
+                    "lane1": "0xffffffea",
+                    "lane2": "0xffffffe6",
+                    "lane3": "0xffffffea"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x5",
+                    "lane3": "0x4"
+                },
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0xffffffff",
                     "lane3": "0x0"
                 }
             },
@@ -5980,6 +6948,50 @@
                     "lane1": "0x0",
                     "lane2": "0x0",
                     "lane3": "0x0"
+                },
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                }
+            },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x68",
+                    "lane1": "0x68",
+                    "lane2": "0x68",
+                    "lane3": "0x68"
+                },
+                "post1": {
+                    "lane0": "0xfffffff4",
+                    "lane1": "0xfffffff4",
+                    "lane2": "0xfffffff4",
+                    "lane3": "0xfffffff4"
+                },
+                "post2": {
+                    "lane0": "0xfffffff3",
+                    "lane1": "0xfffffff3",
+                    "lane2": "0xfffffff3",
+                    "lane3": "0xfffffff3"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4"
                 },
                 "pre3": {
                     "lane0": "0x0",
@@ -6254,6 +7266,50 @@
                     "lane3": "0x0"
                 }
             },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x60",
+                    "lane1": "0x68",
+                    "lane2": "0x61",
+                    "lane3": "0x65"
+                },
+                "post1": {
+                    "lane0": "0xfffffff5",
+                    "lane1": "0xfffffff0",
+                    "lane2": "0xfffffff5",
+                    "lane3": "0xfffffff5"
+                },
+                "post2": {
+                    "lane0": "0xfffffff7",
+                    "lane1": "0xfffffff4",
+                    "lane2": "0xfffffff4",
+                    "lane3": "0xfffffff2"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe9",
+                    "lane1": "0xffffffe9",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffe6"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x5",
+                    "lane2": "0x4",
+                    "lane3": "0x6"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff"
+                }
+            },
             "OPTICAL100": {
                 "main": {
                     "lane0": "0x78",
@@ -6520,6 +7576,50 @@
                     "lane3": "0x0"
                 }
             },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x67",
+                    "lane1": "0x68",
+                    "lane2": "0x68",
+                    "lane3": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xfffffff5",
+                    "lane1": "0xfffffff4",
+                    "lane2": "0xfffffff0",
+                    "lane3": "0xfffffff2"
+                },
+                "post2": {
+                    "lane0": "0xfffffff1",
+                    "lane1": "0xfffffff3",
+                    "lane2": "0xfffffff4",
+                    "lane3": "0xfffffff4"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe9",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe9",
+                    "lane3": "0xffffffe8"
+                },
+                "pre2": {
+                    "lane0": "0x5",
+                    "lane1": "0x4",
+                    "lane2": "0x5",
+                    "lane3": "0x5"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0x0",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff"
+                }
+            },
             "OPTICAL100": {
                 "main": {
                     "lane0": "0x78",
@@ -6783,6 +7883,50 @@
                     "lane0": "0x0",
                     "lane1": "0x0",
                     "lane2": "0x0",
+                    "lane3": "0x0"
+                }
+            },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x67",
+                    "lane1": "0x67",
+                    "lane2": "0x67",
+                    "lane3": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xfffffff4",
+                    "lane1": "0xffffffeb",
+                    "lane2": "0xfffffff4",
+                    "lane3": "0xffffffeb"
+                },
+                "post2": {
+                    "lane0": "0xfffffff5",
+                    "lane1": "0xfffffff7",
+                    "lane2": "0xfffffff5",
+                    "lane3": "0xfffffff7"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe6",
+                    "lane1": "0xffffffea",
+                    "lane2": "0xffffffe6",
+                    "lane3": "0xffffffea"
+                },
+                "pre2": {
+                    "lane0": "0x5",
+                    "lane1": "0x4",
+                    "lane2": "0x5",
+                    "lane3": "0x4"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0x0",
+                    "lane2": "0xffffffff",
                     "lane3": "0x0"
                 }
             },
@@ -7052,6 +8196,50 @@
                     "lane3": "0x0"
                 }
             },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x67",
+                    "lane1": "0x67",
+                    "lane2": "0x67",
+                    "lane3": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xfffffff4",
+                    "lane1": "0xffffffeb",
+                    "lane2": "0xfffffff4",
+                    "lane3": "0xffffffeb"
+                },
+                "post2": {
+                    "lane0": "0xfffffff5",
+                    "lane1": "0xfffffff7",
+                    "lane2": "0xfffffff5",
+                    "lane3": "0xfffffff7"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe6",
+                    "lane1": "0xffffffea",
+                    "lane2": "0xffffffe6",
+                    "lane3": "0xffffffea"
+                },
+                "pre2": {
+                    "lane0": "0x5",
+                    "lane1": "0x4",
+                    "lane2": "0x5",
+                    "lane3": "0x4"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0x0",
+                    "lane2": "0xffffffff",
+                    "lane3": "0x0"
+                }
+            },
             "OPTICAL100": {
                 "main": {
                     "lane0": "0x78",
@@ -7075,7 +8263,6 @@
                     "lane0": "0x0",
                     "lane1": "0x0",
                     "lane2": "0x0",
-
                     "lane3": "0x0"
                 },
                 "pre1": {
@@ -7319,6 +8506,50 @@
                     "lane3": "0x0"
                 }
             },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x63",
+                    "lane1": "0x67",
+                    "lane2": "0x68",
+                    "lane3": "0x68"
+                },
+                "post1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff0",
+                    "lane3": "0xfffffff1"
+                },
+                "post2": {
+                    "lane0": "0xfffffff6",
+                    "lane1": "0xfffffff4",
+                    "lane2": "0xfffffff4",
+                    "lane3": "0xfffffff4"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe9",
+                    "lane3": "0xffffffe8"
+                },
+                "pre2": {
+                    "lane0": "0x5",
+                    "lane1": "0x5",
+                    "lane2": "0x5",
+                    "lane3": "0x5"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff"
+                }
+            },
             "OPTICAL100": {
                 "main": {
                     "lane0": "0x78",
@@ -7488,6 +8719,7 @@
                     "lane0": "0x10",
                     "lane1": "0x10",
                     "lane2": "0x10",
+
                     "lane3": "0x10"
                 },
                 "pre3": {
@@ -7582,6 +8814,50 @@
                     "lane0": "0x0",
                     "lane1": "0x0",
                     "lane2": "0x0",
+                    "lane3": "0x0"
+                }
+            },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x63",
+                    "lane1": "0x68",
+                    "lane2": "0x63",
+                    "lane3": "0x68"
+                },
+                "post1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff1",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff4"
+                },
+                "post2": {
+                    "lane0": "0xfffffff6",
+                    "lane1": "0xfffffff4",
+                    "lane2": "0xfffffff6",
+                    "lane3": "0xfffffff3"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8"
+                },
+                "pre2": {
+                    "lane0": "0x5",
+                    "lane1": "0x5",
+                    "lane2": "0x5",
+                    "lane3": "0x4"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
                     "lane3": "0x0"
                 }
             },
@@ -7851,6 +9127,50 @@
                     "lane3": "0x0"
                 }
             },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x67",
+                    "lane1": "0x67",
+                    "lane2": "0x67",
+                    "lane3": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xfffffff4",
+                    "lane1": "0xfffffff4",
+                    "lane2": "0xfffffff4",
+                    "lane3": "0xffffffeb"
+                },
+                "post2": {
+                    "lane0": "0xfffffff5",
+                    "lane1": "0xfffffff5",
+                    "lane2": "0xfffffff5",
+                    "lane3": "0xfffffff7"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe6",
+                    "lane1": "0xffffffe6",
+                    "lane2": "0xffffffe6",
+                    "lane3": "0xffffffea"
+                },
+                "pre2": {
+                    "lane0": "0x5",
+                    "lane1": "0x5",
+                    "lane2": "0x5",
+                    "lane3": "0x4"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0x0"
+                }
+            },
             "OPTICAL100": {
                 "main": {
                     "lane0": "0x78",
@@ -8117,6 +9437,50 @@
                     "lane3": "0x0"
                 }
             },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x67",
+                    "lane1": "0x67",
+                    "lane2": "0x67",
+                    "lane3": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xfffffff4",
+                    "lane1": "0xfffffff4",
+                    "lane2": "0xfffffff4",
+                    "lane3": "0xffffffeb"
+                },
+                "post2": {
+                    "lane0": "0xfffffff5",
+                    "lane1": "0xfffffff5",
+                    "lane2": "0xfffffff5",
+                    "lane3": "0xfffffff7"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe6",
+                    "lane1": "0xffffffe6",
+                    "lane2": "0xffffffe6",
+                    "lane3": "0xffffffea"
+                },
+                "pre2": {
+                    "lane0": "0x5",
+                    "lane1": "0x5",
+                    "lane2": "0x5",
+                    "lane3": "0x4"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0x0"
+                }
+            },
             "OPTICAL100": {
                 "main": {
                     "lane0": "0x78",
@@ -8380,6 +9744,50 @@
                     "lane0": "0x0",
                     "lane1": "0x0",
                     "lane2": "0x0",
+                    "lane3": "0x0"
+                }
+            },
+            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1)|ARISTA NETWORKS-L-O800-2Q400-5M": {
+                "main": {
+                    "lane0": "0x63",
+                    "lane1": "0x67",
+                    "lane2": "0x65",
+                    "lane3": "0x68"
+                },
+                "post1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff5",
+                    "lane2": "0xfffffff5",
+                    "lane3": "0xfffffff4"
+                },
+                "post2": {
+                    "lane0": "0xfffffff6",
+                    "lane1": "0xfffffff1",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff3"
+                },
+                "post3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe9",
+                    "lane2": "0xffffffe6",
+                    "lane3": "0xffffffe8"
+                },
+                "pre2": {
+                    "lane0": "0x5",
+                    "lane1": "0x5",
+                    "lane2": "0x6",
+                    "lane3": "0x4"
+                },
+                "pre3": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
                     "lane3": "0x0"
                 }
             },


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
We need additional tuning values for EOPTOLINK transceivers

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added the values to media_settings.json

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
Verified that interfaces come up using these transceivers.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202511

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Adding EOPTOLINK tunings for Arista 7280R4-32QF-32DF-F

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### A picture of a cute animal (not mandatory but encouraged)
<img width="1600" height="1065" alt="image" src="https://github.com/user-attachments/assets/919a8c46-82b4-480f-bea1-80b9fb19c4d8" />

