### PR TITLE
ci: add Trivy vulnerability scan for docker-ptf and docker-sonic-mgmt

### DIFF
--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -120,7 +120,7 @@ stages:
           --input $(Pipeline.Workspace)/docker-sonic-mgmt/target/docker-sonic-mgmt.gz \
           --severity HIGH,CRITICAL \
           --ignore-unfixed \
-          --exit-code 0 \
+          --exit-code 1 \
           --format table \
           --no-progress \
           --timeout 15m \

--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -114,7 +114,7 @@ stages:
         trivy --version
       displayName: "Install Trivy"
     - script: |
-        set -ex
+        set -x
         export PATH="$HOME/.local/bin:$PATH"
         ~/.local/bin/trivy image \
           --input $(Pipeline.Workspace)/docker-sonic-mgmt/target/docker-sonic-mgmt.gz \
@@ -125,9 +125,11 @@ stages:
           --no-progress \
           --timeout 15m \
           --output $(Build.ArtifactStagingDirectory)/trivy-sonic-mgmt.txt
+        TRIVY_EXIT=$?
         echo ""
         echo "=== Trivy Scan Summary (docker-sonic-mgmt) ==="
         grep "^Total:" $(Build.ArtifactStagingDirectory)/trivy-sonic-mgmt.txt || echo "No HIGH/CRITICAL unfixed findings."
+        exit $TRIVY_EXIT
       displayName: "Trivy scan docker-sonic-mgmt"
     - publish: $(Build.ArtifactStagingDirectory)/trivy-sonic-mgmt.txt
       artifact: trivy-scan-results

--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -106,17 +106,14 @@ stages:
       displayName: "Download docker-sonic-mgmt artifact"
     - script: |
         set -ex
-        # Pin version to avoid GitHub API rate limit failures on CI agents
         TRIVY_VERSION="0.70.0"
-        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
-          | sh -s -- -b ~/.local/bin "v${TRIVY_VERSION}"
-        export PATH="$HOME/.local/bin:$PATH"
+        curl -fLO https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.deb
+        sudo apt install -y ./trivy_${TRIVY_VERSION}_Linux-64bit.deb
         trivy --version
       displayName: "Install Trivy"
     - script: |
         set -x
-        export PATH="$HOME/.local/bin:$PATH"
-        ~/.local/bin/trivy image \
+        trivy image \
           --input $(Pipeline.Workspace)/docker-sonic-mgmt/target/docker-sonic-mgmt.gz \
           --severity HIGH,CRITICAL \
           --ignore-unfixed \
@@ -127,8 +124,8 @@ stages:
           --output $(Build.ArtifactStagingDirectory)/trivy-sonic-mgmt.txt
         TRIVY_EXIT=$?
         echo ""
-        echo "=== Trivy Scan Summary (docker-sonic-mgmt) ==="
-        grep "^Total:" $(Build.ArtifactStagingDirectory)/trivy-sonic-mgmt.txt || echo "No HIGH/CRITICAL unfixed findings."
+        echo "=== Trivy Scan Results (docker-sonic-mgmt) ==="
+        cat $(Build.ArtifactStagingDirectory)/trivy-sonic-mgmt.txt
         exit $TRIVY_EXIT
       displayName: "Trivy scan docker-sonic-mgmt"
     - publish: $(Build.ArtifactStagingDirectory)/trivy-sonic-mgmt.txt

--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -92,6 +92,49 @@ stages:
   - name: BUILD_BRANCH
     value: $(Build.SourceBranchName)
   jobs:
