### PR TITLE
[7215-C1] tty order and permission fix

### DIFF
--- a/device/nokia/arm64-nokia_ixs7215_c1xa-r0/installer.conf
+++ b/device/nokia/arm64-nokia_ixs7215_c1xa-r0/installer.conf
@@ -1,1 +1,2 @@
 ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="default_hugepagesz=32M hugepages=4 loglevel=4 efi_pstore.pstore_disable=1"
+GRUB_SERIAL_COMMAND="set timeout_style=hidden"

--- a/device/nokia/arm64-nokia_ixs7215_c1xa-r0/udevprefix.conf
+++ b/device/nokia/arm64-nokia_ixs7215_c1xa-r0/udevprefix.conf
@@ -1,1 +1,1 @@
-ttyCO
+ttyCR

--- a/platform/nokia-vs/sonic-platform-nokia/7215-c1/scripts/nokia-7215-postinit.sh
+++ b/platform/nokia-vs/sonic-platform-nokia/7215-c1/scripts/nokia-7215-postinit.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Nokia 7215 post-init platform script.
+#
+# - Creates /dev/ttyCR<n+1> -> /dev/ttyCO<n> symlinks so console clients
+#   can address ports by their physical 1-based numbering.
+
+set -u
+
+# - ttyCR symlinks for ttyCO0..ttyCO47
+
+echo "[nokia-7215-postinit] waiting for /dev/ttyCO0"
+
+tty_timeout=10
+i=0
+while [ $i -lt $tty_timeout ]; do
+    if [ -e /dev/ttyCO0 ]; then
+        break
+    fi
+    sleep 1
+    i=$((i + 1))
+done
+
+if [ ! -e /dev/ttyCO0 ]; then
+    echo "[nokia-7215-postinit] timeout (${tty_timeout}s) waiting for /dev/ttyCO0; skipping ttyCR symlinks"
+    exit 0
+fi
+
+echo "[nokia-7215-postinit] creating /dev/ttyCR1..48 -> /dev/ttyCO0..47 symlinks"
+for n in $(seq 0 47); do
+    src="/dev/ttyCO${n}"
+    dst="/dev/ttyCR$((n + 1))"
+    if [ -e "$src" ]; then
+        chmod 666 "$src"
+        ln -sf "$src" "$dst"
+    fi
+done
+
+exit 0

--- a/platform/nokia-vs/sonic-platform-nokia/7215-c1/service/nokia-7215-postinit.service
+++ b/platform/nokia-vs/sonic-platform-nokia/7215-c1/service/nokia-7215-postinit.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Nokia-7215 Post-init Platform Service
+ConditionPathExists=/usr/local/bin/nokia-7215-postinit.sh
+
+After=nokia-7215init.service
+Wants=nokia-7215init.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/nokia-7215-postinit.sh
+RemainAfterExit=yes
+StandardOutput=tty
+
+[Install]
+WantedBy=multi-user.target

--- a/platform/nokia-vs/sonic-platform-nokia/7215-c1/sonic_platform/eeprom.py
+++ b/platform/nokia-vs/sonic-platform-nokia/7215-c1/sonic_platform/eeprom.py
@@ -40,13 +40,15 @@ class Eeprom(TlvInfoDecoder):
                 self.index = psu_index
                 self.part_number = '1'
                 self.model_str = 'NA'
-                self.serial_number = 'NA'               
+                self.serial_number = 'NA'
+                self.service_tag = 'NA'
 
             if self.is_fan_eeprom:
                 self.index = fan_index
                 self.part_number = '1'
                 self.model_str = 'NA'
-                self.serial_number = 'NA'                
+                self.serial_number = 'NA'
+                self.service_tag = 'NA'
 
 
     def _load_system_eeprom(self):

--- a/platform/nokia-vs/sonic-platform-nokia/debian/sonic-platform-nokia-7215-c1.install
+++ b/platform/nokia-vs/sonic-platform-nokia/debian/sonic-platform-nokia-7215-c1.install
@@ -1,5 +1,7 @@
 7215-c1/scripts/nokia-7215-init.sh usr/local/bin
+7215-c1/scripts/nokia-7215-postinit.sh usr/local/bin
 7215-c1/scripts/cpu_wdt.py  usr/local/bin
 7215-c1/service/nokia-7215init.service  etc/systemd/system
+7215-c1/service/nokia-7215-postinit.service  etc/systemd/system
 7215-c1/service/cpu_wdt.service  etc/systemd/system
 7215-c1/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/arm64-nokia_ixs7215_c1xa-r0

--- a/platform/nokia-vs/sonic-platform-nokia/debian/sonic-platform-nokia-7215-c1.postinst
+++ b/platform/nokia-vs/sonic-platform-nokia/debian/sonic-platform-nokia-7215-c1.postinst
@@ -21,6 +21,7 @@ set -e
 case "$1" in
     configure)
         chmod a+x /usr/local/bin/nokia-7215-init.sh
+        chmod a+x /usr/local/bin/nokia-7215-postinit.sh
         depmod -a
         systemctl restart kmod
         systemctl enable nokia-7215init.service
@@ -30,6 +31,8 @@ case "$1" in
         systemctl enable cpu_wdt.service
         systemctl start cpu_wdt.service
 
+        systemctl enable nokia-7215-postinit.service
+        systemctl start --no-block nokia-7215-postinit.service
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1) Fix order of TTY devices to start from 1
2) Fix permissions of tty files
3) Hide grub menu 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it




#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202603
#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

