### PR TITLE
Fix system-ready status always showing not ready on multi-ASIC platforms

### DIFF
--- a/src/system-health/health_checker/sysmonitor.py
+++ b/src/system-health/health_checker/sysmonitor.py
@@ -11,7 +11,7 @@ from swsscommon import swsscommon
 from sonic_py_common.logger import Logger
 from . import utils
 from sonic_py_common.task_base import ThreadTaskBase
-from sonic_py_common import device_info
+from sonic_py_common import device_info, multi_asic
 from .config import Config
 import signal
 import jinja2
@@ -172,6 +172,21 @@ class Sysmonitor(ThreadTaskBase):
             if srv in dir_list:
                 dir_list.remove(srv)
 
+        #On multi-ASIC: prune host-level services that should only run as per-ASIC instances
+        if multi_asic.is_multi_asic():
+            feature_table = self.config_db.get_table("FEATURE")
+            prune = []
+            for srv_ext in dir_list:
+                if '@' in srv_ext:
+                    continue
+                srv_name = srv_ext.replace('.service', '')
+                if srv_name in feature_table:
+                    raw_scope = feature_table[srv_name].get('has_global_scope', 'True')
+                    if raw_scope.lower() == 'false':
+                        prune.append(srv_ext)
+            for srv_ext in prune:
+                dir_list.remove(srv_ext)
+
         dir_list.sort()
         return dir_list
 
@@ -280,7 +295,7 @@ class Sysmonitor(ThreadTaskBase):
 
     #Gets the service properties
     def run_systemctl_show(self, service):
-        command = ('systemctl show {} --property=Id,LoadState,UnitFileState,Type,ActiveState,SubState,Result'.format(service))
+        command = ('systemctl show {} --property=Id,LoadState,UnitFileState,Type,ActiveState,SubState,Result,ConditionResult'.format(service))
         output = utils.run_command(command)
         srv_properties = output.split('\n')
         prop_dict = {}
@@ -356,12 +371,16 @@ class Sysmonitor(ThreadTaskBase):
                         service_status = "Stopping"
                         service_up_status = "Stopping"
                     elif active_state == "inactive":
-                        if (srv_type == "oneshot"
+                        condition_result = sysctl_show.get('ConditionResult', 'yes')
+                        is_known_non_blocking = (srv_type == "oneshot"
                                 or service_name in spl_srv_list
-                                or fail_reason in NON_BLOCKING_INACTIVE_REASONS):
+                                or fail_reason in NON_BLOCKING_INACTIVE_REASONS)
+                        if is_known_non_blocking or condition_result == "no":
                             service_status = "OK"
                             service_up_status = "OK"
                             unit_status = "OK"
+                            if not is_known_non_blocking and condition_result == "no":
+                                fail_reason = "condition-unmet"
                         else:
                             unit_status = "NOT OK"
                             if fail_reason == "-":
@@ -433,6 +452,21 @@ class Sysmonitor(ThreadTaskBase):
         full_srv_list = self.get_all_service_list()
         if event in full_srv_list:
             ustate = self.get_unit_status(event)
+            if ustate is None:
+                #Service is masked/not-loaded — clean up both dnsrvs_name and stale STATE_DB entry
+                if event in self.dnsrvs_name:
+                    self.dnsrvs_name.remove(event)
+                srv_name, last = event.rsplit('.', 1)
+                if last == "service":
+                    key = 'ALL_SERVICE_STATUS|{}'.format(srv_name)
+                    if self.state_db.exists(self.state_db.STATE_DB, key):
+                        self.state_db.delete(self.state_db.STATE_DB, key)
+                if len(self.dnsrvs_name) == 0:
+                    astate = "UP"
+                else:
+                    astate = "DOWN"
+                self.publish_system_status(astate)
+                return 0
             if ustate == "OK" and system_allsrv_state == "UP":
                 astate = "UP"
             elif ustate == "OK" and system_allsrv_state == "DOWN":

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -18,7 +18,7 @@ import importlib.machinery
 from swsscommon import swsscommon
 
 from mock import Mock, MagicMock, patch, call
