### PR TITLE
marvell-prestera: sai-1.17.1-12 P7.0.0-ACL

### DIFF
--- a/platform/marvell-prestera/sai.mk
+++ b/platform/marvell-prestera/sai.mk
@@ -2,11 +2,11 @@
 
 BRANCH = master
 ifeq ($(CONFIGURED_ARCH),arm64)
-MRVL_SAI_VERSION = 1.17.1-1
+MRVL_SAI_VERSION = 1.17.1-12
 else ifeq ($(CONFIGURED_ARCH),armhf)
-MRVL_SAI_VERSION = 1.17.1-1
+MRVL_SAI_VERSION = 1.17.1-12
 else
-MRVL_SAI_VERSION = 1.17.1-1
+MRVL_SAI_VERSION = 1.17.1-12
 endif
 
 MRVL_SAI_URL_PREFIX = https://github.com/Marvell-switching/sonic-marvell-binaries/raw/master/$(CONFIGURED_ARCH)/sai-plugin/$(BRANCH)/


### PR DESCRIPTION
#### Why I did it
Update marvell-prestera SAI version from P7.0.0--1.17.1-1 onto P7.0.0+ACL-fix--1.17.1-12

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Change version in platform/marvell-prestera/sai.mk

#### How to verify it
Result of the "msai" command in the SONIC-shell:

 MRVL_PSAI_BUILDDIR=/local/store/jenkins/workspace/SAI/Nightly/psai_build__sai_7_0_0/build-x86_64_py311/prestera-sai-src-23Apr2026-mrvl/build 
 MRVL_PSAI_BUILDDATE=Thu Apr 23 10:43:57 UTC 2026 
 MRVL_PSAI_BUILDHOST=c1illp-saixps-ci-009 
 MRVL_PSAI_BUILD_VERSION=P7.0.0 
 MRVL_PSAI_EZB_VERSION=1.13 
 OCP_SAI_VERSION=1.17.1 
 MRVL_PSAI_BUILDID=5 
 Repo Version : 
            XPS_BRANCH=sai_7.0.0 
            XPS_COMMIT_ID=1fcf0e22 

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

#### Change log
Fix: SAIPRST-5618 fail to add 2 acl table groups in ingress direction
Fix: SAIPRST-6350 Msft's internal testcase is failing due to syncd errors
