### PR TITLE
[ifupdown2] Allow mgmt VRF table id 6000 via vrf-table-id-end policy

### DIFF
--- a/files/dhcp/ifupdown2_policy.json
+++ b/files/dhcp/ifupdown2_policy.json
@@ -8,5 +8,10 @@
          "dhcp6-duid" : "LL"
       }
     }
+  },
+  "vrf" : {
+    "module_globals" : {
+       "vrf-table-id-end" : 6000
+    }
   }
 }


### PR DESCRIPTION
closes #27049 

#### Why I did it

PR #25504 ("Updating mgmt vrf table id for 4k vrf pool") changed [`files/image_config/interfaces/interfaces.j2`](https://github.com/sonic-net/sonic-buildimage/blob/master/files/image_config/interfaces/interfaces.j2#L12) so the mgmt VRF is now rendered as `vrf-table 6000` (previously `5000`), to align with the companion [sonic-net/sonic-swss#4168](https://github.com/sonic-net/sonic-swss/pull/4168) that increased the user VRF pool to 4096 and moved `MGMT_VRF_TABLE_ID` to 6000.

ifupdown2 was not updated alongside it. Both `3.0.0-1` and `3.9.0` hardcode the upper bound of the allowed VRF table-id range as a class attribute in `ifupdown2/addons/vrf.py`:

```python
class vrf(Addon, moduleBase):
    VRF_TABLE_START = 1001
    VRF_TABLE_END   = 5000
```

The addon reads optional overrides via `policymanager` and falls back to these class attributes:

```python
self.vrf_table_id_end = policymanager.policymanager_api.get_module_globals(
    module_name=self.__class__.__name__, attr='vrf-table-id-end'
)
if not self.vrf_table_id_end:
    self.vrf_table_id_end = self.VRF_TABLE_END
```

When `interfaces-config.service` runs `ifreload` after `mgmtVrfEnabled` flips to `true`, the addon evaluates the explicit `vrf-table 6000` directive against `[1001, 5000]`, rejects it, and emits:

```
networking[*]: error: <iface>: vrf table id 6000 out of reserved range [1001,5000]
```

The kernel mgmt VRF netdev is never created. The route adds in the mgmt block of `interfaces.j2` then all fail with `Device does not exist` / `Nexthop has invalid gateway`, and management connectivity drops on every `config reload` after enabling mgmt VRF.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

ifupdown2's `policymanager` checks `/etc/network/ifupdown2/policy.d/*.json` for module overrides before falling back to the hardcoded class attributes. Adding a `"vrf"` block to the policy file SONiC already ships ([`files/dhcp/ifupdown2_policy.json`](https://github.com/sonic-net/sonic-buildimage/blob/master/files/dhcp/ifupdown2_policy.json)) raises `vrf_table_id_end` to 6000 at runtime, so `vrf.py`'s validation `int(vrf_table) > self.vrf_table_id_end` becomes `6000 > 6000` (False) and the table id is accepted.

```diff
--- a/files/dhcp/ifupdown2_policy.json
+++ b/files/dhcp/ifupdown2_policy.json
@@ -8,5 +8,10 @@
          "dhcp6-duid" : "LL"
       }
     }
+  },
+  "vrf" : {
+    "module_globals" : {
+       "vrf-table-id-end" : 6000
+    }
   }
 }
```

Only the upper bound is overridden; the lower bound (`1001`) is unchanged so the hardcoded `VRF_TABLE_START` default is correct as-is.

#### How to verify it

##### Minimal verification (ifupdown2 only, no SONiC required)

The simplest possible verification — no `CONFIG_DB`, no `config reload`, no service restart. Just `ifup` reading a one-line iface stanza, exercising the exact `vrf.py` addon code path that gets called during a real `config reload`.

Without this PR (hardcoded `VRF_TABLE_END = 5000`):

```
$ sudo bash -c 'cat > /etc/network/interfaces.d/test-vrf-table.intf <<EOF
auto test-vrf
iface test-vrf
    vrf-table 6000
EOF'

$ sudo ifup test-vrf
error: test-vrf: vrf table id 6000 out of reserved range [1001,5000]

$ ip -d link show test-vrf
Device "test-vrf" does not exist.

$ ip vrf show
Name              Table
-----------------------
No VRF has been configured
```

With this PR (policy override raises range to 6000):

```
$ sudo ifup test-vrf
$ ip -d link show test-vrf
160: test-vrf: <NOARP,MASTER,UP,LOWER_UP> mtu 65575 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether 86:81:7b:40:e6:0d brd ff:ff:ff:ff:ff:ff promiscuity 0 allmulti 0 minmtu 1280 maxmtu 65575 
    vrf table 6000 ...

$ ip vrf show
Name              Table
-----------------------
test-vrf          6000

# cleanup:
$ sudo ifdown test-vrf
$ sudo rm /etc/network/interfaces.d/test-vrf-table.intf
```

##### Before this fix (broken state)