-from sonic_py_common import device_info
+from sonic_py_common import device_info, multi_asic
 
 from .mock_connector import MockConnector
 
@@ -1232,3 +1232,126 @@ def test_check_unit_status_multi_dot_unit_name():
     sysmon.check_unit_status('run-user-1000.mount')
     # Normal service name should still work
     sysmon.check_unit_status('mock_snmp.timer')
+
+
+# --- Tests for multi-ASIC sysready fixes (issue #4936496) ---
+
+mock_condition_unmet_props = {
+    'Type': 'notify', 'Result': 'success',
+    'Id': 'mock_smartmon.service', 'LoadState': 'loaded',
+    'ActiveState': 'inactive', 'SubState': 'dead',
+    'UnitFileState': 'enabled', 'ConditionResult': 'no'
+}
+
+mock_condition_met_inactive_props = {
+    'Type': 'simple', 'Result': 'success',
+    'Id': 'mock_down.service', 'LoadState': 'loaded',
+    'ActiveState': 'inactive', 'SubState': 'dead',
+    'UnitFileState': 'enabled', 'ConditionResult': 'yes'
+}
+
+mock_masked_props = {
+    'Type': '', 'Result': 'success',
+    'Id': 'mock_bgp.service', 'LoadState': 'masked',
+    'ActiveState': 'inactive', 'SubState': 'dead',
+    'UnitFileState': 'masked', 'ConditionResult': 'yes'
+}
+
+
+@patch('health_checker.sysmonitor.Sysmonitor.run_systemctl_show', MagicMock(return_value=mock_condition_unmet_props))
+@patch('health_checker.sysmonitor.Sysmonitor.post_unit_status', MagicMock())
+def test_get_unit_status_condition_unmet_ok():
+    """Inactive service with ConditionResult=no should be treated as OK."""
+    sysmon = Sysmonitor()
+    result = sysmon.get_unit_status('mock_smartmon.service')
+    assert result == 'OK'
+    sysmon.post_unit_status.assert_called_once()
+    call_args = sysmon.post_unit_status.call_args[0]
+    assert call_args[1] == 'OK'              # service_status
+    assert call_args[3] == 'condition-unmet'  # fail_reason
+
+
+@patch('health_checker.sysmonitor.Sysmonitor.run_systemctl_show', MagicMock(return_value=mock_condition_met_inactive_props))
+@patch('health_checker.sysmonitor.Sysmonitor.post_unit_status', MagicMock())
+def test_get_unit_status_condition_met_inactive_not_ok():
+    """Inactive service with ConditionResult=yes should still be NOT OK."""
+    sysmon = Sysmonitor()
+    result = sysmon.get_unit_status('mock_down.service')
+    assert result == 'NOT OK'
+
+
+@patch('health_checker.sysmonitor.Sysmonitor.run_systemctl_show', MagicMock(return_value=mock_masked_props))
+def test_get_unit_status_masked_returns_none():
+    """Masked (not-loaded) service should return None from get_unit_status."""
+    sysmon = Sysmonitor()
+    result = sysmon.get_unit_status('mock_bgp.service')
+    assert result is None
+
+
+@patch('health_checker.sysmonitor.Sysmonitor.get_all_service_list', MagicMock(return_value=['mock_bgp.service', 'mock_snmp.service']))
+@patch('health_checker.sysmonitor.Sysmonitor.get_unit_status', MagicMock(return_value=None))
+@patch('health_checker.sysmonitor.Sysmonitor.publish_system_status', MagicMock())
+def test_check_unit_status_masked_cleanup():
+    """When get_unit_status returns None (masked), check_unit_status should:
+       1. Remove the service from dnsrvs_name
+       2. Delete stale ALL_SERVICE_STATUS entry from STATE_DB
+    """
+    sysmon = Sysmonitor()
+    sysmon.dnsrvs_name = {'mock_bgp.service'}
+
+    # Use a real MagicMock for state_db so delete/exists work
+    sysmon.state_db = MagicMock()
+    sysmon.state_db.STATE_DB = 0
+    sysmon.state_db.exists = MagicMock(return_value=1)
+    sysmon.state_db.delete = MagicMock()
+
+    sysmon.check_unit_status('mock_bgp.service')
+
+    assert 'mock_bgp.service' not in sysmon.dnsrvs_name
+    sysmon.state_db.delete.assert_called_once_with(0, 'ALL_SERVICE_STATUS|mock_bgp')
+
+
+@patch('swsscommon.swsscommon.ConfigDBConnector.connect', MagicMock())
+@patch('sonic_py_common.multi_asic.is_multi_asic', MagicMock(return_value=True))
+@patch('docker.DockerClient')
+@patch('health_checker.utils.run_command')
+@patch('swsscommon.swsscommon.ConfigDBConnector')
+@patch('sonic_py_common.device_info.get_device_runtime_metadata', MagicMock(return_value=device_runtime_metadata))
+def test_get_all_service_list_multi_asic(mock_config_db, mock_run, mock_docker_client):
+    """On multi-ASIC, host-level services with has_global_scope=False should be
+       pruned from the monitored list. Services with has_global_scope=True should remain.
+    """
+    mock_db_data = MagicMock()
+    mock_get_table = MagicMock()
+    mock_db_data.get_table = mock_get_table
+    mock_config_db.return_value = mock_db_data
+    mock_get_table.return_value = {
+        'bgp': {
+            'state': 'enabled',
+            'has_global_scope': 'False',
+            'has_per_asic_scope': 'True',
+        },
+        'radv': {
+            'state': 'enabled',
+            'has_global_scope': 'True',
+            'has_per_asic_scope': 'False',
+        },
+        'syncd': {
+            'state': 'enabled',
+            'has_global_scope': 'false',   # lowercase — must also be handled
+            'has_per_asic_scope': 'True',
+        },
+        'database': {
+            'state': 'always_enabled',
+            'has_global_scope': 'True',
+            'has_per_asic_scope': 'True',
+        },
+    }
+    sysmon = Sysmonitor()
+    result = sysmon.get_all_service_list()
+    # Host-level services with has_global_scope=False should be pruned
+    assert 'bgp.service' not in result
+    assert 'syncd.service' not in result
+    # Global-scope services should remain
+    assert 'radv.service' in result
+    assert 'database.service' in result


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

