### PR TITLE
ASPEED: fix fw_env setup and slot-2 backup in platform_arm64.conf

### DIFF
--- a/platform/aspeed/platform_arm64.conf
+++ b/platform/aspeed/platform_arm64.conf
@@ -121,61 +121,59 @@ get_install_device()
 
 get_install_device
 
-# Configure U-Boot environment access
+# Run the new image's sonic-fw-env-config.sh (loop-mounted from its squashfs),
+# not the old rootfs's copy which may predate AST2700 fixes.
 configure_uboot_env() {
     echo "Configuring U-Boot environment access..."
 
-    # Check for MTD device first by parsing /proc/mtd
-    # Example line: mtd1: 00020000 00010000 "u-boot-env"
-    MTD_ENV_LINE=$(grep -E '"u-boot-env"|"uboot-env"' /proc/mtd 2>/dev/null || true)
+    new_squashfs="$demo_mnt/$image_dir/$FILESYSTEM_SQUASHFS"
+    if [ ! -f "$new_squashfs" ]; then
+        echo "ERROR: new image squashfs not found at $new_squashfs"
+        return 1
+    fi
 
-    if [ -n "$MTD_ENV_LINE" ]; then
-        # Parse MTD device name, size, and erasesize from /proc/mtd
-        MTD_DEV=$(echo "$MTD_ENV_LINE" | awk -F: '{print $1}')
-        MTD_SIZE=$(echo "$MTD_ENV_LINE" | awk '{print "0x" $2}')
-        MTD_ERASESIZE=$(echo "$MTD_ENV_LINE" | awk '{print "0x" $3}')
+    loop_mnt=$(mktemp -d) || {
+        echo "ERROR: mktemp -d failed."
+        return 1
+    }
 
-        if [ -c "/dev/$MTD_DEV" ]; then
-            FW_ENV_CONFIG="/dev/$MTD_DEV 0x0 $MTD_SIZE $MTD_ERASESIZE"
-            echo "Detected U-Boot env from /proc/mtd: $FW_ENV_CONFIG"
+    if ! mount -o ro,loop -t squashfs "$new_squashfs" "$loop_mnt"; then
+        echo "ERROR: failed to mount $new_squashfs on $loop_mnt"
+        rmdir "$loop_mnt" 2>/dev/null
+        return 1
+    fi
+
+    cue_rc=0
+    cue_sh=""
+    for p in "$loop_mnt/usr/bin/sonic-fw-env-config.sh" \
+             "$loop_mnt/sbin/sonic-fw-env-config.sh"; do
+        if [ -x "$p" ]; then
+            cue_sh="$p"
+            break
         fi
+    done
+
+    if [ -z "$cue_sh" ]; then
+        echo "ERROR: sonic-fw-env-config.sh not found in $new_squashfs"
+        cue_rc=1
+    elif ! onie_platform="$onie_platform" "$cue_sh"; then
+        echo "ERROR: $cue_sh failed."
+        cue_rc=1
     fi
 
-    # If not found in MTD, try device tree
-    if [ -z "$FW_ENV_CONFIG" ]; then
-        DTB_HAS_ENV_BLK=$(grep -E "uboot-env|u-boot-env" /proc/mtd 2>/dev/null | sed -e 's/:.*$//' || true)
-        if [ -n "$DTB_HAS_ENV_BLK" ] && [ -c "/dev/$DTB_HAS_ENV_BLK" ]; then
-            PROC_ENV_FILE=$(find /proc/device-tree/ -name env_size 2>/dev/null || true)
-            if [ -n "$PROC_ENV_FILE" ]; then
-                UBOOT_ENV_SIZ="0x$(hd $PROC_ENV_FILE | awk 'FNR==1 {print $2 $3 $4 $5}')"
-                UBOOT_ENV_ERASE_SIZ="0x$(grep -E "uboot-env|u-boot-env" /proc/mtd | awk '{print $3}')"
-                if [[ -n "$UBOOT_ENV_SIZ" && -n "$UBOOT_ENV_ERASE_SIZ" ]]; then
-                    FW_ENV_CONFIG="/dev/$DTB_HAS_ENV_BLK 0x00000000 $UBOOT_ENV_SIZ $UBOOT_ENV_ERASE_SIZ"
-                    echo "Detected U-Boot env from device tree: $FW_ENV_CONFIG"
-                fi
-            fi
-        fi
-    fi
+    umount "$loop_mnt" 2>/dev/null || umount -l "$loop_mnt" 2>/dev/null || true
+    rmdir "$loop_mnt" 2>/dev/null || true
 
-    # If still not found, use eMMC default location
-    if [ -z "$FW_ENV_CONFIG" ]; then
-        # AST2700 default: U-Boot environment on eMMC at 31.25 MB offset
-        # This matches typical U-Boot configuration for eMMC devices
-        FW_ENV_CONFIG="/dev/mmcblk0 0x1F40000 0x20000 0x1000"
-        echo "Using default eMMC U-Boot env location: $FW_ENV_CONFIG"
-    fi
+    [ "$cue_rc" -ne 0 ] && return "$cue_rc"
 
-    # Write configuration file
-    echo "$FW_ENV_CONFIG" > /etc/fw_env.config
-    echo "Created /etc/fw_env.config: $FW_ENV_CONFIG"
-
-    # Verify fw_printenv can access the environment
     if fw_printenv bootcmd >/dev/null 2>&1; then
         echo "U-Boot environment is accessible"
-    else
-        echo "WARNING: Cannot access U-Boot environment. fw_printenv/fw_setenv may not work."
-        echo "You may need to adjust the offset in /etc/fw_env.config"
+        return 0
     fi
+
+    echo "ERROR: fw_printenv cannot read U-Boot environment."
+    cat /etc/fw_env.config 2>/dev/null | sed 's/^/  /'
+    return 1
 }
 
 # Prepare U-Boot boot menu
