### PR TITLE
[Fix] fix existing /tmp/pending_config_initialization to align with the global convention /etc/sonic/pending_config_initialization

### DIFF
--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -291,7 +291,7 @@ do_config_initialization()
     if [ -r ${MINGRAPH_FILE} ]; then
         echo "No config_db.json found but minigraph.xml is available, using minigraph..."
         reload_minigraph
-        rm -f /tmp/pending_config_initialization
+        rm -f /etc/sonic/pending_config_initialization
         sonic-db-cli CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"
         return 0
     fi
@@ -455,7 +455,7 @@ boot_config()
         # Mark config as initialized so subsequent boots don't re-trigger
         # initialization unnecessarily (warm-reboot to new image scenario).
         sonic-db-cli CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"
-        rm -f /tmp/pending_config_initialization
+        rm -f /etc/sonic/pending_config_initialization
         return 0
     fi
 


### PR DESCRIPTION
#### Why I did it


The marker file `pending_config_initialization` is used to track whether SONiC needs to run config initialization (e.g., apply minigraph or YANG default) on the next boot.

After https://github.com/sonic-net/sonic-buildimage/pull/25215, the original file `/tmp/pending_config_initialization` is renamed to '/etc/sonic/pending_config_initialization'

Most of the `/tmp/pending_config_initialization` has been updated #25215 , raising this PR to update the 2 remaining ones, the two remaining ones are noticed by me during the investigation of issue https://github.com/sonic-net/sonic-buildimage/issues/27131 , but not functional related.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

In `files/image_config/config-setup/config-setup`, replaced the two stale `/tmp/...` paths with the conventional `/etc/sonic/...` path:

```diff
 do_config_initialization()
     ...
-    rm -f /tmp/pending_config_initialization
+    rm -f /etc/sonic/pending_config_initialization
     sonic-db-cli CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"
     return 0

 boot_config()
     ...
     sonic-db-cli CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"
-    rm -f /tmp/pending_config_initialization
+    rm -f /etc/sonic/pending_config_initialization
     return 0
```

No other changes — purely a path correction to match the producer (`rc.local`) and the consumer (`docker_image_ctl.j2`).

#### How to verify it

Simple change, to be covered in the PR testing

#### Which release branch to backport (provide reason below if selected)

<!-- This is a low-risk path correction; backport candidates can be selected by reviewers if the same bug is observed on a release branch. -->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

- [ ]
- [ ]

#### Description for the changelog

config-setup: clean up `pending_config_initialization` from `/etc/sonic/` (the convention used by `rc.local` and `docker_image_ctl.j2`) instead of the stale `/tmp/` path.

#### Link to config_db schema for YANG module changes

N/A — no YANG / config_db schema changes.

#### A picture of a cute animal (not mandatory but encouraged)