### PR TITLE
[Multi-ASIC] Added fast-reboot support for multi-asic

### DIFF
--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -215,6 +215,23 @@ ztp_is_enabled()
     return $rv
 }
 
+set_config_db_initialized()
+{
+    local value="$1"
+    local asic_num=0
+
+    sonic-db-cli CONFIG_DB SET "CONFIG_DB_INITIALIZED" "$value"
+
+    if [[ ${NUM_ASIC:-1} -le 1 ]]; then
+        return 0
+    fi
+
+    while [[ $asic_num -lt $NUM_ASIC ]]; do
+        sonic-db-cli -n "asic$asic_num" CONFIG_DB SET "CONFIG_DB_INITIALIZED" "$value"
+        ((asic_num = asic_num + 1))
+    done
+}
+
 # Generate requested SONiC configuration and save it as destination file
 # Usage: generate_config < factory | ztp > <destination_file>
 #
@@ -367,7 +384,7 @@ do_db_migration()
         # Migrate the DB to the latest schema version if needed
         /usr/local/bin/db_migrator.py -o migrate
     fi
-    sonic-db-cli CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"
+    set_config_db_initialized "1"
 
     #Enforce CHASSIS_APP_DB.tsa_enabled to be in sync with BGP_DEVICE_GLOBAL.STATE.tsa_enabled
     if [[ -f /etc/sonic/chassisdb.conf ]] && [[ $disaggregated_chassis -ne 1 ]]; then
@@ -454,7 +471,7 @@ boot_config()
         echo "Warm boot detected, skipping config initialization and ZTP."
         # Mark config as initialized so subsequent boots don't re-trigger
         # initialization unnecessarily (warm-reboot to new image scenario).
-        sonic-db-cli CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"
+        set_config_db_initialized "1"	
         rm -f /etc/sonic/pending_config_initialization
         return 0
     fi

