### PR TITLE
[Arista] Add 'sai_instru_stat_accum_enable=1' to Arista DNX SKUs

### DIFF
--- a/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/0/jr2p-a7280dra3-36-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/0/jr2p-a7280dra3-36-36x400G.config.bcm
@@ -987,3 +987,4 @@ sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
 sai_lag_default_crc_hash=1
 sai_ecmp_group_members_increment=8
+sai_instru_stat_accum_enable=1

--- a/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/1/jr2p-a7280dra3-36-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/1/jr2p-a7280dra3-36-36x400G.config.bcm
@@ -986,3 +986,4 @@ sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
 sai_lag_default_crc_hash=1
 sai_ecmp_group_members_increment=8
+sai_instru_stat_accum_enable=1

--- a/device/arista/x86_64-arista_7280r4_32qf_32df/Arista-7280R4-32QF-32DF-64O/template/q3d-a7280R4-32QFx400G-32DFx400G.config.bcm.j2
+++ b/device/arista/x86_64-arista_7280r4_32qf_32df/Arista-7280R4-32QF-32DF-64O/template/q3d-a7280R4-32QFx400G-32DFx400G.config.bcm.j2
@@ -448,3 +448,4 @@ sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
 sai_ecmp_group_members_increment=8
+sai_instru_stat_accum_enable=1

--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
@@ -867,3 +867,4 @@ appl_param_active_links_thr_high=58
 appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
 sai_ecmp_group_members_increment=8
+sai_instru_stat_accum_enable=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1021,3 +1021,4 @@ appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
 sai_ecmp_group_members_increment=8
+sai_instru_stat_accum_enable=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1021,3 +1021,4 @@ appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
 sai_ecmp_group_members_increment=8
+sai_instru_stat_accum_enable=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1038,3 +1038,4 @@ appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
 sai_ecmp_group_members_increment=8
+sai_instru_stat_accum_enable=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1038,3 +1038,4 @@ appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
 sai_ecmp_group_members_increment=8
+sai_instru_stat_accum_enable=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1058,3 +1058,4 @@ appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
 sai_ecmp_group_members_increment=8
+sai_instru_stat_accum_enable=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1058,3 +1058,4 @@ appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
 sai_ecmp_group_members_increment=8
+sai_instru_stat_accum_enable=1

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -372,3 +372,4 @@ rcy_mirror_to_forward_port_map
 port_priorities_sch
 sai_lag_default_crc_hash
 sai_ecmp_group_members_increment
+sai_instru_stat_accum_enable


### PR DESCRIPTION
#### Why I did it

'sai_instru_stat_accum_enable=1' makes counters like credit-wd-del no longer clear-on-read causing the output to accumulate in the output of show queue counters as desired.

#### How I did it

Include `sai_instru_stat_accum_enable=1' in all Arista DNX SKU soc property files

#### How to verify it

Manually disabled the fabric on a QuartzDD device using the bcmcmd `port enable sfi false` as used in `voq/test_voq_counter.py`, then confirmed that the credit-wd-del counter only ever incremented (never reset) via `show queue counter --voq --nonzero`

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
