### PR TITLE
Fan support for multiple duty cycles in one word

### DIFF
--- a/platform/pddf/i2c/modules/fan/driver/pddf_fan_api.c
+++ b/platform/pddf/i2c/modules/fan/driver/pddf_fan_api.c
@@ -687,9 +687,7 @@ int sonic_i2c_get_fan_rpm_default(void *client, FAN_DATA_ATTR *udata, void *info
             goto ret;
 
         if (udata->mask != 0) {
-            val &= udata->mask;
-            int bit_shift = count_trailing_zeros(udata->mask);
-            val >>= bit_shift;
+            val = (int)(((uint32_t)val & udata->mask) >> count_trailing_zeros(udata->mask));
         }
         skip_neg_check = true;
     }
@@ -702,7 +700,6 @@ int sonic_i2c_get_fan_rpm_default(void *client, FAN_DATA_ATTR *udata, void *info
         else if (udata->len ==2)
         {
             val = i2c_smbus_read_word_swapped((struct i2c_client *)client, udata->offset);
-            
         }
     }
 
@@ -780,12 +777,18 @@ int sonic_i2c_set_fan_pwm_default(struct i2c_client *client, FAN_DATA_ATTR *udat
 	int val = 0;
     struct fan_attr_info *painfo = (struct fan_attr_info *)info;
 
-	val = painfo->val.intval & udata->mask;
+	val = painfo->val.intval;
 
 	if (val > 255)
 	{
 	  return -EINVAL;
 	}
+
+	if (strcmp(udata->devtype, "multifpgapci") == 0)
+	{
+	    val <<= count_trailing_zeros(udata->mask);
+	}
+	val &= udata->mask;
 
     if (strcmp(udata->devtype, "cpld") == 0)
     {
@@ -829,6 +832,7 @@ int sonic_i2c_get_fan_pwm_default(void *client, FAN_DATA_ATTR *udata, void *info
     int status = 0;
     int val = 0;
     bool skip_neg_check = false;
+    bool skip_mask = false;
     struct fan_attr_info *painfo = (struct fan_attr_info *)info;
 
     if (strcmp(udata->devtype, "cpld") == 0)
@@ -845,7 +849,11 @@ int sonic_i2c_get_fan_pwm_default(void *client, FAN_DATA_ATTR *udata, void *info
         if (status)
             goto ret;
 
+        if (udata->mask != 0) {
+            val = (int)(((uint32_t)val & udata->mask) >> count_trailing_zeros(udata->mask));
+        }
         skip_neg_check = true;
+        skip_mask = true;
     }
     else
     {
@@ -856,14 +864,15 @@ int sonic_i2c_get_fan_pwm_default(void *client, FAN_DATA_ATTR *udata, void *info
         else if (udata->len ==2)
         {
             val = i2c_smbus_read_word_swapped((struct i2c_client *)client, udata->offset);
-            
+
         }
     }
 
     if (!skip_neg_check && val < 0) {
         status = val;
     } else {
-        val = val & udata->mask;
+        if (!skip_mask)
+            val = val & udata->mask;
         painfo->val.intval = val;
     }
 
@@ -1000,6 +1009,7 @@ int sonic_i2c_get_fan_dc_default(void *client, FAN_DATA_ATTR *udata, void *info)
     int val = 0;
     uint32_t dc = 0;
     bool skip_neg_check = false;
+    bool skip_mask = false;
     struct fan_attr_info *painfo = (struct fan_attr_info *)info;
 
     if (strcmp(udata->devtype, "cpld") == 0)
@@ -1016,7 +1026,11 @@ int sonic_i2c_get_fan_dc_default(void *client, FAN_DATA_ATTR *udata, void *info)
         if (status)
             goto ret;
 
+        if (udata->mask != 0) {
+            val = (int)(((uint32_t)val & udata->mask) >> count_trailing_zeros(udata->mask));
+        }
         skip_neg_check = true;
+        skip_mask = true;
     }
     else
     {
@@ -1034,7 +1048,8 @@ int sonic_i2c_get_fan_dc_default(void *client, FAN_DATA_ATTR *udata, void *info)
     if (!skip_neg_check && val < 0) {
         status = val;
     } else {
-        val = val & udata->mask;
+        if (!skip_mask)
+            val = val & udata->mask;
         /* val is the fan_pwm which needs to be converted to duty cycle */
         if (pddf_fan_funcs.reg_value_to_duty_cycle)
         {
@@ -1077,6 +1092,10 @@ int sonic_i2c_set_fan_dc_default(void *client, FAN_DATA_ATTR *udata, void *info)
         reg_val = val;
     }
 
+	if (strcmp(udata->devtype, "multifpgapci") == 0)
+	{
+	    reg_val <<= count_trailing_zeros(udata->mask);
+	}
 	reg_val = reg_val & udata->mask;
 
     if (strcmp(udata->devtype, "cpld") == 0)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
On some PDDF platforms, multiple fans share a single PWM/duty-cycle register word, with each fan controlled by a bitfield in that word. The existing multifpgapci fan handlers only apply the mask without shifting based on the mask’s bit position, which leads to incorrect values when the fan’s bits are not at bit 0. This causes `show platform fan` to report incorrect or zero speeds, and control operations can affect the wrong bits. I fixed the mask/shift handling so that fan PWM/duty-cycle values are read and written correctly for these platforms.


##### Work item tracking
- Microsoft ADO **(number only)**:
- https://github.com/sonic-net/sonic-buildimage/issues/26989 

#### How I did it
- Updated the PDDF multifpgapci fan PWM and duty-cycle get/set handlers so that when a mask is present, the code:
  - Masks the raw register value and then right-shifts based on the number of trailing zeros in the mask when reading, so the fan’s field is brought down to bit 0 before use.
  - Left-shifts the value based on the same mask when writing, then re-applies the mask before updating the register, so only the intended bitfield is modified.
- Introduced small control flags in the handlers so that negative-value checks and subsequent masking are skipped in the few paths where the value has already been normalized and validated.
- Kept the behavior for other device types unchanged and scoped the new logic specifically to the multifpgapci case so platforms that already rely on single-byte/word registers without bitfield packing continue to work as before.

#### How to verify it

1. Use a platform where the PDDF multifpgapci fan driver is configured so that multiple fans’ PWM/duty-cycle values are packed into a single register word with non-overlapping masks.
2. Boot an image that contains this change.
3. Run `show platform fan` and confirm that:
   - Fan speeds / duty cycles are non-zero and consistent with hardware behavior.
   - All fans that share the register report distinct, sensible values.
4. Run `sudo pddf_fanutil getspeed ` and read the value.
5. Set fan speed using `sudo pddf_fanutil setspeed 80`
6. Run `sudo pddf_fanutil getspeed ` and read the value, confirming it has changed accordingly.
   - The reported PWM/duty-cycle matches the requested setting for each affected fan.
7. Repeat the test with another system with duty cycle values on separate register words and confirm functionality is not regressed by this change.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] SONiC Software Version: SONiC.master-26990.1107932-ae3647de4
Tested on NH-4010 system to ensure change did not regress existing fan functionality

Tested change on NH-4210 with a separate branch including the changes from https://github.com/sonic-net/sonic-buildimage/pull/27154
To test functionality on a system with multiple duty cycles in one register word.
Confirm change resolved issue of only the first duty cycle being written and read by following the above test plan.

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix PDDF multifpgapci fan PWM/duty-cycle mask handling when multiple fans share one register word.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

N/A – no config_db or YANG model changes.

#### A picture of a cute animal (not mandatory but encouraged)

