### PR TITLE
[arista]: Support arista FW for uefi images

### DIFF
--- a/platform/broadcom/platform-modules-arista.mk
+++ b/platform/broadcom/platform-modules-arista.mk
@@ -37,6 +37,7 @@ export ARISTA_PLATFORM_MODULE \
 ARISTA_FWUTIL_VERSION = 202511.4
 ARISTA_FWUTIL = arista-fwutil_$(ARISTA_FWUTIL_VERSION)_amd64.deb
 $(ARISTA_FWUTIL)_PATH = $(PLATFORM_PATH)/extra-debs
+$(ARISTA_FWUTIL)_PLATFORM = $(ARISTA_PLATFORMS)
 
 #Install fwutil package if it exists
 ifneq (,$(wildcard $($(ARISTA_FWUTIL)_PATH)/$(ARISTA_FWUTIL)))
@@ -47,6 +48,7 @@ endif
 ARISTA_FIRMWARE_VERSION = 202511.1
 ARISTA_FIRMWARE = arista-firmware_$(ARISTA_FIRMWARE_VERSION)_all.deb
 $(ARISTA_FIRMWARE)_PATH = $(PLATFORM_PATH)/extra-debs
+$(ARISTA_FIRMWARE)_PLATFORM = $(ARISTA_PLATFORMS)
 
 #Install firmware package if it exists
 ifneq (,$(wildcard $($(ARISTA_FIRMWARE)_PATH)/$(ARISTA_FIRMWARE)))


### PR DESCRIPTION
Add _PLATFORM makefile entry to arista firmware so UEFI/onie build picks it up

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

