### PR TITLE
[202511][Nexthop][NH-4010] Fix broken sonic_platform: add DPM2 and use nh_adm1266 driver

### DIFF
--- a/device/nexthop/x86_64-nexthop_4010-r0/pddf/pddf-device.json.j2
+++ b/device/nexthop/x86_64-nexthop_4010-r0/pddf/pddf-device.json.j2
@@ -34,7 +34,6 @@
     "std_kos": [
       "at24",
       "i2c-dev",
-      "adm1266",
       "optoe"
     ],
     "pddf_kos": [
@@ -57,6 +56,7 @@
       "nh_pmbus_core",
       "nh_isl68137",
       "nh_tda38740",
+      "nh_adm1266",
       "nh_tmp464"
     ]
   },
@@ -242,6 +242,10 @@
         {
           "chn": "3",
           "dev": "DPM1"
+        },
+        {
+          "chn": "5",
+          "dev": "DPM2"
         },
         {
           "chn": "6",
@@ -12392,7 +12396,15 @@
       "dev_info": {"device_type":"DPM", "device_name":"DPM1", "device_parent":"MULTIFPGAPCIE0"},
       "i2c":
       {
-          "topo_info":{ "parent_bus":"0x7", "dev_addr":"0x41", "dev_type":"adm1266"}
+          "topo_info":{ "parent_bus":"0x7", "dev_addr":"0x41", "dev_type":"nh_adm1266"}
+      }
+  },
+  "DPM2":
+  {
+      "dev_info": {"device_type":"DPM", "device_name":"DPM2", "device_parent":"MULTIFPGAPCIE0"},
+      "i2c":
+      {
+          "topo_info":{ "parent_bus":"0x9", "dev_addr":"0x41", "dev_type":"nh_adm1266"}
       }
   },
   "VOLTAGE1":


### PR DESCRIPTION
Manual backport of https://github.com/sonic-net/sonic-buildimage/pull/26686 to 202511.

#### Why I did it

To fix the error like below:
```
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    sonic_platform.platform.Platform()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/dist-packages/sonic_platform/platform.py", line 27, in __init__
    PddfPlatform.__init__(self)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/usr/local/lib/python3.13/dist-packages/sonic_platform_pddf_base/pddf_platform.py", line 36, in __init__
    self._chassis = Chassis(self.pddf_data, self.pddf_plugin_data)
                    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/dist-packages/sonic_platform/chassis.py", line 58, in __init__
    RebootCauseManager(pddf_data.data, pddf_plugin_data) if (pddf_plugin_data and pddf_data) else None
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/dist-packages/sonic_platform/reboot_cause_manager.py", line 279, in __init__
    Adm1266(dpm_name, platform_spec, self._pddf_data)
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/dist-packages/sonic_platform/adm1266.py", line 523, in __init__
    self._calculate_paths_from_pddf_device_data(dpm_device_name, pddf_device_data)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/dist-packages/sonic_platform/adm1266.py", line 539, in _calculate_paths_from_pddf_device_data
    raise ValueError(f"DPM device '{dpm_device_name}' not found in pddf-device.json.")
ValueError: DPM device 'DPM2' not found in pddf-device.json.
>>>
admin@gold414:~$ show plat firm status
Error: DPM device 'DPM2' not found in pddf-device.json.. Aborting...
Aborted!
```

##### Work item tracking
- Microsoft ADO **(number only)**:
- Fixes https://github.com/sonic-net/sonic-buildimage/issues/26687

#### How I did it

We were missing `DPM2` in nexthop_4010 platforms, so added that to `pddf-device.json.j2`.

Also, update the DPMs to use our `nh_adm1266` custom driver.

#### How to verify it

Tested this change on the NH-4010 DUT:
- `sonic_platform` module is able to load again:
```
admin@gold414:~$ python
Python 3.13.5 (tags/v3.13.5-dirty:6cb20a219a8, Jun 26 2025, 18:55:22) [GCC 14.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sonic_platform
>>> sonic_platform.platform.Platform()
<sonic_platform.platform.Platform object at 0x7f0a5cb997f0>
```
- we could get reboot-cause from the DPMs as well:
```
admin@gold414:~$ nh_reboot_cause -v
=== Captured at 2026-04-10 01:29:56 UTC ===
[2026-04-10 01:29:00 UTC] cause: FPGA_PWR_CYC_REQ; description: FPGA requested power cycle; source: cpu_card
[2026-04-10 01:28:25 UTC] cause: reboot; description: n/a; source: SW
 DPM records:
  cpu_card:powerup_1679:uid_1677           timestamp: 2026-04-10 01:29:00 UTC
                                           power_fault_cause: FPGA_PWR_CYC_REQ (FPGA requested power cycle); under_voltage: VH1(POS12V); over_voltage: n/a
                                           gpio_in_[7:4,9:8,R,R,R,3:1]: 0b110000000111 [GPI7, GPI6, GPI3, GPI2, GPI1]
                                           pdio_in_[16:1]: 0b0000000000000011 [PDI2, PDI1]

  switch_card:powerup_1677:uid_10666       timestamp: 37.413437s after power-on
                                           power_fault_cause: n/a; under_voltage: n/a; over_voltage: n/a
                                           gpio_in_[7:4,9:8,R,R,R,3:1]: 0b000000000000
                                           pdio_in_[16:1]: 0b0111110010000000 [PDI15, PDI14, PDI13, PDI12, PDI11, PDI8]

  switch_card:powerup_1676:uid_10665       timestamp: 2026-04-10 01:29:01 UTC
                                           power_fault_cause: CPU_CMD_PCYC (CPU card commanded power cycle); under_voltage: VH1(12V); over_voltage: n/a
                                           gpio_in_[7:4,9:8,R,R,R,3:1]: 0b000000000000
                                           pdio_in_[16:1]: 0b0111100110000000 [PDI15, PDI14, PDI13, PDI12, PDI9, PDI8]

  switch_card:powerup_1676:uid_10664       timestamp: 2026-04-10 01:28:51 UTC
                                           power_fault_cause: n/a; under_voltage: n/a; over_voltage: n/a
                                           gpio_in_[7:4,9:8,R,R,R,3:1]: 0b000000000000
                                           pdio_in_[16:1]: 0b0111110010000000 [PDI15, PDI14, PDI13, PDI12, PDI11, PDI8]
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

