### PR TITLE
Use ptf 0.10.0 for docker-sonic-mgmt

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -103,7 +103,7 @@ RUN pip install --no-cache-dir --upgrade pip \
     prettytable \
     "protobuf>=6.33.5,<8" \
     psutil \
-    ptf \
+    ptf==0.10.0 \
     pyasn1 \
     pycryptodome \
     pyfiglet \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
We saw Ansible error "A worker was found in a dead state" on multiple test cases after ptf 0.12.0 release
Fixes #27183 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Use the fixed 0.10.0 ptf version in docker-sonic-mgmt

#### How to verify it
Verify it on acl/test_stress_acl.py

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)
202511

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
PTF 0.12.0 was released on 2026/05/02 and caused regression in multiple tests with failure:
A worker was found in a dead state
Fix it by using the last ptf version 0.10.0 in docker-sonic-mgmt
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