On Multi-ASIC platforms, show system-health sysready-status permanently reports "System is not ready" due to three bugs in sysmonitor.py:

1. Services skipped by systemd conditions (e.g., smartmontools with ConditionVirtualization=no on KVM) are falsely reported as Down — sysmonitor doesn't check ConditionResult.
2. Masked host-level services (bgp, syncd, teamd, swss) silently block system-ready via in-memory dnsrvs_name entries that are never cleaned up, and stale ALL_SERVICE_STATUS rows persist in STATE_DB.
3. The monitored service list doesn't check has_global_scope — host-level services with has_global_scope=False are monitored even though only per-ASIC instances should run.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

1. run_systemctl_show + get_unit_status: Query ConditionResult from systemd. Treat inactive + ConditionResult=no as OK with reason condition-unmet. Only
applies when existing non-blocking checks don't already match (preserves exec-condition for gnoi-shutdown).
2. get_all_service_list: Post-filter the final service list on Multi-ASIC — prune host-level services where has_global_scope=False. Per-ASIC instances are
already discovered from sonic.target.wants.
3. check_unit_status: When get_unit_status() returns None (masked/not-loaded), clean up both dnsrvs_name and stale ALL_SERVICE_STATUS entries from STATE_DB.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

`show system-health sysready-status`

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

