### PR TITLE
[arp_update]: Fix dualtor performance regression by setting arping/ndisc6 wait timeout to 0

### DIFF
--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -42,14 +42,14 @@ run_arping_with_retry() {
     local ifname="$1"
     local ip="$2"
     run_with_retry_cmd "arping on ${ifname} to ${ip}" \
-        arping -q -w 1 -c 1 -i "$ifname" "$ip" >/dev/null 2>&1
+        arping -q -w 0 -c 1 -i "$ifname" "$ip" >/dev/null 2>&1
 }
 
 run_ndisc6_with_retry() {
     local ifname="$1"
     local ip="$2"
     run_with_retry_cmd "ndisc6 on ${ifname} to ${ip}" \
-        ndisc6 -q -w 1 -1 "$ip" "$ifname" >/dev/null 2>&1
+        ndisc6 -q -w 0 -1 "$ip" "$ifname" >/dev/null 2>&1
 }
 
 while /bin/true; do
@@ -155,8 +155,8 @@ while /bin/true; do
   SUBTYPE=$(sonic-db-cli CONFIG_DB hget 'DEVICE_METADATA|localhost' 'subtype' | tr '[:upper:]' '[:lower:]')
   for vlan in $VLAN; do
       # generate a list of arping commands:
-      #   arping -q -w 1 -c 1 -i <VLAN interface> <IP 1>;
-      #   arping -q -w 1 -c 1 -i <VLAN interface> <IP 2>;
+      #   arping -q -w 0 -c 1 -i <VLAN interface> <IP 1>;
+      #   arping -q -w 0 -c 1 -i <VLAN interface> <IP 2>;
       #   ...
       while read -r ip ifname; do
           [ -z "$ip" ] && continue
@@ -168,8 +168,8 @@ while /bin/true; do
       eval $ping6cmd
 
       # generate a list of ndisc6 commands (exclude link-local addrs since it is done above):
-      #   ndisc6 -q -w 1 -1 <IP 1> <VLAN interface>;
-      #   ndisc6 -q -w 1 -1 <IP 2> <VLAN interface>;
+      #   ndisc6 -q -w 0 -1 <IP 1> <VLAN interface>;
+      #   ndisc6 -q -w 0 -1 <IP 2> <VLAN interface>;
       #   ...
       while read -r ip ifname; do
           [ -z "$ip" ] && continue


### PR DESCRIPTION
GARP and unsolicited NA are announcements that do not expect replies, so waiting 1 second per neighbor is unnecessary and causes timeouts on dual-ToR setups with many neighbors (24-30s vs expected 2-3s).

Change -w 1 to -w 0 for arping and ndisc6 to restore original performance while keeping the retry logic from PR #25169.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix performance regression introduced by PR #25169 (cherry-picked via #26815) on dual-ToR active-active setups.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Changed `-w 1` to `-w 0` for `arping` and `ndisc6` in `arp_update` script. Since GARP and unsolicited NA are announcements (not requests), waiting for a reply is unnecessary.

#### How to verify it
Run `arp/test_arp_dualtor.py::test_standby_unsolicited_neigh_learning` — should complete within 5 seconds instead of timing out at 24-30s.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)
202511

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fixed arp_update performance regression on dual-ToR by removing unnecessary 1-second wait on arping/ndisc6 announcements."

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

