### PR TITLE
Fix docker-start for DooD with native dockerd enabled

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -1092,7 +1092,11 @@ docker-start :
 	$(Q)sudo bash -c "{ echo \"export http_proxy=$$http_proxy\"; \
 	            echo \"export https_proxy=$$https_proxy\"; \
 	            echo \"export no_proxy=$$no_proxy\"; } >> /etc/default/docker"
-	$(Q)test x$(SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD) != x"y" && sudo service docker status &> /dev/null || ( sudo service docker start &> /dev/null && ./scripts/wait_for_docker.sh 60 )
+	$(Q)if [ x$(SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD) = x"y" ]; then \
+		test -S /var/run/docker.sock && sudo docker ps &> /dev/null || ./scripts/wait_for_docker.sh 60; \
+	else \
+		sudo service docker status &> /dev/null || ( sudo service docker start &> /dev/null && ./scripts/wait_for_docker.sh 60 ); \
+	fi
 
 # targets for building simple docker images that do not depend on any debian packages
 $(addprefix $(TARGET_PATH)/, $(SONIC_SIMPLE_DOCKER_IMAGES)) : $(TARGET_PATH)/%.gz : .platform docker-start $$(addsuffix -load,$$(addprefix $(TARGET_PATH)/,$$($$*.gz_LOAD_DOCKERS)))


### PR DESCRIPTION
When SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD=y, skip docker service management and only test docker responsiveness. In DooD, the docker daemon is owned by the host and cannot be restarted from the container.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Build fails in Docker-out-of-Docker (DooD) when SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD=y because the logic in the docker-start target incorrectly attempts to start the docker service inside the container.

The Problem:
In DooD with native dockerd enabled, the host's dockerd is mounted into the slave container via /var/run/docker.sock dockerd is owned and managed by the host init system, NOT the container. 
The current logic: 
`test x$(SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD) != x"y" && sudo service docker status &> /dev/null || ( sudo service docker start &> /dev/null && ./scripts/wait_for_docker.sh 60 )` 
When SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD=y, the condition x$(SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD) != x"y" evaluates to FALSE The || operator then forces evaluation of the right side: sudo service docker start ... This fails because the container cannot manage the host's docker service.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Changed the docker-start target logic from a boolean expression to an explicit if/else.

#### How to verify it
- Test with native dockerd enabled (DooD scenario) - should succeed without attempting to manage the docker service `SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD=y make docker-start`

- Test without native dockerd (standard build) - should proceed with normal docker service checks 
`make docker-start
`
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Fixed docker-start target to skip service management when using native dockerd in DooD mode

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

