### PR TITLE
Fix ComponentCPLD crash on missing cpld_num

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
@@ -389,6 +389,8 @@ class DeviceDataManager:
     @classmethod
     def get_cpld_component_list(cls):
         from .component import ComponentCPLD, ComponentCPLDSN2201, ComponentCPLDSN4280, ComponenetFPGADPU
+        if cls.is_simx_platform():
+            return []
         if cls.get_platform_name() in ['x86_64-nvidia_sn2201-r0']:
             # For SN2201, special chass is required for handle BIOS
             # Currently, only fetching BIOS version is supported


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
`show platform firmware status` crashes on the multi-ASIC platform with:

```
RuntimeError: Failed to read file /var/run/hw-management/config/cpld_num due to
FileNotFoundError(2, 'No such file or directory')
```

The crash occurs because `ComponentCPLD.get_component_list()` unconditionally reads
`/var/run/hw-management/config/cpld_num` and raises a `RuntimeError` when the file
is missing. On some simulation platforms where hw-management does not fully initialize, this file does
not exist and the command crashes instead of degrading gracefully.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Return empty list on SimX platform

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

- On SimX switch where hw-management does not create
   ```
   show platform firmware status
   ```

   Before fix: `RuntimeError` crash, exit code 1
   After fix: Command succeeds (exit code 0), shows ONIE/SSD/BIOS rows,
   no CPLD rows (expected — hw-management not initialized)

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

