### PR TITLE
Enable P4RT Docker build by default.

### DIFF
--- a/rules/config
+++ b/rules/config
@@ -206,7 +206,7 @@ INCLUDE_DHCP_RELAY = y
 INCLUDE_DHCP_SERVER ?= n
 
 # INCLUDE_P4RT - build docker-p4rt for P4RT support
-INCLUDE_P4RT = n
+INCLUDE_P4RT = y
 
 # INCLUDE_PTF - build docker-ptf and docker-ptf-sai test containers.
 # These are only needed for PTF (Packet Test Framework) testing and are

--- a/src/sonic-p4rt/Makefile
+++ b/src/sonic-p4rt/Makefile
@@ -40,6 +40,12 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 		cd $(CURDIR)/sonic-pins && bazel $(BAZEL_OPTS) shutdown
 	}
 	trap cleanup EXIT
+
+	mkdir -p /sonic/src/sonic-swss-common/common
+	if [ -f /usr/include/swss/cfg_schema.h ]; then
+		cp /usr/include/swss/cfg_schema.h /sonic/src/sonic-swss-common/common/cfg_schema.h
+	fi
+
 	pushd ./sonic-pins
 	bazel $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) $(BAZEL_BUILD_TARGETS)
 	bazel $(BAZEL_OPTS) test $(BAZEL_BUILD_OPTS) //$(BAZEL_TARGET_PATH)/...


### PR DESCRIPTION

#### Why I did it
Currently, the P4RT Docker build is disabled by default, requiring manual configuration overrides. This change enables the P4RT Docker build by default to streamline the build process and ensure the P4RT component is consistently included across standard platforms.

#### How I did it
enabled the build flag from config to build the p4rt docker by default.
Updated rules/config to set the build flag INCLUDE_P4RT = y

#### How to verify it
Verified with the P4rt docker is getting built by default.
