### PR TITLE
[Security] temporarily remove vpp test from sonic-mgmt docker image build

### DIFF
--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -95,6 +95,8 @@ stages:
     - template: .azure-pipelines/pr_test_template.yml@sonic-mgmt
       parameters:
         CHECKOUT_SONIC_MGMT: true
+        # todo: enable vpp build in sonic-mgmt docker image build pipeline, and add vpp test pipeline back.
+        INCLUDE_JOBS: "t0_job,t1_job,t2_job,t0_2vlans_job,t0_sonic_job,dpu_job,t1_multi_asic_job"
         OVERRIDE_PARAMS:
           REPO_NAME: "sonic-mgmt"
           SETUP_CONTAINER_PARAMS: "-i ${{ parameters.registry_url }}/docker-sonic-mgmt:lastbuild"


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The `docker-sonic-mgmt` image build pipeline is currently **blocked** due to a failing `t1_lag_vpp_job` test stage.

- **Failing build**: https://dev.azure.com/mssonic/build/_build/results?buildId=1101907&view=results
- **Root cause**: The VPP (Vector Packet Processing) test infrastructure in sonic-mgmt has unresolved dependencies/issues that cause the `t1_lag_vpp_job` to fail consistently, preventing the entire docker-sonic-mgmt build pipeline from succeeding.

This is a **temporary workaround** to unblock the pipeline while the VPP test issues are investigated and resolved separately.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

In `.azure-pipelines/docker-sonic-mgmt.yml`, explicitly set the `INCLUDE_JOBS` parameter to include only the stable test jobs, **excluding `t1_lag_vpp_job`**:

```
INCLUDE_JOBS: "t0_job,t1_job,t2_job,t0_2vlans_job,t0_sonic_job,dpu_job,t1_multi_asic_job"
```

The default value in `pr_test_template.yml` includes all jobs:
```
default: "t0_job,t1_job,t2_job,t0_2vlans_job,t0_sonic_job,dpu_job,t1_multi_asic_job,t1_lag_vpp_job"
```

By overriding this parameter, the VPP test job is skipped while all other test jobs continue to run normally.

#### How to verify it

1. Verify the pipeline passes without the `t1_lag_vpp_job` stage.
2. Confirm all other test stages (`t0_job`, `t1_job`, `t2_job`, etc.) still execute and pass as expected.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

Temporarily exclude VPP test job (`t1_lag_vpp_job`) from docker-sonic-mgmt build pipeline to unblock CI.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

:hedgehog: