### PR TITLE
[rc.local] Skip pending_config_initialization on multi-ASIC platforms

### DIFF
--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -297,7 +297,19 @@ if [ -f $FIRST_BOOT_FILE ]; then
         [ -f /host/migration/golden_config_db.json ] && mv /host/migration/golden_config_db.json /etc/sonic/old_config/
         touch /etc/sonic/pending_config_migration
     else
-        touch /etc/sonic/pending_config_initialization
+        # config-setup boot_config() skips do_config_initialization on
+        # multi-ASIC platforms, so creating pending_config_initialization
+        # there leaves CONFIG_DB_INITIALIZED stuck at 0 and blocks
+        # swss@N forever. Source asic.conf to learn NUM_ASIC; if it is
+        # missing or unparseable the original behavior is preserved.
+        NUM_ASIC=
+        ASIC_CONF=/usr/share/sonic/device/$platform/asic.conf
+        [ -f "$ASIC_CONF" ] && . "$ASIC_CONF"
+        if [ "$NUM_ASIC" -gt 1 ] 2>/dev/null; then
+            echo "Multi-ASIC platform detected (NUM_ASIC=$NUM_ASIC), skip creating pending_config_initialization flag file"
+        else
+            touch /etc/sonic/pending_config_initialization
+        fi
     fi
 
     # Notify firstboot to Platform, to use it for reboot-cause


### PR DESCRIPTION
This change fixes a permanent boot deadlock on multi-ASIC SONiC master images, where `swss@N` fails `start-pre` and is parked by systemd `StartLimitBurst` for ~12+ minutes per window, indefinitely across reboots.

Skip touching `/etc/sonic/pending_config_initialization` in `rc.local`'s first-boot `else` branch **only** when `asic.conf` confirms multi-ASIC (`NUM_ASIC > 1`); fall back to the original behavior in every other case so single-ASIC boot is byte-for-byte unchanged.

Tracked in #27131. Validates against sonic-net/sonic-mgmt#24234.

#### Why I did it

##### The deadlock chain (4 layers)

1. **`rc.local` first-boot `else` branch (this fix)** — when none of `/host/old_config`, `/host/minigraph.xml`, or `/host/migration/minigraph.xml` exists, `rc.local` blindly creates `/etc/sonic/pending_config_initialization`. **No `NUM_ASIC` guard.**
2. **`docker_image_ctl.j2` `postStartAction()`** (lines 296–340) — when the database container starts, if `pending_config_initialization` exists, it sets `CONFIG_DB_INITIALIZED=0` per namespace and stops there (path A). Without the file it falls through to `SET=0 → migrate → SET=1` (path B).
3. **`config-setup boot_config()`** evaluates branches in this order:
   1. `pending_config_migration` handler (no `NUM_ASIC` guard, so multi-ASIC with a minigraph or old_config recovers fine — paths 1/2/3)
   2. warm-boot branch — sets `CONFIG_DB_INITIALIZED=1` per namespace
   3. **`NUM_ASIC > 1` early-return**, with the comment _"For multi-npu platform we don't support config initialization. Assumption is there should be existing minigraph or config_db from previous image."_
   4. `pending_config_initialization` handler — **never reached on multi-ASIC**
4. **`swss@N.service` startup** — `swss.sh wait_for_database_service` polls `until CONFIG_DB_INITIALIZED == 1`, hits the unit's 90 s `TimeoutStartSec`, fails. Three failures within `StartLimitIntervalSec=1200s` exhaust `StartLimitBurst=3` and the service is parked.

##### Why this only started failing recently