On any image built from `master` at or after [`cdb7a13186`](https://github.com/sonic-net/sonic-buildimage/commit/cdb7a13186) (PR #25504), without this PR applied — run from the DUT console, since SSH from elsewhere will time out after the reload:

```
admin@dut:~$ sudo sonic-db-cli CONFIG_DB hset "MGMT_VRF_CONFIG|vrf_global" mgmtVrfEnabled true
admin@dut:~$ sudo config save -y && sudo config reload -y -f
... (reload completes) ...

admin@dut:~$ ip -d link show type vrf
   (empty — no mgmt netdev was created)

admin@dut:~$ ip vrf show
Name              Table
-----------------------
No VRF has been configured

admin@dut:~$ ip -4 route show table 6000
   (empty — no default route, no connected route)

admin@dut:~$ ip -4 rule show | grep 6000
32764:	from all to 172.17.0.1/24 lookup 6000
32764:	from all to 10.11.0.5 lookup 6000
32764:	from all to 10.11.0.6 lookup 6000
32765:	from 10.250.59.2 lookup 6000

admin@dut:~$ ip -4 route get 8.8.8.8
RTNETLINK answers: Network is unreachable

admin@dut:~$ sudo grep "out of reserved range" /var/log/syslog
networking[*]: error: eth0: mgmt: vrf table id 6000 out of reserved range [1001,5000]
networking[*]: error: mgmt: vrf table id 6000 out of reserved range [1001,5000]
```

Note that the policy rules above appear in `ip rule show` even though the table itself is empty — `ip rule add` does not depend on the table or netdev existing, so `interfaces.j2`'s `up ip rule add ... table 6000` lines run successfully even when the preceding `up ip route add ... table 6000` lines fail with `Device for nexthop is not up`. The rules end up pointing at an empty table 6000.

From a host on the management network:
```
$ ssh admin@<dut-mgmt-ip>
ssh: connect to host <dut-mgmt-ip> port 22: No route to host
```

Recovery from this state requires console access:
`sudo sonic-db-cli CONFIG_DB del "MGMT_VRF_CONFIG|vrf_global" && sudo config save -y && sudo config reload -y -f`.

##### After this fix (expected state)

```
admin@dut:~$ python3 -c "
import sys; sys.path.insert(0, '/usr/share/ifupdown2')
from ifupdown import policymanager
v = policymanager.policymanager_api.get_module_globals(
    module_name='vrf', attr='vrf-table-id-end')
print(v, type(v).__name__)"
6000 int

admin@dut:~$ sudo sonic-db-cli CONFIG_DB hset "MGMT_VRF_CONFIG|vrf_global" mgmtVrfEnabled true
admin@dut:~$ sudo config save -y && sudo config reload -y -f

admin@dut:~$ ip -d link show type vrf
1201: mgmt: <NOARP,MASTER,UP,LOWER_UP> mtu 65575 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether ca:4b:df:c9:11:79 brd ff:ff:ff:ff:ff:ff promiscuity 0 allmulti 0 minmtu 1280 maxmtu 65575 
    vrf table 6000 addrgenmode eui64 ...

admin@dut:~$ ip vrf show
Name              Table
-----------------------
mgmt              6000

admin@dut:~$ ip -4 route show table 6000
default via 10.250.59.1 dev eth0 metric 201 
10.250.59.0/24 dev eth0 proto kernel scope link src 10.250.59.2 
local 10.250.59.2 dev eth0 proto kernel scope host src 10.250.59.2 
broadcast 10.250.59.255 dev eth0 proto kernel scope link src 10.250.59.2 
127.0.0.0/16 dev lo-m proto kernel scope link src 127.0.0.1 
local 127.0.0.1 dev lo-m proto kernel scope host src 127.0.0.1 
broadcast 127.0.255.255 dev lo-m proto kernel scope link src 127.0.0.1 

admin@dut:~$ ip -4 rule show
1000:	from all lookup [l3mdev-table]
1001:	from all lookup local
32764:	from all to 172.17.0.1/24 lookup mgmt
32764:	from all to 10.11.0.5 lookup mgmt
32764:	from all to 10.11.0.6 lookup mgmt
32765:	from 10.250.59.2 lookup mgmt
32766:	from all lookup main
32767:	from all lookup default

admin@dut:~$ cat /etc/iproute2/rt_tables.d/ifupdown2_vrf_map.conf
# This file is autogenerated by ifupdown2.
# It contains the vrf name to table mapping.
# Reserved table range 1001 6000
6000 mgmt

admin@dut:~$ sudo grep -E "out of reserved range|cannot be interpreted as an integer" /var/log/syslog
   (no matches)
```

Note how `ip rule show` now lists the same policy rules as in the broken case but with `lookup mgmt` instead of `lookup 6000`: ifupdown2 has registered the symbolic name in `/etc/iproute2/rt_tables.d/ifupdown2_vrf_map.conf` and the kernel renders the rule output by name. The kernel-installed `1000: from all lookup [l3mdev-table]` rule is what dispatches eth0 traffic into the mgmt VRF (since eth0 has `master mgmt`).

From a host on the management network — SSH stays usable across the reload (modulo a brief flap during eth0 re-binding):
```
$ ssh admin@<dut-mgmt-ip>
admin@<dut-mgmt-ip>:~$
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511 — affected by #25504 cherry-pick (#26410). Same fix applies.

#### Tested branch (Please provide the tested image version)

- [ ] master

#### Description for the changelog

`[ifupdown2]` Allow mgmt VRF table id 6000 by setting `vrf-table-id-end` policy in `ifupdown2_policy.json`, restoring mgmt VRF setup that PR #25504 broke when it raised the table id past ifupdown2's hardcoded `VRF_TABLE_END = 5000`.

#### Link to config_db schema for YANG module changes

N/A — no schema change.

#### A picture of a cute animal (not mandatory but encouraged)

🦦

