### PR TITLE
[build] add libsaimetadata as build dependency for libsaivs

### DIFF
--- a/rules/sairedis.mk
+++ b/rules/sairedis.mk
@@ -17,6 +17,7 @@ $(eval $(call add_derived_package,$(LIBSAIREDIS),$(LIBSAIREDIS_DEV)))
 
 LIBSAIVS = libsaivs_$(LIBSAIREDIS_VERSION)_$(CONFIGURED_ARCH).deb
 $(eval $(call add_derived_package,$(LIBSAIREDIS),$(LIBSAIVS)))
+$(LIBSAIVS)_DEPENDS += $(LIBSAIMETADATA)
 
 LIBSAIVS_DEV = libsaivs-dev_$(LIBSAIREDIS_VERSION)_$(CONFIGURED_ARCH).deb
 $(eval $(call add_derived_package,$(LIBSAIREDIS),$(LIBSAIVS_DEV)))


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
## Why I did it
Update sonic-sairedis submodule introduces changes to libsaivs linkage, which now declares a runtime dependency on libsaimetadata. Without a corresponding build dependency in buildimage, the package installation fails with dpkg dependency errors.
```
[ FAIL LOG START ] [ target/debs/bookworm/libsaivs_1.0.0_amd64.deb-install ]
Build start time: Sat May 2 06:56:03 UTC 2026
Selecting previously unselected package libsaivs.
(Reading database ... 225747 files and directories currently installed.)
Preparing to unpack .../libsaivs_1.0.0_amd64.deb ...
Unpacking libsaivs (1.0.0) ...
dpkg: dependency problems prevent configuration of libsaivs:
 libsaivs depends on libsaimetadata (>= 1.0.0); however:
  Package libsaimetadata is not installed.

dpkg: error processing package libsaivs (--install):
 dependency problems - leaving unconfigured
Processing triggers for libc-bin (2.36-9+deb12u13) ...
Errors were encountered while processing:
 libsaivs
[  FAIL LOG END  ] [ target/debs/bookworm/libsaivs_1.0.0_amd64.deb-install ]
```
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added `$(LIBSAIMETADATA)` as a build dependency for `$(LIBSAIVS)` in `rules/sairedis.mk`. This ensures libsaimetadata is built and available before libsaivs is installed.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

