### PR TITLE
[aspeed][BMC] Do not mask sonic-hostservice.service on BMC images

### DIFF
--- a/files/build_scripts/aspeed_bmc_filter_services.py
+++ b/files/build_scripts/aspeed_bmc_filter_services.py
@@ -30,9 +30,6 @@ BMC_EXCLUDED_SERVICES = {
     'dhcp_dos_logger.service',       # DHCP DoS detection - no switch ports on BMC
     'warmboot-finalizer.service',    # Warm boot reconciliation - no SWSS/BGP on BMC
 
-    # SONiC NOS services - not needed for BMC
-    'sonic-hostservice.service',     # SONiC host services (VLAN, LAG, etc.) - NOS-specific
-
     # UUID daemon - not needed
     'uuidd.service',                 # UUID daemon - kernel provides UUID generation
     'uuidd.socket',                  # UUID daemon socket activation


### PR DESCRIPTION
#### Why I did it

`sonic-hostservice.service` is currently listed in `BMC_EXCLUDED_SERVICES` in `files/build_scripts/aspeed_bmc_filter_services.py` with the comment "SONiC host services (VLAN, LAG, etc.) - NOS-specific". This is incomplete: the `sonic-hostservice` daemon (from the `sonic-host-services-data` package) is not only the VLAN/LAG/route helper — it is also the D-Bus host process that registers the gNOI `host_modules` (`reboot`, `time_proxy`, `os`, `gnoi_password`, …) on `org.SONiC.HostService.*`.

On aspeed BMC images, `gnmi` is enabled (see init_cfg / FEATURE) and customers use `gnoi.System.Reboot`, `gnoi.System.KillProcess`, etc. via the gNMI/gNOI server in the `gnmi` container. Those calls reach into the host through D-Bus, calling into the `host_modules`. Because the build masks the unit (`/etc/systemd/system/sonic-hostservice.service -> /dev/null`), the daemon never starts on BMC, and every gNOI call that goes through host_services fails with:

```
Error org.freedesktop.DBus.Error.ServiceUnknown:
The name org.SONiC.HostService.reboot was not provided by any .service files
```

This was confirmed end-to-end on a Komodo BMC (Aspeed AST2720) running internal SONiC build `161861823-bff76049fe`:

- `sonic-host-services-data` package installed, `host_modules/reboot.py` present
- `org.SONiC.HostService.conf` D-Bus policy installed in `/etc/dbus-1/system.d/`
- `/lib/systemd/system/sonic-hostservice.service` present and well-formed
- but `/etc/systemd/system/sonic-hostservice.service` is a symlink to `/dev/null` (dated to image build time)
- → `systemctl status sonic-hostservice` shows `masked`, daemon not running, gNOI Reboot fails

Removing the entry lets the daemon start through the normal sonic-host-services-data postinst / preset path; gNOI host_modules then work on BMC the same way they do on NPU.

##### Work item tracking
- Microsoft ADO **(number only)**: 37699684

#### How I did it

Removed `'sonic-hostservice.service'` from `BMC_EXCLUDED_SERVICES` in `files/build_scripts/aspeed_bmc_filter_services.py`. No other change is needed: the package's own debian preset enables the unit when nothing masks it.

The other entries in `BMC_EXCLUDED_SERVICES` (backend-acl, pcie-check, midplane-network-{npu,dpu}, topology, copp-config, dhcp_dos_logger, warmboot-finalizer, uuidd.{service,socket}, getty@tty1) are left in place — those are genuinely NPU-only or unused on BMC.

#### How to verify it

1. Build an aspeed BMC image (e.g. `arm64-nexthop_b27-r0`) from this branch.
2. Install on the BMC and reboot.
3. On the BMC:
   ```
   systemctl status sonic-hostservice          # should be loaded; active (running) — not masked
   ls -l /etc/systemd/system/sonic-hostservice.service   # should NOT be a symlink to /dev/null
   busctl list --system | grep org.SONiC.HostService     # should show reboot/time_proxy/os/...
   ```
4. From a remote host with `gnmi_cli` / `gnoi_client`:
   ```
   gnoi_client -target_addr <bmc>:8080 -insecure -rpc System.Reboot -jsonin '{"method":1,"message":"unit test"}'
   ```
   Expected: BMC reboots (or returns success and reboots after the configured delay) instead of the previous D-Bus `ServiceUnknown` error.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

Reason: gNOI on BMC is broken on every release branch that contains `files/build_scripts/aspeed_bmc_filter_services.py` with the current `BMC_EXCLUDED_SERVICES` content. Backport needed for any release branch shipping the aspeed BMC image.

#### Tested branch (Please provide the tested image version)

- [ ] master (build pending after this change)
- [x] internal `SONiC.internal.161861823-bff76049fe` (Apr 27 2026) — reproduced the failure; manual `systemctl unmask sonic-hostservice && systemctl start sonic-hostservice` makes gNOI Reboot work.

#### Description for the changelog

[aspeed][BMC] Stop masking `sonic-hostservice.service` on BMC images so gNOI host_modules (reboot, time_proxy, os, ...) work over D-Bus.

#### A picture of a cute animal (not mandatory but encouraged)

🐧
