### PR TITLE
Build an VS image that uses UEFI alongside existing BIOS image

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -32,6 +32,7 @@ IMAGE_VERSION="${SONIC_IMAGE_VERSION}"
 generate_kvm_image()
 {
     NUM_ASIC=$1
+	BOOT_FIRMWARE=${2:-BIOS}
     if [ $NUM_ASIC == 4 ]; then 
          KVM_IMAGE=$OUTPUT_KVM_4ASIC_IMAGE
          RECOVERY_ISO=$onie_recovery_kvm_4asic_image
@@ -44,11 +45,15 @@ generate_kvm_image()
          NUM_ASIC=1
     fi
 
-    echo "Build $NUM_ASIC-asic KVM image"
-    KVM_IMAGE_DISK=${KVM_IMAGE%.gz}
+    echo "Build $NUM_ASIC-asic ${BOOT_FIRMWARE} KVM image"
+    if [[ "$BOOT_FIRMWARE" == "UEFI" ]]; then
+        KVM_IMAGE_DISK=${KVM_IMAGE%.img.gz}-uefi.img
+    else
+        KVM_IMAGE_DISK=${KVM_IMAGE%.gz}
+    fi
     sudo rm -f $KVM_IMAGE_DISK $KVM_IMAGE_DISK.gz
 
-    SONIC_USERNAME=$USERNAME PASSWD=$PASSWORD sudo -E ./scripts/build_kvm_image.sh $KVM_IMAGE_DISK $RECOVERY_ISO $OUTPUT_ONIE_IMAGE $KVM_IMAGE_DISK_SIZE
+    SONIC_USERNAME=$USERNAME PASSWD=$PASSWORD sudo -E ./scripts/build_kvm_image.sh $KVM_IMAGE_DISK $RECOVERY_ISO $OUTPUT_ONIE_IMAGE $KVM_IMAGE_DISK_SIZE ${BOOT_FIRMWARE}
 
     if [ $? -ne 0 ]; then
         echo "Error : build kvm image failed"
@@ -172,7 +177,8 @@ elif [ "$IMAGE_TYPE" = "kvm" ]; then
 
     generate_onie_installer_image
     # Generate single asic KVM image
-    generate_kvm_image
+    generate_kvm_image 1
+    generate_kvm_image 1 UEFI
     if [ "$BUILD_MULTIASIC_KVM" == "y" ]; then
         # Generate 4-asic KVM image
         generate_kvm_image 4

--- a/build_image.sh
+++ b/build_image.sh
@@ -32,7 +32,7 @@ IMAGE_VERSION="${SONIC_IMAGE_VERSION}"
 generate_kvm_image()
 {
     NUM_ASIC=$1
-	BOOT_FIRMWARE=${2:-BIOS}
+    BOOT_FIRMWARE=${2:-BIOS}
     if [ $NUM_ASIC == 4 ]; then 
          KVM_IMAGE=$OUTPUT_KVM_4ASIC_IMAGE
          RECOVERY_ISO=$onie_recovery_kvm_4asic_image

--- a/install_sonic.py
+++ b/install_sonic.py
@@ -34,7 +34,8 @@ def main():
 
     # select ONIE embed
     p.expect(grub_selection)
-    p.sendline(KEY_DOWN)
+    p.send(KEY_DOWN)
+    p.sendline()
 
     # select ONIE install
     p.expect(['ONIE: Install OS'])

--- a/platform/vs/onie.mk
+++ b/platform/vs/onie.mk
@@ -1,5 +1,5 @@
 ONIE_RECOVERY_IMAGE = onie-recovery-x86_64-kvm_x86_64-r0.iso
-$(ONIE_RECOVERY_IMAGE)_URL = "$(BUILD_PUBLIC_URL)/onie/onie-recovery-x86_64-kvm_x86_64-r0.iso"
+$(ONIE_RECOVERY_IMAGE)_URL = "$(BUILD_PUBLIC_URL)/onie/efi/onie-recovery-x86_64-kvm_x86_64-r0.iso"
 
 ONIE_RECOVERY_KVM_4ASIC_IMAGE = onie-recovery-x86_64-kvm_x86_64_4_asic-r0.iso
 $(ONIE_RECOVERY_KVM_4ASIC_IMAGE)_URL = "$(BUILD_PUBLIC_URL)/onie/onie-recovery-x86_64-kvm_x86_64_4_asic-r0.iso"

--- a/scripts/build_kvm_image.sh
+++ b/scripts/build_kvm_image.sh
@@ -86,13 +86,19 @@ trap on_error ERR
 
 echo "Installing SONiC"
 
+efi_vars=${DISK%.img}_vars.fd
+
+cp /usr/share/OVMF/OVMF_VARS_4M.fd $efi_vars
+
 /usr/bin/kvm -m $MEM \
+    -machine "q35,smm=on" \
     -name "onie" \
     -boot "order=cd,once=d" -cdrom "$ONIE_RECOVERY_ISO" \
-    -device e1000,netdev=onienet \
-    -netdev user,id=onienet,hostfwd=:0.0.0.0:3041-:22 \
-    -vnc 0.0.0.0:0 \
-    -vga std \
+    -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE_4M.secboot.fd \
+    -drive if=pflash,format=raw,file=$efi_vars \
+    -device virtio-net,netdev=onienet \
+    -netdev user,id=onienet \
+    -nographic \
     -drive file=$DISK,media=disk,if=virtio,index=0 \
     -drive file=$INSTALLER_DISK,if=virtio,index=1 \
     -serial telnet:127.0.0.1:$KVM_PORT,server > $kvm_log 2>&1 &
@@ -116,11 +122,13 @@ kill $kvm_pid
 echo "Booting up SONiC"
 
 /usr/bin/kvm -m $MEM \
+    -machine "q35,smm=on" \
     -name "onie" \
-    -device e1000,netdev=onienet \
+    -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE_4M.secboot.fd \
+    -drive if=pflash,format=raw,file=$efi_vars \
+    -device virtio-net,netdev=onienet \
     -netdev user,id=onienet,hostfwd=:0.0.0.0:3041-:22 \
-    -vnc 0.0.0.0:0 \
-    -vga std \
+    -nographic \
     -snapshot \
     -drive file=$DISK,media=disk,if=virtio,index=0 \
     -serial telnet:127.0.0.1:$KVM_PORT,server > $kvm_log 2>&1 &

--- a/scripts/build_kvm_image.sh
+++ b/scripts/build_kvm_image.sh
@@ -9,6 +9,7 @@ DISK=$1
 ONIE_RECOVERY_ISO=$2
 INSTALLER=$3
 DISK_SIZE=$4
+BOOT_FIRMWARE=$5
 
 INSTALLER_DISK="./sonic-installer.img"
 
@@ -86,16 +87,18 @@ trap on_error ERR
 
 echo "Installing SONiC"
 
-efi_vars=${DISK%.img}_vars.fd
 
-cp /usr/share/OVMF/OVMF_VARS_4M.fd $efi_vars
+if [[ "$BOOT_FIRMWARE" == "UEFI" ]]; then
+    efi_vars=${DISK%.img}_vars.fd
+    cp /usr/share/OVMF/OVMF_VARS_4M.fd $efi_vars
+    uefi_options="-drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE_4M.secboot.fd -drive if=pflash,format=raw,file=$efi_vars"
+fi
 
 /usr/bin/kvm -m $MEM \
     -machine "q35,smm=on" \
     -name "onie" \
     -boot "order=cd,once=d" -cdrom "$ONIE_RECOVERY_ISO" \
-    -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE_4M.secboot.fd \
-    -drive if=pflash,format=raw,file=$efi_vars \
+    ${uefi_options} \
     -device virtio-net,netdev=onienet \
     -netdev user,id=onienet \
     -nographic \
@@ -124,8 +127,7 @@ echo "Booting up SONiC"
 /usr/bin/kvm -m $MEM \
     -machine "q35,smm=on" \
     -name "onie" \
-    -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE_4M.secboot.fd \
-    -drive if=pflash,format=raw,file=$efi_vars \
+    ${uefi_options} \
     -device virtio-net,netdev=onienet \
     -netdev user,id=onienet,hostfwd=:0.0.0.0:3041-:22 \
     -nographic \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

For testing devices that use UEFI as the bootloader instead of BIOS (which is likely most newer devices), it helps to build a UEFI-based KVM image, so that the exact behavior on such devices can be tested.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Modify the image build scripts to create a KVM image in a UEFI environment, and save the EFI variables used there. This will be needed for starting up the image correctly afterwards.

Also use a newer ONIE with UEFI support for building this image.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Copy the EFI sonic-vs.img.gz file and the vars file to `~/sonic-vm/images/`, and run add-topo with `-e '"{"use_uefi": true}"'` appended in sonic-mgmt that has sonic-net/sonic-mgmt#24332 present to start a UEFI-based KVM image.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

