### PR TITLE
[docker-sonic-mgmt] Relax protobuf pin to >=5.29.6,<6 to fix snappi resolution

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -101,7 +101,7 @@ RUN pip install --no-cache-dir --upgrade pip \
     passlib \
     pexpect \
     prettytable \
-    "protobuf>=6.33.5,<8" \
+    "protobuf>=5.29.6,<6" \
     psutil \
     ptf \
     pyasn1 \


### PR DESCRIPTION
### Why I did it
`snappi` and `snappi-ixnetwork` in `docker-sonic-mgmt` are unpinned, and pip's resolver currently selects the very old `snappi==1.28.1` combined with a recent `snappi-ixnetwork`. That pair is API-incompatible and breaks snappi tests at fixture setup time:

```
snappi_tests/pfcwd/test_pfcwd_basic_with_snappi.py::test_pfcwd_basic_single_lossless_prio[multidut_port_info0-tgen_port_info0-True]
-------------------------------- live log setup --------------------------------
03/05/2026 07:37:17 __init__._fixture_generator_decorator    L0088 ERROR  |
AttributeError("'Api' object has no attribute 'config_delete'")
Traceback (most recent call last):
  File ".../tests/common/plugins/log_section_start/__init__.py", line 84, in _fixture_generator_decorator
    res = next(it)
  File ".../tests/common/snappi_tests/snappi_fixtures.py", line 75, in snappi_api
    api = snappi.api(location=location, ext="ixnetwork")
  File "/opt/venv/lib/python3.12/site-packages/snappi/snappi.py", line 103, in api
    return lib.Api(**params)
  File "/opt/venv/lib/python3.12/site-packages/snappi_ixnetwork/snappi_api.py", line 99, in __init__
    self._flows_delete = self.config_delete()
AttributeError: 'Api' object has no attribute 'config_delete'. Did you mean: 'config_update'?
```

#### Why pip silently picked the very old `snappi==1.28.1`

PR #26695 added `"protobuf>=6.33.5,<8"` to mitigate CVE-2025-4565 and CVE-2026-0994. Looking at the published metadata on PyPI:

| package | declared `protobuf` requirement |
| --- | --- |
| `snappi==1.53.0` (latest) | `protobuf~=5.29.5` *(i.e. >=5.29.5,<5.30)* |
| `snappi==1.28.1`          | `protobuf>=4.24.4` (no upper bound) |
| `snappi-ixnetwork==1.53.2` | *(no direct `protobuf` requirement)* |

Recent `snappi` release caps `protobuf` at `<6`, so pip's resolver rejects all of them against `protobuf>=6.33.5,<8` and **backtracks `snappi` all the way down to `1.28.1`** — the last release with an open-ended `protobuf` requirement that admits protobuf 6.x.

In short: the protobuf 6.x pin silently forced `snappi` and `snappi-ixnetwork` onto incompatible major versions.

### How I did it
Relax the protobuf pin in `dockers/docker-sonic-mgmt/Dockerfile.j2` from `protobuf>=6.33.5,<8` to **`protobuf>=5.29.6,<6`**.

`protobuf 5.29.6` carries the **backported** fixes for both CVEs that #26695 was guarding against:

- CVE-2025-4565 — fixed in `4.25.8` / **`5.29.5`** / `6.31.1`.
- CVE-2026-0994 — fixed in **`5.29.6`** / `6.33.5`.

So security coverage from #26695 is preserved, and `snappi`'s `protobuf~=5.29.5` requirement is now satisfiable — letting pip resolve `snappi` and `snappi-ixnetwork` to a current, mutually-compatible pair.

### How to verify it
manually run build sonic-mgmt, 
```
root@c088d0d54797:/# pip show snappi protobuf snappi-ixnetwork
Name: snappi
Version: 1.53.0
Summary: The Snappi Open Traffic Generator Python Package
Home-page: 
Author: 
Author-email: Keysight Technologies <andy.balogh@keysight.com>
License-Expression: MIT
Location: /opt/venv/lib/python3.12/site-packages
Requires: grpcio, grpcio-tools, protobuf, PyYAML, requests, semantic_version, urllib3
Required-by: 
---
Name: protobuf
Version: 5.29.6
Summary: 
Home-page: https://developers.google.com/protocol-buffers/
Author: protobuf@googlegroups.com
Author-email: protobuf@googlegroups.com
License: 3-Clause BSD License
Location: /opt/venv/lib/python3.12/site-packages
Requires: 
Required-by: googleapis-common-protos, grpcio-tools, opentelemetry-proto, snappi
---
Name: snappi_ixnetwork
Version: 1.53.2
Summary: The Snappi IxNetwork Open Traffic Generator Python Package
Home-page: 
Author: 
Author-email: Keysight Technologies <andy.balogh@keysight.com>
License-Expression: MIT
Location: /opt/venv/lib/python3.12/site-packages
Requires: allure-pytest, black, build, dpkt, flake8, ipaddr, ipaddress, ixnetwork-restpy, netaddr, pytest-cov
Required-by: 
root@c088d0d54797:/# 
```

### Description for the changelog
[docker-sonic-mgmt] Relax `protobuf` pin to `>=5.29.6,<6` so pip stops backtracking `snappi` to the ancient `1.28.1` (which then mismatches `snappi-ixnetwork` and produces `'Api' object has no attribute 'config_delete'`). `protobuf 5.29.6` retains the CVE-2025-4565 and CVE-2026-0994 fixes from #26695.

### A picture of a cute animal (not mandatory but encouraged)
🐢