### PR TITLE
Fix eval injection in Tencent platform sensor.py

### DIFF
--- a/platform/broadcom/sonic-platform-modules-tencent/common/lib/plat_hal/sensor.py
+++ b/platform/broadcom/sonic-platform-modules-tencent/common/lib/plat_hal/sensor.py
@@ -20,7 +20,6 @@ class sensor(devicebase):
     __ValueConfig = None
     __Flag = None
     __Unit = None
-    __format = None
     __read_times = None
 
     __Min_config = None
@@ -69,14 +68,6 @@ class sensor(devicebase):
         self.__Unit = val
 
     @property
-    def format(self):
-        return self.__format
-
-    @format.setter
-    def format(self, val):
-        self.__format = val
-
-    @property
     def read_times(self):
         return self.__read_times
 
@@ -114,17 +105,19 @@ class sensor(devicebase):
             return True, val_list[int((len(val_list) - 1) / 2)]
         return False, None
 
+    def _scale(self, val):
+        """Apply divisor/multiplier scaling to a raw sensor value."""
+        if self.divisor is not None:
+            return round(float(val) / self.divisor * self.multiplier, 3)
+        return round(float(val), 3)
+
     @property
     def Value(self):
         try:
             ret, val = self.get_median(self.ValueConfig, self.read_times)
             if ret is False or val is None:
                 return None
-            if self.format is None:
-                self.__Value = int(val)
-            else:
-                self.__Value = eval(self.format % val)
-            self.__Value = round(float(self.__Value), 3)
+            self.__Value = self._scale(val)
         except Exception as e:
             return None
         return self.__Value
@@ -136,11 +129,7 @@ class sensor(devicebase):
     @property
     def Min(self):
         try:
-            if self.format is None:
-                self.__Min = self.Min_config
-            else:
-                self.__Min = eval(self.format % self.Min_config)
-            self.__Min = round(float(self.__Min), 3)
+            self.__Min = round(float(self._scale(self.Min_config)), 3)
         except Exception as e:
             return None
         return self.__Min
@@ -152,11 +141,7 @@ class sensor(devicebase):
     @property
     def Max(self):
         try:
-            if self.format is None:
-                self.__Max = self.Max_config
-            else:
-                self.__Max = eval(self.format % self.Max_config)
-            self.__Max = round(float(self.__Max), 3)
+            self.__Max = round(float(self._scale(self.Max_config)), 3)
         except Exception as e:
             return None
         return self.__Max
@@ -168,10 +153,7 @@ class sensor(devicebase):
     @property
     def Low(self):
         try:
-            if self.format is None:
-                self.__Low = self.Low_config
-            else:
-                self.__Low = eval(self.format % self.Low_config)
+            self.__Low = self._scale(self.Low_config)
         except Exception as e:
             return None
         return self.__Low
@@ -183,10 +165,7 @@ class sensor(devicebase):
     @property
     def High(self):
         try:
-            if self.format is None:
-                self.__High = self.High_config
-            else:
-                self.__High = eval(self.format % self.High_config)
+            self.__High = self._scale(self.High_config)
         except Exception as e:
             return None
         return self.__High
@@ -203,7 +182,8 @@ class sensor(devicebase):
         self.Low_config = conf.get("Low", None)
         self.High_config = conf.get("High", None)
         self.Unit = conf.get('Unit', None)
-        self.format = conf.get('format', None)
+        self.divisor = conf.get('divisor', None)
+        self.multiplier = conf.get('multiplier', 1.0)
         self.read_times = conf.get('read_times', 1)
 
     def __str__(self):
@@ -212,9 +192,10 @@ class sensor(devicebase):
             "Min :          %s \n" \
             "Max : %s \n" \
             "Unit  : %s \n" \
-            "format:       : %s \n"
+            "divisor:      : %s \n" \
+            "multiplier:   : %s \n"
 
         tmpstr = formatstr % (self.ValueConfig, self.Min,
                               self.Max, self.Unit,
-                              self.format)
+                              self.divisor, self.multiplier)
         return tmpstr

--- a/platform/broadcom/sonic-platform-modules-tencent/common/lib/plat_hal/temp.py
+++ b/platform/broadcom/sonic-platform-modules-tencent/common/lib/plat_hal/temp.py
@@ -115,18 +115,12 @@ class temp(sensor):
                         max = tmp
                 if max is None:
                     return None
-                if self.format is None:
-                    self.__Value = int(max)
-                else:
-                    self.__Value = eval(self.format % max)
+                self.__Value = self._scale(max)
             else:
                 ret, val = self.get_value(self.ValueConfig)
                 if ret is False or val is None:
                     return None
-                if self.format is None:
-                    self.__Value = int(val)
-                else:
-                    self.__Value = eval(self.format % val)
+                self.__Value = self._scale(val)
         except Exception as e:
             return None
         if self.fix_value is not None and self.__Value != self.temp_invalid and self.__Value != self.temp_error:

--- a/platform/broadcom/sonic-platform-modules-tencent/common/lib/plat_hal/tests/test_sensor_format_validation.py
+++ b/platform/broadcom/sonic-platform-modules-tencent/common/lib/plat_hal/tests/test_sensor_format_validation.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+Unit tests for sensor.py divisor/multiplier scaling (F078 fix).
+
+Verifies that eval() is gone and that divisor/multiplier correctly
+replaces the old 'format' string patterns from platform config.
+"""
+import sys
+import os
+import types
+import unittest
+
+# ---------------------------------------------------------------------------
+# Stub heavy dependencies
+# ---------------------------------------------------------------------------
+_plat_hal_pkg = types.ModuleType("plat_hal")
+sys.modules.setdefault("plat_hal", _plat_hal_pkg)
+
+_devicebase_mod = types.ModuleType("plat_hal.devicebase")
+
+
+class _StubDevicebase:
+    def get_value(self, conf):
+        return False, None
+
+    def get_median(self, conf, read_times):
+        return False, None
+
+
+_devicebase_mod.devicebase = _StubDevicebase
+sys.modules["plat_hal.devicebase"] = _devicebase_mod
+_plat_hal_pkg.devicebase = _devicebase_mod
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_HAL_DIR = os.path.dirname(_HERE)
+if _HAL_DIR not in sys.path:
+    sys.path.insert(0, _HAL_DIR)
+
+from sensor import sensor
+
+# Also register sensor under plat_hal.sensor so temp.py can import it
+_sensor_mod = types.ModuleType("plat_hal.sensor")
+_sensor_mod.sensor = sensor
+sys.modules["plat_hal.sensor"] = _sensor_mod
+_plat_hal_pkg.sensor = _sensor_mod
+
+import temp as temp_mod
+from temp import temp
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_sensor(divisor=None, multiplier=None, min_val=100, max_val=50000,
+                low_val=200, high_val=45000):
+    conf = {
+        "value": None,
+        "flag": None,
+        "Min": min_val,
+        "Max": max_val,
+        "Low": low_val,
+        "High": high_val,
+        "Unit": None,
+        "read_times": 1,
+    }
+    if divisor is not None:
+        conf["divisor"] = divisor
+    if multiplier is not None:
+        conf["multiplier"] = multiplier
+    return sensor(conf)
+
+
+# ---------------------------------------------------------------------------
+# Tests: no eval() in sensor.py or temp.py
+# ---------------------------------------------------------------------------
+
+class TestNoEval(unittest.TestCase):
+    def test_sensor_module_has_no_eval(self):
+        import inspect
+        import sensor as sensor_mod
+        source = inspect.getsource(sensor_mod)
+        self.assertNotIn("eval(", source,
+            "sensor.py must not contain eval()")
+
+    def test_temp_module_has_no_format_eval(self):
+        """temp.py Value property must not use eval(self.format %)."""
+        temp_path = os.path.join(_HAL_DIR, "temp.py")
+        with open(temp_path) as f:
+            source = f.read()
+        self.assertNotIn("eval(self.format", source,
+            "temp.py must not contain eval(self.format ...)")
+
+    def test_temp_scale_method_available(self):
+        """temp instance must have _scale() from sensor inheritance — no AttributeError."""
+        conf = {
+            "name": "test_temp",
+            "temp_id": "TEMP0",
+            "Temperature": {
+                "value": None,
+                "flag": None,
+                "Min": 0,
+                "Max": 80000,
+                "Low": 0,
+                "High": 75000,
+                "Unit": None,
+                "divisor": 1000,
+                "read_times": 1,
+            },
+        }
+        t = temp(conf)
+        # Must not raise AttributeError
+        result = t._scale("50000")
+        self.assertAlmostEqual(result, 50.0, places=3)
+
+    def test_temp_scale_no_divisor(self):
+        """temp without divisor returns round(float(val), 3)."""
+        conf = {
+            "name": "test_temp",
+            "temp_id": "TEMP0",
+            "Temperature": {
+                "value": None,
+                "flag": None,
+                "Min": 0,
+                "Max": 100,
+                "Low": 0,
+                "High": 90,
+                "Unit": None,
+                "read_times": 1,
+            },
+        }
+        t = temp(conf)
+        self.assertAlmostEqual(t._scale("42.5"), 42.5, places=3)
+
+
+# ---------------------------------------------------------------------------
+# Tests: _scale() correctness
+# ---------------------------------------------------------------------------
+
+class TestScaling(unittest.TestCase):
+    def test_no_divisor_returns_float_rounded(self):
+        """No divisor: _scale returns round(float(val), 3)."""
+        s = make_sensor()
+        self.assertAlmostEqual(s._scale("3.200"), 3.2, places=3)
+        self.assertAlmostEqual(s._scale("42"), 42.0, places=3)
+
+    def test_divisor_1_preserves_float(self):
+        """divisor=1 (replaces 'format': '%s'): preserves float precision."""
+        s = make_sensor(divisor=1)
+        self.assertAlmostEqual(s._scale("3.200"), 3.2, places=3)
+        self.assertAlmostEqual(s._scale("3.600"), 3.6, places=3)
+
+    def test_divisor_1000(self):
+        """float(float(%s)/1000) equivalent"""
+        s = make_sensor(divisor=1000)
+        self.assertAlmostEqual(s._scale("5000"), 5.0, places=3)
+        self.assertAlmostEqual(s._scale("1234"), 1.234, places=3)
+
+    def test_divisor_1000000(self):
+        """float(float(%s)/1000000) equivalent"""
+        s = make_sensor(divisor=1000000)
+        self.assertAlmostEqual(s._scale("2000000"), 2.0, places=3)
+
+    def test_divisor_1000_multiplier_1124(self):
+        """float(float(%s)/1000) * 1.124 equivalent"""
+        s = make_sensor(divisor=1000, multiplier=1.124)
+        expected = round(5000 / 1000 * 1.124, 3)
+        self.assertAlmostEqual(s._scale("5000"), expected, places=3)
+
+    def test_default_multiplier_is_1(self):
+        s = make_sensor(divisor=1000)
+        self.assertEqual(s.multiplier, 1.0)
+
+    def test_scale_result_rounded_to_3dp(self):
+        s = make_sensor(divisor=1000)
+        result = s._scale("1")
+        self.assertEqual(result, round(1 / 1000 * 1.0, 3))
+
+
+# ---------------------------------------------------------------------------
+# Tests: Min/Max/Low/High property scaling
+# ---------------------------------------------------------------------------
+
+class TestPropertyScaling(unittest.TestCase):
+    def test_min_scaled(self):
+        s = make_sensor(divisor=1000)
+        self.assertAlmostEqual(s.Min, 0.1, places=3)  # 100/1000
+
+    def test_max_scaled(self):
+        s = make_sensor(divisor=1000)
+        self.assertAlmostEqual(s.Max, 50.0, places=3)  # 50000/1000
+
+    def test_low_scaled(self):
+        s = make_sensor(divisor=1000)
+        self.assertAlmostEqual(s.Low, 0.2, places=3)  # 200/1000
+
+    def test_high_scaled(self):
+        s = make_sensor(divisor=1000)
+        self.assertAlmostEqual(s.High, 45.0, places=3)  # 45000/1000
+
+    def test_divisor_1_float_min_preserved(self):
+        """divisor=1 preserves float Min (fixes MAC_QSFPDD_VDD3.3V_* regression)."""
+        s = make_sensor(divisor=1, min_val=3.200, max_val=3.600,
+                        low_val=3.100, high_val=3.700)
+        self.assertAlmostEqual(s.Min, 3.2, places=3)
+        self.assertAlmostEqual(s.Max, 3.6, places=3)
+
+    def test_no_divisor_float_min_preserved(self):
+        """No divisor: float Min also preserved (round(float(val), 3))."""
+        s = make_sensor(min_val=3.200, max_val=3.600)
+        self.assertAlmostEqual(s.Min, 3.2, places=3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/platform/broadcom/sonic-platform-modules-tencent/tcs8400/hal-config/x86_64_tencent_tcs8400_r0_0x407b_device.py
+++ b/platform/broadcom/sonic-platform-modules-tencent/tcs8400/hal-config/x86_64_tencent_tcs8400_r0_0x407b_device.py
@@ -101,7 +101,7 @@ devices = {
                 "Min": threshold.PSU_TEMP_MIN,
                 "Max": threshold.PSU_TEMP_MAX,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "FanStatus": {"bus": 41, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x0400},
             "FanSpeed": {
@@ -118,7 +118,7 @@ devices = {
                     "Min": threshold.PSU_AC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_AC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
 
                 },
                 'DC': {
@@ -126,14 +126,14 @@ devices = {
                     "Min": threshold.PSU_DC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_DC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 },
                 'other': {
                     "value": {"loc": "/sys/bus/i2c/devices/i2c-41/41-0058/hwmon/hwmon*/in1_input", "way": "sysfs"},
                     "Min": threshold.ERR_VALUE,
                     "Max": threshold.ERR_VALUE,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 }
             },
             "InputsCurrent":
@@ -142,7 +142,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_CURRENT_MIN,
                 "Max": threshold.PSU_INPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "InputsPower":
             {
@@ -150,7 +150,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_POWER_MIN,
                 "Max": threshold.PSU_INPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
             "OutputsStatus": {"bus": 41, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x8800},
             "OutputsVoltage":
@@ -159,7 +159,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_VOLTAGE_MIN,
                 "Max": threshold.PSU_OUTPUT_VOLTAGE_MAX,
                 "Unit": Unit.Voltage,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsCurrent":
             {
@@ -167,7 +167,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_CURRENT_MIN,
                 "Max": threshold.PSU_OUTPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsPower":
             {
@@ -175,7 +175,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_POWER_MIN,
                 "Max": threshold.PSU_OUTPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
         },
         {
@@ -192,7 +192,7 @@ devices = {
                 "Min": threshold.PSU_TEMP_MIN,
                 "Max": threshold.PSU_TEMP_MAX,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "FanStatus": {"bus": 42, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x0400},
             "FanSpeed": {
@@ -209,7 +209,7 @@ devices = {
                     "Min": threshold.PSU_AC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_AC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
 
                 },
                 'DC': {
@@ -217,14 +217,14 @@ devices = {
                     "Min": threshold.PSU_DC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_DC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 },
                 'other': {
                     "value": {"loc": "/sys/bus/i2c/devices/i2c-42/42-0058/hwmon/hwmon*/in1_input", "way": "sysfs"},
                     "Min": threshold.ERR_VALUE,
                     "Max": threshold.ERR_VALUE,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 }
             },
             "InputsCurrent":
@@ -233,7 +233,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_CURRENT_MIN,
                 "Max": threshold.PSU_INPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "InputsPower":
             {
@@ -241,7 +241,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_POWER_MIN,
                 "Max": threshold.PSU_INPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
             "OutputsStatus": {"bus": 42, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x8800},
             "OutputsVoltage":
@@ -250,7 +250,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_VOLTAGE_MIN,
                 "Max": threshold.PSU_OUTPUT_VOLTAGE_MAX,
                 "Unit": Unit.Voltage,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsCurrent":
             {
@@ -258,7 +258,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_CURRENT_MIN,
                 "Max": threshold.PSU_OUTPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsPower":
             {
@@ -266,7 +266,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_POWER_MIN,
                 "Max": threshold.PSU_OUTPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
         }
     ],
@@ -282,7 +282,7 @@ devices = {
                 "High": 70000,
                 "Max": 80000,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             }
         },
         {
@@ -296,7 +296,7 @@ devices = {
                 "High": 100000,
                 "Max": 104000,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             }
         },
         {
@@ -310,7 +310,7 @@ devices = {
                 "High": 40000,
                 "Max": 50000,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             }
         },
         {
@@ -324,7 +324,7 @@ devices = {
                 "High": 70000,
                 "Max": 80000,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             }
         },
         {
@@ -338,7 +338,7 @@ devices = {
                 "High": 100000,
                 "Max": 105000,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             }
         },
         {
@@ -350,7 +350,7 @@ devices = {
                 "High": 80000,
                 "Max": 100000,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             }
         },
     ],
@@ -715,7 +715,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 5345,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "VDD3.3_CLK",
@@ -728,7 +728,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3560,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "VDD1.0V",
@@ -741,7 +741,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1049,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "VDD1.8V",
@@ -754,7 +754,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1903,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_BOARD_VDD3.3V",
@@ -767,7 +767,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3499,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "VDD1.2V",
@@ -780,7 +780,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1272,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "VDD_CORE",
@@ -793,7 +793,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 950,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "ANALOG0.75V",
@@ -806,7 +806,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 800,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD1.2V",
@@ -819,7 +819,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1259,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "VDDO1.8V",
@@ -832,7 +832,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1937,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_ANA1.2V",
@@ -845,7 +845,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1276,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_ANA1.8V",
@@ -858,7 +858,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1910,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "QSFP56_VDD3.3V_A",
@@ -871,7 +871,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3595,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "QSFP56_VDD3.3V_B",
@@ -884,7 +884,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3601,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "QSFPDD_VDD3.3V_A",
@@ -897,7 +897,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3565,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "QSFPDD_VDD3.3V_B",
@@ -910,7 +910,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3564,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "VDD5.0V",
@@ -923,7 +923,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 5429,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "CONNECT_BOARD_VDD3.3V",
@@ -936,7 +936,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3437,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "VDD12V",
@@ -949,7 +949,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 12700,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "VDD3.3_STBY",
@@ -962,7 +962,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3489,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "SSD_VDD3.3V",
@@ -975,7 +975,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3475,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "PHY_VDD1V0",
@@ -988,7 +988,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1050,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "ODD_PHY_M",
@@ -1001,7 +1001,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3444,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "VCCIN",
@@ -1014,7 +1014,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1879,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "P1V05",
@@ -1027,7 +1027,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1103,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "P1V2_VDDQ",
@@ -1040,7 +1040,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1258,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "P2V5_VPP",
@@ -1053,7 +1053,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 2342,
-            "format": "float(float(%s)/1000) * 1.124",
+            "divisor": 1000, "multiplier": 1.124,
         },
         {
             "name": "P3V3_STBY",
@@ -1066,7 +1066,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3476,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "P5V_AUX_IN",
@@ -1079,7 +1079,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 5229,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "P1V7_VCCSCFUSESUS_IN",
@@ -1092,7 +1092,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1789,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
     ],
     "cpu": [

--- a/platform/broadcom/sonic-platform-modules-tencent/tcs8400/hal-config/x86_64_tencent_tcs8400_r0_device.py
+++ b/platform/broadcom/sonic-platform-modules-tencent/tcs8400/hal-config/x86_64_tencent_tcs8400_r0_device.py
@@ -101,7 +101,7 @@ devices = {
                 "Min": threshold.PSU_TEMP_MIN,
                 "Max": threshold.PSU_TEMP_MAX,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "FanStatus": {"bus": 41, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x0400},
             "FanSpeed": {
@@ -118,7 +118,7 @@ devices = {
                     "Min": threshold.PSU_AC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_AC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
 
                 },
                 'DC': {
@@ -126,14 +126,14 @@ devices = {
                     "Min": threshold.PSU_DC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_DC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 },
                 'other': {
                     "value": {"loc": "/sys/bus/i2c/devices/i2c-41/41-0058/hwmon/hwmon*/in1_input", "way": "sysfs"},
                     "Min": threshold.ERR_VALUE,
                     "Max": threshold.ERR_VALUE,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 }
             },
             "InputsCurrent":
@@ -142,7 +142,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_CURRENT_MIN,
                 "Max": threshold.PSU_INPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "InputsPower":
             {
@@ -150,7 +150,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_POWER_MIN,
                 "Max": threshold.PSU_INPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
             "OutputsStatus": {"bus": 41, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x8800},
             "OutputsVoltage":
@@ -159,7 +159,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_VOLTAGE_MIN,
                 "Max": threshold.PSU_OUTPUT_VOLTAGE_MAX,
                 "Unit": Unit.Voltage,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsCurrent":
             {
@@ -167,7 +167,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_CURRENT_MIN,
                 "Max": threshold.PSU_OUTPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsPower":
             {
@@ -175,7 +175,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_POWER_MIN,
                 "Max": threshold.PSU_OUTPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
         },
         {
@@ -192,7 +192,7 @@ devices = {
                 "Min": threshold.PSU_TEMP_MIN,
                 "Max": threshold.PSU_TEMP_MAX,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "FanStatus": {"bus": 42, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x0400},
             "FanSpeed": {
@@ -209,7 +209,7 @@ devices = {
                     "Min": threshold.PSU_AC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_AC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
 
                 },
                 'DC': {
@@ -217,14 +217,14 @@ devices = {
                     "Min": threshold.PSU_DC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_DC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 },
                 'other': {
                     "value": {"loc": "/sys/bus/i2c/devices/i2c-42/42-0058/hwmon/hwmon*/in1_input", "way": "sysfs"},
                     "Min": threshold.ERR_VALUE,
                     "Max": threshold.ERR_VALUE,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 }
             },
             "InputsCurrent":
@@ -233,7 +233,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_CURRENT_MIN,
                 "Max": threshold.PSU_INPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "InputsPower":
             {
@@ -241,7 +241,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_POWER_MIN,
                 "Max": threshold.PSU_INPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
             "OutputsStatus": {"bus": 42, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x8800},
             "OutputsVoltage":
@@ -250,7 +250,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_VOLTAGE_MIN,
                 "Max": threshold.PSU_OUTPUT_VOLTAGE_MAX,
                 "Unit": Unit.Voltage,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsCurrent":
             {
@@ -258,7 +258,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_CURRENT_MIN,
                 "Max": threshold.PSU_OUTPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsPower":
             {
@@ -266,7 +266,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_POWER_MIN,
                 "Max": threshold.PSU_OUTPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
         }
     ],
@@ -282,7 +282,7 @@ devices = {
                 "High": 70000,
                 "Max": 80000,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             }
         },
         {
@@ -296,7 +296,7 @@ devices = {
                 "High": 100000,
                 "Max": 104000,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             }
         },
         {
@@ -310,7 +310,7 @@ devices = {
                 "High": 40000,
                 "Max": 50000,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             }
         },
         {
@@ -324,7 +324,7 @@ devices = {
                 "High": 70000,
                 "Max": 80000,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             }
         },
         {
@@ -338,7 +338,7 @@ devices = {
                 "High": 100000,
                 "Max": 105000,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             }
         },
         {
@@ -350,7 +350,7 @@ devices = {
                 "High": 80000,
                 "Max": 100000,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             }
         },
     ],
@@ -715,7 +715,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 5345,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "VDD3.3_CLK",
@@ -728,7 +728,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3560,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "VDD1.0V",
@@ -741,7 +741,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1049,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "VDD1.8V",
@@ -754,7 +754,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1903,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_BOARD_VDD3.3V",
@@ -767,7 +767,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3499,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "VDD1.2V",
@@ -780,7 +780,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1272,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "VDD_CORE",
@@ -793,7 +793,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 950,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "ANALOG0.75V",
@@ -806,7 +806,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 800,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD1.2V",
@@ -819,7 +819,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1259,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "VDDO1.8V",
@@ -832,7 +832,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1937,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_ANA1.2V",
@@ -845,7 +845,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1276,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_ANA1.8V",
@@ -858,7 +858,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1910,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "QSFP56_VDD3.3V_A",
@@ -871,7 +871,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3595,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "QSFP56_VDD3.3V_B",
@@ -884,7 +884,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3601,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "QSFPDD_VDD3.3V_A",
@@ -897,7 +897,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3565,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "QSFPDD_VDD3.3V_B",
@@ -910,7 +910,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3564,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "VDD5.0V",
@@ -923,7 +923,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 5429,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "SW_VDD1.2V",
@@ -936,7 +936,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1284,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "VDD2.5V",
@@ -949,7 +949,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 2620,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "CONNECT_BOARD_VDD3.3V",
@@ -962,7 +962,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3437,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "VDD12V",
@@ -975,7 +975,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 12700,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "VDD3.3_STBY",
@@ -988,7 +988,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3489,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "SSD_VDD3.3V",
@@ -1001,7 +1001,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3475,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "VCCIN",
@@ -1014,7 +1014,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1879,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "P1V05",
@@ -1027,7 +1027,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1103,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "P1V2_VDDQ",
@@ -1040,7 +1040,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1258,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "P2V5_VPP",
@@ -1053,7 +1053,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 2342,
-            "format": "float(float(%s)/1000) * 1.124",
+            "divisor": 1000, "multiplier": 1.124,
         },
         {
             "name": "P3V3_STBY",
@@ -1066,7 +1066,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3476,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "P5V_AUX_IN",
@@ -1079,7 +1079,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 5229,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "P1V7_VCCSCFUSESUS_IN",
@@ -1092,7 +1092,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1789,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
     ],
     "cpu": [

--- a/platform/broadcom/sonic-platform-modules-tencent/tcs9400/hal-config/x86_64_tencent_tcs9400_r0_0x407c_device.py
+++ b/platform/broadcom/sonic-platform-modules-tencent/tcs9400/hal-config/x86_64_tencent_tcs9400_r0_0x407c_device.py
@@ -99,7 +99,7 @@ devices = {
                 "Min": threshold.PSU_TEMP_MIN,
                 "Max": threshold.PSU_TEMP_MAX,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "FanStatus": {"bus": 79, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x0400},
             "FanSpeed": {
@@ -116,7 +116,7 @@ devices = {
                     "Min": threshold.PSU_AC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_AC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
 
                 },
                 'DC': {
@@ -124,14 +124,14 @@ devices = {
                     "Min": threshold.PSU_DC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_DC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 },
                 'other': {
                     "value": {"loc": "/sys/bus/i2c/devices/i2c-79/79-0058/hwmon/hwmon*/in1_input", "way": "sysfs"},
                     "Min": threshold.ERR_VALUE,
                     "Max": threshold.ERR_VALUE,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 }
             },
             "InputsCurrent":
@@ -140,7 +140,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_CURRENT_MIN,
                 "Max": threshold.PSU_INPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "InputsPower":
             {
@@ -148,7 +148,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_POWER_MIN,
                 "Max": threshold.PSU_INPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
             "OutputsStatus": {"bus": 79, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x8800},
             "OutputsVoltage":
@@ -157,7 +157,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_VOLTAGE_MIN,
                 "Max": threshold.PSU_OUTPUT_VOLTAGE_MAX,
                 "Unit": Unit.Voltage,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsCurrent":
             {
@@ -165,7 +165,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_CURRENT_MIN,
                 "Max": threshold.PSU_OUTPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsPower":
             {
@@ -173,7 +173,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_POWER_MIN,
                 "Max": threshold.PSU_OUTPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
         },
         {
@@ -190,7 +190,7 @@ devices = {
                 "Min": threshold.PSU_TEMP_MIN,
                 "Max": threshold.PSU_TEMP_MAX,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "FanStatus": {"bus": 80, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x0400},
             "FanSpeed": {
@@ -207,7 +207,7 @@ devices = {
                     "Min": threshold.PSU_AC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_AC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
 
                 },
                 'DC': {
@@ -215,14 +215,14 @@ devices = {
                     "Min": threshold.PSU_DC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_DC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 },
                 'other': {
                     "value": {"loc": "/sys/bus/i2c/devices/i2c-80/80-0058/hwmon/hwmon*/in1_input", "way": "sysfs"},
                     "Min": threshold.ERR_VALUE,
                     "Max": threshold.ERR_VALUE,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 }
             },
             "InputsCurrent":
@@ -231,7 +231,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_CURRENT_MIN,
                 "Max": threshold.PSU_INPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "InputsPower":
             {
@@ -239,7 +239,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_POWER_MIN,
                 "Max": threshold.PSU_INPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
             "OutputsStatus": {"bus": 80, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x8800},
             "OutputsVoltage":
@@ -248,7 +248,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_VOLTAGE_MIN,
                 "Max": threshold.PSU_OUTPUT_VOLTAGE_MAX,
                 "Unit": Unit.Voltage,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsCurrent":
             {
@@ -256,7 +256,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_CURRENT_MIN,
                 "Max": threshold.PSU_OUTPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsPower":
             {
@@ -264,7 +264,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_POWER_MIN,
                 "Max": threshold.PSU_OUTPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
         },
         {
@@ -281,7 +281,7 @@ devices = {
                 "Min": threshold.PSU_TEMP_MIN,
                 "Max": threshold.PSU_TEMP_MAX,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "FanStatus": {"bus": 82, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x0400},
             "FanSpeed": {
@@ -298,7 +298,7 @@ devices = {
                     "Min": threshold.PSU_AC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_AC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
 
                 },
                 'DC': {
@@ -306,14 +306,14 @@ devices = {
                     "Min": threshold.PSU_DC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_DC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 },
                 'other': {
                     "value": {"loc": "/sys/bus/i2c/devices/i2c-82/82-0058/hwmon/hwmon*/in1_input", "way": "sysfs"},
                     "Min": threshold.ERR_VALUE,
                     "Max": threshold.ERR_VALUE,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 }
             },
             "InputsCurrent":
@@ -322,7 +322,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_CURRENT_MIN,
                 "Max": threshold.PSU_INPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "InputsPower":
             {
@@ -330,7 +330,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_POWER_MIN,
                 "Max": threshold.PSU_INPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
             "OutputsStatus": {"bus": 82, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x8800},
             "OutputsVoltage":
@@ -339,7 +339,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_VOLTAGE_MIN,
                 "Max": threshold.PSU_OUTPUT_VOLTAGE_MAX,
                 "Unit": Unit.Voltage,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsCurrent":
             {
@@ -347,7 +347,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_CURRENT_MIN,
                 "Max": threshold.PSU_OUTPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsPower":
             {
@@ -355,7 +355,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_POWER_MIN,
                 "Max": threshold.PSU_OUTPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
         },
         {
@@ -372,7 +372,7 @@ devices = {
                 "Min": threshold.PSU_TEMP_MIN,
                 "Max": threshold.PSU_TEMP_MAX,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "FanStatus": {"bus": 81, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x0400},
             "FanSpeed": {
@@ -389,7 +389,7 @@ devices = {
                     "Min": threshold.PSU_AC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_AC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
 
                 },
                 'DC': {
@@ -397,14 +397,14 @@ devices = {
                     "Min": threshold.PSU_DC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_DC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 },
                 'other': {
                     "value": {"loc": "/sys/bus/i2c/devices/i2c-81/81-0058/hwmon/hwmon*/in1_input", "way": "sysfs"},
                     "Min": threshold.ERR_VALUE,
                     "Max": threshold.ERR_VALUE,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 }
             },
             "InputsCurrent":
@@ -413,7 +413,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_CURRENT_MIN,
                 "Max": threshold.PSU_INPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "InputsPower":
             {
@@ -421,7 +421,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_POWER_MIN,
                 "Max": threshold.PSU_INPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
             "OutputsStatus": {"bus": 81, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x8800},
             "OutputsVoltage":
@@ -430,7 +430,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_VOLTAGE_MIN,
                 "Max": threshold.PSU_OUTPUT_VOLTAGE_MAX,
                 "Unit": Unit.Voltage,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsCurrent":
             {
@@ -438,7 +438,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_CURRENT_MIN,
                 "Max": threshold.PSU_OUTPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsPower":
             {
@@ -446,7 +446,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_POWER_MIN,
                 "Max": threshold.PSU_OUTPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
         },
     ],
@@ -462,7 +462,7 @@ devices = {
                 "High": 100000,
                 "Max": 102000,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             }
         },
         {
@@ -476,7 +476,7 @@ devices = {
                 "High": 40000,
                 "Max": 50000,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             }
         },
         {
@@ -490,7 +490,7 @@ devices = {
                 "High": 70000,
                 "Max": 75000,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             }
         },
         {
@@ -504,7 +504,7 @@ devices = {
                 "High": 100000,
                 "Max": 105000,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             }
         },
         {
@@ -516,7 +516,7 @@ devices = {
                 "High": 80000,
                 "Max": 100000,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             }
         },
     ],
@@ -1008,7 +1008,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 809,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD12V",
@@ -1021,7 +1021,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 12600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD1.0V_FPGA",
@@ -1034,7 +1034,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1071,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD1.8V_FPGA",
@@ -1047,7 +1047,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1890,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD1.2V_FPGA",
@@ -1060,7 +1060,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1260,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD3.3V",
@@ -1073,7 +1073,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3465,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_SW_VDD1.2V",
@@ -1086,7 +1086,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1260,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD5V_CLK_MCU",
@@ -1099,7 +1099,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 5334,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD5V_VR",
@@ -1112,7 +1112,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 5334,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD3.3_CLK",
@@ -1125,7 +1125,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3486,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDDO1.8V",
@@ -1138,7 +1138,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1901,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDDO1.2V",
@@ -1151,7 +1151,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1260,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD_CORE",
@@ -1164,7 +1164,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 950,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD_ANALOG",
@@ -1177,7 +1177,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 809,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD1.2V_MAC",
@@ -1190,7 +1190,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1260,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_AVDD1.8V",
@@ -1203,7 +1203,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1890,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "BASE_VDD12V",
@@ -1216,7 +1216,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 12600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "BASE_SW_VDD1.0V",
@@ -1229,7 +1229,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1050,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "BASE_VDD3.3V",
@@ -1242,7 +1242,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3444,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "BASE_SW_OVDD",
@@ -1255,7 +1255,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3444,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "BASE_SSD_VDD3.3V",
@@ -1268,7 +1268,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3465,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "CPU_VCCIN",
@@ -1281,7 +1281,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1950,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "CPU_P1V05",
@@ -1294,7 +1294,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1100,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "CPU_P1V2_VDDQ",
@@ -1307,7 +1307,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1260,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "CPU_P2V5_VPP",
@@ -1320,7 +1320,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 2447,
-            "format": "float(float(%s)/1000) * 1.124",
+            "divisor": 1000, "multiplier": 1.124,
         },
         {
             "name": "CPU_P3V3_STBY",
@@ -1333,7 +1333,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3465,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "CPU_P5V_AUX_IN",
@@ -1346,7 +1346,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 5500,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "CPU_P1V7_VCCSCFUSESUS_IN",
@@ -1359,7 +1359,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1785,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "UPORT_VDD1.0V_FPGA",
@@ -1372,7 +1372,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1061,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "UPORT_VDD1.8V_FPGA",
@@ -1385,7 +1385,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1901,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "UPORT_VDD1.2V_FPGA",
@@ -1398,7 +1398,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1260,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "UPORT_VDD3.3V",
@@ -1411,7 +1411,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "UPORT_QSFP56_VDD3.3V_A",
@@ -1424,7 +1424,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "UPORT_QSFP56_VDD3.3V_B",
@@ -1437,7 +1437,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "UPORT_QSFP56_VDD3.3V_C",
@@ -1450,7 +1450,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "UPORT_QSFP56_VDD3.3V_D",
@@ -1463,7 +1463,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "UPORT_VDD3.3_MON",
@@ -1476,7 +1476,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3465,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "UPORT_VDD12V",
@@ -1489,7 +1489,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 12600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "DPORT_VDD1.0V_FPGA",
@@ -1502,7 +1502,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1061,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "DPORT_VDD1.8V_FPGA",
@@ -1515,7 +1515,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1901,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "DPORT_VDD1.2V_FPGA",
@@ -1528,7 +1528,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1260,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "DPORT_VDD3.3V",
@@ -1541,7 +1541,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "DPORT_QSFP56_VDD3.3V_A",
@@ -1554,7 +1554,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "DPORT_QSFP56_VDD3.3V_B",
@@ -1567,7 +1567,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "DPORT_QSFP56_VDD3.3V_C",
@@ -1580,7 +1580,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "DPORT_QSFP56_VDD3.3V_D",
@@ -1593,7 +1593,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "DPORT_VDD3.3_MON",
@@ -1606,7 +1606,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3465,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "DPORT_VDD12V",
@@ -1619,7 +1619,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 12600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_QSFPDD_VDD3.3V_A",
@@ -1632,7 +1632,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3.600,
-            "format": "%s",
+            "divisor": 1,
         },
         {
             "name": "MAC_QSFPDD_VDD3.3V_B",
@@ -1645,7 +1645,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3.600,
-            "format": "%s",
+            "divisor": 1,
         },
         {
             "name": "MAC_QSFPDD_VDD3.3V_C",
@@ -1658,7 +1658,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3.600,
-            "format": "%s",
+            "divisor": 1,
         },
         {
             "name": "MAC_QSFPDD_VDD3.3V_D",
@@ -1671,7 +1671,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3.600,
-            "format": "%s",
+            "divisor": 1,
         },
         {
             "name": "MAC_QSFPDD_VDD3.3V_E",
@@ -1684,7 +1684,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3.600,
-            "format": "%s",
+            "divisor": 1,
         },
         {
             "name": "MAC_QSFPDD_VDD3.3V_F",
@@ -1697,7 +1697,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3.600,
-            "format": "%s",
+            "divisor": 1,
         },
         {
             "name": "MAC_QSFPDD_VDD3.3V_G",
@@ -1710,7 +1710,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3.600,
-            "format": "%s",
+            "divisor": 1,
         },
         {
             "name": "MAC_QSFPDD_VDD3.3V_H",
@@ -1723,7 +1723,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3.600,
-            "format": "%s",
+            "divisor": 1,
         },
     ],
     "cpu": [

--- a/platform/broadcom/sonic-platform-modules-tencent/tcs9400/hal-config/x86_64_tencent_tcs9400_r0_device.py
+++ b/platform/broadcom/sonic-platform-modules-tencent/tcs9400/hal-config/x86_64_tencent_tcs9400_r0_device.py
@@ -99,7 +99,7 @@ devices = {
                 "Min": threshold.PSU_TEMP_MIN,
                 "Max": threshold.PSU_TEMP_MAX,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "FanStatus": {"bus": 79, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x0400},
             "FanSpeed": {
@@ -116,7 +116,7 @@ devices = {
                     "Min": threshold.PSU_AC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_AC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
 
                 },
                 'DC': {
@@ -124,14 +124,14 @@ devices = {
                     "Min": threshold.PSU_DC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_DC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 },
                 'other': {
                     "value": {"loc": "/sys/bus/i2c/devices/i2c-79/79-0058/hwmon/hwmon*/in1_input", "way": "sysfs"},
                     "Min": threshold.ERR_VALUE,
                     "Max": threshold.ERR_VALUE,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 }
             },
             "InputsCurrent":
@@ -140,7 +140,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_CURRENT_MIN,
                 "Max": threshold.PSU_INPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "InputsPower":
             {
@@ -148,7 +148,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_POWER_MIN,
                 "Max": threshold.PSU_INPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
             "OutputsStatus": {"bus": 79, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x8800},
             "OutputsVoltage":
@@ -157,7 +157,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_VOLTAGE_MIN,
                 "Max": threshold.PSU_OUTPUT_VOLTAGE_MAX,
                 "Unit": Unit.Voltage,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsCurrent":
             {
@@ -165,7 +165,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_CURRENT_MIN,
                 "Max": threshold.PSU_OUTPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsPower":
             {
@@ -173,7 +173,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_POWER_MIN,
                 "Max": threshold.PSU_OUTPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
         },
         {
@@ -190,7 +190,7 @@ devices = {
                 "Min": threshold.PSU_TEMP_MIN,
                 "Max": threshold.PSU_TEMP_MAX,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "FanStatus": {"bus": 80, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x0400},
             "FanSpeed": {
@@ -207,7 +207,7 @@ devices = {
                     "Min": threshold.PSU_AC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_AC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
 
                 },
                 'DC': {
@@ -215,14 +215,14 @@ devices = {
                     "Min": threshold.PSU_DC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_DC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 },
                 'other': {
                     "value": {"loc": "/sys/bus/i2c/devices/i2c-80/80-0058/hwmon/hwmon*/in1_input", "way": "sysfs"},
                     "Min": threshold.ERR_VALUE,
                     "Max": threshold.ERR_VALUE,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 }
             },
             "InputsCurrent":
@@ -231,7 +231,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_CURRENT_MIN,
                 "Max": threshold.PSU_INPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "InputsPower":
             {
@@ -239,7 +239,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_POWER_MIN,
                 "Max": threshold.PSU_INPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
             "OutputsStatus": {"bus": 80, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x8800},
             "OutputsVoltage":
@@ -248,7 +248,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_VOLTAGE_MIN,
                 "Max": threshold.PSU_OUTPUT_VOLTAGE_MAX,
                 "Unit": Unit.Voltage,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsCurrent":
             {
@@ -256,7 +256,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_CURRENT_MIN,
                 "Max": threshold.PSU_OUTPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsPower":
             {
@@ -264,7 +264,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_POWER_MIN,
                 "Max": threshold.PSU_OUTPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
         },
         {
@@ -281,7 +281,7 @@ devices = {
                 "Min": threshold.PSU_TEMP_MIN,
                 "Max": threshold.PSU_TEMP_MAX,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "FanStatus": {"bus": 82, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x0400},
             "FanSpeed": {
@@ -298,7 +298,7 @@ devices = {
                     "Min": threshold.PSU_AC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_AC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
 
                 },
                 'DC': {
@@ -306,14 +306,14 @@ devices = {
                     "Min": threshold.PSU_DC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_DC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 },
                 'other': {
                     "value": {"loc": "/sys/bus/i2c/devices/i2c-82/82-0058/hwmon/hwmon*/in1_input", "way": "sysfs"},
                     "Min": threshold.ERR_VALUE,
                     "Max": threshold.ERR_VALUE,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 }
             },
             "InputsCurrent":
@@ -322,7 +322,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_CURRENT_MIN,
                 "Max": threshold.PSU_INPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "InputsPower":
             {
@@ -330,7 +330,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_POWER_MIN,
                 "Max": threshold.PSU_INPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
             "OutputsStatus": {"bus": 82, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x8800},
             "OutputsVoltage":
@@ -339,7 +339,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_VOLTAGE_MIN,
                 "Max": threshold.PSU_OUTPUT_VOLTAGE_MAX,
                 "Unit": Unit.Voltage,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsCurrent":
             {
@@ -347,7 +347,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_CURRENT_MIN,
                 "Max": threshold.PSU_OUTPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsPower":
             {
@@ -355,7 +355,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_POWER_MIN,
                 "Max": threshold.PSU_OUTPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
         },
         {
@@ -372,7 +372,7 @@ devices = {
                 "Min": threshold.PSU_TEMP_MIN,
                 "Max": threshold.PSU_TEMP_MAX,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "FanStatus": {"bus": 81, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x0400},
             "FanSpeed": {
@@ -389,7 +389,7 @@ devices = {
                     "Min": threshold.PSU_AC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_AC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
 
                 },
                 'DC': {
@@ -397,14 +397,14 @@ devices = {
                     "Min": threshold.PSU_DC_INPUT_VOLTAGE_MIN,
                     "Max": threshold.PSU_DC_INPUT_VOLTAGE_MAX,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 },
                 'other': {
                     "value": {"loc": "/sys/bus/i2c/devices/i2c-81/81-0058/hwmon/hwmon*/in1_input", "way": "sysfs"},
                     "Min": threshold.ERR_VALUE,
                     "Max": threshold.ERR_VALUE,
                     "Unit": Unit.Voltage,
-                    "format": "float(float(%s)/1000)"
+                    "divisor": 1000
                 }
             },
             "InputsCurrent":
@@ -413,7 +413,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_CURRENT_MIN,
                 "Max": threshold.PSU_INPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "InputsPower":
             {
@@ -421,7 +421,7 @@ devices = {
                 "Min": threshold.PSU_INPUT_POWER_MIN,
                 "Max": threshold.PSU_INPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
             "OutputsStatus": {"bus": 81, "addr": 0x58, "offset": 0x79, "way": "i2cword", "mask": 0x8800},
             "OutputsVoltage":
@@ -430,7 +430,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_VOLTAGE_MIN,
                 "Max": threshold.PSU_OUTPUT_VOLTAGE_MAX,
                 "Unit": Unit.Voltage,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsCurrent":
             {
@@ -438,7 +438,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_CURRENT_MIN,
                 "Max": threshold.PSU_OUTPUT_CURRENT_MAX,
                 "Unit": Unit.Current,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             },
             "OutputsPower":
             {
@@ -446,7 +446,7 @@ devices = {
                 "Min": threshold.PSU_OUTPUT_POWER_MIN,
                 "Max": threshold.PSU_OUTPUT_POWER_MAX,
                 "Unit": Unit.Power,
-                "format": "float(float(%s)/1000000)"
+                "divisor": 1000000
             },
         },
     ],
@@ -462,7 +462,7 @@ devices = {
                 "High": 100000,
                 "Max": 102000,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             }
         },
         {
@@ -476,7 +476,7 @@ devices = {
                 "High": 40000,
                 "Max": 50000,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             }
         },
         {
@@ -490,7 +490,7 @@ devices = {
                 "High": 70000,
                 "Max": 75000,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             }
         },
         {
@@ -504,7 +504,7 @@ devices = {
                 "High": 100000,
                 "Max": 105000,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             }
         },
         {
@@ -516,7 +516,7 @@ devices = {
                 "High": 80000,
                 "Max": 100000,
                 "Unit": Unit.Temperature,
-                "format": "float(float(%s)/1000)"
+                "divisor": 1000
             }
         },
     ],
@@ -1008,7 +1008,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 809,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD12V",
@@ -1021,7 +1021,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 12600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD1.0V_FPGA",
@@ -1034,7 +1034,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1071,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD1.8V_FPGA",
@@ -1047,7 +1047,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1890,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD1.2V_FPGA",
@@ -1060,7 +1060,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1260,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD3.3V",
@@ -1073,7 +1073,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3465,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_SW_VDD1.2V",
@@ -1086,7 +1086,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1260,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD5V_CLK_MCU",
@@ -1099,7 +1099,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 5334,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD5V_VR",
@@ -1112,7 +1112,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 5334,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD3.3_CLK",
@@ -1125,7 +1125,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3486,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDDO1.8V",
@@ -1138,7 +1138,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1901,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDDO1.2V",
@@ -1151,7 +1151,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1260,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD_CORE",
@@ -1164,7 +1164,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 950,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD_ANALOG",
@@ -1177,7 +1177,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 809,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_VDD1.2V_MAC",
@@ -1190,7 +1190,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1260,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_AVDD1.8V",
@@ -1203,7 +1203,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1890,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "BASE_VDD12V",
@@ -1216,7 +1216,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 12600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "BASE_SW_VDD1.2V",
@@ -1229,7 +1229,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1260,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "BASE_VDD2.5V",
@@ -1242,7 +1242,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 2615,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "BASE_VDD3.3V",
@@ -1255,7 +1255,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3444,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "BASE_SSD_VDD3.3V",
@@ -1268,7 +1268,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3465,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "CPU_VCCIN",
@@ -1281,7 +1281,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1950,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "CPU_P1V05",
@@ -1294,7 +1294,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1100,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "CPU_P1V2_VDDQ",
@@ -1307,7 +1307,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1260,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "CPU_P2V5_VPP",
@@ -1320,7 +1320,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 2447,
-            "format": "float(float(%s)/1000) * 1.124",
+            "divisor": 1000, "multiplier": 1.124,
         },
         {
             "name": "CPU_P3V3_STBY",
@@ -1333,7 +1333,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3465,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "CPU_P5V_AUX_IN",
@@ -1346,7 +1346,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 5500,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "CPU_P1V7_VCCSCFUSESUS_IN",
@@ -1359,7 +1359,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1785,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "UPORT_VDD1.0V_FPGA",
@@ -1372,7 +1372,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1061,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "UPORT_VDD1.8V_FPGA",
@@ -1385,7 +1385,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1901,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "UPORT_VDD1.2V_FPGA",
@@ -1398,7 +1398,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1260,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "UPORT_VDD3.3V",
@@ -1411,7 +1411,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "UPORT_QSFP56_VDD3.3V_A",
@@ -1424,7 +1424,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "UPORT_QSFP56_VDD3.3V_B",
@@ -1437,7 +1437,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "UPORT_QSFP56_VDD3.3V_C",
@@ -1450,7 +1450,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "UPORT_QSFP56_VDD3.3V_D",
@@ -1463,7 +1463,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "UPORT_VDD3.3_MON",
@@ -1476,7 +1476,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3465,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "UPORT_VDD12V",
@@ -1489,7 +1489,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 12600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "DPORT_VDD1.0V_FPGA",
@@ -1502,7 +1502,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1061,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "DPORT_VDD1.8V_FPGA",
@@ -1515,7 +1515,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1901,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "DPORT_VDD1.2V_FPGA",
@@ -1528,7 +1528,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 1260,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "DPORT_VDD3.3V",
@@ -1541,7 +1541,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "DPORT_QSFP56_VDD3.3V_A",
@@ -1554,7 +1554,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "DPORT_QSFP56_VDD3.3V_B",
@@ -1567,7 +1567,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "DPORT_QSFP56_VDD3.3V_C",
@@ -1580,7 +1580,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "DPORT_QSFP56_VDD3.3V_D",
@@ -1593,7 +1593,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "DPORT_VDD3.3_MON",
@@ -1606,7 +1606,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3465,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "DPORT_VDD12V",
@@ -1619,7 +1619,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 12600,
-            "format": "float(float(%s)/1000)",
+            "divisor": 1000,
         },
         {
             "name": "MAC_QSFPDD_VDD3.3V_A",
@@ -1632,7 +1632,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3.600,
-            "format": "%s",
+            "divisor": 1,
         },
         {
             "name": "MAC_QSFPDD_VDD3.3V_B",
@@ -1645,7 +1645,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3.600,
-            "format": "%s",
+            "divisor": 1,
         },
         {
             "name": "MAC_QSFPDD_VDD3.3V_C",
@@ -1658,7 +1658,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3.600,
-            "format": "%s",
+            "divisor": 1,
         },
         {
             "name": "MAC_QSFPDD_VDD3.3V_D",
@@ -1671,7 +1671,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3.600,
-            "format": "%s",
+            "divisor": 1,
         },
         {
             "name": "MAC_QSFPDD_VDD3.3V_E",
@@ -1684,7 +1684,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3.600,
-            "format": "%s",
+            "divisor": 1,
         },
         {
             "name": "MAC_QSFPDD_VDD3.3V_F",
@@ -1697,7 +1697,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3.600,
-            "format": "%s",
+            "divisor": 1,
         },
         {
             "name": "MAC_QSFPDD_VDD3.3V_G",
@@ -1710,7 +1710,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3.600,
-            "format": "%s",
+            "divisor": 1,
         },
         {
             "name": "MAC_QSFPDD_VDD3.3V_H",
@@ -1723,7 +1723,7 @@ devices = {
             "read_times": 11,
             "Unit": "V",
             "Max": 3.600,
-            "format": "%s",
+            "divisor": 1,
         },
     ],
     "cpu": [


### PR DESCRIPTION
#### Why I did it

##### Work item tracking
- Microsoft ADO:

The `format` field in Tencent platform sensor config was passed directly to `eval()` in sensor.py and temp.py without validation, allowing arbitrary Python execution as root in the pmon daemon.

#### How I did it

Replace `eval(self.format % val)` with explicit `divisor`/`multiplier` fields. `_scale()` in sensor.py computes `round(float(val) / divisor * multiplier, 3)`.

Update all Tencent hal-config device files to replace `"format"` strings with the corresponding numeric fields:
- `"format": "float(float(%s)/1000)"` → `"divisor": 1000`
- `"format": "float(float(%s)/1000000)"` → `"divisor": 1000000`
- `"format": "float(float(%s)/1000) * 1.124"` → `"divisor": 1000, "multiplier": 1.124`
- `"format": "%s"` → `"divisor": 1`

temp.py Value property override is also updated to use `_scale()`.

#### How to verify it

Unit tests added in `tests/test_sensor_format_validation.py` (17 tests):
- No `eval()` in sensor.py source
- No `eval(self.format` in temp.py source
- `temp` instances have `_scale()` via inheritance (runtime instantiation test)
- Scaling correctness for all three divisor/multiplier combinations
- Float precision preserved with `divisor=1`

Run: `cd platform/broadcom/sonic-platform-modules-tencent/common/lib/plat_hal && python3 -m pytest tests/test_sensor_format_validation.py -v`

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Description for the changelog

Replace eval() with explicit divisor/multiplier scaling in Tencent platform sensor.py and temp.py.

#### Link to config_db schema for YANG module changes

N/A
