### PR TITLE
Use exact label filter for K8s container discovery in k8s_pod_control.sh

### DIFF
--- a/files/scripts/k8s_pod_control.sh
+++ b/files/scripts/k8s_pod_control.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Shared Kubernetes pod control script for SONiC sidecar services
-# 1. Discovers K8s-managed containers via 'docker ps' name filtering
-# 2. Uses 'docker restart' to restart the target container
-# 3. K8s container names follow the pattern k8s_<container>_<pod>_<ns>_<uid>
+# 1. Discovers K8s-managed containers via 'docker ps' label filtering
+#    (exact match on io.kubernetes.container.name + io.kubernetes.pod.namespace,
+#    which are injected by the dockershim/CRI on every K8s-managed container).
+# 2. Uses 'docker restart' to restart the target container.
 #
 # Usage: SERVICE_NAME=telemetry k8s_pod_control.sh start
 #        Or source this script after setting SERVICE_NAME
@@ -26,22 +27,28 @@ NS="sonic"
 NODE_NAME="$(hostname | tr '[:upper:]' '[:lower:]')"
 log() { /usr/bin/logger -t "k8s-podctl#system" "$*"; }
 
-# Docker filter for K8s-managed containers of this service.
-# K8s container names follow: k8s_<container>_<pod>_<ns>_<uid>
-DOCKER_FILTER="name=k8s_${SERVICE_NAME}_"
+# Docker label filters for K8s-managed containers of this service.
+# Using labels (rather than name= substring matching) gives an EXACT match on
+# the container name, so e.g. SERVICE_NAME=telemetry will not also match a
+# hypothetical 'telemetry_v2' container, and is independent of the
+# k8s_<container>_<pod>_<ns>_<uid> dockershim naming convention.
+DOCKER_FILTERS=(
+  --filter "label=io.kubernetes.container.name=${SERVICE_NAME}"
+  --filter "label=io.kubernetes.pod.namespace=${NS}"
+)
 
 container_ids_on_node() {
-  docker ps -q --filter "${DOCKER_FILTER}" 2>/dev/null || true
+  docker ps -q "${DOCKER_FILTERS[@]}" 2>/dev/null || true
 }
 
 pods_on_node() {
-  docker ps -a --filter "${DOCKER_FILTER}" \
+  docker ps -a "${DOCKER_FILTERS[@]}" \
     --format '{{index .Labels "io.kubernetes.pod.name"}} {{.State}}' \
     2>/dev/null || true
 }
 
 pod_names_on_node() {
-  docker ps -a --filter "${DOCKER_FILTER}" \
+  docker ps -a "${DOCKER_FILTERS[@]}" \
     --format '{{index .Labels "io.kubernetes.pod.name"}}' \
     2>/dev/null || true
 }

--- a/files/scripts/k8s_pod_control.sh
+++ b/files/scripts/k8s_pod_control.sh
@@ -47,12 +47,6 @@ pods_on_node() {
     2>/dev/null || true
 }
 
