### PR TITLE
[docker-ptf] Remove gnoic

### DIFF
--- a/ThirdPartyLicenses.txt
+++ b/ThirdPartyLicenses.txt
@@ -978,7 +978,6 @@ Microsoft is offering you a license to use the following components, to the exte
  */
 
 4. apt-clean, apt-gzip-indexes, apt-no-languages imported from docker v1.11.1
-5. gnoic imported from https://github.com/karimra/gnoic using Apache License 2.0
 /*
  *                                 Apache License
  *                           Version 2.0, January 2004

--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -103,7 +103,7 @@ RUN apt-get update          \
         quilt               \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Go toolchain for building grpcurl and gnoic from source
+# Install Go toolchain for building grpcurl and gnmic from source
 # to ensure they use a patched Go stdlib (GO-2026-4337: crypto/tls)
 {% if CONFIGURED_ARCH == "armhf" %}
 RUN GO_ARCH=armv6l \
@@ -410,20 +410,6 @@ RUN cd gnxi \
 
 # Deactivating a virtualenv.
 # ENV PATH="$BACKUP_OF_PATH"
-
-# Build gnoic from source with patched Go and golang.org/x/* deps
-# upgraded to latest to address current and future golang.org/x/* CVEs.
-RUN git clone https://github.com/karimra/gnoic.git \
-    && cd gnoic \
-    && git checkout 27bc5a6 \
-    && go get google.golang.org/grpc@v1.79.3 \
-    && go get github.com/go-viper/mapstructure/v2@v2.4.0 \
-    && go get github.com/go-jose/go-jose/v4@latest \
-    && go get golang.org/x/crypto@latest golang.org/x/net@latest golang.org/x/text@latest golang.org/x/sys@latest golang.org/x/oauth2@latest \
-    && go mod tidy \
-    && go build -o /usr/local/bin/gnoic . \
-    && cd .. \
-    && rm -rf gnoic /root/go/pkg/mod /root/.cache/go-build
 
 # Build gnmic from source with upgraded deps to address known CVEs
 COPY gocloud-patches/ /tmp/gocloud-patches/

--- a/files/build/versions-public/default/versions-git
+++ b/files/build/versions-public/default/versions-git
@@ -10,7 +10,6 @@ https://github.com/FreeRADIUS/pam_radius.git==d17fc655f0007728b67d0d25c0ca20b604
 https://github.com/fullstorydev/grpcurl.git==d00c28104be4b06f4dd887196ccfc57b054aa069
 https://github.com/google/gnxi.git==987664c754f18c0b9ea39b2de86317c14c226d5b
 https://github.com/jeroennijhof/pam_tacplus.git==b839c440e33c36eced9dcbc287fcfe6237c4c4ce
-https://github.com/karimra/gnoic.git==27bc5a65d391d07c903f6cd0a05b73219657e00d
 https://github.com/Mellanox/libpsample.git==62bb27d9a49424e45191eee81df7ce0d8c74e774
 https://github.com/openconfig/gnmic.git==883b7f9ab0d486f9dc9272a1018070d7f23197b7
 https://github.com/openconfig/oc-pyang.git==a116b53b1c1a149bc9a5d42dc26f3d0ab797846a


### PR DESCRIPTION
## Why I did it

`gnoic` is unused inside the PTF container, and its upstream (karimra/gnoic) has not cut a release containing the `golang.org/x/crypto` v0.45.0 fixes for **CVE-2025-58181** (GHSA-j5w8-q4qc-rx2x) and **CVE-2025-47914** (GHSA-f6x5-jh6r-wrfv). The latest tag v0.2.1 still ships `x/crypto v0.43.0`, and the renovate security PR ([karimra/gnoic#170](https://github.com/karimra/gnoic/pull/170)) is unmerged.

Carrying a private patched build of an unused tool just to satisfy S360 scans is not worth the maintenance cost.

## How I did it

- Removed the `gnoic` build block from `dockers/docker-ptf/Dockerfile.j2`.
- Updated the Go-toolchain install comment to no longer mention gnoic.
- Removed the gnoic entry from `files/build/versions-public/default/versions-git`.
- Removed the gnoic line from `ThirdPartyLicenses.txt` (the shared Apache 2.0 license body is preserved because entry #4 `apt-clean` still uses it).

`grpcurl` and `gnmic` are unaffected — they continue to be built from source with `go get golang.org/x/...@latest && go mod tidy`, which already covers the related CVEs flagged by S360.

## How to verify it

- `grep -r gnoic dockers/docker-ptf/ files/build/versions-public/ ThirdPartyLicenses.txt` returns nothing.
- Build `docker-ptf`; the resulting image no longer contains `/usr/local/bin/gnoic`.
- Re-run the S360 / Qualys ContainerImageScan against the new digest; CVE-2025-58181 and CVE-2025-47914 against `/usr/local/bin/gnoic` should disappear.

## Which release branch to backport (if applicable)

N/A — master only. Older release branches do not contain the gnoic build block.