Commit [`9a624176`](https://github.com/sonic-net/sonic-buildimage/commit/9a62417626b4d5a2e5d3137045f255b40cff6c54) ("Move the pending_config files from /tmp/ to /etc/sonic/", PR #25215, 2026-03-31, master only) moved both pending files from a tmpfs (`/tmp/`) to a persistent disk path (`/etc/sonic/`).

Before `9a624176`, the deadlock self-healed:
- First boot: `rc.local` creates `/tmp/pending_config_initialization` → `swss@N` fails → operator runs `config load_minigraph` (which sets `CONFIG_DB_INITIALIZED=1`) → device works.
- First reboot: `/tmp` is wiped → `rc.local` sees no firsttime flag → no pending file created → `database@N` postStartAction goes path B and sets `CONFIG_DB_INITIALIZED=1` → healthy on every subsequent boot.

After `9a624176`, the file persists in `/etc/sonic/`, so every reboot re-deadlocks even though provisioning was completed.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

```diff
     elif [ -n "$migration" ] && [ -f /host/migration/minigraph.xml ];  then
         ...
         touch /etc/sonic/pending_config_migration
     else
-        touch /etc/sonic/pending_config_initialization
+        # config-setup boot_config() skips do_config_initialization on
+        # multi-ASIC platforms, so creating pending_config_initialization
+        # there leaves CONFIG_DB_INITIALIZED stuck at 0 and blocks
+        # swss@N forever. Source asic.conf to learn NUM_ASIC; if it is
+        # missing or unparseable the original behavior is preserved.
+        NUM_ASIC=
+        ASIC_CONF=/usr/share/sonic/device/$platform/asic.conf
+        [ -f "$ASIC_CONF" ] && . "$ASIC_CONF"
+        if [ "$NUM_ASIC" -gt 1 ] 2>/dev/null; then
+            echo "Multi-ASIC platform detected (NUM_ASIC=$NUM_ASIC), skip creating pending_config_initialization flag file"
+        else
+            touch /etc/sonic/pending_config_initialization
+        fi
     fi
```

##### Behavior matrix for the `NUM_ASIC` guard

| `NUM_ASIC` value | Action | Rationale |
|---|---|---|
| (unset / `asic.conf` missing) | `touch` | fallback — preserves original behavior |
| `1` | `touch` | confirmed single-ASIC — preserves original |
| `0`, `-1`, `2.0`, `abc`, `"1 2"`, ... | `touch` | non-pure-integer → `[ -gt ]` returns `2` to stderr → fallback |
| `2`, `4`, `8`, `16`, ... | **skip** | confirmed multi-ASIC — the only case that changes |

`2>/dev/null` suppresses the `[ -gt ]` "Illegal number" stderr noise on the non-numeric arm; the failed test still correctly drops into the `else` (touch).

##### Single-ASIC and other multi-ASIC paths are unchanged

| Boot path | Single-ASIC | Multi-ASIC |
|---|---|---|
| 1. `/host/old_config/` exists | `pending_config_migration`, unchanged | `pending_config_migration`, unchanged |
| 2. `/host/minigraph.xml` exists | `pending_config_migration`, unchanged | `pending_config_migration`, unchanged |
| 3. `/host/migration/minigraph.xml` exists (and `migration=true`) | `pending_config_migration`, unchanged | `pending_config_migration`, unchanged |
| 4. nothing above (factory blank) | `pending_config_initialization` (unchanged → factory default config / ZTP) | **(this PR)** no file → `database@N` postStartAction sets `CONFIG_DB_INITIALIZED=1`; redis empty until ZTP/operator provisions |

This is precisely the "no pending file" branch already covered by `docker_image_ctl.j2` postStartAction path B, and matches what `config-setup boot_config()` already declares as the design contract for multi-ASIC platforms.

#### How to verify it

##### Reproduce the bug (without this fix)

On a master multi-ASIC image (e.g. `SONiC.master.1102802-c97e1ce43`) on `vms-kvm-four-asic-t1-lag`:

```sh
ls -la /etc/sonic/pending_config_initialization     # exists
for ns in '' asic0 asic1 asic2 asic3; do
    [ -z "$ns" ] && redis-cli -n 4 GET CONFIG_DB_INITIALIZED \
                 || ip netns exec $ns redis-cli -n 4 GET CONFIG_DB_INITIALIZED
done                                                 # 0 in every namespace
systemctl status swss@0 swss@1 swss@2 swss@3        # failed / parked
```

##### After this PR is applied (or simulated by `rm /etc/sonic/pending_config_initialization && reboot`)

`database@N` postStartAction goes path B → all 5 namespaces (host + asic0..3) set `CONFIG_DB_INITIALIZED=1` → `swss@N` starts cleanly.

##### sonic-mgmt regression on `vms-kvm-four-asic-t1-lag`

Test: `tests/platform_tests/counterpoll/test_counterpoll_watermark.py::test_counterpoll_queue_watermark_pg_drop`. The test calls `random.choice(["config reload", "switch reboot"])`; only the reboot path exercises this bug because `config reload` internally calls `client.set(CONFIG_DB_INITIALIZED, 1)` per namespace (masking the deadlock).

| condition | runs | result | reboot-path duration |
|---|---|---|---|
| Baseline (no fix) reboot path | 4/4 | **FAIL** — "COUNTERS_DB failed to populate after 180s", `StartLimitBurst` exhausted | 1141–1193 s each |
| Baseline (no fix) reload path | 4/4 | PASS (config reload internally SET=1) | normal |
| **This PR on DUT, forced reboot path** | **1/1** | **PASS** | **651 s** (equivalent to reload) |

##### Static checks
- `bash -n files/image_config/platform/rc.local` — passes
- `sh -n files/image_config/platform/rc.local` — passes
- Logic verified against representative `NUM_ASIC` inputs: empty, `0`, `1`, `2`, `4`, `16`, `abc`, `"1 2"`, `2.0`, `-1`. Only positive integers > 1 take the new skip path; all others fall back to the original `touch`.

#### Which release branch to backport (provide reason below if selected)

**No backport needed.** The regression was introduced by commit [`9a624176`](https://github.com/sonic-net/sonic-buildimage/commit/9a62417626b4d5a2e5d3137045f255b40cff6c54) (PR #25215, 2026-03-31), which is master-only and has not been backported to any release branch. Therefore 202305 / 202311 / 202405 / 202411 / 202505 / 202511 do not contain the bug being fixed.

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [x] master — `SONiC.master.1102802-c97e1ce43` on `vms-kvm-four-asic-t1-lag` (`x86_64-kvm_x86_64_4_asic-r0` / `msft_four_asic_vs`)

#### Description for the changelog

[rc.local] Skip touching `pending_config_initialization` on multi-ASIC platforms (NUM_ASIC>1) to fix `swss@N` `start-pre` deadlock on first boot after PR #25215 made the flag persistent. Single-ASIC behavior is unchanged. Fixes #27131.

#### Link to config_db schema for YANG module changes

N/A — no schema change.

#### A picture of a cute animal (not mandatory but encouraged)

🐹