@@ -212,16 +210,20 @@ prepare_boot_menu() {
         # Upgrade scenario - save current image as "old" (image_2)
         echo "Upgrade installation: Saving current image as backup"
 
-        CURR_SONIC_IMAGE="$(sonic-installer list | grep "Current: " | cut -f2 -d' ')"
-        FIRST_SONIC_IMAGE="$(fw_printenv sonic_version_1 2>/dev/null | cut -f2 -d'=')"
-        SECOND_SONIC_IMAGE="$(fw_printenv sonic_version_2 2>/dev/null | cut -f2 -d'=')"
+        CURR_SONIC_IMAGE="$(sonic-installer list 2>/dev/null | grep "Current: " | cut -f2 -d' ')"
+        FIRST_SONIC_IMAGE="$(fw_printenv -n sonic_version_1 2>/dev/null || true)"
+        SECOND_SONIC_IMAGE="$(fw_printenv -n sonic_version_2 2>/dev/null || true)"
 
         echo "Current running image: $CURR_SONIC_IMAGE"
         echo "Image slot 1 (sonic_version_1): $FIRST_SONIC_IMAGE"
         echo "Image slot 2 (sonic_version_2): $SECOND_SONIC_IMAGE"
 
-        # Determine which slot the current image is in
-        if [ "$CURR_SONIC_IMAGE" = "$FIRST_SONIC_IMAGE" ]; then
+        # Guard against fw_printenv-broken state: without a valid current image,
+        # empty==empty below would match slot 1 and wipe slot 2 with empty values.
+        # Requiring the comparand to be non-empty closes the same hole per-branch.
+        if [ -z "$CURR_SONIC_IMAGE" ]; then
+            echo "WARNING: current SONiC image unknown; skipping slot-2 backup."
+        elif [ -n "$FIRST_SONIC_IMAGE" ] && [ "$CURR_SONIC_IMAGE" = "$FIRST_SONIC_IMAGE" ]; then
             # Currently running image_1, save it to image_2 slot
             echo "Current image matches slot 1, saving to slot 2 as backup"
             image_dir_old=$(fw_printenv -n image_dir 2>/dev/null || true)
@@ -234,7 +236,7 @@ prepare_boot_menu() {
             fw_setenv  fit_name_old "$fit_name_old"
             fw_setenv  sonic_version_2 "$sonic_version_2"
             fw_setenv  linuxargs_old "$linuxargs_old"
-        elif [ "$CURR_SONIC_IMAGE" = "$SECOND_SONIC_IMAGE" ]; then
+        elif [ -n "$SECOND_SONIC_IMAGE" ] && [ "$CURR_SONIC_IMAGE" = "$SECOND_SONIC_IMAGE" ]; then
             # Currently running image_2, keep it in slot 2
             echo "Current image matches slot 2, keeping it as backup"
             # No need to update image_2 variables, they're already correct


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

On AST2700, configure_uboot_env in platform_arm64.conf had inline /proc/mtd and device-tree probing that never matched (the env lives on /dev/mmcblk0boot0), so it always fell through to the hardcoded /dev/mmcblk0 0x1F40000 0x20000 0x1000 default.
That wrong config corrupted /etc/fw_env.config and silently broke every subsequent fw_setenv in prepare_boot_menu.

And in prepare_boot_menu's upgrade path: when sonic-installer list (or fw_printenv) returned empty, the slot-match [ "$CURR_SONIC_IMAGE" = "$FIRST_SONIC_IMAGE" ] evaluated empty==empty as true and wiped the slot-2 backup variables (image_dir_old, fit_name_old, sonic_version_2, linuxargs_old) with empty values, destroying the rollback target.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

1. configure_uboot_env: replace inline MTD / DTB / hardcoded-eMMC detection with a call to sonic-fw-env-config.sh, which already prefers the authoritative per-device fw_env file (/usr/share/sonic/device/${onie_platform}/fw_env) before falling back to detection. The script is loop-mounted from the new image's squashfs ($demo_mnt/$image_dir/$FILESYSTEM_SQUASHFS), not the old rootfs's copy, so upgrades that include AST2700 fixes pick them up immediately. Verify with fw_printenv bootcmd and return non-zero on failure (previously only printed a WARNING).
2. prepare_boot_menu slot-backup guard:
    - Skip slot-2 backup entirely when CURR_SONIC_IMAGE is empty (log a warning).
    - Require FIRST_SONIC_IMAGE / SECOND_SONIC_IMAGE to be non-empty before comparing, so empty==empty can no longer match a slot.
    - Use fw_printenv -n for clean value extraction (drops the var= prefix; replaces cut -f2 -d'=').
    - Silence sonic-installer list stderr.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

1. Fresh install; cat /etc/fw_env.config shows the per-device entry (e.g. /dev/mmcblk0boot0...), not the bogus /dev/mmcblk0 0x1F40000 ...; fw_printenv bootcmd succeeds; box boots into SONiC.
2. Upgrade via sonic-installer install — slot 1 gets the new image; fw_printenv sonic_version_2 / image_dir_old / fit_name_old / linuxargs_old show the previous image, not empty strings; sonic-installer set-default <old> rolls back successfully.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

