### PR TITLE
Force PFCWD to use software recovery path on NH-5010 SKUs

### DIFF
--- a/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O32-C32/nh5010-default.bcm
+++ b/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O32-C32/nh5010-default.bcm
@@ -2269,3 +2269,6 @@ macsec_fips_enable=1
 xflow_macsec_secure_chan_to_num_secure_assoc=4
 xflow_macsec_secure_chan_to_num_secure_assoc_encrypt=2
 xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=4
+
+#Disable hardware PFC watchdog
+sai_pfc_dlr_init_capability=0

--- a/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/defaults/nh5010.bcm
+++ b/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/defaults/nh5010.bcm
@@ -2276,3 +2276,5 @@ macsec_fips_enable=1
 xflow_macsec_secure_chan_to_num_secure_assoc=4
 xflow_macsec_secure_chan_to_num_secure_assoc_encrypt=2
 xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=4
+#Disable hardware PFC watchdog
+sai_pfc_dlr_init_capability=0

--- a/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/templates/nh5010.bcm.j2
+++ b/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/templates/nh5010.bcm.j2
@@ -1900,3 +1900,6 @@ macsec_fips_enable=1
 xflow_macsec_secure_chan_to_num_secure_assoc=4
 xflow_macsec_secure_chan_to_num_secure_assoc_encrypt=2
 xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=4
+
+#Disable hardware PFC watchdog
+sai_pfc_dlr_init_capability=0


### PR DESCRIPTION
Set sai_pfc_dlr_init_capability=0 to disable hardware PFCWD and force the software ACL-based recovery path. Without this change, the hardware DLR (Drop Latency Reduction) path is attempted but fails on NH-5010 platforms with the error:

2026 Apr 17 15:32:00.866898 str5-nh5010-ut2-4 ERR syncd#syncd: [none] SAI_API_QUEUE:_brcm_sai_dnx_set_queue_attr_pfc_deadlock_recovery:2990 pfc dlr recovery start port:97 qid:3 failed with error Invalid port (0xffffffee).

This results in PFC storms firing but no drop ACL being installed, leaving the system vulnerable to PFC deadlock conditions.

Modified files:
- NH-5010-F-O32-C32/nh5010-default.bcm
- NH-5010-F-O64/defaults/nh5010.bcm
- NH-5010-F-O64/templates/nh5010.bcm.j2

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

