### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202511.1.0.7
+ref=202511.1.0.8


### PR DESCRIPTION
### Description of PR

Summary:
Cherry-pick of sonic-net/sonic-buildimage#27155 to master. Bumps the `platform-cisco-8000` submodule ref in `platform/checkout/cisco-8000.ini` from `202511.1.0.7` to `202511.1.0.8`.

Fixes # (issue)

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?
Keep master in sync with the Cisco-8000 platform ref update made on the 202511 branch in #27155.

#### How did you do it?
Updated `platform/checkout/cisco-8000.ini` to set `ref=202511.1.0.8`.

#### How did you verify/test it?
- Inspected `platform/checkout/cisco-8000.ini` and confirmed `ref=202511.1.0.8`.
- Run a Cisco-8000 platform build and confirm the platform-cisco-8000 submodule checks out tag `202511.1.0.8`.

#### Any platform specific information?
Cisco-8000 platform only.

#### Supported testbed topology if it's a new test case?
N/A

### Documentation
N/A