### PR TITLE
[sonic-yang-models] Migrate IP prefix typedefs; preserve host bits where needed

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -3176,7 +3176,7 @@
         },
         "PREFIX_LIST": {
             "ANCHOR_PREFIX|10.0.0.0/8" : {},
-            "ANCHOR_PREFIX|FC00::/48" : {}
+            "ANCHOR_PREFIX|fc00::/48" : {}
         },
         "DEBUG_COUNTER": {
             "DEBUG_4": {

--- a/src/sonic-yang-models/yang-models/sonic-bgp-peerrange.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-peerrange.yang
@@ -7,10 +7,6 @@ module sonic-bgp-peerrange {
         prefix inet;
     }
 
-    import sonic-types {
-        prefix stypes;
-    }
-
     import sonic-vrf {
         prefix vrf;
     }
@@ -77,7 +73,7 @@ module sonic-bgp-peerrange {
                 }
 
                 leaf-list ip_range {
-                    type stypes:sonic-ip-prefix;
+                    type inet:ip-prefix;
                     ordered-by user;
                     description "A range of addresses";
                 }
@@ -113,7 +109,7 @@ module sonic-bgp-peerrange {
                 }
 
                 leaf-list ip_range {
-                    type stypes:sonic-ip-prefix;
+                    type inet:ip-prefix;
                     ordered-by user;
                     description "A range of addresses";
                 }

--- a/src/sonic-yang-models/yang-models/sonic-bgp-prefix-list.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-prefix-list.yang
@@ -6,6 +6,10 @@ module sonic-bgp-prefix-list {
     namespace "http://github.com/sonic-net/sonic-bgp-prefix-list";
     prefix bgppl;
 
+    import ietf-inet-types {
+        prefix inet;
+    }
+
     import sonic-types {
         prefix stypes;
     }
@@ -38,10 +42,7 @@ module sonic-bgp-prefix-list {
                 }
 
                 leaf ip-prefix {
-                    type union {
-                        type stypes:sonic-ip4-prefix;
-                        type stypes:sonic-ip6-prefix;
-                    }
+                    type inet:ip-prefix;
                     description "IPv4 or IPv6 prefix in CIDR notation.";
                 }
 

--- a/src/sonic-yang-models/yang-models/sonic-bgp-sentinel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-sentinel.yang
@@ -7,10 +7,6 @@ module sonic-bgp-sentinel {
         prefix inet;
     }
 
-    import sonic-types {
-        prefix stypes;
-    }
-
     organization
         "SONiC";
 
@@ -49,7 +45,7 @@ module sonic-bgp-sentinel {
                 }
 
                 leaf-list ip_range {
-                    type stypes:sonic-ip-prefix;
+                    type inet:ip-prefix;
                     ordered-by user;
                     description "A range of addresses";
                 }

--- a/src/sonic-yang-models/yang-models/sonic-dash.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dash.yang
@@ -66,7 +66,7 @@ module sonic-dash {
 
                 leaf-list address_spaces {
                      description "IP prefixes belonging to this virtual network.";
-                     type stypes:sonic-ip-prefix;
+                     type inet:ip-prefix;
                      ordered-by user;
                 }
 
@@ -296,13 +296,13 @@ module sonic-dash {
 
                 leaf-list src_addr {
                     description "Source IP prefixes to match.";
-                    type stypes:sonic-ip-prefix;
+                    type inet:ip-prefix;
                     ordered-by user;
                 }
 
                 leaf-list dst_addr {
                     description "Destination IP prefixes to match.";
-                    type stypes:sonic-ip-prefix;
+                    type inet:ip-prefix;
                     ordered-by user;
                 }
 
@@ -412,7 +412,7 @@ module sonic-dash {
 
                 leaf prefix {
                      description "Destination IP prefix for LPM lookup.";
-                     type stypes:sonic-ip-prefix;
+                     type inet:ip-prefix;
                 }
 
                 leaf action_type {

--- a/src/sonic-yang-models/yang-models/sonic-fine-grained-ecmp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-fine-grained-ecmp.yang
@@ -17,10 +17,6 @@ module sonic-fine-grained-ecmp {
         prefix port;
     }
 
-    import sonic-types {
-        prefix stypes;
-    }
-
     organization
         "SONiC";
 
@@ -122,7 +118,7 @@ module sonic-fine-grained-ecmp {
                 key "ip_prefix";
 
                 leaf ip_prefix{
-                    type stypes:sonic-ip-prefix;
+                    type inet:ip-prefix;
                     description "FG_NHG_PREFIX for which FG behavior is
                     desired";
                 }

--- a/src/sonic-yang-models/yang-models/sonic-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-interface.yang
@@ -131,10 +131,7 @@ module sonic-interface {
 
 				leaf ip-prefix {
 					description "IPv4 or IPv6 address with prefix length assigned to the interface";
-					type union {
-						type stypes:sonic-ip4-prefix;
-						type stypes:sonic-ip6-prefix;
-					}
+					type stypes:sonic-ip-address-with-prefix;
 				}
 
 				leaf scope {

--- a/src/sonic-yang-models/yang-models/sonic-loopback-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-loopback-interface.yang
@@ -82,10 +82,7 @@ module sonic-loopback-interface {
 
                 leaf ip-prefix {
                     description "IPv4 or IPv6 address with prefix length assigned to the loopback interface";
-                    type union {
-                        type stypes:sonic-ip4-prefix;
-                        type stypes:sonic-ip6-prefix;
-                    }
+                    type stypes:sonic-ip-address-with-prefix;
                 }
 
                 leaf scope {

--- a/src/sonic-yang-models/yang-models/sonic-mgmt_interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mgmt_interface.yang
@@ -46,7 +46,7 @@ module sonic-mgmt_interface {
                 leaf ip_prefix {
                     description "IPv4 or IPv6 address with prefix length for the management interface";
                     must "(contains(current(), ':') and contains(../gwaddr, ':')) or (contains(current(), '.') and contains(../gwaddr, '.'))";
-                    type stypes:sonic-ip-prefix;
+                    type stypes:sonic-ip-address-with-prefix;
                 }
 
                 leaf gwaddr {
@@ -57,7 +57,7 @@ module sonic-mgmt_interface {
 
                 leaf-list forced_mgmt_routes {
                     type union {
-                        type stypes:sonic-ip-prefix;
+                        type inet:ip-prefix;
                         type inet:ip-address;
                     }
                     ordered-by user;

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -232,7 +232,7 @@ module sonic-portchannel {
                 leaf ip_prefix {
                     description "IPv4 or IPv6 address with prefix length assigned to the PortChannel interface";
                     /* key elements are mandatory by default */
-                    type stypes:sonic-ip-prefix;
+                    type stypes:sonic-ip-address-with-prefix;
                 }
             } /* end of list PORTCHANNEL_INTERFACE_IPPREFIX_LIST */
 

--- a/src/sonic-yang-models/yang-models/sonic-smart-switch.yang
+++ b/src/sonic-yang-models/yang-models/sonic-smart-switch.yang
@@ -70,7 +70,7 @@ module sonic-smart-switch {
 				}
 
 				leaf ip_prefix {
-					type stypes:sonic-ip4-prefix;
+					type stypes:sonic-ip4-address-with-prefix;
 					description "IP prefix of the midplane bridge";
 				}
 			}

--- a/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
@@ -120,7 +120,7 @@ module sonic-vlan-sub-interface {
 
                 leaf ip-prefix {
                     description "IPv4 or IPv6 address with prefix length assigned to the sub-interface";
-                    type stypes:sonic-ip-prefix;
+                    type stypes:sonic-ip-address-with-prefix;
                 }
             }
         }

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -168,10 +168,7 @@ module sonic-vlan {
 
 				leaf ip-prefix {
 					description "IP address and prefix length assigned to the VLAN interface";
-					type union {
-						type stypes:sonic-ip4-prefix;
-						type stypes:sonic-ip6-prefix;
-					}
+					type stypes:sonic-ip-address-with-prefix;
 				}
 
 				leaf scope {

--- a/src/sonic-yang-models/yang-models/sonic-vnet.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vnet.yang
@@ -124,7 +124,7 @@ module sonic-vnet {
 
                 leaf prefix {
                     description "IPv4 prefix in CIDR format";
-                    type stypes:sonic-ip4-prefix;
+                    type inet:ipv4-prefix;
                 }
 
                 leaf nexthop {
@@ -160,7 +160,7 @@ module sonic-vnet {
                 
                 leaf prefix {
                     description "IPv4 prefix in CIDR format";
-                    type stypes:sonic-ip4-prefix;
+                    type inet:ipv4-prefix;
                 }
                 
                 leaf endpoint {

--- a/src/sonic-yang-models/yang-models/sonic-voq-inband-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-voq-inband-interface.yang
@@ -50,7 +50,7 @@ module sonic-voq-inband-interface {
                 }
                 leaf ip-prefix {
                     description "IP prefix assigned to the inband interface";
-                    type stypes:sonic-ip-prefix;
+                    type stypes:sonic-ip-address-with-prefix;
                 }
             }
         }

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -23,8 +23,36 @@ module sonic-types {
         }
     }
 
-    typedef sonic-ip4-prefix {
-        description "IPv4 prefix in CIDR notation";
+    /*
+     * The sonic-ip*-address-with-prefix typedefs intentionally do NOT use
+     * inet:ipv4-prefix / inet:ipv6-prefix / inet:ip-prefix. Those IETF types
+     * are canonicalized by libyang (host bits zeroed; IPv6 lowercased and
+     * RFC 5952 compressed) on store, which would silently rewrite values
+     * such as "10.0.0.1/31" to "10.0.0.0/31". SONiC stores the configured
+     * interface address (host bits set) plus prefix length together in a
+     * single CONFIG_DB key, so canonicalization would lose the host bits.
+     * These typedefs reuse the IETF patterns for validation but, being
+     * plain strings, preserve the literal value. Use these for fields that
+     * carry an interface address with a prefix length; use inet:ip-prefix
+     * (or its v4/v6 siblings) for true network prefixes (routes, ACL
+     * matches, prefix lists) where canonical form is desirable.
+     *
+     * RFC 9911 (2025-12-22) introduced inet:ipv4-address-and-prefix,
+     * inet:ipv6-address-and-prefix, and inet:ip-address-and-prefix in
+     * ietf-inet-types -- patterns byte-for-byte identical to the typedefs
+     * below and explicitly defined as preserving host bits. Those would
+     * be the natural replacement, but SONiC currently builds against
+     * libyang 1.0.73, which bundles ietf-inet-types@2013-07-15 (RFC 6991)
+     * and so does not know those types. Once the libyang3 migration in
+     * src/libyang3-py3 lands (libyang3 ships ietf-inet-types@2025-12-22),
+     * revisit this and consider replacing these typedefs with the IETF
+     * address-and-prefix types. Verify first that libyang3's plugin for
+     * ipv6-address-and-prefix does not lowercase / RFC-5952-compress
+     * IPv6 -- the type description references canonical form, but the
+     * intent of the type is host-bit preservation.
+     */
+    typedef sonic-ip4-address-with-prefix {
+        description "IPv4 address with prefix length, host bits preserved (no canonicalization)";
         type string {
             pattern
              '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
@@ -33,8 +61,8 @@ module sonic-types {
         }
     }
 
-    typedef sonic-ip6-prefix {
-        description "IPv6 prefix in CIDR notation";
+    typedef sonic-ip6-address-with-prefix {
+        description "IPv6 address with prefix length, host bits and case preserved (no canonicalization)";
         type string {
             pattern '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'
                  + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'
@@ -47,11 +75,11 @@ module sonic-types {
         }
     }
 
-    typedef sonic-ip-prefix {
-      description "IPv4 or IPv6 prefix in CIDR notation";
+    typedef sonic-ip-address-with-prefix {
+      description "IPv4 or IPv6 address with prefix length, host bits preserved (no canonicalization)";
       type union {
-        type sonic-ip4-prefix;
-        type sonic-ip6-prefix;
+        type sonic-ip4-address-with-prefix;
+        type sonic-ip6-address-with-prefix;
       }
     }
 


### PR DESCRIPTION
#### Why I did it

The `sonic-ip4-prefix`, `sonic-ip6-prefix`, and `sonic-ip-prefix` typedefs in `sonic-types` were plain strings with patterns copied from RFC 6991, used in two semantically different ways across the YANG models:

1. **True network prefixes** (BGP peer ranges, prefix lists, ACL/DASH match prefixes, route entries) — canonical form (host bits zeroed; IPv6 lowercase / RFC 5952 compressed) is the correct representation, and aligning these with IETF types improves tooling/UI/documentation interoperability.
2. **Interface address combined with prefix length** in a single CONFIG_DB key (e.g. `INTERFACE|Ethernet0|10.0.0.1/31`) — the host bits identify which address is configured on the interface and must not be rewritten.

A blanket switch to `inet:ipv4-prefix` / `inet:ipv6-prefix` / `inet:ip-prefix` is **not** a no-op: libyang ships built-in type plugins that canonicalize on store, silently rewriting `10.0.0.1/31` → `10.0.0.0/31` and `FC00::/48` → `fc00::/48`. This breaks interface addressing and is caught by the `test_xlate_rev_xlate` round-trip test in sonic-yang-mgmt.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Split the typedefs by semantic intent:

- **Network-prefix fields** now use `inet:ip-prefix` / `inet:ipv4-prefix` / `inet:ipv6-prefix`, picking up canonical form and IETF tooling alignment. Affects `sonic-bgp-peerrange`, `sonic-bgp-prefix-list`, `sonic-bgp-sentinel`, `sonic-dash`, `sonic-fine-grained-ecmp`, `sonic-vnet`, and the `forced_mgmt_routes` leaf-list in `sonic-mgmt_interface`.
- **Interface-address-with-prefix fields** use new typedefs in `sonic-types`: `sonic-ip4-address-with-prefix`, `sonic-ip6-address-with-prefix`, `sonic-ip-address-with-prefix`. They reuse the IETF patterns for validation but, being plain strings, preserve the literal value (host bits + case). The names make the intent explicit, and a block comment in `sonic-types` explains why they exist instead of `inet:ip-prefix`. Affects `sonic-interface`, `sonic-loopback-interface`, `sonic-mgmt_interface` (`ip_prefix`), `sonic-portchannel`, `sonic-vlan`, `sonic-vlan-sub-interface`, `sonic-voq-inband-interface`, and the `MID_PLANE_BRIDGE.GLOBAL.ip_prefix` leaf in `sonic-smart-switch`.
- Updated `sample_config_db.json` to lowercase the `ANCHOR_PREFIX|fc00::/48` entry (the PREFIX_LIST field flows through `inet:ip-prefix` and is therefore stored canonically).
- Cleaned up now-unused `import sonic-types` and `import ietf-inet-types` lines accordingly.

**Future direction:** RFC 9911 (2025-12-22) introduced `inet:ipv4-address-and-prefix`, `inet:ipv6-address-and-prefix`, and `inet:ip-address-and-prefix` — patterns byte-for-byte identical to the new sonic typedefs and explicitly host-bit-preserving. These would be the natural replacement, but SONiC currently links libyang 1.0.73, which bundles `ietf-inet-types@2013-07-15` (RFC 6991) and does not know the new types. libyang ships `ietf-inet-types` as one of its built-in modules, so the bundled revision is pinned by the libyang version. Once the libyang3 migration in `src/libyang3-py3` lands (libyang3 bundles `ietf-inet-types@2025-12-22`), revisit and consider replacing the sonic-* typedefs with the IETF address-and-prefix types — but verify first that libyang3's plugin for `ipv6-address-and-prefix` does not lowercase / RFC-5952-compress IPv6.

#### How to verify it

Build the affected wheels and run their test suites:

```
make target/python-wheels/bookworm/sonic_yang_models-1.0-py3-none-any.whl
make target/python-wheels/bookworm/sonic_yang_mgmt-1.0-py3-none-any.whl
```

Expected results (verified locally on this branch):
- `sonic-yang-models` test suite: **929 passed**
- `sonic-yang-mgmt` test suite: **52 passed**, including `test_xlate_rev_xlate` which fails on a naive switch to `inet:ip-prefix`

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

No backport needed — this is a forward-only refactor of YANG types, not a fix for shipped behavior.

#### Tested branch (Please provide the tested image version)

- [x] master as of 2026-04-29

#### Description for the changelog

sonic-yang-models: align IP-prefix YANG types with IETF where canonical form applies; introduce explicit `sonic-ip*-address-with-prefix` typedefs where host bits must be preserved.

#### Link to config_db schema for YANG module changes

No CONFIG_DB schema changes; only the YANG type backing existing fields changed. Affected tables: [INTERFACE](https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#interface), [LOOPBACK_INTERFACE](https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#loopback-interface), [MGMT_INTERFACE](https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#management-interface), [PORTCHANNEL_INTERFACE](https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#portchannel), [VLAN_INTERFACE](https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#vlan), [VLAN_SUB_INTERFACE](https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#vlan-sub-interface-table), [VOQ_INBAND_INTERFACE](https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#voq-inband-interface), [MID_PLANE_BRIDGE](https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#mid_plane_bridge), [PREFIX_LIST](https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#prefix-list), and route/match-prefix tables under DASH, BGP, and VNET.