### PR TITLE
platform: ragile/ruijie: use yaml.SafeLoader in PCIe utility

### DIFF
--- a/platform/broadcom/sonic-platform-modules-ragile/ra-b6510-32c/sonic_pcie/pcie_common.py
+++ b/platform/broadcom/sonic-platform-modules-ragile/ra-b6510-32c/sonic_pcie/pcie_common.py
@@ -25,7 +25,7 @@ class PcieUtil(PcieBase):
         config_file = self.config_path + "/" + "pcie.yaml"
         try:
             with open(config_file) as conf_file:
-                self.confInfo = yaml.load(conf_file)
+                self.confInfo = yaml.load(conf_file, Loader=yaml.SafeLoader)
         except IOError as e:
             print("Error: {}".format(str(e)))
             print("Not found config file, please add a config file manually, or generate it by running [pcieutil pcie_generate]")

--- a/platform/broadcom/sonic-platform-modules-ragile/ra-b6910-64c/sonic_pcie/pcie_common.py
+++ b/platform/broadcom/sonic-platform-modules-ragile/ra-b6910-64c/sonic_pcie/pcie_common.py
@@ -25,7 +25,7 @@ class PcieUtil(PcieBase):
         config_file = self.config_path + "/" + "pcie.yaml"
         try:
             with open(config_file) as conf_file:
-                self.confInfo = yaml.load(conf_file)
+                self.confInfo = yaml.load(conf_file, Loader=yaml.SafeLoader)
         except IOError as e:
             print("Error: {}".format(str(e)))
             print("Not found config file, please add a config file manually, or generate it by running [pcieutil pcie_generate]")

--- a/platform/broadcom/sonic-platform-modules-ragile/ra-b6920-4s/sonic_pcie/pcie_common.py
+++ b/platform/broadcom/sonic-platform-modules-ragile/ra-b6920-4s/sonic_pcie/pcie_common.py
@@ -25,7 +25,7 @@ class PcieUtil(PcieBase):
         config_file = self.config_path + "/" + "pcie.yaml"
         try:
             with open(config_file) as conf_file:
-                self.confInfo = yaml.load(conf_file)
+                self.confInfo = yaml.load(conf_file, Loader=yaml.SafeLoader)
         except IOError as e:
             print("Error: {}".format(str(e)))
             print("Not found config file, please add a config file manually, or generate it by running [pcieutil pcie_generate]")

--- a/platform/broadcom/sonic-platform-modules-ruijie/b6510-48vs8cq/sonic_pcie/pcie_common.py
+++ b/platform/broadcom/sonic-platform-modules-ruijie/b6510-48vs8cq/sonic_pcie/pcie_common.py
@@ -25,7 +25,7 @@ class PcieUtil(PcieBase):
         config_file = self.config_path + "/" + "pcie.yaml"
         try:
             with open(config_file) as conf_file:
-                self.confInfo = yaml.load(conf_file)
+                self.confInfo = yaml.load(conf_file, Loader=yaml.SafeLoader)
         except IOError as e:
             print("Error: {}".format(str(e)))
             print("Not found config file, please add a config file manually, or generate it by running [pcieutil pcie_generate]")


### PR DESCRIPTION
#### Why I did it

##### Work item tracking
- Microsoft ADO:

`yaml.load()` without a `Loader` argument uses an unsafe default that can instantiate arbitrary Python objects from YAML tags. Passing `Loader=yaml.SafeLoader` restricts parsing to safe scalar types.

#### How I did it

Added `Loader=yaml.SafeLoader` to `yaml.load()` calls in `pcie_common.py` across four affected platform variants:
- `sonic-platform-modules-ragile/ra-b6510-32c`
- `sonic-platform-modules-ragile/ra-b6910-64c`
- `sonic-platform-modules-ragile/ra-b6920-4s`
- `sonic-platform-modules-ruijie/b6510-48vs8cq`

#### How to verify it

No unit tests exist for this PCIe module in sonic-buildimage. The change is a one-line addition of `Loader=yaml.SafeLoader` to each `yaml.load()` call; existing PCIe check/generation functionality is unaffected as `SafeLoader` handles all standard YAML scalar types used in `pcie.yaml`.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] 

#### Description for the changelog

Use yaml.SafeLoader in Ragile/Ruijie platform PCIe utilities to avoid unsafe YAML deserialization.

#### Link to config_db schema for YANG module changes

N/A