+  - job: trivy_scan
+    displayName: "Trivy vulnerability scan (docker-sonic-mgmt)"
+    pool: sonic-ubuntu-1c
+    continueOnError: true
+    timeoutInMinutes: 30
+    steps:
+    - checkout: self
+      clean: true
+      fetchDepth: 1
+    - download: current
+      artifact: docker-sonic-mgmt
+      displayName: "Download docker-sonic-mgmt artifact"
+    - script: |
+        set -ex
+        # Pin version to avoid GitHub API rate limit failures on CI agents
+        TRIVY_VERSION="0.70.0"
+        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
+          | sh -s -- -b ~/.local/bin "v${TRIVY_VERSION}"
+        export PATH="$HOME/.local/bin:$PATH"
+        trivy --version
+      displayName: "Install Trivy"
+    - script: |
+        set -ex
+        export PATH="$HOME/.local/bin:$PATH"
+        ~/.local/bin/trivy image \
+          --input $(Pipeline.Workspace)/docker-sonic-mgmt/target/docker-sonic-mgmt.gz \
+          --severity HIGH,CRITICAL \
+          --ignore-unfixed \
+          --exit-code 0 \
+          --format table \
+          --no-progress \
+          --timeout 15m \
+          --output $(Build.ArtifactStagingDirectory)/trivy-sonic-mgmt.txt
+        echo ""
+        echo "=== Trivy Scan Summary (docker-sonic-mgmt) ==="
+        grep "^Total:" $(Build.ArtifactStagingDirectory)/trivy-sonic-mgmt.txt || echo "No HIGH/CRITICAL unfixed findings."
+      displayName: "Trivy scan docker-sonic-mgmt"
+    - publish: $(Build.ArtifactStagingDirectory)/trivy-sonic-mgmt.txt
+      artifact: trivy-scan-results
+      displayName: "Publish Trivy scan results"
+      condition: always()
+      continueOnError: true
+
     - template: .azure-pipelines/pr_test_template.yml@sonic-mgmt
       parameters:
         CHECKOUT_SONIC_MGMT: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -214,3 +214,49 @@ stages:
     parameters:
       CHECKOUT_SONIC_MGMT: ${{ parameters.CHECKOUT_SONIC_MGMT }}
       PTF_MODIFIED: $(PTF_MODIFIED)
+
+  # Trivy scan for docker-ptf — informational, runs in parallel with KVM tests
+  - job: trivy_scan
+    displayName: "Trivy vulnerability scan (docker-ptf)"
+    pool: sonic-ubuntu-1c
+    continueOnError: true
+    timeoutInMinutes: 60
+    steps:
+    - checkout: self
+      clean: true
+      fetchDepth: 1
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        artifact: sonic-buildimage.vs
+      displayName: "Download sonic-buildimage.vs artifact"
+    - script: |
+        set -ex
+        # Pin version to avoid GitHub API rate limit failures on CI agents
+        TRIVY_VERSION="0.70.0"
+        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
+          | sh -s -- -b ~/.local/bin "v${TRIVY_VERSION}"
+        export PATH="$HOME/.local/bin:$PATH"
+        trivy --version
+      displayName: "Install Trivy"
+    - script: |
+        set -ex
+        export PATH="$HOME/.local/bin:$PATH"
+        # docker-ptf.gz is ~1.3GB; scan takes 15-20 min on CI agents
+        ~/.local/bin/trivy image \
+          --input $(Pipeline.Workspace)/target/docker-ptf.gz \
+          --severity HIGH,CRITICAL \
+          --ignore-unfixed \
+          --exit-code 0 \
+          --format table \
+          --no-progress \
+          --timeout 30m \
+          --output $(Build.ArtifactStagingDirectory)/trivy-ptf.txt
+        echo ""
+        echo "=== Trivy Scan Summary (docker-ptf) ==="
+        grep "^Total:" $(Build.ArtifactStagingDirectory)/trivy-ptf.txt || echo "No HIGH/CRITICAL unfixed findings."
+      displayName: "Trivy scan docker-ptf"
+    - publish: $(Build.ArtifactStagingDirectory)/trivy-ptf.txt
+      artifact: trivy-scan-results
+      displayName: "Publish Trivy scan results"
+      condition: always()
+      continueOnError: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -246,7 +246,7 @@ stages:
           --input $(Pipeline.Workspace)/target/docker-ptf.gz \
           --severity HIGH,CRITICAL \
           --ignore-unfixed \
-          --exit-code 0 \
+          --exit-code 1 \
           --format table \
           --no-progress \
           --timeout 30m \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -239,7 +239,7 @@ stages:
         trivy --version
       displayName: "Install Trivy"
     - script: |