-pod_names_on_node() {
-  docker ps -a "${DOCKER_FILTERS[@]}" \
-    --format '{{index .Labels "io.kubernetes.pod.name"}}' \
-    2>/dev/null || true
-}
-
 restart_containers() {
   mapfile -t cids < <(container_ids_on_node)
   if (( ${#cids[@]} == 0 )); then

--- a/files/scripts/tests/test_k8s_pod_control.sh
+++ b/files/scripts/tests/test_k8s_pod_control.sh
@@ -169,23 +169,6 @@ result="$(pods_on_node)"
 assert_eq "no match returns empty" "" "$result"
 
 echo ""
-echo "=== pod_names_on_node ==="
-
-set_filters_for "telemetry"
-result="$(pod_names_on_node)"
-assert_eq "returns pod name only" \
-  "ds-leafrouter-telemetry-zgmsl" "$result"
-
-set_filters_for "multi"
-result="$(pod_names_on_node)"
-line_count=$(printf '%s\n' "$result" | grep -c .)
-assert_eq "returns multiple pod names" "2" "$line_count"
-
-set_filters_for "nonexistent"
-result="$(pod_names_on_node)"
-assert_eq "no match returns empty" "" "$result"
-
-echo ""
 echo "=== restart_containers ==="
 
 set_filters_for "telemetry"

--- a/files/scripts/tests/test_k8s_pod_control.sh
+++ b/files/scripts/tests/test_k8s_pod_control.sh
@@ -38,18 +38,33 @@ cat > "${MOCK_DIR}/docker" <<'MOCK_DOCKER'
 subcmd="$1"; shift
 case "$subcmd" in
   ps)
-    quiet=false; all=false; filter=""; format=""
+    quiet=false; all=false; format=""
+    container_name=""; pod_namespace=""
     while (( $# > 0 )); do
       case "$1" in
         -q) quiet=true; shift ;;
         -a) all=true; shift ;;
-        --filter) filter="$2"; shift 2 ;;
+        --filter)
+          case "$2" in
+            label=io.kubernetes.container.name=*)
+              container_name="${2#label=io.kubernetes.container.name=}"
+              ;;
+            label=io.kubernetes.pod.namespace=*)
+              pod_namespace="${2#label=io.kubernetes.pod.namespace=}"
+              ;;
+          esac
+          shift 2
+          ;;
         --format) format="$2"; shift 2 ;;
         *) shift ;;
       esac
     done
-    case "$filter" in
-      "name=k8s_telemetry_")
+    # Only respond when namespace is sonic (matches script's NS).
+    if [[ "$pod_namespace" != "sonic" ]]; then
+      exit 0
+    fi
+    case "$container_name" in
+      "telemetry")
         if $quiet; then
           echo "abc123def456"
         elif [[ "$format" == *".State"* ]]; then
@@ -58,7 +73,7 @@ case "$subcmd" in
           echo "ds-leafrouter-telemetry-zgmsl"
         fi
         ;;
-      "name=k8s_multi_")
+      "multi")
         if $quiet; then
           printf '%s\n' "aaa111" "bbb222"
         elif [[ "$format" == *".State"* ]]; then
@@ -67,7 +82,7 @@ case "$subcmd" in
           printf '%s\n' "pod-multi-1" "pod-multi-2"
         fi
         ;;
-      "name=k8s_nonexistent_")
+      "nonexistent")
         ;;  # no output
     esac
     ;;
@@ -104,10 +119,20 @@ export SERVICE_NAME="telemetry"
 source "$SOURCE_SCRIPT"
 
 # ── Test suite ────────────────────────────────────────────────────────
-echo "=== DOCKER_FILTER ==="
+echo "=== DOCKER_FILTERS ==="
 
-assert_eq "DOCKER_FILTER for telemetry" \
-  "name=k8s_telemetry_" "$DOCKER_FILTER"
+assert_eq "DOCKER_FILTERS contains container.name filter for telemetry" \
+  "label=io.kubernetes.container.name=telemetry" "${DOCKER_FILTERS[1]}"
+assert_eq "DOCKER_FILTERS contains pod.namespace filter" \
+  "label=io.kubernetes.pod.namespace=sonic" "${DOCKER_FILTERS[3]}"
+
+# Helper to rebuild DOCKER_FILTERS for a different SERVICE_NAME (mirrors script)
+set_filters_for() {
+  DOCKER_FILTERS=(
+    --filter "label=io.kubernetes.container.name=$1"
+    --filter "label=io.kubernetes.pod.namespace=${NS}"
+  )
+}
 
 echo ""
 echo "=== container_ids_on_node ==="
@@ -116,64 +141,64 @@ result="$(container_ids_on_node)"
 assert_eq "returns container ID for telemetry" "abc123def456" "$result"
 
 # Switch to multi-container service
-DOCKER_FILTER="name=k8s_multi_"
+set_filters_for "multi"
 result="$(container_ids_on_node)"
 line_count=$(printf '%s\n' "$result" | grep -c .)
 assert_eq "returns multiple container IDs" "2" "$line_count"
 
 # No match
-DOCKER_FILTER="name=k8s_nonexistent_"
+set_filters_for "nonexistent"
 result="$(container_ids_on_node)"
 assert_eq "no match returns empty" "" "$result"
 
 echo ""
 echo "=== pods_on_node ==="
 
-DOCKER_FILTER="name=k8s_telemetry_"
+set_filters_for "telemetry"
 result="$(pods_on_node)"
 assert_eq "returns pod name and state" \
   "ds-leafrouter-telemetry-zgmsl running" "$result"
 
-DOCKER_FILTER="name=k8s_multi_"
+set_filters_for "multi"
 result="$(pods_on_node)"
 line_count=$(printf '%s\n' "$result" | grep -c .)
 assert_eq "returns multiple pods" "2" "$line_count"
 
-DOCKER_FILTER="name=k8s_nonexistent_"
+set_filters_for "nonexistent"
 result="$(pods_on_node)"
 assert_eq "no match returns empty" "" "$result"
 
 echo ""
 echo "=== pod_names_on_node ==="
 
-DOCKER_FILTER="name=k8s_telemetry_"
+set_filters_for "telemetry"
 result="$(pod_names_on_node)"
 assert_eq "returns pod name only" \
   "ds-leafrouter-telemetry-zgmsl" "$result"
 
-DOCKER_FILTER="name=k8s_multi_"
+set_filters_for "multi"
 result="$(pod_names_on_node)"
 line_count=$(printf '%s\n' "$result" | grep -c .)
 assert_eq "returns multiple pod names" "2" "$line_count"
 
-DOCKER_FILTER="name=k8s_nonexistent_"
+set_filters_for "nonexistent"
 result="$(pod_names_on_node)"
 assert_eq "no match returns empty" "" "$result"
 
 echo ""
 echo "=== restart_containers ==="
 
-DOCKER_FILTER="name=k8s_telemetry_"
+set_filters_for "telemetry"
 SERVICE_NAME="telemetry"
 restart_containers; rc=$?
 assert_eq "restart single container succeeds" "0" "$rc"
 
-DOCKER_FILTER="name=k8s_multi_"
+set_filters_for "multi"
 SERVICE_NAME="multi"
 restart_containers; rc=$?
 assert_eq "restart multiple containers succeeds" "0" "$rc"
 
-DOCKER_FILTER="name=k8s_nonexistent_"
+set_filters_for "nonexistent"
 SERVICE_NAME="nonexistent"
 restart_containers; rc=$?
 assert_eq "restart with no containers is no-op" "0" "$rc"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The previous container-discovery filter used a Docker name-prefix filter, which is a substring/regex match, and need to depend on the k8s_<container>_<pod>_<ns>_<uid> naming convention, which is fragile.

#### How I did it
Replaced the name-prefix filter with two exact-match label filters on labels injected by the dockershim/CRI on every K8s-managed container:
DOCKER_FILTERS=(
  --filter "label=io.kubernetes.container.name=${SERVICE_NAME}"
  --filter "label=io.kubernetes.pod.namespace=${NS}"
)

#### How to verify it
Unit test and verified on DUT.
name=/k8s_telemetry_ds-backendleafrouter-telemetry-rtggd_sonic_44953106-5bc0-4935-aaee-2b6afe97eba2_0
io.kubernetes.container.name = telemetry
io.kubernetes.pod.namespace  = sonic
io.kubernetes.pod.name       = ds-backendleafrouter-telemetry-rtggd
io.kubernetes.docker.type    = container
io.kubernetes.pod.uid        = 44953106-5bc0-4935-aaee-2b6afe97eba2

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

