### PR TITLE
Fix VLA size in setreg_store for DX010

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/dx010/modules/dx010_cpld.c
+++ b/platform/broadcom/sonic-platform-modules-cel/dx010/modules/dx010_cpld.c
@@ -190,7 +190,7 @@ static ssize_t setreg_store(struct device *dev, struct device_attribute *devattr
     uint16_t addr;
     uint8_t value;
     char *tok;
-    char clone[count];
+    char clone[count + 1];
     char *pclone = clone;
     char *last;
 


### PR DESCRIPTION
Increase size of clone array to accommodate null terminator.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fixes #26885

#### How to verify it

Build and install on a DX010

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202511.0

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fixed crash in Celestica DX010 platform module.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

