### PR TITLE
[dhcp_relay] Fix agent_relay_mode: align YANG and CLI with ISC behavior

### DIFF
--- a/dockers/docker-dhcp-relay/cli-plugin-tests/test_dhcpv4_relay.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/test_dhcpv4_relay.py
@@ -494,7 +494,8 @@ class TestConfigDhcpv4Relay(object):
         agent_relay_modes = [
             "discard",
             "append",
-            "replace"
+            "replace",
+            "forward"
         ]
 
         for add_mode in agent_relay_modes:

--- a/dockers/docker-dhcp-relay/cli/config/plugins/dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli/config/plugins/dhcp_relay.py
@@ -223,7 +223,7 @@ def validate_source_interface(vlan_name, source_interface, db):
 @click.option("--vrf-selection", required=False, type=click.Choice(["enable", "disable"]), help="VRF selection flag for DHCPv4 relay")
 @click.option("--server-id-override", required=False, type=click.Choice(["enable", "disable"]), help="Enable/Disable server ID override for DHCPv4 relay")
 @click.option("--server-vrf", required=False, help="Server VRF name for DHCPv4 relay")
-@click.option("--agent-relay-mode", required=False, type=click.Choice(["discard", "append", "replace"]),
+@click.option("--agent-relay-mode", required=False, type=click.Choice(["discard", "append", "replace", "forward"]),
               help="Set agent relay mode for DHCPv4 relay")
 @click.option("--max-hop-count", required=False, type=int, help="Maximum hop count for DHCPv4 relay")
 @click.argument("vlan_name", metavar="<VLAN_NAME>", required=True)
@@ -318,7 +318,7 @@ def update_dhcpv4_relay(db, vlan_name, dhcpv4_servers, source_interface, link_se
 @click.option("--vrf-selection", required=False, type=click.Choice(["enable", "disable"]), help="Enable/Disable VRF selection for DHCPv4 relay")
 @click.option("--server-id-override", required=False, type=click.Choice(["enable", "disable"]), help="Enable/Disable server ID override for DHCPv4 relay")
 @click.option("--server-vrf", required=False, help="Server VRF name for DHCPv4 relay")
-@click.option("--agent-relay-mode", required=False, type=click.Choice(["discard", "append", "replace"]),
+@click.option("--agent-relay-mode", required=False, type=click.Choice(["discard", "append", "replace", "forward"]),
               help="Set agent relay mode for DHCPv4 relay")
 @click.option("--max-hop-count", required=False, type=int, help="Maximum hop count for DHCPv4 relay")
 @click.argument("vlan_name", metavar="<VLAN_NAME>", required=True)
@@ -518,7 +518,7 @@ def dhcp_relay_ipv4_helper():
 @click.option("--vrf-selection", required=False, type=click.Choice(["enable", "disable"]), help="Enable/Disable VRF selection for DHCPv4 relay")
 @click.option("--server-id-override", required=False, type=click.Choice(["enable", "disable"]), help="Enable/Disable server ID override for DHCPv4 relay")
 @click.option("--server-vrf", required=False, help="Server VRF name for DHCPv4 relay")
-@click.option("--agent-relay-mode", required=False, type=click.Choice(["discard", "append", "replace"]),
+@click.option("--agent-relay-mode", required=False, type=click.Choice(["discard", "append", "replace", "forward"]),
               help="Set agent relay mode for DHCPv4 relay")
 @click.option("--max-hop-count", required=False, type=int, help="Maximum hop count for DHCPv4 relay")
 @clicommon.pass_db
@@ -545,7 +545,7 @@ def add_dhcp_relay_ipv4_helper(db, vid, dhcp_relay_helpers, source_interface, li
 @click.option("--vrf-selection", required=False, type=click.Choice(["enable", "disable"]), help="Enable/Disable VRF selection for DHCPv4 relay")
 @click.option("--server-id-override", required=False, type=click.Choice(["enable", "disable"]), help="Enable/Disable server ID override for DHCPv4 relay")
 @click.option("--server-vrf", required=False, help="Server VRF name for DHCPv4 relay")
-@click.option("--agent-relay-mode", required=False, type=click.Choice(["discard", "append", "replace"]),
+@click.option("--agent-relay-mode", required=False, type=click.Choice(["discard", "append", "replace", "forward"]),
               help="Set agent relay mode for DHCPv4 relay")
 @click.option("--max-hop-count", required=False, type=int, help="Maximum hop count for DHCPv4 relay")
 @clicommon.pass_db

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2200,7 +2200,7 @@
                 "link_selection": "enable",
                 "vrf_selection": "enable",
                 "server_id_override": "enable",
-                "agent_relay_mode": "forward_untouched",
+                "agent_relay_mode": "discard",
                 "max_hop_count": "4"
             },
             "Vlan222": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/dhcpv4_relay.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/dhcpv4_relay.json
@@ -12,7 +12,16 @@
         "desc": "Add dhcpv4 relay with link-select option enabled."
     },
     "DHCPv4_RELAY_WITH_AGENT_RELAY_MODE_DISCARD": {
-        "desc": "Add dhcpv4 relay with minimum config."
+        "desc": "Add dhcpv4 relay with agent_relay_mode set to discard."
+    },
+    "DHCPv4_RELAY_WITH_AGENT_RELAY_MODE_APPEND": {
+        "desc": "Add dhcpv4 relay with agent_relay_mode set to append."
+    },
+    "DHCPv4_RELAY_WITH_AGENT_RELAY_MODE_REPLACE": {
+        "desc": "Add dhcpv4 relay with agent_relay_mode set to replace."
+    },
+    "DHCPv4_RELAY_WITH_AGENT_RELAY_MODE_FORWARD": {
+        "desc": "Add dhcpv4 relay with agent_relay_mode set to forward."
     },
     "DHCPv4_RELAY_WITH_VALID_MAX_HOP_CNT": {
         "desc": "Add dhcpv4 relay with valid max_hop_cnt."

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/dhcpv4_relay.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/dhcpv4_relay.json
@@ -105,6 +105,51 @@
             }
         }
     },
+    "DHCPv4_RELAY_WITH_AGENT_RELAY_MODE_APPEND": {
+        "sonic-dhcpv4-relay:sonic-dhcpv4-relay": {
+            "sonic-dhcpv4-relay:DHCPV4_RELAY": {
+                "DHCPV4_RELAY_LIST": [
+                    {
+                        "name": "Vlan777",
+                        "dhcpv4_servers": [
+                            "192.168.20.100"
+                        ],
+                        "agent_relay_mode": "append"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCPv4_RELAY_WITH_AGENT_RELAY_MODE_REPLACE": {
+        "sonic-dhcpv4-relay:sonic-dhcpv4-relay": {
+            "sonic-dhcpv4-relay:DHCPV4_RELAY": {
+                "DHCPV4_RELAY_LIST": [
+                    {
+                        "name": "Vlan777",
+                        "dhcpv4_servers": [
+                            "192.168.20.100"
+                        ],
+                        "agent_relay_mode": "replace"
+                    }
+                ]
+            }
+        }
+    },
+    "DHCPv4_RELAY_WITH_AGENT_RELAY_MODE_FORWARD": {
+        "sonic-dhcpv4-relay:sonic-dhcpv4-relay": {
+            "sonic-dhcpv4-relay:DHCPV4_RELAY": {
+                "DHCPV4_RELAY_LIST": [
+                    {
+                        "name": "Vlan777",
+                        "dhcpv4_servers": [
+                            "192.168.20.100"
+                        ],
+                        "agent_relay_mode": "forward"
+                    }
+                ]
+            }
+        }
+    },
     "DHCPv4_RELAY_WITH_VALID_MAX_HOP_CNT": {
         "sonic-dhcpv4-relay:sonic-dhcpv4-relay": {
             "sonic-dhcpv4-relay:DHCPV4_RELAY": {

--- a/src/sonic-yang-models/yang-models/sonic-dhcpv4-relay.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dhcpv4-relay.yang
@@ -118,7 +118,7 @@ module sonic-dhcpv4-relay {
                 leaf agent_relay_mode {
                     description "How to forward packets that already have a relay option";
                     type stypes:relay-agent-mode;
-                    default replace;
+                    default discard;
                 }
 
                 leaf max_hop_count {

--- a/src/sonic-yang-models/yang-models/sonic-dhcpv4-relay.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dhcpv4-relay.yang
@@ -118,7 +118,7 @@ module sonic-dhcpv4-relay {
                 leaf agent_relay_mode {
                     description "How to forward packets that already have a relay option";
                     type stypes:relay-agent-mode;
-                    default forward_untouched;
+                    default replace;
                 }
 
                 leaf max_hop_count {

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -532,20 +532,20 @@ module sonic-types {
     
     typedef relay-agent-mode {
         type enumeration {
-            enum forward_and_append {
-                description "Forward and append our own relay option";
+            enum append {
+                description "Forward and append our own Option 82";
             }
-            enum forward_and_replace {
-                description "Forward, but replace theirs with ours";
+            enum replace {
+                description "Strip existing Option 82, add ours, and forward";
             }
-            enum forward_untouched {
-                description "Forward without changes";
+            enum forward {
+                description "Forward unchanged without modifying Option 82";
             }
             enum discard {
                 description "Discard the packet";
             }
         }
-        description "This enumeration type defines what to do about a dhcp packets that already has a relay option.";
+        description "This enumeration type defines what to do about a dhcp packet that already has a relay option.";
     }    
 
     {% if yang_model_type == "cvl" %}


### PR DESCRIPTION
#### Why I did it

The YANG typedef `relay-agent-mode` used long-form ISC internal enum names
(`forward_and_append`, `forward_and_replace`, `forward_untouched`, `discard`)
while the CLI accepted short-form ISC CLI aliases (`append`, `replace`, `discard`).
This caused `config save` / `config reload` to fail with:

```
libyang[0]: Invalid value "append" in "agent_relay_mode" element.
```

Additionally, the fourth ISC mode (`forward` / forward untouched) was missing
from the CLI entirely, with no way to configure pass-through behavior.

Fixes sonic-net/sonic-mgmt#24052.
Depends on sonic-net/sonic-dhcp-relay#106 (daemon fix, submodule bump to follow once that merges).

#### How I did it

- `sonic-types.yang.j2`: rename `relay-agent-mode` typedef enums to short-form (`append`, `replace`, `forward`, `discard`) — strict 1:1 mapping from long-form ISC names; `discard` remains the default (SONiC's ISC template always passed `-m discard` explicitly, preserving existing behavior)
- `sonic-dhcpv4-relay.yang`: update `agent_relay_mode` leaf default to `discard`
- `dhcp_relay.py`: add `forward` to `click.Choice` in all four `--agent-relay-mode` declarations
- CLI plugin tests: add `forward` to the `agent_relay_modes` test list
- YANG model tests: add fixtures for all four valid values

#### How to verify it

```
sudo config dhcp_relay ipv4 helper update Vlan1000 --agent-relay-mode append
sudo config save -y
# No libyang validation error
```

#### Which release branch to backport

None

#### Description for the changelog

Fix `agent_relay_mode` YANG enum names: rename long-form ISC internal names to short-form CLI aliases (`append`, `replace`, `forward`, `discard`), add missing `forward` mode to CLI, and set default to `discard` (preserving existing SONiC behavior).

#### Link to config_db schema for YANG module changes

No external schema link needed; changes are self-contained in `sonic-types.yang.j2` and `sonic-dhcpv4-relay.yang`.

#### Supported devices and platforms

All platforms using `sonic-dhcp-relay`.