-        set -ex
+        set -x
         export PATH="$HOME/.local/bin:$PATH"
         # docker-ptf.gz is ~1.3GB; scan takes 15-20 min on CI agents
         ~/.local/bin/trivy image \
@@ -251,9 +251,11 @@ stages:
           --no-progress \
           --timeout 30m \
           --output $(Build.ArtifactStagingDirectory)/trivy-ptf.txt
+        TRIVY_EXIT=$?
         echo ""
         echo "=== Trivy Scan Summary (docker-ptf) ==="
         grep "^Total:" $(Build.ArtifactStagingDirectory)/trivy-ptf.txt || echo "No HIGH/CRITICAL unfixed findings."
+        exit $TRIVY_EXIT
       displayName: "Trivy scan docker-ptf"
     - publish: $(Build.ArtifactStagingDirectory)/trivy-ptf.txt
       artifact: trivy-scan-results

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -228,21 +228,19 @@ stages:
     - task: DownloadPipelineArtifact@2
       inputs:
         artifact: sonic-buildimage.vs
-      displayName: "Download sonic-buildimage.vs artifact"
+        itemPattern: "target/docker-ptf.gz"
+      displayName: "Download docker-ptf artifact"
     - script: |
         set -ex
-        # Pin version to avoid GitHub API rate limit failures on CI agents
         TRIVY_VERSION="0.70.0"
-        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
-          | sh -s -- -b ~/.local/bin "v${TRIVY_VERSION}"
-        export PATH="$HOME/.local/bin:$PATH"
+        curl -fLO https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.deb
+        sudo apt install -y ./trivy_${TRIVY_VERSION}_Linux-64bit.deb
         trivy --version
       displayName: "Install Trivy"
     - script: |
         set -x
-        export PATH="$HOME/.local/bin:$PATH"
         # docker-ptf.gz is ~1.3GB; scan takes 15-20 min on CI agents
-        ~/.local/bin/trivy image \
+        trivy image \
           --input $(Pipeline.Workspace)/target/docker-ptf.gz \
           --severity HIGH,CRITICAL \
           --ignore-unfixed \
@@ -253,8 +251,8 @@ stages:
           --output $(Build.ArtifactStagingDirectory)/trivy-ptf.txt
         TRIVY_EXIT=$?
         echo ""
-        echo "=== Trivy Scan Summary (docker-ptf) ==="
-        grep "^Total:" $(Build.ArtifactStagingDirectory)/trivy-ptf.txt || echo "No HIGH/CRITICAL unfixed findings."
+        echo "=== Trivy Scan Results (docker-ptf) ==="
+        cat $(Build.ArtifactStagingDirectory)/trivy-ptf.txt
         exit $TRIVY_EXIT
       displayName: "Trivy scan docker-ptf"
     - publish: $(Build.ArtifactStagingDirectory)/trivy-ptf.txt


### PR DESCRIPTION
#### Why I did it

Add informational vulnerability scanning for the PTF and sonic-mgmt container images to surface HIGH/CRITICAL CVEs in CI.

##### Work item tracking
- Microsoft ADO:

#### How I did it

- `azure-pipelines.yml`: new `trivy_scan` job in the Test stage that downloads the existing `sonic-buildimage.vs` artifact and scans `docker-ptf.gz` with Trivy for HIGH/CRITICAL unfixed CVEs
- `.azure-pipelines/docker-sonic-mgmt.yml`: new `trivy_scan` job in the Test stage that scans `docker-sonic-mgmt.gz` from the same pipeline

Both jobs run in parallel with existing test jobs (no build time increase). `exit-code 0` and `continueOnError: true` — informational only, does not block PR merge. Results are published as pipeline artifacts.

#### How to verify it

Run the pipeline and check the `trivy_scan` job output in the Test stage. A scan summary and per-CVE table are printed to the job log, and results are published as the `trivy-scan-results` artifact.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ]

#### Description for the changelog

Add informational Trivy CVE scanning for docker-ptf and docker-sonic-mgmt in CI.

#### Link to config_db schema for YANG module changes

N/A
