### PR TITLE
Replace FD_SET/select() with poll() to avoid FD_SETSIZE abort

### DIFF
--- a/src/libteam/patch/0018-Replace-FD_SET-select-with-poll-to-avoid-FD_SETSIZE-abort.patch
+++ b/src/libteam/patch/0018-Replace-FD_SET-select-with-poll-to-avoid-FD_SETSIZE-abort.patch
@@ -1,0 +1,115 @@
+From 73f320a3383b94a36cad8f2ae7004dd02c6063d3 Mon Sep 17 00:00:00 2001
+From: Spandan Chowdhury <spandan@nexthop.ai>
+Date: Fri, 1 May 2026 18:21:00 -0700
+Subject: [PATCH] Replace FD_SET/select() with poll() to avoid FD_SETSIZE abort
+
+cli_usock_wait_recv() in libteamdctl and team_check_events() in
+libteam use FD_SET()/select() to wait for readability on a single
+fd. Both fail when the fd value reaches or exceeds FD_SETSIZE (1024
+in glibc): under _FORTIFY_SOURCE=2, FD_SET expands to __fdelt_chk()
+and aborts the process with:
+
+    *** bit out of range 0 - FD_SETSIZE on fd_set ***
+
+A long-running consumer that manages many team interfaces
+concurrently will hit this. Each team_alloc()/team_init() keeps 4
+libnl sockets (nl_sock, nl_sock_event, nl_cli.sock,
+nl_cli.sock_event) and 1 epoll fd (from team_init_event_fd()) open
+for the lifetime of the team handle. Once the persistent fd table
+grows past 1024, the next unix socket opened by teamdctl_connect()
+is assigned a fd >= FD_SETSIZE, and the next teamdctl_*() call that
+reaches cli_usock_wait_recv() aborts the process.
+
+Replace both sites with poll(), which takes raw fd numbers and has
+no FD_SETSIZE ceiling. Behavior is preserved: single fd,
+read-readiness, same timeout semantics (5000 ms in
+cli_usock_wait_recv, non-blocking in team_check_events).
+---
+ libteam/libteam.c       | 16 +++++++---------
+ libteamdctl/cli_usock.c | 20 +++++++-------------
+ 2 files changed, 14 insertions(+), 22 deletions(-)
+
+diff --git a/libteam/libteam.c b/libteam/libteam.c
+index ee78aff..d36b9fa 100644
+--- a/libteam/libteam.c
++++ b/libteam/libteam.c
+@@ -42,7 +42,7 @@
+ #include <stdarg.h>
+ #include <unistd.h>
+ #include <syslog.h>
+-#include <sys/select.h>
++#include <poll.h>
+ #include <sys/epoll.h>
+ #include <time.h>
+ #include <netlink/netlink.h>
+@@ -1031,17 +1031,15 @@ int team_handle_events(struct team_handle *th)
+ TEAM_EXPORT
+ int team_check_events(struct team_handle *th)
+ {
+-	fd_set rfds;
+-	int fdmax;
+-	struct timeval tv;
+ 	int fd = team_get_event_fd(th);
++	struct pollfd pfd = {
++		.fd = fd,
++		.events = POLLIN,
++	};
+ 	int ret;
+ 
+-	memset(&tv, 0, sizeof(tv));
+-	FD_ZERO(&rfds);
+-	FD_SET(fd, &rfds);
+-	fdmax = fd + 1;
+-	ret = select(fdmax, &rfds, NULL, NULL, &tv);
++	/* Non-blocking, equivalent to the original timeval=0 select(). */
++	ret = poll(&pfd, 1, 0);
+ 	if (ret == -1)
+ 		return -errno;
+ 	return team_handle_events(th);
+diff --git a/libteamdctl/cli_usock.c b/libteamdctl/cli_usock.c
+index d3fbdba..141c34b 100644
+--- a/libteamdctl/cli_usock.c
++++ b/libteamdctl/cli_usock.c
+@@ -23,6 +23,7 @@
+ #include <stdarg.h>
+ #include <sys/types.h>
+ #include <sys/socket.h>
++#include <poll.h>
+ #include <unistd.h>
+ #include <teamdctl.h>
+ #include "teamdctl_private.h"
+@@ -79,25 +80,18 @@ static int cli_usock_send(int sock, char *msg)
+ 	return 0;
+ }
+ 
+-#define WAIT_SEC (TEAMDCTL_REPLY_TIMEOUT / 1000)
+-#define WAIT_USEC (TEAMDCTL_REPLY_TIMEOUT % 1000 * 1000)
+-
+ static int cli_usock_wait_recv(int sock)
+ {
+-	fd_set rfds;
+-	int fdmax;
++	struct pollfd pfd = {
++		.fd = sock,
++		.events = POLLIN,
++	};
+ 	int ret;
+-	struct timeval tv;
+ 
+-	tv.tv_sec = WAIT_SEC;
+-	tv.tv_usec = WAIT_USEC;
+-	FD_ZERO(&rfds);
+-	FD_SET(sock, &rfds);
+-	fdmax = sock + 1;
+-	ret = select(fdmax, &rfds, NULL, NULL, &tv);
++	ret = poll(&pfd, 1, TEAMDCTL_REPLY_TIMEOUT);
+ 	if (ret == -1)
+ 		return -errno;
+-	if (!FD_ISSET(sock, &rfds))
++	if (ret == 0)
+ 		return -ETIMEDOUT;
+ 	return 0;
+ }
+-- 
+2.43.0
+

--- a/src/libteam/patch/series
+++ b/src/libteam/patch/series
@@ -15,3 +15,4 @@
 0015-add-support-for-custom-retry.patch
 0016-block-retry-count-changes.patch
 0017-Specify-netlink-recv-buffer-size-to-avoid-a-syscall.patch
+0018-Replace-FD_SET-select-with-poll-to-avoid-FD_SETSIZE-abort.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
fixes https://github.com/sonic-net/sonic-buildimage/issues/26789

Each `TeamPortSync` instance keeps five long-lived file descriptors alive: four `libnl` sockets and one `epoll` `fd` opened by `team_alloc()` and `team_init()`. Once the `fd` table grows past `FD_SETSIZE` (1024 in `glibc`), the next unix socket that `teamdctl_connect()` opens inside the constructor - for the per-LAG liveness check - is assigned a fd ≥ 1024. The follow-up `teamdctl_config_get_raw_direct()` call hands that fd to `FD_SET()` inside `cli_usock_wait_recv()`. Under glibc's `_FORTIFY_SOURCE=2`, `FD_SET` expands to `__fdelt_chk()`, which aborts the process with `*** bit out of range 0 - FD_SETSIZE` on `fd_set`. `teamsyncd` dies via `SIGABRT`, and eventually `systemd` cascades the failure into a `teamd` restart.


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added a patch to replace both `FD_SET`/`select()` call sites with `poll()`, which takes raw `fd` numbers and has no `FD_SETSIZE` ceiling. Behavior is preserved end to end: each site waits for read-readiness on a single `fd` with the original timeout (5000 ms in `cli_usock_wait_recv`, non-blocking in `team_check_events`).

#### How to verify it
Test that were failing with high scale portchannels have been passing on DUTs with the changes.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

