### PR TITLE
snmp: allow any string for sysContact, add newline injection guard

### DIFF
--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -91,7 +91,7 @@ sysLocation    {{ SNMP.LOCATION.Location }}
 sysLocation    public
 {% endif %}
 {% if SNMP is defined and SNMP.CONTACT is defined %}
-sysContact     {{ SNMP.CONTACT.keys() | first }} {{ SNMP.CONTACT.values() | first }}
+sysContact     {{ SNMP.CONTACT.keys() | first | replace('\n', ' ') }} {{ SNMP.CONTACT.values() | first | replace('\n', ' ') }}
 {% else %}
 sysContact     Azure Cloud Switch vteam <linuxnetdev@microsoft.com>
 {% endif %}

--- a/src/sonic-yang-models/yang-models/sonic-snmp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-snmp.yang
@@ -29,6 +29,7 @@ module sonic-snmp {
         leaf Contact {
           type string {
              length "1..255";
+             pattern '[^\n]+';
           }
           description
             "SNMP System Contact.";


### PR DESCRIPTION
#### Why I did it

RFC 1213 defines sysContact as a free-form string (0-255 chars). The current CLI enforces email format, which prevents operators from setting contact strings required by their management platforms.

Also adds a missing newline sanitization guard in the Jinja2 template to prevent config injection into snmpd.conf (same pattern as the sysLocation fix).

##### Work item tracking
- Microsoft ADO:

#### How I did it

- Added `pattern '[^\n]+'` to the `Contact` leaf in `sonic-snmp.yang` to block newline characters
- Added `| replace('\n', ' ')` filter to both the contact name and contact value renders in `snmpd.conf.j2`
- CLI and test changes are in a companion PR to sonic-utilities

#### How to verify it

- Set a non-email contact string: `config snmp contact add "NOC Team" "noc-team+monitoring"`
- Confirm it is accepted and `sysContact` in snmpd.conf renders correctly
- Attempt newline injection; confirm it is stripped to a space in the rendered config

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ]

#### Description for the changelog

snmp: allow any string for sysContact per RFC 1213, add newline injection guard

#### Link to config_db schema for YANG module changes

https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
