### PR TITLE
[frrcfgd] Add PROTOCOL_ROUTE_MAP YANG + runtime handler (with set_src for parity)

### DIFF
--- a/dockers/docker-fpm-frr/frr/zebra/zebra.protocol_route_map.conf.j2
+++ b/dockers/docker-fpm-frr/frr/zebra/zebra.protocol_route_map.conf.j2
@@ -1,0 +1,56 @@
+{# ============================================================
+   Render the PROTOCOL_ROUTE_MAP CONFIG_DB table as zebra's
+       ip|ipv6 protocol <PROTO> route-map <NAME>
+   wrapped in a 'vrf <N> / ... / exit-vrf' block for non-default VRFs.
+   Key format from CONFIG_DB: "<vrf>|<addr_family>|<protocol>".
+   Shared between bgpcfgd (zebra.conf.j2) and frrcfgd
+   (frr.conf.j2); Jinja may present the key as either a
+   'pipe|joined' string or a tuple, so we normalize both.
+   Entries are grouped by VRF so each non-default VRF renders as a
+   single 'vrf <N> / ... / exit-vrf' block regardless of how many
+   filters it carries.
+
+   The blank line inside the `if` is intentional: the enclosing
+   template concatenates this output after the zebra.interfaces
+   block (which ends without a trailing newline). The leading
+   newline keeps rendered entries on their own line.
+   ============================================================ #}
+{# addr_family carries sonic-types:ip-family values ('IPv4'/'IPv6'); same
+   mapping convention as bgpd.conf.db.pref_list.j2 and bgpd.conf.db.route_map.j2. #}
+{% set ip_str = {'IPv4': 'ip', 'IPv6': 'ipv6'} %}
+{% if PROTOCOL_ROUTE_MAP is defined and PROTOCOL_ROUTE_MAP|length > 0 %}
+
+{# Pass 1: bucket valid rows into ns.by_vrf = {vrf: [(ip_kw, proto, rm), ...]} #}
+{% set ns = namespace(by_vrf={}) %}
+{% for prm_key, prm_val in PROTOCOL_ROUTE_MAP.items() %}
+{%   if prm_key is string %}
+{%     set parts = prm_key.split('|') %}
+{%   elif prm_key is iterable %}
+{%     set parts = prm_key %}
+{%   else %}
+{%     set parts = [] %}
+{%   endif %}
+{%   if parts|length == 3 and prm_val is mapping and 'route_map' in prm_val %}
+{%     set prm_ip_kw = ip_str.get(parts[1]) %}
+{%     if prm_ip_kw is not none %}
+{%       set _ = ns.by_vrf.setdefault(parts[0], []).append((prm_ip_kw, parts[2], prm_val['route_map'])) %}
+{%     endif %}
+{%   endif %}
+{% endfor %}
+{# Pass 2: emit one block per VRF. #}
+{% for vrf, entries in ns.by_vrf.items() %}
+{%   if vrf == 'default' %}
+{%     for ip_kw, proto, rm in entries %}
+{{ ip_kw }} protocol {{ proto }} route-map {{ rm }}
+{%     endfor %}
+!
+{%   else %}
+vrf {{ vrf }}
+{%     for ip_kw, proto, rm in entries %}
+ {{ ip_kw }} protocol {{ proto }} route-map {{ rm }}
+{%     endfor %}
+exit-vrf
+!
+{%   endif %}
+{% endfor %}
+{% endif %}

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -120,7 +120,8 @@ class BgpdClientMgr(threading.Thread):
             'IGMP_INTERFACE_QUERY': ['pimd'],
             'SRV6_MY_LOCATORS': ['zebra'],
             'SRV6_MY_SOURCE': ['zebra'],
-            'SRV6_MY_SIDS': ['mgmtd']
+            'SRV6_MY_SIDS': ['mgmtd'],
+            'PROTOCOL_ROUTE_MAP': ['mgmtd']
 
     }
     VTYSH_CMD_DAEMON = [(r'show (ip|ipv6) route($|\s+\S+)', ['zebra']),
@@ -1943,6 +1944,7 @@ class BGPConfigDaemon:
                          ('set_origin',                     '[bgpd]{no:no-prefix}set origin {:tolower}'),
                          ('set_local_pref',                 '[bgpd]{no:no-prefix}set local-preference {}'),
                          ('set_next_hop',                   '{no:no-prefix}set ip next-hop {}'),
+                         ('set_src',                        '[zebra]{no:no-prefix}set src {}'),
                          ('set_ipv6_next_hop_global',       '[bgpd]{no:no-prefix}set ipv6 next-hop global {}'),
                          ('set_ipv6_next_hop_prefer_global', '[bgpd]{no:no-prefix}set ipv6 next-hop prefer-global', ['true', 'false']),
                          (['set_metric_action', '+set_metric', '+set_med'], '{}set metric {} ', handle_rmap_set_metric),
@@ -2294,6 +2296,17 @@ class BGPConfigDaemon:
                                         nh_attr('ifname'), nh_attr('tag'), nh_attr('distance'),
                                         nh_attr('nexthop-vrf'))
 
+        # PROTOCOL_ROUTE_MAP state: normalized "<vrf>|<afi>|<proto>" key
+        # -> currently applied route_map name. Used to emit `no ip protocol ...
+        # route-map <NAME>` on delete, and to short-circuit idempotent sets.
+        self.protocol_route_map_state = {}
+        prm_table = self.config_db.get_table('PROTOCOL_ROUTE_MAP')
+        for key, entry in prm_table.items():
+            prm_key = '|'.join(key) if isinstance(key, tuple) else str(key)
+            rm = entry.get('route_map') if isinstance(entry, dict) else None
+            if rm:
+                self.protocol_route_map_state[prm_key] = rm
+
         self.table_handler_list = [
             ('VRF', self.vrf_handler),
             ('DEVICE_METADATA', self.metadata_handler),
@@ -2339,6 +2352,7 @@ class BGPConfigDaemon:
             ('SRV6_MY_LOCATORS', self.bgp_table_handler_common),
             ('SRV6_MY_SOURCE', self.bgp_table_handler_common),
             ('SRV6_MY_SIDS', self.bgp_table_handler_common),
+            ('PROTOCOL_ROUTE_MAP', self.protocol_route_map_handler),
         ]
         self.bgp_message = queue.Queue(0)
         self.table_data_cache = self.config_db.get_table_data([tbl for tbl, _ in self.table_handler_list])
@@ -3954,6 +3968,94 @@ class BGPConfigDaemon:
                                                          {'remote-address', 'vrf', 'interface', 'local-address'}])
     def bfd_mhop_handler(self, table, key, data):
         self.bgp_table_handler_common(table, key, data, [{'remote-address', 'vrf', 'local-address'}])
+
+    def protocol_route_map_handler(self, table, key, data):
+        """
+        Translate PROTOCOL_ROUTE_MAP rows to zebra commands.
+
+        CONFIG_DB key: "<vrf>|<addr_family>|<protocol>". Emits:
+            [vrf <vrf>]
+             ip|ipv6 protocol <protocol> route-map <route_map>
+            [exit-vrf]
+        The default VRF renders without the vrf/exit-vrf wrapping.
+
+        Per-key state (self.protocol_route_map_state) lets deletes emit
+        'no ... route-map <NAME>' using the last-applied name, and lets
+        idempotent sets short-circuit.
+        """
+        syslog.syslog(syslog.LOG_INFO,
+                      '[bgp cfgd](protocol_route_map) table={} key={} data={}'.format(table, key, data))
+
+        prm_key = '|'.join(key) if isinstance(key, tuple) else str(key)
+        parts = prm_key.split('|')
+        if len(parts) != 3:
+            syslog.syslog(syslog.LOG_ERR,
+                          'PROTOCOL_ROUTE_MAP: malformed key {} (expected vrf|afi|protocol)'.format(prm_key))
+            return
+
+        # addr_family uses sonic-types:ip-family (values 'IPv4'/'IPv6'); FRR
+        # expects 'ip'/'ipv6' as the CLI keyword. Same mapping used by
+        # bgpd.conf.db.pref_list.j2 and bgpd.conf.db.route_map.j2.
+        entry_vrf, afi, protocol = parts
+        ip_kw = {'IPv4': 'ip', 'IPv6': 'ipv6'}.get(afi)
+        if ip_kw is None:
+            syslog.syslog(syslog.LOG_ERR,
+                          'PROTOCOL_ROUTE_MAP: unsupported addr_family {} in key {}'.format(afi, prm_key))
+            return
+
+        prev_rm = self.protocol_route_map_state.get(prm_key)
+
+        # Decide what command to push, but DON'T mutate state yet — state must
+        # only reflect what FRR has actually accepted. Mutating before the
+        # vtysh succeeds would let a transient failure desync us permanently:
+        # the idempotent `prev_rm == route_map` guard would then silently skip
+        # every retry.
+        is_delete = data is None
+        if is_delete:
+            if prev_rm is None:
+                syslog.syslog(syslog.LOG_DEBUG,
+                              'PROTOCOL_ROUTE_MAP: del for untracked key {}; skipping'.format(prm_key))
+                return
+            inner = 'no {} protocol {} route-map {}'.format(ip_kw, protocol, prev_rm)
+            new_rm = None
+        else:
+            route_map = data.get('route_map') if isinstance(data, dict) else None
+            if not route_map:
+                syslog.syslog(syslog.LOG_ERR,
+                              'PROTOCOL_ROUTE_MAP: missing route_map for key {}'.format(prm_key))
+                return
+            if prev_rm == route_map:
+                syslog.syslog(syslog.LOG_DEBUG,
+                              'PROTOCOL_ROUTE_MAP: {} already bound to {}; skipping vtysh'.format(prm_key, route_map))
+                return
+            # FRR's `ip|ipv6 protocol X route-map Y` is upsert-style: emitting
+            # the new binding replaces any prior route-map for the same
+            # (vrf, afi, proto). No explicit `no ... route-map <prev>` needed.
+            inner = '{} protocol {} route-map {}'.format(ip_kw, protocol, route_map)
+            new_rm = route_map
+
+        # entry_vrf is the union type (literal "default" or a leafref into
+        # VRF_LIST) and route_map is a leafref into ROUTE_MAP_SET, both
+        # validated by YANG against ^[A-Za-z0-9_][A-Za-z0-9_-]*$-ish
+        # identifiers, so inserting them into the vtysh command string carries
+        # no shell-injection risk. If the schema is ever loosened, this
+        # assumption needs revisiting.
+        if entry_vrf == self.DEFAULT_VRF:
+            command = "vtysh -c 'configure terminal' -c '{}'".format(inner)
+        else:
+            command = ("vtysh -c 'configure terminal' "
+                       "-c 'vrf {}' -c '{}' -c 'exit-vrf'".format(entry_vrf, inner))
+
+        if not self.__run_command(table, command):
+            syslog.syslog(syslog.LOG_ERR,
+                          'PROTOCOL_ROUTE_MAP: failed running vtysh for key {}'.format(prm_key))
+            return
+
+        # Command succeeded — now it's safe to publish the new state.
+        if is_delete:
+            self.protocol_route_map_state.pop(prm_key, None)
+        else:
+            self.protocol_route_map_state[prm_key] = new_rm
 
     def start(self):
         self.subscribe_all()

--- a/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.route_map.j2
+++ b/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.route_map.j2
@@ -109,6 +109,9 @@ route-map {{rm_key[0]}} {{rm_val['route_operation']}} {{rm_key[1]}}
 {% if 'set_next_hop' in rm_val %}
  set ip next-hop {{rm_val['set_next_hop']}}
 {% endif %}
+{% if 'set_src' in rm_val %}
+ set src {{rm_val['set_src']}}
+{% endif %}
 {% if 'set_ipv6_next_hop_global' in rm_val %}
  set ipv6 next-hop global {{rm_val['set_ipv6_next_hop_global']}}
 {% endif %}

--- a/src/sonic-frr-mgmt-framework/templates/frr/frr.conf.j2
+++ b/src/sonic-frr-mgmt-framework/templates/frr/frr.conf.j2
@@ -24,6 +24,7 @@ fpm address 127.0.0.1
 !
 {% include "zebra/zebra.interfaces.conf.j2" %}
 !
+{% include "zebra/zebra.protocol_route_map.conf.j2" %}
 {% if MGMT_VRF_CONFIG %}
 {% if MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == 'false' %}
 {% include "staticd.db.default_route.conf.j2" %}

--- a/src/sonic-frr-mgmt-framework/tests/test_config.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_config.py
@@ -307,3 +307,265 @@ def test_bgp_neighbor_description_injection(run_cmd):
         if any('description' in arg for arg in cmd):
             assert any(injection_payload in arg for arg in cmd), \
                 "injection payload not found as literal arg: {}".format(cmd)
+
+
+def _make_prm_daemon(run_cmd, initial_table=None):
+    """Helper: build a BGPConfigDaemon and seed protocol_route_map_state
+    from initial_table (a dict of key -> {'route_map': ...}), then reset
+    run_cmd so the caller sees only the vtysh it triggers.
+
+    The daemon's own __init__ runs against a mocked config_db that returns
+    empty tables, so the state dict starts empty; we reseed it afterwards
+    to simulate pre-existing rows without touching the init path.
+    """
+    from frrcfgd.frrcfgd import BGPConfigDaemon
+    run_cmd.return_value = True
+    daemon = BGPConfigDaemon()
+
+    initial_table = initial_table or {}
+    daemon.protocol_route_map_state = {}
+    for k, v in initial_table.items():
+        norm_key = '|'.join(k) if isinstance(k, tuple) else str(k)
+        rm = v.get('route_map') if isinstance(v, dict) else None
+        if rm:
+            daemon.protocol_route_map_state[norm_key] = rm
+    run_cmd.reset_mock()
+    return daemon
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_prm_set_default_vrf_ipv4(run_cmd):
+    """SET on default VRF, ipv4, bgp emits 'ip protocol bgp route-map <NAME>'."""
+    daemon = _make_prm_daemon(run_cmd)
+    daemon.protocol_route_map_handler(
+        'PROTOCOL_ROUTE_MAP', 'default|IPv4|bgp', {'route_map': 'RM_FROM_BGP'})
+    assert run_cmd.call_count == 1
+    cmd = run_cmd.call_args[0][1]
+    assert "configure terminal" in cmd
+    assert "ip protocol bgp route-map RM_FROM_BGP" in cmd
+    assert "vrf " not in cmd  # default VRF: no 'vrf …' wrapping in the vtysh
+    assert daemon.protocol_route_map_state['default|IPv4|bgp'] == 'RM_FROM_BGP'
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_prm_set_default_vrf_ipv6_ospf6(run_cmd):
+    """IPv6 renders the 'ipv6' keyword instead of 'ip'."""
+    daemon = _make_prm_daemon(run_cmd)
+    daemon.protocol_route_map_handler(
+        'PROTOCOL_ROUTE_MAP', 'default|IPv6|ospf6', {'route_map': 'RM_V6'})
+    cmd = run_cmd.call_args[0][1]
+    assert "ipv6 protocol ospf6 route-map RM_V6" in cmd
+    assert "ip protocol" not in cmd  # should NOT emit ipv4 form
+    assert daemon.protocol_route_map_state['default|IPv6|ospf6'] == 'RM_V6'
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_prm_set_named_vrf_wraps_in_vrf_block(run_cmd):
+    """Non-default VRF wraps the line in 'vrf <N> / ... / exit-vrf'."""
+    daemon = _make_prm_daemon(run_cmd)
+    daemon.protocol_route_map_handler(
+        'PROTOCOL_ROUTE_MAP', 'Vrf_red|IPv4|static', {'route_map': 'RM_STATIC'})
+    cmd = run_cmd.call_args[0][1]
+    assert "vrf Vrf_red" in cmd
+    assert "ip protocol static route-map RM_STATIC" in cmd
+    assert "exit-vrf" in cmd
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_prm_set_with_tuple_key(run_cmd):
+    """swsscommon may deliver compound keys as tuples; handler must accept both."""
+    daemon = _make_prm_daemon(run_cmd)
+    daemon.protocol_route_map_handler(
+        'PROTOCOL_ROUTE_MAP', ('default', 'IPv4', 'connected'),
+        {'route_map': 'RM_CONN'})
+    cmd = run_cmd.call_args[0][1]
+    assert "ip protocol connected route-map RM_CONN" in cmd
+    assert daemon.protocol_route_map_state['default|IPv4|connected'] == 'RM_CONN'
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_prm_idempotent_set_skipped(run_cmd):
+    """Applying the same route-map twice must emit vtysh only once."""
+    daemon = _make_prm_daemon(run_cmd)
+    daemon.protocol_route_map_handler(
+        'PROTOCOL_ROUTE_MAP', 'default|IPv4|bgp', {'route_map': 'RM_A'})
+    assert run_cmd.call_count == 1
+    run_cmd.reset_mock()
+    daemon.protocol_route_map_handler(
+        'PROTOCOL_ROUTE_MAP', 'default|IPv4|bgp', {'route_map': 'RM_A'})
+    assert run_cmd.call_count == 0
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_prm_update_route_map(run_cmd):
+    """Updating to a different route-map emits a fresh binding."""
+    daemon = _make_prm_daemon(run_cmd)
+    daemon.protocol_route_map_handler(
+        'PROTOCOL_ROUTE_MAP', 'default|IPv4|bgp', {'route_map': 'RM_A'})
+    run_cmd.reset_mock()
+    daemon.protocol_route_map_handler(
+        'PROTOCOL_ROUTE_MAP', 'default|IPv4|bgp', {'route_map': 'RM_B'})
+    assert run_cmd.call_count == 1
+    cmd = run_cmd.call_args[0][1]
+    assert "ip protocol bgp route-map RM_B" in cmd
+    assert "RM_A" not in cmd
+    assert daemon.protocol_route_map_state['default|IPv4|bgp'] == 'RM_B'
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_prm_delete_emits_no_form(run_cmd):
+    """Deletion emits 'no ip protocol <PROTO> route-map <NAME>' using stored RM."""
+    daemon = _make_prm_daemon(
+        run_cmd,
+        initial_table={('default', 'IPv4', 'bgp'): {'route_map': 'RM_FROM_BGP'}},
+    )
+    daemon.protocol_route_map_handler(
+        'PROTOCOL_ROUTE_MAP', 'default|IPv4|bgp', None)
+    assert run_cmd.call_count == 1
+    cmd = run_cmd.call_args[0][1]
+    assert "no ip protocol bgp route-map RM_FROM_BGP" in cmd
+    assert 'default|IPv4|bgp' not in daemon.protocol_route_map_state
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_prm_delete_named_vrf(run_cmd):
+    """Deletion of a named-VRF row wraps the 'no' in 'vrf <N> / exit-vrf'."""
+    daemon = _make_prm_daemon(
+        run_cmd,
+        initial_table={('Vrf_red', 'IPv4', 'static'): {'route_map': 'RM_STATIC'}},
+    )
+    daemon.protocol_route_map_handler(
+        'PROTOCOL_ROUTE_MAP', 'Vrf_red|IPv4|static', None)
+    cmd = run_cmd.call_args[0][1]
+    assert "vrf Vrf_red" in cmd
+    assert "no ip protocol static route-map RM_STATIC" in cmd
+    assert "exit-vrf" in cmd
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_prm_delete_untracked_is_noop(run_cmd):
+    """Delete on a key never set is a silent noop — no vtysh push."""
+    daemon = _make_prm_daemon(run_cmd)
+    daemon.protocol_route_map_handler(
+        'PROTOCOL_ROUTE_MAP', 'default|IPv4|bgp', None)
+    assert run_cmd.call_count == 0
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_prm_malformed_key_is_ignored(run_cmd):
+    """Keys with the wrong number of components must be rejected without a push."""
+    daemon = _make_prm_daemon(run_cmd)
+    daemon.protocol_route_map_handler(
+        'PROTOCOL_ROUTE_MAP', 'default|ipv4', {'route_map': 'RM'})
+    assert run_cmd.call_count == 0
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_prm_unsupported_afi_is_ignored(run_cmd):
+    """addr_family outside IPv4/IPv6 must not produce a vtysh command."""
+    daemon = _make_prm_daemon(run_cmd)
+    daemon.protocol_route_map_handler(
+        'PROTOCOL_ROUTE_MAP', 'default|IPvX|bgp', {'route_map': 'RM'})
+    assert run_cmd.call_count == 0
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_prm_missing_route_map_is_ignored(run_cmd):
+    """A SET with no route_map field is rejected — YANG should have blocked
+    this, but the daemon must not push a broken vtysh command if it slips through."""
+    daemon = _make_prm_daemon(run_cmd)
+    daemon.protocol_route_map_handler(
+        'PROTOCOL_ROUTE_MAP', 'default|IPv4|bgp', {})
+    assert run_cmd.call_count == 0
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_prm_registered_in_table_handler_list(run_cmd):
+    """Sanity check: PROTOCOL_ROUTE_MAP is wired into table_handler_list so
+    CONFIG_DB subscription routes to our handler."""
+    from frrcfgd.frrcfgd import BGPConfigDaemon
+    run_cmd.return_value = True
+    daemon = BGPConfigDaemon()
+    mapped = dict(daemon.table_handler_list)
+    assert 'PROTOCOL_ROUTE_MAP' in mapped
+    assert mapped['PROTOCOL_ROUTE_MAP'] == daemon.protocol_route_map_handler
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_prm_set_state_not_updated_on_failure(run_cmd):
+    """If vtysh fails, the handler must NOT record the new route-map in
+    protocol_route_map_state — otherwise a retry would be silently
+    short-circuited by the idempotent `prev_rm == route_map` check."""
+    daemon = _make_prm_daemon(run_cmd)
+    run_cmd.return_value = False  # simulate transient FRR failure
+    daemon.protocol_route_map_handler(
+        'PROTOCOL_ROUTE_MAP', 'default|IPv4|bgp', {'route_map': 'RM_A'})
+    assert run_cmd.call_count == 1  # command was attempted
+    assert 'default|IPv4|bgp' not in daemon.protocol_route_map_state
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_prm_failed_set_is_retryable(run_cmd):
+    """After a failed SET, a retry with the same data must re-emit the vtysh
+    (not be short-circuited as 'already applied'), and a successful retry
+    must then advance state."""
+    daemon = _make_prm_daemon(run_cmd)
+    # First attempt fails.
+    run_cmd.return_value = False
+    daemon.protocol_route_map_handler(
+        'PROTOCOL_ROUTE_MAP', 'default|IPv4|bgp', {'route_map': 'RM_A'})
+    assert 'default|IPv4|bgp' not in daemon.protocol_route_map_state
+    # Retry succeeds.
+    run_cmd.return_value = True
+    run_cmd.reset_mock()
+    daemon.protocol_route_map_handler(
+        'PROTOCOL_ROUTE_MAP', 'default|IPv4|bgp', {'route_map': 'RM_A'})
+    assert run_cmd.call_count == 1  # not skipped as idempotent
+    assert daemon.protocol_route_map_state['default|IPv4|bgp'] == 'RM_A'
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_prm_delete_state_not_updated_on_failure(run_cmd):
+    """If the `no ... route-map` vtysh fails, state must still reflect the
+    old route-map so a retry can emit the same 'no' form."""
+    daemon = _make_prm_daemon(
+        run_cmd,
+        initial_table={('default', 'IPv4', 'bgp'): {'route_map': 'RM_A'}},
+    )
+    run_cmd.return_value = False
+    daemon.protocol_route_map_handler(
+        'PROTOCOL_ROUTE_MAP', 'default|IPv4|bgp', None)
+    assert run_cmd.call_count == 1
+    # State still shows RM_A so retry can emit `no ... route-map RM_A`.
+    assert daemon.protocol_route_map_state['default|IPv4|bgp'] == 'RM_A'
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_prm_update_failure_preserves_prior_route_map(run_cmd):
+    """If an update from RM_A -> RM_B fails, state must still show RM_A
+    (matching what zebra actually has), not RM_B."""
+    daemon = _make_prm_daemon(
+        run_cmd,
+        initial_table={('default', 'IPv4', 'bgp'): {'route_map': 'RM_A'}},
+    )
+    run_cmd.return_value = False
+    daemon.protocol_route_map_handler(
+        'PROTOCOL_ROUTE_MAP', 'default|IPv4|bgp', {'route_map': 'RM_B'})
+    assert daemon.protocol_route_map_state['default|IPv4|bgp'] == 'RM_A'

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -133,6 +133,7 @@ yang_files = [
     'sonic-fabric-monitor.yang',
     'sonic-fabric-port.yang',
     'sonic-feature.yang',
+    'sonic-protocol-route-map.yang',
     'sonic-fine-grained-ecmp.yang',
     'sonic-fips.yang',
     'sonic-flex_counter.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2011,6 +2011,11 @@
             "default|connected|bgp|ipv4": {
             }
         },
+        "PROTOCOL_ROUTE_MAP": {
+            "default|IPv4|bgp": {
+                "route_map": "map1"
+            }
+        },
         "PREFIX_SET": {
             "prefix1": {
             },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/protocol_route_map.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/protocol_route_map.json
@@ -1,0 +1,63 @@
+{
+    "PROTOCOL_ROUTE_MAP_VALID": {
+        "desc": "Configure per-protocol route filter with valid (vrf, addr_family, protocol) -> route-map bindings."
+    },
+
+    "PROTOCOL_ROUTE_MAP_VALID_NAMED_VRF": {
+        "desc": "Configure per-protocol route filter under a user-defined VRF."
+    },
+
+    "PROTOCOL_ROUTE_MAP_NON_EXIST_RT_MAP": {
+        "desc": "Referring a non-existent ROUTE_MAP_SET entry.",
+        "eStrKey": "LeafRef"
+    },
+
+    "PROTOCOL_ROUTE_MAP_NON_EXIST_VRF": {
+        "desc": "Referring a non-existent VRF name.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["vrf_name"]
+    },
+
+    "PROTOCOL_ROUTE_MAP_MISSING_RT_MAP": {
+        "desc": "Omitting the mandatory route_map leaf.",
+        "eStrKey": "Mandatory",
+        "eStr": ["route_map"]
+    },
+
+    "PROTOCOL_ROUTE_MAP_INVALID_PROTOCOL": {
+        "desc": "Using a protocol value outside the protocol-route-map-protocol enum.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["protocol"]
+    },
+
+    "PROTOCOL_ROUTE_MAP_INVALID_ADDR_FAMILY": {
+        "desc": "Using an addr_family value outside the IPv4/IPv6 enum.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["addr_family"]
+    },
+
+    "PROTOCOL_ROUTE_MAP_AFI_PROTO_MISMATCH_V4_OSPF6": {
+        "desc": "IPv4 addr_family with ospf6 protocol must fail the must expression.",
+        "eStr": ["protocol is not valid for the selected addr_family"]
+    },
+
+    "PROTOCOL_ROUTE_MAP_AFI_PROTO_MISMATCH_V6_OSPF": {
+        "desc": "IPv6 addr_family with ospf protocol must fail the must expression.",
+        "eStr": ["protocol is not valid for the selected addr_family"]
+    },
+
+    "PROTOCOL_ROUTE_MAP_AFI_PROTO_MISMATCH_V4_RIPNG": {
+        "desc": "IPv4 addr_family with ripng protocol must fail the must expression.",
+        "eStr": ["protocol is not valid for the selected addr_family"]
+    },
+
+    "PROTOCOL_ROUTE_MAP_AFI_PROTO_MISMATCH_V6_RIP": {
+        "desc": "IPv6 addr_family with rip protocol must fail the must expression.",
+        "eStr": ["protocol is not valid for the selected addr_family"]
+    },
+
+    "PROTOCOL_ROUTE_MAP_AFI_PROTO_MISMATCH_V6_EIGRP": {
+        "desc": "IPv6 addr_family with eigrp protocol must fail: FRR's EIGRP is IPv4-only.",
+        "eStr": ["protocol is not valid for the selected addr_family"]
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/protocol_route_map.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/protocol_route_map.json
@@ -1,0 +1,264 @@
+{
+    "PROTOCOL_ROUTE_MAP_VALID": {
+        "sonic-route-map:sonic-route-map": {
+            "sonic-route-map:ROUTE_MAP_SET": {
+                "ROUTE_MAP_SET_LIST": [
+                    { "name": "RM_FROM_BGP" },
+                    { "name": "RM_FROM_OSPF6" }
+                ]
+            }
+        },
+        "sonic-protocol-route-map:sonic-protocol-route-map": {
+            "sonic-protocol-route-map:PROTOCOL_ROUTE_MAP": {
+                "PROTOCOL_ROUTE_MAP_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "addr_family": "IPv4",
+                        "protocol": "bgp",
+                        "route_map": "RM_FROM_BGP"
+                    },
+                    {
+                        "vrf_name": "default",
+                        "addr_family": "IPv6",
+                        "protocol": "ospf6",
+                        "route_map": "RM_FROM_OSPF6"
+                    }
+                ]
+            }
+        }
+    },
+
+    "PROTOCOL_ROUTE_MAP_VALID_NAMED_VRF": {
+        "sonic-vrf:sonic-vrf": {
+            "sonic-vrf:VRF": {
+                "VRF_LIST": [
+                    { "name": "Vrf_red" }
+                ]
+            }
+        },
+        "sonic-route-map:sonic-route-map": {
+            "sonic-route-map:ROUTE_MAP_SET": {
+                "ROUTE_MAP_SET_LIST": [
+                    { "name": "RM_STATIC_V4" }
+                ]
+            }
+        },
+        "sonic-protocol-route-map:sonic-protocol-route-map": {
+            "sonic-protocol-route-map:PROTOCOL_ROUTE_MAP": {
+                "PROTOCOL_ROUTE_MAP_LIST": [
+                    {
+                        "vrf_name": "Vrf_red",
+                        "addr_family": "IPv4",
+                        "protocol": "static",
+                        "route_map": "RM_STATIC_V4"
+                    }
+                ]
+            }
+        }
+    },
+
+    "PROTOCOL_ROUTE_MAP_NON_EXIST_RT_MAP": {
+        "sonic-protocol-route-map:sonic-protocol-route-map": {
+            "sonic-protocol-route-map:PROTOCOL_ROUTE_MAP": {
+                "PROTOCOL_ROUTE_MAP_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "addr_family": "IPv4",
+                        "protocol": "bgp",
+                        "route_map": "RM_DOES_NOT_EXIST"
+                    }
+                ]
+            }
+        }
+    },
+
+    "PROTOCOL_ROUTE_MAP_NON_EXIST_VRF": {
+        "sonic-route-map:sonic-route-map": {
+            "sonic-route-map:ROUTE_MAP_SET": {
+                "ROUTE_MAP_SET_LIST": [
+                    { "name": "RM_ANY" }
+                ]
+            }
+        },
+        "sonic-protocol-route-map:sonic-protocol-route-map": {
+            "sonic-protocol-route-map:PROTOCOL_ROUTE_MAP": {
+                "PROTOCOL_ROUTE_MAP_LIST": [
+                    {
+                        "vrf_name": "Vrf_does_not_exist",
+                        "addr_family": "IPv4",
+                        "protocol": "bgp",
+                        "route_map": "RM_ANY"
+                    }
+                ]
+            }
+        }
+    },
+
+    "PROTOCOL_ROUTE_MAP_MISSING_RT_MAP": {
+        "sonic-protocol-route-map:sonic-protocol-route-map": {
+            "sonic-protocol-route-map:PROTOCOL_ROUTE_MAP": {
+                "PROTOCOL_ROUTE_MAP_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "addr_family": "IPv4",
+                        "protocol": "bgp"
+                    }
+                ]
+            }
+        }
+    },
+
+    "PROTOCOL_ROUTE_MAP_INVALID_PROTOCOL": {
+        "sonic-route-map:sonic-route-map": {
+            "sonic-route-map:ROUTE_MAP_SET": {
+                "ROUTE_MAP_SET_LIST": [
+                    { "name": "RM_ANY" }
+                ]
+            }
+        },
+        "sonic-protocol-route-map:sonic-protocol-route-map": {
+            "sonic-protocol-route-map:PROTOCOL_ROUTE_MAP": {
+                "PROTOCOL_ROUTE_MAP_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "addr_family": "IPv4",
+                        "protocol": "magic",
+                        "route_map": "RM_ANY"
+                    }
+                ]
+            }
+        }
+    },
+
+    "PROTOCOL_ROUTE_MAP_INVALID_ADDR_FAMILY": {
+        "sonic-route-map:sonic-route-map": {
+            "sonic-route-map:ROUTE_MAP_SET": {
+                "ROUTE_MAP_SET_LIST": [
+                    { "name": "RM_ANY" }
+                ]
+            }
+        },
+        "sonic-protocol-route-map:sonic-protocol-route-map": {
+            "sonic-protocol-route-map:PROTOCOL_ROUTE_MAP": {
+                "PROTOCOL_ROUTE_MAP_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "addr_family": "IPvX",
+                        "protocol": "bgp",
+                        "route_map": "RM_ANY"
+                    }
+                ]
+            }
+        }
+    },
+
+    "PROTOCOL_ROUTE_MAP_AFI_PROTO_MISMATCH_V4_OSPF6": {
+        "sonic-route-map:sonic-route-map": {
+            "sonic-route-map:ROUTE_MAP_SET": {
+                "ROUTE_MAP_SET_LIST": [
+                    { "name": "RM_ANY" }
+                ]
+            }
+        },
+        "sonic-protocol-route-map:sonic-protocol-route-map": {
+            "sonic-protocol-route-map:PROTOCOL_ROUTE_MAP": {
+                "PROTOCOL_ROUTE_MAP_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "addr_family": "IPv4",
+                        "protocol": "ospf6",
+                        "route_map": "RM_ANY"
+                    }
+                ]
+            }
+        }
+    },
+
+    "PROTOCOL_ROUTE_MAP_AFI_PROTO_MISMATCH_V6_OSPF": {
+        "sonic-route-map:sonic-route-map": {
+            "sonic-route-map:ROUTE_MAP_SET": {
+                "ROUTE_MAP_SET_LIST": [
+                    { "name": "RM_ANY" }
+                ]
+            }
+        },
+        "sonic-protocol-route-map:sonic-protocol-route-map": {
+            "sonic-protocol-route-map:PROTOCOL_ROUTE_MAP": {
+                "PROTOCOL_ROUTE_MAP_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "addr_family": "IPv6",
+                        "protocol": "ospf",
+                        "route_map": "RM_ANY"
+                    }
+                ]
+            }
+        }
+    },
+
+    "PROTOCOL_ROUTE_MAP_AFI_PROTO_MISMATCH_V4_RIPNG": {
+        "sonic-route-map:sonic-route-map": {
+            "sonic-route-map:ROUTE_MAP_SET": {
+                "ROUTE_MAP_SET_LIST": [
+                    { "name": "RM_ANY" }
+                ]
+            }
+        },
+        "sonic-protocol-route-map:sonic-protocol-route-map": {
+            "sonic-protocol-route-map:PROTOCOL_ROUTE_MAP": {
+                "PROTOCOL_ROUTE_MAP_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "addr_family": "IPv4",
+                        "protocol": "ripng",
+                        "route_map": "RM_ANY"
+                    }
+                ]
+            }
+        }
+    },
+
+    "PROTOCOL_ROUTE_MAP_AFI_PROTO_MISMATCH_V6_RIP": {
+        "sonic-route-map:sonic-route-map": {
+            "sonic-route-map:ROUTE_MAP_SET": {
+                "ROUTE_MAP_SET_LIST": [
+                    { "name": "RM_ANY" }
+                ]
+            }
+        },
+        "sonic-protocol-route-map:sonic-protocol-route-map": {
+            "sonic-protocol-route-map:PROTOCOL_ROUTE_MAP": {
+                "PROTOCOL_ROUTE_MAP_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "addr_family": "IPv6",
+                        "protocol": "rip",
+                        "route_map": "RM_ANY"
+                    }
+                ]
+            }
+        }
+    },
+
+    "PROTOCOL_ROUTE_MAP_AFI_PROTO_MISMATCH_V6_EIGRP": {
+        "sonic-route-map:sonic-route-map": {
+            "sonic-route-map:ROUTE_MAP_SET": {
+                "ROUTE_MAP_SET_LIST": [
+                    { "name": "RM_ANY" }
+                ]
+            }
+        },
+        "sonic-protocol-route-map:sonic-protocol-route-map": {
+            "sonic-protocol-route-map:PROTOCOL_ROUTE_MAP": {
+                "PROTOCOL_ROUTE_MAP_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "addr_family": "IPv6",
+                        "protocol": "eigrp",
+                        "route_map": "RM_ANY"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-protocol-route-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-protocol-route-map.yang
@@ -1,0 +1,113 @@
+module sonic-protocol-route-map {
+    namespace "http://github.com/sonic-net/sonic-protocol-route-map";
+    prefix sprm;
+    yang-version 1.1;
+
+    import sonic-vrf {
+        prefix vrf;
+    }
+
+    import sonic-route-map {
+        prefix rmap;
+    }
+
+    import sonic-types {
+        prefix stypes;
+    }
+
+    description
+        "SONiC YANG for protocol route-map. Each entry binds a route-map to
+         a (vrf, addr_family, protocol) tuple; the route-map decides which
+         routes from that protocol are installed into the FIB.";
+
+    revision 2026-04-20 {
+        description
+            "Initial revision.";
+    }
+
+    typedef protocol-route-map-protocol {
+        type enumeration {
+            enum any;
+            enum bgp;
+            enum connected;
+            enum eigrp;
+            enum isis;
+            enum kernel;
+            enum nhrp;
+            enum ospf;
+            enum ospf6;
+            enum rip;
+            enum ripng;
+            enum sharp;
+            enum static;
+            enum table;
+        }
+        description
+            "Source protocol whose routes are filtered through the route-map.
+             AFI/protocol compatibility is enforced by a 'must' expression on
+             the enclosing list (e.g. ospf6/ripng are IPv6-only, ospf/rip are
+             IPv4-only).";
+    }
+
+    container sonic-protocol-route-map {
+
+        container PROTOCOL_ROUTE_MAP {
+
+            description
+                "Protocol route-map table. Each entry binds a route-map to a
+                 (vrf, addr_family, protocol) tuple.";
+
+            list PROTOCOL_ROUTE_MAP_LIST {
+                key "vrf_name addr_family protocol";
+
+                // eigrp, ospf, and rip are IPv4-only; ospf6 and ripng are
+                // IPv6-only; nhrp is dual-stack. When a new protocol gains
+                // another AFI, extend this expression and the protocol enum
+                // above.
+                must "not(addr_family = 'IPv4' and (protocol = 'ospf6' or protocol = 'ripng')) and "
+                   + "not(addr_family = 'IPv6' and (protocol = 'ospf'  or protocol = 'rip' "
+                   +                            "or protocol = 'eigrp'))" {
+                    error-message
+                        "protocol is not valid for the selected addr_family";
+                }
+
+                leaf vrf_name {
+                    type union {
+                        type string {
+                            pattern "default";
+                        }
+                        type leafref {
+                            path "/vrf:sonic-vrf/vrf:VRF/vrf:VRF_LIST/vrf:name";
+                        }
+                    }
+                    description
+                        "VRF the binding applies in. Use 'default' for the
+                         global routing table.";
+                }
+
+                leaf addr_family {
+                    type stypes:ip-family;
+                    description
+                        "Address family (IPv4 or IPv6) the binding applies to.";
+                }
+
+                leaf protocol {
+                    type protocol-route-map-protocol;
+                    description
+                        "Source protocol whose routes are filtered through
+                         the route-map.";
+                }
+
+                leaf route_map {
+                    type leafref {
+                        path "/rmap:sonic-route-map/rmap:ROUTE_MAP_SET/rmap:ROUTE_MAP_SET_LIST/rmap:name";
+                    }
+                    mandatory true;
+                    description
+                        "Route-map applied to routes from <protocol> to
+                         decide which are installed into the FIB.";
+                }
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-route-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-route-map.yang
@@ -308,6 +308,15 @@ module sonic-route-map {
                     description "Set IP nexthop";
                 }
 
+                leaf set_src {
+                    type inet:ip-address;
+                    description
+                        "Set the source IP address (IPv4 or IPv6) that zebra uses when
+                         installing matched routes into the kernel FIB. The address must
+                         be locally configured on the device (typically a Loopback0
+                         address). Renders to FRR's route-map 'set src <addr>' clause.";
+                }
+
                 leaf set_ipv6_next_hop_global {
                     type string;
                     description "Set IPv6 global next hop";


### PR DESCRIPTION
Implements the HLD posted here: https://github.com/sonic-net/SONiC/pull/2367

Add a new SONiC YANG module that models protocol route-map — the policy that decides which routes from each routing protocol are installed into the FIB (and therefore APPL_DB and the hardware ASIC). Backed by FRR's `ip|ipv6 protocol <PROTO> route-map <NAME>` (see https://docs.frrouting.org/en/stable/zebra.html#zebra-route-filtering); a deny-match flows through `nexthop_active_check` -> `rib_process` and short-circuits `rib_install_kernel`, so fpmsyncd never sees the prefix and APPL_DB / hardware are never programmed for it. The route remains in zebra's RIB.

**Scoped to `frrcfgd` (unified FRR config)** per HLD review feedback — the previous version of this PR also carried a bgpcfgd runtime manager and a `zebra.conf.j2` boot-render include; both have been dropped. `frrcfgd` is the only mode supported.

Each CONFIG_DB entry in `PROTOCOL_ROUTE_MAP` binds a route-map to a `(vrf, addr_family, protocol)` tuple; `addr_family` reuses `sonic-types:ip-family` (IPv4/IPv6); a `must` expression enforces AFI/protocol compatibility (ospf/rip/eigrp IPv4-only, ospf6/ripng IPv6-only); `route_map` is a mandatory leafref into `ROUTE_MAP_SET`.

The `frrcfgd` translation path is supported end-to-end, boot and runtime:
- **Boot**: `dockers/docker-fpm-frr/frr/zebra/zebra.protocol_route_map.conf.j2` walks the `PROTOCOL_ROUTE_MAP` table and emits `ip|ipv6 protocol <PROTO> route-map <NAME>` grouped by VRF; included from `src/sonic-frr-mgmt-framework/templates/frr/frr.conf.j2`.
- **Runtime**: `protocol_route_map_handler` in `frrcfgd.py` translates SET / DEL events into the same vtysh commands, routed via `mgmtd` because the FRR CLI is a `DEFPY_YANG`.

Net effect: a `sonic-db-cli` write to `PROTOCOL_ROUTE_MAP` takes effect immediately — no `config_reload` required.

#### `set_src` — minimal feature-parity addition

A new `set_src` leaf is added on `ROUTE_MAP_SET_LIST`, matching template render in `bgpd.conf.db.route_map.j2`, and matching runtime entry in `frrcfgd.py`'s route-map dispatch dict.

**Why:** SONiC has historically stamped BGP-installed FIB entries with `Loopback0` as source via a hardcoded `RM_SET_SRC` route-map rendered by bgpcfgd's `ZebraSetSrc` manager. A `frrcfgd`-managed DUT loses that without a way to express `set src` from CONFIG_DB. Once `PROTOCOL_ROUTE_MAP` lands, an operator can drive the same setup from CONFIG_DB — but only if a route-map schema can carry `set src`. The `set_src` leaf is the smallest addition that unlocks that path, so this PR includes it as a **minimum, in-scope companion to `PROTOCOL_ROUTE_MAP`**. 

#### Why I did it

SONiC has YANG coverage for route-maps, prefix-lists, community sets, etc., but no schema for "limit which routes from this protocol are programmed into the FIB / APPL_DB / hardware." Today the only way to configure `ip protocol <proto> route-map <name>` is to hand-edit `frr.conf` — not survivable across `config_reload`, not declarative, not visible through the standard SONiC configuration plane. This PR adds a CONFIG_DB-driven schema so the feature is configured through the standard SONiC flow, plus the conversion layer to render and runtime-update the corresponding FRR config through `frrcfgd`.

The primary operator use case is reducing hardware route capacity pressure: routes from a chosen protocol can be selectively excluded from the FIB without affecting the BGP/OSPF/etc. control plane. A second use case, enabled by the accompanying `set_src` leaf, is stamping BGP-installed FIB entries with a specific source address (parity with the classic bgpcfgd `RM_SET_SRC` behavior).

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

New YANG module `src/sonic-yang-models/yang-models/sonic-protocol-route-map.yang`:

- Table `PROTOCOL_ROUTE_MAP` keyed on `vrf_name | addr_family | protocol`.
- `vrf_name`: union of the literal `default` and a leafref into `sonic-vrf`.
- `addr_family`: `sonic-types:ip-family` (`IPv4` / `IPv6`); rendered into the FRR `ip` / `ipv6` CLI keyword via the same `{'IPv4':'ip','IPv6':'ipv6'}` lookup the prefix-list and route-map templates already use.
- `protocol`: enum (any, bgp, connected, eigrp, isis, kernel, nhrp, ospf, ospf6, rip, ripng, static, table) — same set as FRR's `frr-route-types`.
- `route_map`: mandatory leafref into `sonic-route-map:ROUTE_MAP_SET`.

Additive edit to `src/sonic-yang-models/yang-models/sonic-route-map.yang`:

- New `set_src` leaf on `ROUTE_MAP_SET_LIST`, `type inet:ip-address` (already imported). One leaf; description-only otherwise.

Conversion layer:

- Boot rendering: new include `dockers/docker-fpm-frr/frr/zebra/zebra.protocol_route_map.conf.j2`, pulled into `sonic-frr-mgmt-framework/templates/frr/frr.conf.j2`. Renders empty when the table is missing; emits a single `vrf <N> / ... / exit-vrf` block per non-default VRF (rows for the same VRF grouped) and bare lines for the default VRF.
- Route-map template render: `bgpd.conf.db.route_map.j2` gains `{% if 'set_src' in rm_val %} set src {{rm_val['set_src']}} {% endif %}` between `set_next_hop` and `set_ipv6_next_hop_global`, so a `ROUTE_MAP` row carrying `set_src` renders inside the route-map body at boot.
- Runtime apply: `protocol_route_map_handler` in `frrcfgd.py` that: (a) seeds `protocol_route_map_state` from CONFIG_DB at init, (b) translates SET / UPDATE / DELETE events into vtysh, (c) advances state only on `__run_command` success so failures are retryable, (d) is registered against `mgmtd` in `TABLE_DAEMON` because the FRR CLIs are `DEFPY_YANG` and `frrcfgd` dispatches them through mgmtd's northbound (going to `['zebra']` directly returns "Unknown command").
- Runtime `set_src`: a `('set_src', '[zebra]{no:no-prefix}set src {}')` entry in `route_map_key_map` — one-line dispatch addition mirroring the template render.

##### Example

Filter BGP-learned IPv4 routes and OSPFv3 IPv6 routes in the default VRF, and filter both static and BGP routes in `Vrf_red`:

**CONFIG_DB:**

```json
{
    "PROTOCOL_ROUTE_MAP": {
        "default|IPv4|bgp":    { "route_map": "RM_FROM_BGP" },
        "default|IPv6|ospf6":  { "route_map": "RM_FROM_OSPF6" },
        "Vrf_red|IPv4|static": { "route_map": "RM_STATIC_V4" },
        "Vrf_red|IPv4|bgp":    { "route_map": "RM_BGP_RED" }
    }
}
```

**Reproducing the classic RM_SET_SRC behavior via CONFIG_DB, using `set_src`:**

```json
{
    "ROUTE_MAP": {
        "RM_FROM_BGP|10": { "route_operation": "permit", "set_src": "10.1.0.1" }
    },
    "PROTOCOL_ROUTE_MAP": {
        "default|IPv4|bgp": { "route_map": "RM_FROM_BGP" }
    }
}
```

**Corresponding FRR CLI (rendered into `frr.conf` and pushed via vtysh):**

```
route-map RM_FROM_BGP permit 10
 set src 10.1.0.1
!
ip protocol bgp route-map RM_FROM_BGP
!
```

This maps onto FRR's own YANG list `filter-protocol` under `/frr-vrf:lib/vrf[name=N]/frr-zebra:zebra/` (`frr-zebra.yang`). The SONiC schema flattens FRR's VRF-augmented tree into a single multi-key CONFIG_DB table and tightens the type system (enum protocol, IPv4/IPv6 AFI only, AFI/protocol `must`-guard).

#### How to verify it

The yang-models test harness (`src/sonic-yang-models/tests/yang_model_tests/test_yang_model.py`) globs `yang-models/*.yang` and every fixture under `tests/yang_model_tests/tests/`, so the new model + tests run automatically in CI. Expected outcomes for `PROTOCOL_ROUTE_MAP`:

- Positive: `PROTOCOL_ROUTE_MAP_VALID`, `PROTOCOL_ROUTE_MAP_VALID_NAMED_VRF` load cleanly.
- Negative: `LeafRef` (NON_EXIST_RT_MAP), `InvalidValue` x2 (NON_EXIST_VRF, INVALID_PROTOCOL), `Mandatory` (MISSING_RT_MAP), `Must` x5 (AFI_PROTO_MISMATCH_V4_OSPF6, V6_OSPF, V4_RIPNG, V6_RIP, V6_EIGRP).

- frrcfgd unit tests run in `src/sonic-frr-mgmt-framework` that verify the config translation.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

Add `PROTOCOL_ROUTE_MAP` CONFIG_DB table and YANG schema, plus frrcfgd handler and frr.conf template: bind a route-map to `(vrf, addr_family, protocol)` so chosen routes are filtered out before FIB / APPL_DB / hardware install. Renders to FRR's `ip|ipv6 protocol <PROTO> route-map <NAME>`. Also adds a `set_src` leaf on `ROUTE_MAP_SET_LIST` with matching template + frrcfgd dispatch so the classic RM_SET_SRC source-stamping behavior is expressible via CONFIG_DB.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

`Configuration.md` entry for `PROTOCOL_ROUTE_MAP` and the `set_src` leaf will be added in a follow-up doc PR.

#### A picture of a cute animal (not mandatory but encouraged)