### PR TITLE
Add resource_type leaf to DEVICE_NEIGHBOR_METADATA YANG model

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_neighbor_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_neighbor_metadata.json
@@ -7,5 +7,8 @@
     },
     "DEVICE_NEIGHBOR_METADATA_TYPE_NOT_PROVISIONED_PATTERN": {
         "desc": "DEVICE_NEIGHBOR_METADATA value as not-provisioned for Type field"
+    },
+    "DEVICE_NEIGHBOR_METADATA_VALID_RESOURCE_TYPE": {
+        "desc": "DEVICE_NEIGHBOR_METADATA with resource_type field for metro optimization"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_neighbor_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_neighbor_metadata.json
@@ -55,7 +55,8 @@
                         "hwsku": "Arista",
                         "type": "SpineRouter",
                         "deployment_id": "1",
-                        "slice_type": "AZNG_Production"
+                        "slice_type": "AZNG_Production",
+                        "resource_type": "Storage"
                     },
                     {
                         "cluster": "AAA00PrdStr00",
@@ -95,6 +96,20 @@
                         "hwsku": "Arista",
                         "type": "LeafRouter",
                         "deployment_id": "1"
+                    }
+                ]
+            }
+        }
+    },
+    "DEVICE_NEIGHBOR_METADATA_VALID_RESOURCE_TYPE": {
+        "sonic-device_neighbor_metadata:sonic-device_neighbor_metadata": {
+            "sonic-device_neighbor_metadata:DEVICE_NEIGHBOR_METADATA": {
+                "DEVICE_NEIGHBOR_METADATA_LIST": [
+                    {
+                        "name": "Ethernet120",
+                        "hwsku": "Arista",
+                        "type": "ToRRouter",
+                        "resource_type": "Compute"
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-device_neighbor_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_neighbor_metadata.yang
@@ -97,6 +97,11 @@ module sonic-device_neighbor_metadata {
                     type string;
                 }
 
+                leaf resource_type {
+                    description "Resource type of the neighbor device (e.g., Storage, Compute).";
+                    type string;
+                }
+
             }
             /* end of list DEVICE_NEIGHBOR_METADATA_LIST */
         }


### PR DESCRIPTION
#### Why I did it
`resource_type` in `DEVICE_NEIGHBOR_METADATA` provides additional flexibility in filtering and tagging routes based on the neighbor device's resource type (e.g., Storage, Compute). 

#### How I did it
- Added `leaf resource_type` (type `string`) to `DEVICE_NEIGHBOR_METADATA_LIST` in `sonic-device_neighbor_metadata.yang`
- Added `resource_type` to existing YANG test data
- Added dedicated test case `DEVICE_NEIGHBOR_METADATA_VALID_RESOURCE_TYPE` for resource_type validation

#### How to verify it
- YANG validation passes with `resource_type` in `DEVICE_NEIGHBOR_METADATA`
- YANG model test suite passes

#### Which release branch to backport
202511

#### Description for the changelog
Added `resource_type` field to `DEVICE_NEIGHBOR_METADATA` YANG model to support route filtering and tagging based on neighbor resource type.
