### PR TITLE
Add interface name in the log

### DIFF
--- a/src/sonic-bgpcfgd/staticroutebfd/main.py
+++ b/src/sonic-bgpcfgd/staticroutebfd/main.py
@@ -217,6 +217,23 @@ class StaticRouteBfd(object):
 
         return False, ""
 
+    def ifname_from_local_addr(self, local_addr):
+        """
+        Find interface name whose address in LOCAL_INTERFACE_TABLE matches local_addr
+        (same source as BFD session local_addr / BfdOrch local_addr field).
+        """
+        if not local_addr or not str(local_addr).strip():
+            return None
+        want = str(local_addr).strip()
+        for if_name, ip_map in self.local_db[LOCAL_INTERFACE_TABLE].items():
+            if not ip_map:
+                continue
+            for ip in ip_map.values():
+                if ip and ip == want:
+                    return if_name
+        return None
+
+
     def update_bfd_pending(self, if_name):
         del_list=[]
         for k, v in self.local_db[LOCAL_BFD_PENDING_TABLE].items():
@@ -651,7 +668,12 @@ class StaticRouteBfd(object):
 
         nh_key = vrf + "|" + peer_ip
         state = data['state'] if 'state' in data else "DOWN"
-        log_info("bfd seesion %s state %s" %(bfd_key, state))
+        local_addr = bfd_session.get('local_addr', '')
+        ifname_log = self.ifname_from_local_addr(local_addr)
+        if not ifname_log:
+            ifname_log = intf if intf and intf != "default" else "unknown"
+        log_info("bfd session %s ifname %s state %s" % (bfd_key, ifname_log, state))
+
 
         self.local_db[LOCAL_BFD_TABLE][bfd_key]["state"] = state
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
BFD session can going down or flap for multiple reasons. There is a need to correlate BFD session status with associated interface. It helps to identify if BFD issue is due to interface state change. 

Right now user need to execute other CLI commands to get the interface associated with IP address  of BFD session change.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Interface  name is added to syslog along with session IP address. 

#### How to verify it

Loaded the new image with changes and brought BFD session down. Able to see interface name along with IP address in syslog
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
Signed-off-by: Sridhar Talari Rajagopal <stalarir@cisco.com>

#### A picture of a cute animal (not mandatory but encouraged)

