### PR TITLE
Update dynamic threshold for Q1/Q2/Q3 egress lossy profiles

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/buffers_defaults_t0.j2
@@ -35,17 +35,17 @@
         "QUEUE1_DOWNLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE2_DOWNLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE3_DOWNLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE4_DOWNLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
@@ -70,17 +70,17 @@
         "QUEUE1_UPLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE2_UPLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE3_UPLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE4_UPLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
@@ -108,7 +108,7 @@
 
 {% if DEVICE_METADATA
   and DEVICE_METADATA['localhost']
-  and DEVICE_METADATA['localhost'].type == "LeafRouter"
+  and DEVICE_METADATA['localhost'].type in ('LeafRouter', 'ToRRouter')
   and DEVICE_NEIGHBOR
   and DEVICE_NEIGHBOR_METADATA %}
 {%- macro generate_queue_buffers(ports) %}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/buffers_defaults_t1.j2
@@ -108,7 +108,7 @@
 
 {% if DEVICE_METADATA
   and DEVICE_METADATA['localhost']
-  and DEVICE_METADATA['localhost'].type in ('LeafRouter, 'ToRRouter')
+  and DEVICE_METADATA['localhost'].type in ('LeafRouter', 'ToRRouter')
   and DEVICE_NEIGHBOR
   and DEVICE_NEIGHBOR_METADATA %}
 {%- macro generate_queue_buffers(ports) %}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/buffers_defaults_t1.j2
@@ -35,17 +35,17 @@
         "QUEUE1_DOWNLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE2_DOWNLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE3_DOWNLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE4_DOWNLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
@@ -70,17 +70,17 @@
         "QUEUE1_UPLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE2_UPLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE3_UPLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE4_UPLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
@@ -108,7 +108,7 @@
 
 {% if DEVICE_METADATA
   and DEVICE_METADATA['localhost']
-  and DEVICE_METADATA['localhost'].type == "LeafRouter"
+  and DEVICE_METADATA['localhost'].type in ('LeafRouter, 'ToRRouter')
   and DEVICE_NEIGHBOR
   and DEVICE_NEIGHBOR_METADATA %}
 {%- macro generate_queue_buffers(ports) %}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t0.j2
@@ -35,17 +35,17 @@
         "QUEUE1_DOWNLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE2_DOWNLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE3_DOWNLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE4_DOWNLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
@@ -70,17 +70,17 @@
         "QUEUE1_UPLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE2_UPLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE3_UPLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE4_UPLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
@@ -108,7 +108,7 @@
 
 {% if DEVICE_METADATA
   and DEVICE_METADATA['localhost']
-  and DEVICE_METADATA['localhost'].type == "ToRRouter"
+  and DEVICE_METADATA['localhost'].type in ('LeafRouter', 'ToRRouter')
   and DEVICE_NEIGHBOR
   and DEVICE_NEIGHBOR_METADATA %}
 {%- macro generate_queue_buffers(ports) %}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/buffers_defaults_t1.j2
@@ -35,17 +35,17 @@
         "QUEUE1_DOWNLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE2_DOWNLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE3_DOWNLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE4_DOWNLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
@@ -70,17 +70,17 @@
         "QUEUE1_UPLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE2_UPLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE3_UPLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
             "size": "1778",
-            "dynamic_th": "-7"
+            "dynamic_th": "3"
         },
         "QUEUE4_UPLINK_LOSSY_PROFILE": {
             "pool": "egress_lossy_pool",
@@ -108,7 +108,7 @@
 
 {% if DEVICE_METADATA
   and DEVICE_METADATA['localhost']
-  and DEVICE_METADATA['localhost'].type == "ToRRouter"
+  and DEVICE_METADATA['localhost'].type in ('LeafRouter', 'ToRRouter')
   and DEVICE_NEIGHBOR
   and DEVICE_NEIGHBOR_METADATA %}
 {%- macro generate_queue_buffers(ports) %}


### PR DESCRIPTION
#### Why I did it
Update the alpha values for Q1/Q2/Q3 egress profiles to provide more buffers for the traffic.
Update the egress queue profiles for all ToR/Leaf switches

##### Work item tracking
- Microsoft ADO **(number only)**:
37712828

#### How I did it
Updated the dynamic threshold values for Q1/Q2/Q3 lossy queues.

#### How to verify it

Generated the values after updating T0/T1 Ninja templates.

#### Which release branch to backport (provide reason below if selected)

- [x] 202411
- [x] 202505
- [x] 202511

