### PR TITLE
[FRR] bmp: don't prepend local-AS to AS_PATH in BMP updates

### DIFF
--- a/src/sonic-frr/patch/0115-bgpd-bmp-don-t-prepend-local-AS-in-BMP-updates.patch
+++ b/src/sonic-frr/patch/0115-bgpd-bmp-don-t-prepend-local-AS-in-BMP-updates.patch
@@ -1,0 +1,398 @@
+Subject: [PATCH] bgpd: bmp: don't prepend local-AS to AS_PATH in BMP updates
+
+From: Kalash Nainwal <kalash@nexthop.ai>
+
+BMP Route Monitoring messages for monitored routes carried an AS_PATH
+with the local AS prepended, as if the route were being re-advertised
+outbound. Observed with a peer in AS 40001 advertising 100.100.100.1/32
+to a router in AS 40002:
+
+    "as_path":[40002,40001], "as_path_count":2, "peer_asn":40001
+
+The collector expected AS_PATH=[40001] — the value as received from the
+peer — but saw [40002,40001] because the local AS was prepended on its
+way out to the collector.
+
+Root cause: bmp_update() in bgp_bmp.c reuses bgp_packet_attribute(),
+the outbound attribute serializer, which performs peer-specific outbound
+transformations on AS_PATH (prepend peer->local_as for eBGP, confed-seq
+handling, change-local-as). These are correct for sending an UPDATE to
+a peer, but BMP is a reporting channel — pre-policy, post-policy, and
+loc-rib must all emit the AS_PATH as stored (received / selected),
+never with the outbound local-AS prepended.
+
+Fix: add a bool for_bmp parameter to bgp_packet_attribute(). When true:
+
+ - Skip the peer-sort-based AS_PATH transformations and emit
+   attr->aspath as-is (no local-AS prepend, no confed-seq manipulation).
+
+ - Force 32-bit ASN encoding regardless of the peer's AS4 capability
+   state. This is needed for loc-rib re-dumps after a VRF/peer flap:
+   peer->cap can be momentarily cleared while the session renegotiates,
+   which would otherwise cause aspath_put() to emit 16-bit AS_PATH
+   segments. Modern BMP collectors always parse ASNs as 32-bit, so a
+   16-bit segment produces a byte-level parse error and the collector
+   disconnects, losing all subsequent peer-up / peer-down / route-monitor
+   messages.
+
+bmp_update() passes for_bmp=true (covers pre-policy, post-policy, and
+loc-rib). The outbound callers in bgp_updgrp_packet.c pass false to keep
+their current behaviour.
+
+Also update the bgp_bmp topotest expected JSON files for all three
+modes: previously they encoded the prepended local-AS ("65501 65502"
+where 65501 is the local AS); now they expect the raw AS_PATH "65502"
+as received from the peer in AS 65502.
+
+Signed-off-by: Kalash Nainwal <kalash@nexthop.ai>
+---
+ bgpd/bgp_attr.c                                    | 44 +++++++++++++++++++---
+ bgpd/bgp_attr.h                                    |  3 +-
+ bgpd/bgp_bmp.c                                     |  8 +++-
+ bgpd/bgp_updgrp_packet.c                           |  4 +-
+ .../bgp_bmp/bmp1/bmp-update-loc-rib-step1.json     |  4 +-
+ .../bgp_bmp/bmp1/bmp-update-loc-rib-step2.json     |  4 +-
+ .../bgp_bmp/bmp1/bmp-update-post-policy-step1.json |  4 +-
+ .../bgp_bmp/bmp1/bmp-update-post-policy-step2.json |  4 +-
+ .../bgp_bmp/bmp1/bmp-update-pre-policy-step1.json  |  4 +-
+ .../bgp_bmp/bmp1/bmp-update-pre-policy-step2.json  |  4 +-
+ .../bgp_bmp/bmp1vrf/bmp-update-loc-rib-step1.json  |  4 +-
+ .../bmp1vrf/bmp-update-post-policy-step1.json      |  4 +-
+ .../bmp1vrf/bmp-update-pre-policy-step1.json       |  4 +-
+ 13 files changed, 67 insertions(+), 28 deletions(-)
+
+diff --git a/bgpd/bgp_attr.c b/bgpd/bgp_attr.c
+index 3b154c28a..5c2466539 100644
+--- a/bgpd/bgp_attr.c
++++ b/bgpd/bgp_attr.c
+@@ -4950,15 +4950,25 @@ bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *peer, struct strea
+ 				struct prefix *p, afi_t afi, safi_t safi, struct peer *from,
+ 				struct prefix_rd *prd, mpls_label_t *label, uint8_t num_labels,
+ 				bool addpath_capable, uint32_t addpath_tx_id,
+-				struct bgp_path_info *bpi)
++				struct bgp_path_info *bpi, bool for_bmp)
+ {
+ 	size_t cp;
+ 	size_t aspath_sizep;
+ 	struct aspath *aspath;
+ 	int send_as4_path = 0;
+ 	int send_as4_aggregator = 0;
+-	bool use32bit = CHECK_FLAG(peer->cap, PEER_CAP_AS4_RCV) &&
+-			CHECK_FLAG(peer->cap, PEER_CAP_AS4_ADV);
++	/*
++	 * For BMP Route Monitoring always encode ASNs as 32-bit. BMP is an
++	 * observability channel, not a BGP session; the peer's AS4 capability
++	 * state is irrelevant and may be stale across peer/VRF flaps, which
++	 * would produce 16-bit AS_PATH segments that modern BMP collectors
++	 * (always 32-bit) can't parse. As a side effect this also suppresses
++	 * the AS4_PATH backward-compat attribute (send_as4_path is only set
++	 * when use32bit is false), which BMP collectors don't need anyway.
++	 */
++	bool use32bit = for_bmp ||
++			(CHECK_FLAG(peer->cap, PEER_CAP_AS4_RCV) &&
++			 CHECK_FLAG(peer->cap, PEER_CAP_AS4_ADV));
+ 
+ 	if (!bgp)
+ 		bgp = peer->bgp;
+@@ -4989,8 +4999,26 @@ bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *peer, struct strea
+ 
+ 	/* AS path attribute. */
+ 
++	/*
++	 * The for_bmp path is taken from bmp_update(), which only ever feeds
++	 * in attributes that come from receive-side storage in the three BMP
++	 * modes FRR currently emits:
++	 *
++	 *   - pre-policy Adj-RIB-In:   adjin->attr (raw on-wire from peer)
++	 *   - post-policy Adj-RIB-In:  bpi->attr   (path-info in local RIB)
++	 *   - Loc-RIB:                 bpi->attr   (selected best path)
++	 *
++	 * None of these have been through the outbound peer-specific AS_PATH
++	 * transformations below (local-AS prepend for eBGP, confed-seq,
++	 * change-local-as), so they're skipped when for_bmp is set.
++	 *
++	 * If RFC 8671 Adj-RIB-Out monitoring is added, post-policy
++	 * Adj-RIB-Out MUST be encoded "as actually transmitted to the peer"
++	 * (RFC 8671 §5.1) — that future caller must invoke this function
++	 * with for_bmp=false so the transformations below run.
++	 */
+ 	/* If remote-peer is EBGP */
+-	if (peer->sort == BGP_PEER_EBGP
++	if (!for_bmp && peer->sort == BGP_PEER_EBGP
+ 	    && (!CHECK_FLAG(peer->af_flags[afi][safi],
+ 			    PEER_FLAG_AS_PATH_UNCHANGED)
+ 		|| attr->aspath->segments == NULL)
+@@ -5036,12 +5064,18 @@ bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *peer, struct strea
+ 				aspath = aspath_add_seq(aspath, peer->local_as);
+ 			}
+ 		}
+-	} else if (peer->sort == BGP_PEER_CONFED) {
++	} else if (!for_bmp && peer->sort == BGP_PEER_CONFED) {
+ 		/* A confed member, so we need to do the AS_CONFED_SEQUENCE
+ 		 * thing */
+ 		aspath = aspath_dup(attr->aspath);
+ 		aspath = aspath_add_confed_seq(aspath, peer->local_as);
+ 	} else
++		/*
++		 * NOTE: with for_bmp=true we always reach here, including for
++		 * confed peers — the confed-seq above is intentionally
++		 * skipped. See the for_bmp commentary above the EBGP block for
++		 * the rationale and the RFC 8671 Adj-RIB-Out caveat.
++		 */
+ 		aspath = attr->aspath;
+ 
+ 	/* If peer is not AS4 capable, then:
+diff --git a/bgpd/bgp_attr.h b/bgpd/bgp_attr.h
+index 3340822d5..64f512165 100644
+--- a/bgpd/bgp_attr.h
++++ b/bgpd/bgp_attr.h
+@@ -399,7 +399,8 @@ extern bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *peer, struc
+ 				       struct prefix *p, afi_t afi, safi_t safi, struct peer *from,
+ 				       struct prefix_rd *prd, mpls_label_t *label,
+ 				       uint8_t num_labels, bool addpath_capable,
+-				       uint32_t addpath_tx_id, struct bgp_path_info *bpi);
++				       uint32_t addpath_tx_id, struct bgp_path_info *bpi,
++				       bool for_bmp);
+ extern void bgp_dump_routes_attr(struct stream *s, struct bgp_path_info *bpi,
+ 				 const struct prefix *p);
+ extern bool attrhash_cmp(const void *arg1, const void *arg2);
+diff --git a/bgpd/bgp_bmp.c b/bgpd/bgp_bmp.c
+index c095a3ea7..693748717 100644
+--- a/bgpd/bgp_bmp.c
++++ b/bgpd/bgp_bmp.c
+@@ -1116,9 +1116,13 @@ static struct stream *bmp_update(const struct prefix *p, struct prefix_rd *prd,
+ 	attrlen_pos = stream_get_endp(s);
+ 	stream_putw(s, 0);
+ 
+-	/* 5: Encode all the attributes, except MP_REACH_NLRI attr. */
++	/* 5: Encode all the attributes, except MP_REACH_NLRI attr.
++	 * Pass for_bmp=true to bgp_packet_attribute() so it skips outbound
++	 * peer-specific AS_PATH transformations and emits attr->aspath as
++	 * stored — BMP is a reporting channel, not a BGP peer session.
++	 */
+ 	total_attr_len = bgp_packet_attribute(NULL, peer, s, attr, &vecarr, NULL, afi, safi, peer,
+-					      NULL, NULL, 0, 0, 0, NULL);
++					      NULL, NULL, 0, 0, 0, NULL, true);
+ 
+ 	/* space check? */
+ 
+diff --git a/bgpd/bgp_updgrp_packet.c b/bgpd/bgp_updgrp_packet.c
+index 141cb81ef..adbfe2de2 100644
+--- a/bgpd/bgp_updgrp_packet.c
++++ b/bgpd/bgp_updgrp_packet.c
+@@ -757,7 +757,7 @@ struct bpacket *subgroup_update_packet(struct update_subgroup *subgrp)
+ 			 * attr. */
+ 			total_attr_len = bgp_packet_attribute(NULL, peer, s, adv->baa->attr,
+ 							      &vecarr, NULL, afi, safi, from, NULL,
+-							      NULL, 0, 0, 0, path);
++							      NULL, 0, 0, 0, path, false);
+ 
+ 			space_remaining =
+ 				STREAM_CONCAT_REMAIN(s, snlri, STREAM_SIZE(s))
+@@ -1170,7 +1170,7 @@ void subgroup_default_update_packet(struct update_subgroup *subgrp,
+ 	stream_putw(s, 0);
+ 	total_attr_len = bgp_packet_attribute(NULL, peer, s, attr, &vecarr, &p, afi, safi, from,
+ 					      NULL, &label, num_labels, addpath_capable,
+-					      BGP_ADDPATH_TX_ID_FOR_DEFAULT_ORIGINATE, NULL);
++					      BGP_ADDPATH_TX_ID_FOR_DEFAULT_ORIGINATE, NULL, false);
+ 
+ 	/* Set Total Path Attribute Length. */
+ 	stream_putw_at(s, pos, total_attr_len);
+diff --git a/tests/topotests/bgp_bmp/bmp1/bmp-update-loc-rib-step1.json b/tests/topotests/bgp_bmp/bmp1/bmp-update-loc-rib-step1.json
+index 27f1fe6e2..c5ca60c29 100644
+--- a/tests/topotests/bgp_bmp/bmp1/bmp-update-loc-rib-step1.json
++++ b/tests/topotests/bgp_bmp/bmp1/bmp-update-loc-rib-step1.json
+@@ -2,7 +2,7 @@
+     "loc-rib": {
+         "update": {
+             "172.31.0.15/32": {
+-                "as_path": "65501 65502",
++                "as_path": "65502",
+                 "bgp_nexthop": "192.168.0.2",
+                 "bmp_log_type": "update",
+                 "ip_prefix": "172.31.0.15/32",
+@@ -16,7 +16,7 @@
+             },
+             "2001::1111/128": {
+                 "afi": 2,
+-                "as_path": "65501 65502",
++                "as_path": "65502",
+                 "bmp_log_type": "update",
+                 "ip_prefix": "2001::1111/128",
+                 "is_filtered": false,
+diff --git a/tests/topotests/bgp_bmp/bmp1/bmp-update-loc-rib-step2.json b/tests/topotests/bgp_bmp/bmp1/bmp-update-loc-rib-step2.json
+index 0aa6bd4fe..ab693155c 100644
+--- a/tests/topotests/bgp_bmp/bmp1/bmp-update-loc-rib-step2.json
++++ b/tests/topotests/bgp_bmp/bmp1/bmp-update-loc-rib-step2.json
+@@ -3,7 +3,7 @@
+         "update": {
+             "2001::1111/128": {
+                 "afi": 2,
+-                "as_path": "65501 65502",
++                "as_path": "65502",
+                 "bmp_log_type": "update",
+                 "ip_prefix": "2001::1111/128",
+                 "is_filtered": false,
+@@ -22,7 +22,7 @@
+             },
+             "172.31.0.15/32": {
+                 "afi": 1,
+-                "as_path": "65501 65502",
++                "as_path": "65502",
+                 "bmp_log_type": "update",
+                 "ip_prefix": "172.31.0.15/32",
+                 "is_filtered": false,
+diff --git a/tests/topotests/bgp_bmp/bmp1/bmp-update-post-policy-step1.json b/tests/topotests/bgp_bmp/bmp1/bmp-update-post-policy-step1.json
+index d30ef9fd3..7a50c435c 100644
+--- a/tests/topotests/bgp_bmp/bmp1/bmp-update-post-policy-step1.json
++++ b/tests/topotests/bgp_bmp/bmp1/bmp-update-post-policy-step1.json
+@@ -2,7 +2,7 @@
+     "post-policy": {
+         "update": {
+             "172.31.0.15/32": {
+-                "as_path": "65501 65502",
++                "as_path": "65502",
+                 "bgp_nexthop": "192.168.0.2",
+                 "bmp_log_type": "update",
+                 "ip_prefix": "172.31.0.15/32",
+@@ -17,7 +17,7 @@
+             },
+             "2001::1111/128": {
+                 "afi": 2,
+-                "as_path": "65501 65502",
++                "as_path": "65502",
+                 "bmp_log_type": "update",
+                 "ip_prefix": "2001::1111/128",
+                 "ipv6": true,
+diff --git a/tests/topotests/bgp_bmp/bmp1/bmp-update-post-policy-step2.json b/tests/topotests/bgp_bmp/bmp1/bmp-update-post-policy-step2.json
+index 9bf2d5776..862b78061 100644
+--- a/tests/topotests/bgp_bmp/bmp1/bmp-update-post-policy-step2.json
++++ b/tests/topotests/bgp_bmp/bmp1/bmp-update-post-policy-step2.json
+@@ -3,7 +3,7 @@
+         "update": {
+             "172.31.0.15/32": {
+                 "afi": 1,
+-                "as_path": "65501 65502",
++                "as_path": "65502",
+                 "bmp_log_type": "update",
+                 "ip_prefix": "172.31.0.15/32",
+                 "ipv6": false,
+@@ -22,7 +22,7 @@
+             },
+             "2001::1111/128": {
+                 "afi": 2,
+-                "as_path": "65501 65502",
++                "as_path": "65502",
+                 "bmp_log_type": "update",
+                 "ip_prefix": "2001::1111/128",
+                 "ipv6": true,
+diff --git a/tests/topotests/bgp_bmp/bmp1/bmp-update-pre-policy-step1.json b/tests/topotests/bgp_bmp/bmp1/bmp-update-pre-policy-step1.json
+index fafe6f7c2..52c7c0985 100644
+--- a/tests/topotests/bgp_bmp/bmp1/bmp-update-pre-policy-step1.json
++++ b/tests/topotests/bgp_bmp/bmp1/bmp-update-pre-policy-step1.json
+@@ -2,7 +2,7 @@
+     "pre-policy": {
+         "update": {
+             "172.31.0.15/32": {
+-                "as_path": "65501 65502",
++                "as_path": "65502",
+                 "bgp_nexthop": "192.168.0.2",
+                 "bmp_log_type": "update",
+                 "ip_prefix": "172.31.0.15/32",
+@@ -17,7 +17,7 @@
+             },
+             "2001::1111/128": {
+                 "afi": 2,
+-                "as_path": "65501 65502",
++                "as_path": "65502",
+                 "bmp_log_type": "update",
+                 "ip_prefix": "2001::1111/128",
+                 "ipv6": true,
+diff --git a/tests/topotests/bgp_bmp/bmp1/bmp-update-pre-policy-step2.json b/tests/topotests/bgp_bmp/bmp1/bmp-update-pre-policy-step2.json
+index 95acb5903..307c8d598 100644
+--- a/tests/topotests/bgp_bmp/bmp1/bmp-update-pre-policy-step2.json
++++ b/tests/topotests/bgp_bmp/bmp1/bmp-update-pre-policy-step2.json
+@@ -3,7 +3,7 @@
+         "update": {
+             "172.31.0.15/32": {
+                 "afi": 1,
+-                "as_path": "65501 65502",
++                "as_path": "65502",
+                 "bmp_log_type": "update",
+                 "ip_prefix": "172.31.0.15/32",
+                 "ipv6": false,
+@@ -22,7 +22,7 @@
+             },
+             "2001::1111/128": {
+                 "afi": 2,
+-                "as_path": "65501 65502",
++                "as_path": "65502",
+                 "bmp_log_type": "update",
+                 "ip_prefix": "2001::1111/128",
+                 "ipv6": true,
+diff --git a/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-loc-rib-step1.json b/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-loc-rib-step1.json
+index d6c87dd4f..af5880b99 100644
+--- a/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-loc-rib-step1.json
++++ b/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-loc-rib-step1.json
+@@ -2,7 +2,7 @@
+     "loc-rib": {
+         "update": {
+             "172.31.0.15/32": {
+-                "as_path": "65501 65502",
++                "as_path": "65502",
+                 "bgp_nexthop": "192.168.0.2",
+                 "bmp_log_type": "update",
+                 "ip_prefix": "172.31.0.15/32",
+@@ -16,7 +16,7 @@
+             },
+             "2111::1111/128": {
+                 "afi": 2,
+-                "as_path": "65501 65502",
++                "as_path": "65502",
+                 "bmp_log_type": "update",
+                 "ip_prefix": "2111::1111/128",
+                 "is_filtered": false,
+diff --git a/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-post-policy-step1.json b/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-post-policy-step1.json
+index 04e01623d..8b904086e 100644
+--- a/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-post-policy-step1.json
++++ b/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-post-policy-step1.json
+@@ -2,7 +2,7 @@
+     "post-policy": {
+         "update": {
+             "172.31.0.15/32": {
+-                "as_path": "65501 65502",
++                "as_path": "65502",
+                 "bgp_nexthop": "192.168.0.2",
+                 "bmp_log_type": "update",
+                 "ip_prefix": "172.31.0.15/32",
+@@ -17,7 +17,7 @@
+             },
+             "2111::1111/128": {
+                 "afi": 2,
+-                "as_path": "65501 65502",
++                "as_path": "65502",
+                 "bmp_log_type": "update",
+                 "ip_prefix": "2111::1111/128",
+                 "ipv6": true,
+diff --git a/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-pre-policy-step1.json b/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-pre-policy-step1.json
+index 760ee0409..c1298dc3c 100644
+--- a/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-pre-policy-step1.json
++++ b/tests/topotests/bgp_bmp/bmp1vrf/bmp-update-pre-policy-step1.json
+@@ -2,7 +2,7 @@
+     "pre-policy": {
+         "update": {
+             "172.31.0.15/32": {
+-                "as_path": "65501 65502",
++                "as_path": "65502",
+                 "bgp_nexthop": "192.168.0.2",
+                 "bmp_log_type": "update",
+                 "ip_prefix": "172.31.0.15/32",
+@@ -17,7 +17,7 @@
+             },
+             "2111::1111/128": {
+                 "afi": 2,
+-                "as_path": "65501 65502",
++                "as_path": "65502",
+                 "bmp_log_type": "update",
+                 "ip_prefix": "2111::1111/128",
+                 "ipv6": true,

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -30,3 +30,4 @@
 0112-SONiC-ONLY-lib-build-add-configure-check-for-tc_mallinfo2-and-fallback.patch
 0113-zebra-Refactor-SRv6-netlink-code-to-remove-duplication.patch
 0114-Provide-interface-when-installing-uninstalling-SRv6-uA-SIDs.patch
+0115-bgpd-bmp-don-t-prepend-local-AS-in-BMP-updates.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
closes #27018 

BMP Route Monitoring messages for monitored routes carried an `AS_PATH` with the local AS prepended, as if the route were being re-advertised outbound. Observed with a peer in AS 40001 advertising 100.100.100.1/32 to a router in AS 40002 (which is sending BMP updates to its collector as):

```
"as_path":[40002,40001], "as_path_count":2, "peer_asn":40001
```

The collector expected `AS_PATH=[40001]` — the value as received from the peer — but saw `[40002,40001]` because local AS was prepended on its way out to the collector.

#### Why I did it

`bmp_update()` in `bgp_bmp.c` reuses `bgp_packet_attribute()`, the outbound attribute serializer, which performs peer-specific outbound transformations on AS_PATH (prepend `peer->local_as` for eBGP, confed-seq handling, change-local-as). These are correct for sending an UPDATE to a peer, but BMP is a reporting channel — `pre-policy`, `post-policy`, and `loc-rib` should all emit the AS_PATH as stored (received / selected), never with the outbound local-AS prepended.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added a `bool for_bmp` parameter to `bgp_packet_attribute()`. When `true`:

- **Skip the peer-sort-based AS_PATH transformations** and emit `attr->aspath` as-is (no local-AS prepend, no confed-seq manipulation).

- **Force 32-bit ASN encoding** regardless of the peer's AS4 capability state. This is needed for `loc-rib` re-dumps after a VRF/peer flap: `peer->cap` can be momentarily cleared while the session renegotiates, which would otherwise cause `aspath_put()` to emit 16-bit AS_PATH segments. Modern BMP collectors always parse ASNs as 32-bit, so a 16-bit segment produces a byte-level parse error and the collector disconnects (losing all subsequent peer-up / peer-down / route-monitor messages).

`bmp_update()` passes `for_bmp=true` unconditionally — covers pre-policy, post-policy, and loc-rib. The outbound callers in `bgp_updgrp_packet.c` pass `false` to preserve their current behaviour.

The bgp_bmp topotest expected JSON files for all three modes were updated accordingly: `\"65501 65502\"` → `\"65502\"`.

#### How to verify it

- `bgp_bmp/` topotests: all 31 pass locally (`./tests/topotests/docker/frr-topotests.sh -v bgp_bmp/`).
- `bgp_basic_functionality_topo1/` topotests: all 11 pass locally (sanity check that outbound AS_PATH behaviour is unchanged).

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

