### PR TITLE
[202511] Install python3-ijson and relax ijson version pins

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -194,6 +194,9 @@ fi
 install_deb_package $debs_path/libyang_*.deb $debs_path/libyang-cpp_*.deb $debs_path/python3-yang_*.deb $debs_path/libpcre3_*.deb
 install_pip_package {{sonic_yang_models_py3_wheel_path}}
 
+# Install python3-ijson from Debian repos (provides yajl2_c backend for streaming JSON parsing)
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install python3-ijson
+
 # Install sonic-yang-mgmt Python3 package
 install_pip_package {{sonic_yang_mgmt_py3_wheel_path}}
 

--- a/src/sonic-yang-mgmt/setup.py
+++ b/src/sonic-yang-mgmt/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     install_requires = [
         'xmltodict==0.12.0',
-        'ijson==3.2.3',
+        'ijson>=3.2.3',
         'jsonpointer>=1.9',
         'jsondiff>=1.2.0',
         'tabulate==0.9.0'
@@ -37,7 +37,7 @@ setup(
     tests_require = [
         'pytest>3',
         'xmltodict==0.12.0',
-        'ijson==3.2.3',
+        'ijson>=3.2.3',
         'jsondiff>=1.2.0'
     ],
     setup_requires = [

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -282,7 +282,7 @@ setup(
     ],
     tests_require = [
         'pytest',
-        'ijson==3.2.3'
+        'ijson>=3.2.3'
     ],
     setup_requires = [
         'pytest-runner',
@@ -291,7 +291,7 @@ setup(
     extras_require = {
         "testing": [
             'pytest',
-            'ijson==3.2.3'
+            'ijson>=3.2.3'
         ],
     },
     include_package_data=True,


### PR DESCRIPTION
## Description
Install python3-ijson Debian package to provide the fast yajl2_c backend for streaming JSON parsing in route_check.py. Relax ijson version pins from ==3.2.3 to >=3.2.3 in sonic-yang-mgmt and sonic-yang-models to allow the Debian package (which provides 3.4.0) to satisfy the dependency.

This is a backport/equivalent of master PRs:
- sonic-net/sonic-buildimage#26633 (Install python3-ijson and relax version pins)

## Motivation
route_check.py on 202511 currently loads the entire FRR routing table JSON into memory, which causes OOM on devices with 500K+ routes. The companion sonic-utilities PR rewrites route_check.py to use ijson streaming, but requires the python3-ijson package to be pre-installed.

## Changes
- `files/build_templates/sonic_debian_extension.j2`: Install python3-ijson before sonic-yang-mgmt
- `src/sonic-yang-mgmt/setup.py`: ijson==3.2.3 → ijson>=3.2.3
- `src/sonic-yang-models/setup.py`: ijson==3.2.3 → ijson>=3.2.3

## Companion PR
- sonic-net/sonic-utilities#4509: Use ijson streaming in route_check.py

## Merge Order
This PR should be merged BEFORE the sonic-utilities PR (sonic-net/sonic-utilities#4509), as route_check.py depends on python3-ijson being available at runtime.

## Verification
- Verified on VS KVM testbed that python3-ijson provides yajl2_c backend
- route_check.py with ijson streaming runs cleanly (0 missing, 0 failed routes)
- Unit tests pass (6/6)