--- a/files/scripts/bgp.sh
+++ b/files/scripts/bgp.sh
@@ -30,7 +30,7 @@ function validate_restore_count()
 
 function check_fast_boot ()
 {
-    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
+    SYSTEM_FAST_REBOOT=`$SONIC_DB_CLI STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
     if [[ x"${SYSTEM_FAST_REBOOT}" == x"true" ]]; then
         FAST_BOOT="true"
     else

--- a/files/scripts/bmp.sh
+++ b/files/scripts/bmp.sh
@@ -18,7 +18,7 @@ function check_warm_boot()
 
 function check_fast_boot ()
 {
-    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
+    SYSTEM_FAST_REBOOT=`$SONIC_DB_CLI STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
     if [[ x"${SYSTEM_FAST_REBOOT}" == x"true" ]]; then
         FAST_BOOT="true"
     else

--- a/files/scripts/service_mgmt.sh
+++ b/files/scripts/service_mgmt.sh
@@ -18,7 +18,7 @@ function check_warm_boot()
 
 function check_fast_boot ()
 {
-    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
+    SYSTEM_FAST_REBOOT=`$SONIC_DB_CLI STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
     if [[ x"${SYSTEM_FAST_REBOOT}" == x"true" ]]; then
         FAST_BOOT="true"
     else

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -539,8 +539,8 @@ stop() {
         clean_up_tables STATE_DB "'FABRIC_PORT_TABLE*'"
         debug "Cleared FABRIC_PORT_TABLE from STATE_DB for ${SERVICE}$DEV..."
     else
-        debug "Killing Docker swss..."
-        /usr/bin/docker kill swss &> /dev/null || debug "Docker swss is not running ($?) ..."
+        debug "Killing Docker ${SERVICE}$DEV..."
+        /usr/bin/docker kill ${SERVICE}$DEV &> /dev/null || debug "Docker ${SERVICE}$DEV is not running ($?) ..."
     fi
 
     # Flush FAST_REBOOT table when swss needs to stop. The only

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -62,7 +62,7 @@ function check_warm_boot()
 
 function check_fast_boot()
 {
-    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
+    SYSTEM_FAST_REBOOT=`$SONIC_DB_CLI STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
     if [[ x"${SYSTEM_FAST_REBOOT}" == x"true" ]]; then
         FAST_BOOT="true"
     else
@@ -549,7 +549,7 @@ stop() {
     # be restarted.
     if [[ x"$FAST_BOOT" != x"true" ]]; then
         debug "Clearing FAST_RESTART_ENABLE_TABLE flag..."
-        sonic-db-cli STATE_DB hset "FAST_RESTART_ENABLE_TABLE|system" "enable" "false"
+        $SONIC_DB_CLI STATE_DB hset "FAST_RESTART_ENABLE_TABLE|system" "enable" "false"
     fi
     # Unlock has to happen before reaching out to peer service
     unlock_service_state_change

--- a/files/scripts/syncd_common.sh
+++ b/files/scripts/syncd_common.sh
@@ -52,7 +52,7 @@ function check_warm_boot()
 
 function check_fast_boot()
 {
-    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
+    SYSTEM_FAST_REBOOT=`$SONIC_DB_CLI STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
     if [[ x"${SYSTEM_FAST_REBOOT}" == x"true" ]]; then
         FAST_BOOT="true"
     else
@@ -88,7 +88,7 @@ function getBootType()
         ;;
     *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
         # check that the key exists
-        SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
+        SYSTEM_FAST_REBOOT=`$SONIC_DB_CLI STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
         if [[ x"${SYSTEM_FAST_REBOOT}" == x"true" ]]; then
             TYPE='fast'
         else

--- a/files/scripts/teamd.sh
+++ b/files/scripts/teamd.sh
@@ -32,7 +32,7 @@ function validate_restore_count()
 
 function check_fast_boot ()
 {
-    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
+    SYSTEM_FAST_REBOOT=`$SONIC_DB_CLI STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
     if [[ x"${SYSTEM_FAST_REBOOT}" == x"true" ]]; then
         FAST_BOOT="true"
     else

--- a/src/sonic-ctrmgrd-rs/crates/docker-wait-any-rs/src/lib.rs
+++ b/src/sonic-ctrmgrd-rs/crates/docker-wait-any-rs/src/lib.rs
@@ -90,7 +90,7 @@ pub async fn wait_for_container(
         if dependent_services.contains(&container_name) {
             let (service_name, namespace) = parse_container_name(&container_name);
             let warm_restart = device_info::is_warm_restart_enabled_in_namespace(service_name, &namespace)?;
-            let fast_reboot = device_info::is_fast_reboot_enabled()?;
+            let fast_reboot = device_info::is_fast_reboot_enabled_in_namespace(&namespace)?;
 
             if warm_restart || fast_reboot {
                 continue;

--- a/src/sonic-ctrmgrd-rs/crates/docker-wait-any-rs/tests/docker_wait_any_test.rs
+++ b/src/sonic-ctrmgrd-rs/crates/docker-wait-any-rs/tests/docker_wait_any_test.rs
@@ -157,7 +157,7 @@ async fn test_teamd_exits_warm_restart_main_will_not_exit() {
             returns: Ok(true)
         ));
     injector
-        .when_called(func!(sonic_rs_common::device_info::is_fast_reboot_enabled, fn() -> Result<bool, sonic_rs_common::device_info::DeviceInfoError>))
+        .when_called(func!(sonic_rs_common::device_info::is_fast_reboot_enabled_in_namespace, fn(&str) -> Result<bool, sonic_rs_common::device_info::DeviceInfoError>))
         .will_execute(fake!(
             func_type: fn() -> Result<bool, sonic_rs_common::device_info::DeviceInfoError>,
             returns: Ok(false)

--- a/src/sonic-rs-common/src/device_info.rs
+++ b/src/sonic-rs-common/src/device_info.rs
@@ -85,3 +85,9 @@ pub fn is_fast_reboot_enabled() -> Result<bool> {
         .map_err(|e| DeviceInfoError::SwSS(e))?;
     is_fast_reboot_enabled_with_db(&state_db)
 }
+
+pub fn is_fast_reboot_enabled_in_namespace(namespace: &str) -> Result<bool> {
+    let state_db = StateDBConnector::new_with_namespace(namespace)
+        .map_err(|e| DeviceInfoError::SwSS(e))?;
+    is_fast_reboot_enabled_with_db(&state_db)
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
#### Why I did it
To add fast-reboot support for multi-asic devices, according to this HLD - [[Multi-ASIC] Added fast-reboot support
](https://github.com/sonic-net/SONiC/pull/2306)

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Enhanced services startup scripts to support fast reboot on multiple ASICs

#### How to verify it
by running fast-reboot on a multi-asic device and verifying that all services start with the fast-reboot path.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

