### PR TITLE
Add feature flag in CONFIG_DB to decide whether TSA on supervisor updates the chassis-app-db or calls rexec to linecards

### DIFF
--- a/dockers/docker-fpm-frr/base_image_files/TSA
+++ b/dockers/docker-fpm-frr/base_image_files/TSA
@@ -36,15 +36,10 @@ if [ -f /etc/sonic/chassisdb.conf ] && [ "$SMARTSWITCH" = false ] && [[ $disaggr
   or config reload on all linecards"
     exit 0
   else
-    if [[ $current_tsa_state  == true ]]; then
-      echo "Chassis is already in Maintenance"
-      logger -t TSA -p user.info "Chassis is already in Maintenance"
-    else
-      sonic-cfggen -a "$CONFIG_DB_TSA_STATE_UPDATE" -w
-      echo "Chassis Mode: Normal -> Maintenance"
-      logger -t TSA -p user.info "Chassis Mode: Normal -> Maintenance"
-      rexec all -c "sudo TSA chassis" || logger -t TSA -p user.warning "rexec TSA to linecards failed (exit $?)"
-    fi
+    sonic-cfggen -a "$CONFIG_DB_TSA_STATE_UPDATE" -w
+    echo "Chassis Mode: Normal -> Maintenance"
+    logger -t TSA -p user.info "Chassis Mode: Normal -> Maintenance"
+    rexec all -c "sudo TSA chassis" || logger -t TSA -p user.warning "rexec TSA to linecards failed (exit $?)"
     echo "Please execute \"rexec all -c 'sudo config save -y'\" to preserve System mode in Maintenance after reboot\
   or config reload on all linecards"
     exit 0

--- a/dockers/docker-fpm-frr/base_image_files/TSA
+++ b/dockers/docker-fpm-frr/base_image_files/TSA
@@ -16,21 +16,39 @@ if [ -f $PLATFORM_ENV_CONF_FILE ]; then
 fi
 
 if [ -f /etc/sonic/chassisdb.conf ] && [ "$SMARTSWITCH" = false ] && [[ $disaggregated_chassis -ne 1 ]]; then
-  CHASSIS_TSA_STATE_UPDATE="CHASSIS_APP_DB HMSET "BGP_DEVICE_GLOBAL\|STATE" tsa_enabled "true""
+  chassis_tsa_supported="$(sonic-cfggen -d -v BGP_DEVICE_GLOBAL.STATE.chassis_tsa_supported 2>/dev/null || false)"
+
   CONFIG_DB_TSA_STATE_UPDATE='{"BGP_DEVICE_GLOBAL":{"STATE":{"tsa_enabled": "true"}}}'
   current_tsa_state="$(sonic-cfggen -d -v BGP_DEVICE_GLOBAL.STATE.tsa_enabled)"
-  if [[ $current_tsa_state  == true ]]; then
-    echo "Chassis is already in Maintenance"
-    logger -t TSA -p user.info "Chassis is already in Maintenance"
-  else
-    sonic-db-cli $CHASSIS_TSA_STATE_UPDATE
-    sonic-cfggen -a "$CONFIG_DB_TSA_STATE_UPDATE" -w
-    echo "Chassis Mode: Normal -> Maintenance"
-    logger -t TSA -p user.info "Chassis Mode: Normal -> Maintenance"
-  fi
-  echo "Please execute 'sudo config save' to preserve System mode in Maintenance after reboot\
+
+  if [[ "$chassis_tsa_supported" == "true" ]]; then
+    CHASSIS_TSA_STATE_UPDATE="CHASSIS_APP_DB HMSET "BGP_DEVICE_GLOBAL\|STATE" tsa_enabled "true""
+    if [[ $current_tsa_state  == true ]]; then
+      echo "Chassis is already in Maintenance"
+      logger -t TSA -p user.info "Chassis is already in Maintenance"
+    else
+      sonic-db-cli $CHASSIS_TSA_STATE_UPDATE
+      sonic-cfggen -a "$CONFIG_DB_TSA_STATE_UPDATE" -w
+      echo "Chassis Mode: Normal -> Maintenance"
+      logger -t TSA -p user.info "Chassis Mode: Normal -> Maintenance"
+    fi
+    echo "Please execute 'sudo config save' to preserve System mode in Maintenance after reboot\
   or config reload on all linecards"
-  exit 0
+    exit 0
+  else
+    if [[ $current_tsa_state  == true ]]; then
+      echo "Chassis is already in Maintenance"
+      logger -t TSA -p user.info "Chassis is already in Maintenance"
+    else
+      sonic-cfggen -a "$CONFIG_DB_TSA_STATE_UPDATE" -w
+      echo "Chassis Mode: Normal -> Maintenance"
+      logger -t TSA -p user.info "Chassis Mode: Normal -> Maintenance"
+      rexec all -c "sudo TSA chassis" || logger -t TSA -p user.warning "rexec TSA to linecards failed (exit $?)"
+    fi
+    echo "Please execute \"rexec all -c 'sudo config save -y'\" to preserve System mode in Maintenance after reboot\
+  or config reload on all linecards"
+    exit 0
+  fi
 fi
 # toggle the mux to standby if dualtor and any mux active
 if
@@ -56,9 +74,11 @@ if [ -z "$STARTED_BY_TSA_TSB_SERVICE" ]; then
 fi
 
 /usr/bin/TS TSA
-echo "Please execute 'sudo config save' to preserve System mode in Maintenance after reboot or config reload"
+if [[ "$1" != "chassis" ]] ; then
+   echo "Please execute 'sudo config save' to preserve System mode in Maintenance after reboot or config reload"
 
-subtype=`sonic-db-cli CONFIG_DB hget 'DEVICE_METADATA|localhost' 'subtype'`
-if [[ $subtype == *"UpstreamLC"* || $subtype == *"DownstreamLC"* ]] ; then
-  echo -e "\nWARNING: Please execute 'TSA' on Supervisor or on all other linecards of the chassis to fully isolate the chassis"
+   subtype=`sonic-db-cli CONFIG_DB hget 'DEVICE_METADATA|localhost' 'subtype'`
+   if [[ $subtype == *"UpstreamLC"* || $subtype == *"DownstreamLC"* ]] ; then
+      echo -e "\nWARNING: Please execute 'TSA' on Supervisor or on all other linecards of the chassis to fully isolate the chassis"
+   fi
 fi

--- a/dockers/docker-fpm-frr/base_image_files/TSB
+++ b/dockers/docker-fpm-frr/base_image_files/TSB
@@ -36,15 +36,10 @@ if [ -f /etc/sonic/chassisdb.conf ] && [ "$SMARTSWITCH" = false ] && [[ $disaggr
   or config reload on all linecards"
     exit 0
   else
-    if [[ $current_tsa_state  == false ]]; then
-      echo "Chassis is already in Normal mode"
-      logger -t TSB -p user.info "Chassis is already in Normal mode"
-    else
-      sonic-cfggen -a "$CONFIG_DB_TSA_STATE_UPDATE" -w
-      echo "Chassis Mode: Maintenance -> Normal"
-      logger -t TSB -p user.info "Chassis Mode: Maintenance -> Normal"
-      rexec all -c "sudo TSB chassis" || logger -t TSB -p user.warning "rexec TSB to linecards failed (exit $?)"
-    fi
+    sonic-cfggen -a "$CONFIG_DB_TSA_STATE_UPDATE" -w
+    echo "Chassis Mode: Maintenance -> Normal"
+    logger -t TSB -p user.info "Chassis Mode: Maintenance -> Normal"
+    rexec all -c "sudo TSB chassis" || logger -t TSB -p user.warning "rexec TSB to linecards failed (exit $?)"
     echo "Please execute \"rexec all -c 'sudo config save -y'\" to preserve System mode in Normal state after reboot\
   or config reload on all linecards"
     exit 0

--- a/dockers/docker-fpm-frr/base_image_files/TSB
+++ b/dockers/docker-fpm-frr/base_image_files/TSB
@@ -16,21 +16,39 @@ if [ -f $PLATFORM_ENV_CONF_FILE ]; then
 fi
 
 if [ -f /etc/sonic/chassisdb.conf ] && [ "$SMARTSWITCH" = false ] && [[ $disaggregated_chassis -ne 1 ]]; then
-  CHASSIS_TSA_STATE_UPDATE="CHASSIS_APP_DB HMSET "BGP_DEVICE_GLOBAL\|STATE" tsa_enabled "false""
+  chassis_tsa_supported="$(sonic-cfggen -d -v BGP_DEVICE_GLOBAL.STATE.chassis_tsa_supported 2>/dev/null || false)"
+
   CONFIG_DB_TSA_STATE_UPDATE='{"BGP_DEVICE_GLOBAL":{"STATE":{"tsa_enabled": "false"}}}'
   current_tsa_state="$(sonic-cfggen -d -v BGP_DEVICE_GLOBAL.STATE.tsa_enabled)"
-  if [[ $current_tsa_state  == false ]]; then
-    echo "Chassis is already in Normal mode"
-    logger -t TSB -p user.info "Chassis is already in Normal mode"
-  else
-    sonic-db-cli $CHASSIS_TSA_STATE_UPDATE
-    sonic-cfggen -a "$CONFIG_DB_TSA_STATE_UPDATE" -w
-    echo "Chassis Mode: Maintenance -> Normal"
-    logger -t TSB -p user.info "Chassis Mode: Maintenance -> Normal"
-  fi
-  echo "Please execute 'sudo config save' to preserve System mode in Normal state after reboot\
+
+  if [[ "$chassis_tsa_supported" == "true" ]]; then
+    CHASSIS_TSA_STATE_UPDATE="CHASSIS_APP_DB HMSET "BGP_DEVICE_GLOBAL\|STATE" tsa_enabled "false""
+    if [[ $current_tsa_state  == false ]]; then
+      echo "Chassis is already in Normal mode"
+      logger -t TSB -p user.info "Chassis is already in Normal mode"
+    else
+      sonic-db-cli $CHASSIS_TSA_STATE_UPDATE
+      sonic-cfggen -a "$CONFIG_DB_TSA_STATE_UPDATE" -w
+      echo "Chassis Mode: Maintenance -> Normal"
+      logger -t TSB -p user.info "Chassis Mode: Maintenance -> Normal"
+    fi
+    echo "Please execute 'sudo config save' to preserve System mode in Normal state after reboot\
   or config reload on all linecards"
-  exit 0
+    exit 0
+  else
+    if [[ $current_tsa_state  == false ]]; then
+      echo "Chassis is already in Normal mode"
+      logger -t TSB -p user.info "Chassis is already in Normal mode"
+    else
+      sonic-cfggen -a "$CONFIG_DB_TSA_STATE_UPDATE" -w
+      echo "Chassis Mode: Maintenance -> Normal"
+      logger -t TSB -p user.info "Chassis Mode: Maintenance -> Normal"
+      rexec all -c "sudo TSB chassis" || logger -t TSB -p user.warning "rexec TSB to linecards failed (exit $?)"
+    fi
+    echo "Please execute \"rexec all -c 'sudo config save -y'\" to preserve System mode in Normal state after reboot\
+  or config reload on all linecards"
+    exit 0
+  fi
 fi
 
 # toggle the mux to auto if dualtor
@@ -55,4 +73,6 @@ if [ -z "$STARTED_BY_TSA_TSB_SERVICE" ]; then
 fi
 
 /usr/bin/TS TSB
-echo "Please execute 'sudo config save' to preserve System mode in Normal state after reboot or config reload"
+if [[ "$1" != "chassis" ]] ; then
+   echo "Please execute 'sudo config save' to preserve System mode in Normal state after reboot or config reload"
+fi

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -337,14 +337,17 @@ function postStartAction()
             fi
         fi
 
-        # In SUP, enforce CHASSIS_APP_DB.tsa_enabled to be in sync with BGP_DEVICE_GLOBAL.STATE.tsa_enabled
+        # In SUP, enforce CHASSIS_APP_DB.tsa_enabled to be in sync with BGP_DEVICE_GLOBAL.STATE.tsa_enabled when chassis TSA uses CHASSIS_APP_DB
         if [[ -z "$DEV" ]] && [[ -f /etc/sonic/chassisdb.conf ]] && [[ $disaggregated_chassis -ne 1 ]]; then
-           tsa_cfg="$($SONIC_DB_CLI CONFIG_DB HGET "BGP_DEVICE_GLOBAL|STATE" "tsa_enabled")"
-           if [[ -n "$tsa_cfg" ]]; then
-              docker exec -i ${DOCKERNAME} $SONIC_DB_CLI CHASSIS_APP_DB HMSET "BGP_DEVICE_GLOBAL|STATE" tsa_enabled ${tsa_cfg}
-              OP_CODE=$?
-              if [ $OP_CODE -ne 0 ]; then
-                echo "Err: Cmd failed (exit code $OP_CODE). CHASSIS_APP_DB and CONFIG_DB may be incosistent wrt tsa_enabled"
+           chassis_tsa_supported_cfg="$($SONIC_DB_CLI CONFIG_DB HGET "BGP_DEVICE_GLOBAL|STATE" "chassis_tsa_supported")"
+           if [[ "$chassis_tsa_supported_cfg" == "true" ]]; then
+              tsa_cfg="$($SONIC_DB_CLI CONFIG_DB HGET "BGP_DEVICE_GLOBAL|STATE" "tsa_enabled")"
+              if [[ -n "$tsa_cfg" ]]; then
+                 docker exec -i ${DOCKERNAME} $SONIC_DB_CLI CHASSIS_APP_DB HMSET "BGP_DEVICE_GLOBAL|STATE" tsa_enabled ${tsa_cfg}
+                 OP_CODE=$?
+                 if [ $OP_CODE -ne 0 ]; then
+                   echo "Err: Cmd failed (exit code $OP_CODE). CHASSIS_APP_DB and CONFIG_DB may be incosistent wrt tsa_enabled"
+                 fi
               fi
            fi
         fi

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -74,10 +74,8 @@
     "BGP_DEVICE_GLOBAL": {
         "STATE": {
             "tsa_enabled": "false",
-            "chassis_tsa_supported": "false",
             "wcmp_enabled": "false",
             "idf_isolation_state": "unisolated"
-
         }
     },
 {%- set features = [("bgp", "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}disabled{% else %}enabled{% endif %}", false, "enabled"),

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -74,8 +74,10 @@
     "BGP_DEVICE_GLOBAL": {
         "STATE": {
             "tsa_enabled": "false",
+            "chassis_tsa_supported": "false",
             "wcmp_enabled": "false",
             "idf_isolation_state": "unisolated"
+
         }
     },
 {%- set features = [("bgp", "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}disabled{% else %}enabled{% endif %}", false, "enabled"),

--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -369,16 +369,19 @@ do_db_migration()
     fi
     sonic-db-cli CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"
 
-    #Enforce CHASSIS_APP_DB.tsa_enabled to be in sync with BGP_DEVICE_GLOBAL.STATE.tsa_enabled
+    # Enforce CHASSIS_APP_DB.tsa_enabled to be in sync with BGP_DEVICE_GLOBAL.STATE.tsa_enabled when chassis TSA uses CHASSIS_APP_DB
     if [[ -f /etc/sonic/chassisdb.conf ]] && [[ $disaggregated_chassis -ne 1 ]]; then
-       tsa_cfg="$(sonic-db-cli CONFIG_DB HGET "BGP_DEVICE_GLOBAL|STATE" "tsa_enabled")"
-       sonic-db-cli CHASSIS_APP_DB HMSET "BGP_DEVICE_GLOBAL|STATE" tsa_enabled ${tsa_cfg}
-       OP_CODE=$?
+       chassis_tsa_supported_cfg="$(sonic-db-cli CONFIG_DB HGET "BGP_DEVICE_GLOBAL|STATE" "chassis_tsa_supported")"
+       if [[ "$chassis_tsa_supported_cfg" == "true" ]]; then
+           tsa_cfg="$(sonic-db-cli CONFIG_DB HGET "BGP_DEVICE_GLOBAL|STATE" "tsa_enabled")"
+           sonic-db-cli CHASSIS_APP_DB HMSET "BGP_DEVICE_GLOBAL|STATE" tsa_enabled ${tsa_cfg}
+           OP_CODE=$?
 
-       if [ $OP_CODE -ne 0 ]; then
-         err_msg="Cmd failed (exit code $OP_CODE). CHASSIS_APP_DB and CONFIG_DB may be incosistent wrt tsa_enabled."
-         echo "$err_msg"
-         logger -t CHASSIS_APP_DB -p user.info "$err_msg"
+           if [ $OP_CODE -ne 0 ]; then
+             err_msg="Cmd failed (exit code $OP_CODE). CHASSIS_APP_DB and CONFIG_DB may be incosistent wrt tsa_enabled."
+             echo "$err_msg"
+             logger -t CHASSIS_APP_DB -p user.info "$err_msg"
+           fi
        fi
     fi
 }

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_device_global.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_device_global.py
@@ -244,7 +244,11 @@ class DeviceGlobalCfgMgr(Manager):
         try:
             ch = swsscommon.SonicV2Connector(use_unix_socket_path=False)
             ch.connect(ch.CHASSIS_APP_DB, False)
-            chassis_tsa_status = ch.get(ch.CHASSIS_APP_DB, "BGP_DEVICE_GLOBAL|STATE", 'tsa_enabled')
+            chassis_tsa = ch.get(ch.CHASSIS_APP_DB, "BGP_DEVICE_GLOBAL|STATE", 'tsa_enabled')
+            # chassis_Tsa is None when the chassis_tsa_supported is false in SUP
+            if chassis_tsa is not None:
+               chassis_tsa_status = chassis_tsa
+
         except Exception as e:
             log_err("Got an exception {}".format(e))
 

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -463,8 +463,8 @@ ASIC/SDK health event related configuration is defined in **SUPPRESS_ASIC_SDK_HE
 
 ### BGP Device Global
 
-The **BGP_DEVICE_GLOBAL** table contains device-level BGP global state.
-It has a STATE object containing device state like **tsa_enabled**, **wcmp_enabled** and **idf_isolation_state**.
+The **BGP_DEVICE_GLOBAL** table contains device-level BGP global state.  
+It has a **STATE** object containing device state such as **tsa_enabled**, **chassis_tsa_supported**, **wcmp_enabled**, and **idf_isolation_state**.
 
 When **tsa_enabled** is set to true, the device is isolated using traffic-shift-away (TSA) route-maps in BGP.
 
@@ -477,7 +477,23 @@ When **tsa_enabled** is set to true, the device is isolated using traffic-shift-
 }
 ```
 
-When **wcmp_enabled** is set to true, the device is configured to use BGP Link Bandwidth Extended Community.
+**chassis_tsa_supported** selects how chassis-wide Traffic-Shift-Away is coordinated on chassis systems:
+
+- When **true**, the supervisor uses **CHASSIS_APP_DB** to publish **`tsa_enabled`** to line cards.
+- When **false**, that **CHASSIS_APP_DB** synchronization is not used; TSA/TSB is applied on each line card (for example via **rexec** on the supervisor).
+
+YANG defines a default for this leaf; for the exact value, see **sonic-bgp-device-global** (`BGP_DEVICE_GLOBAL/STATE/chassis_tsa_supported`).
+
+```json
+{
+"BGP_DEVICE_GLOBAL": {
+    "STATE": {
+        "chassis_tsa_supported": "false"
+    }
+}
+```
+
+When **wcmp_enabled** is set to true, the device is configured to use BGP Link Bandwidth Extended Community.  
 Weighted ECMP load balances traffic between the equal cost paths in proportion to the capacity of the local links.
 
 ```json

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1890,6 +1890,7 @@
         "BGP_DEVICE_GLOBAL": {
             "STATE": {
                 "tsa_enabled": "false",
+                "chassis_tsa_supported": "false",
                 "wcmp_enabled": "false",
                 "idf_isolation_state": "unisolated"
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
@@ -81,5 +81,22 @@
         "desc": "Load bgp device global table with confederation invalid asn",
         "eStrKey": "InvalidValue",
         "eStr": ["asn"]
+    },
+    "BGP_DEVICE_GLOBAL_WITH_CHASSIS_TSA_SUPPORTED_DEFAULT_VALUE": {
+        "desc": "Verify default value for chassis_tsa_supported in BGP_DEVICE_GLOBAL.",
+        "eStrKey": "Verify",
+        "verify": {
+            "xpath": "/sonic-bgp-device-global:sonic-bgp-device-global/BGP_DEVICE_GLOBAL/STATE/chassis_tsa_supported",
+            "key": "sonic-bgp-device-global:chassis_tsa_supported",
+            "value": false
+        }
+    },
+    "BGP_DEVICE_GLOBAL_WITH_CHASSIS_TSA_SUPPORTED_TRUE": {
+        "desc": "Verify chassis_tsa_supported can be set to true."
+    },
+    "BGP_DEVICE_GLOBAL_WITH_CHASSIS_TSA_SUPPORTED_INVALID_VALUE": {
+        "desc": "Configure invalid chassis_tsa_supported in BGP_DEVICE_GLOBAL.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["chassis_tsa_supported"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_device_global.json
@@ -132,5 +132,31 @@
                 }
             }
         }
+    },
+    "BGP_DEVICE_GLOBAL_WITH_CHASSIS_TSA_SUPPORTED_DEFAULT_VALUE": {
+        "sonic-bgp-device-global:sonic-bgp-device-global": {
+            "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
+                "STATE":{
+                }
+            }
+        }
+    },
+    "BGP_DEVICE_GLOBAL_WITH_CHASSIS_TSA_SUPPORTED_TRUE": {
+        "sonic-bgp-device-global:sonic-bgp-device-global": {
+            "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
+                "STATE":{
+                    "chassis_tsa_supported": "true"
+                }
+            }
+        }
+    },
+    "BGP_DEVICE_GLOBAL_WITH_CHASSIS_TSA_SUPPORTED_INVALID_VALUE": {
+        "sonic-bgp-device-global:sonic-bgp-device-global": {
+            "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
+                "STATE":{
+                    "chassis_tsa_supported": "invalid_value"
+                }
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
@@ -12,6 +12,10 @@ module sonic-bgp-device-global {
     description
         "SONIC Device-specific BGP global data";
 
+    revision 2026-04-28 {
+        description "Add chassis_tsa_supported to select CHASSIS_APP_DB vs per-linecard TSA orchestration";
+    }
+
     revision 2024-01-28 {
         description "Add Weighted ECMP using BGP link bandwidth";
     }
@@ -35,6 +39,15 @@ module sonic-bgp-device-global {
                     default "false";
                     description
                     "When set to true, Traffic is shifted away (TSA), i.e, BGP routes are not advertised to neighboring routers";
+                }
+
+                leaf chassis_tsa_supported {
+                    type boolean;
+                    default "false";
+                    description
+                    "When true, chassis-wide TSA state is synchronized using CHASSIS_APP_DB on the supervisor.
+                     When false (default), CHASSIS_APP_DB is not used for TSA; the supervisor applies CONFIG_DB locally and
+                     should push TSA/TSB to linecards out-of-band (for example via rexec).";
                 }
 
                 leaf wcmp_enabled {

--- a/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
@@ -46,8 +46,8 @@ module sonic-bgp-device-global {
                     default "false";
                     description
                     "When true, chassis-wide TSA state is synchronized using CHASSIS_APP_DB on the supervisor.
-                     When false (default), CHASSIS_APP_DB is not used for TSA; the supervisor applies CONFIG_DB locally and
-                     should push TSA/TSB to linecards out-of-band (for example via rexec).";
+                     When false (default), CHASSIS_APP_DB is not used for TSA, the supervisor should push TSA/TSB
+                     to linecards out-of-band (for example via rexec).";
                 }
 
                 leaf wcmp_enabled {


### PR DESCRIPTION
…

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The MSFT tooling is not enhanced yet to handle the Reliable Chassis TSA feature. So this PR adds a new flag in CONFIG_DB to decide whether chassis TSA updates the'tsa_enabled'  flag in  CHASSIS_APP_DB  or sends 'sudo TSA/TSB chassis' to Line cards with rexec command.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

1. Add a feature supported flag in CONFIG_DB  with default value as 'false'.  After MSFT tooling is enhanced, the default value will be changed to 'true' as per MSFT. So this PR does not add any cli commands to configure this flag. 

BGP_DEVICE_GLOBAL": {
    "STATE": {
        "chassis_tsa_supported": "false"
    }
}
2. Updated TSA, TSB and TS scripts to use this config flag to decide whether to set chassis-app-db or invoke rexec to TSA each LC
3. Added a check for this flag in config-setup before updating chassis-app-db  "BGP_DEVICE_GLOBAL|STATE" 'tsa_enabled' flag.
4. Since "BGP_DEVICE_GLOBAL|STATE" 'tsa_enabled' flag is updated only when chassis_tsa_supported flag in CONFIG_DB is set to true, made a minor change in bgpcfgd to consider this.

#### How to verify it
Verified TSA/TSB functionality with "chassis_tsa_supported" set to false/true. (set to true by setting the flag manually in CONFIG_DB). 
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->
Master  
- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

