### PR TITLE
[Mellanox] Add debug env flags and exponential backoff for FW query

### DIFF
--- a/platform/mellanox/platform-utils/mellanox_fw_manager/firmware_base.py
+++ b/platform/mellanox/platform-utils/mellanox_fw_manager/firmware_base.py
@@ -263,38 +263,72 @@ class FirmwareManagerBase(Process):
             FirmwareManagerError: If query fails or versions cannot be retrieved
         """
         cmd = ['mlxfwmanager', '--query-format', 'XML', '-d', self.pci_id]
-        result = self._run_command(cmd, capture_output=True, text=True)
-        if result.returncode != 0:
-            raise FirmwareManagerError("Query returned non-zero exit code")
+        env = self._get_env()
+        result = self._run_command(cmd, env=env, capture_output=True, text=True)
 
-        root = ET.fromstring(result.stdout)
+        output = result.stdout or ''
+
+        if result.returncode != 0:
+            raise FirmwareManagerError(f"Query returned non-zero exit code: {output}")
+
+        # Extract XML block from potentially verbose debug output
+        xml_start = output.find('<Devices>')
+        xml_end = output.find('</Devices>')
+        if xml_start < 0 or xml_end < 0:
+            raise FirmwareManagerError(f"No XML device data found in query output: {output}")
+
+        xml_str = output[xml_start:xml_end + len('</Devices>')]
+        root = ET.fromstring(xml_str)
         current_version = root.find('.//Device/Versions/FW').get('current')
         psid = root.find('.//Device').get('psid')
 
-        if not current_version or not psid:
-            raise FirmwareManagerError("Version or PSID not found in response")
+        if not current_version or current_version == '--' or not psid:
+            raise FirmwareManagerError(f"Version or PSID not found in response: {output}")
 
         available_version = self._get_available_firmware_version(psid)
         return current_version, available_version
 
     def _get_firmware_versions(self) -> Tuple[Optional[str], Optional[str]]:
-        """Get current and available firmware versions with retry logic."""
-        query_retry_count = 0
-        query_retry_count_max = 10
+        """Get current and available firmware versions with exponential backoff retry."""
+        max_wait = 60
+        delay = 1
+        max_delay = 16
+        start_time = time.monotonic()
+        attempt = 0
 
-        while query_retry_count < query_retry_count_max:
+        while True:
+            attempt += 1
             try:
                 return self._query_firmware_versions()
             except Exception as e:
-                if query_retry_count >= query_retry_count_max - 1:
-                    self.logger.error(f"Failed to get firmware versions after {query_retry_count_max} attempts: {str(e)}")
+                elapsed = time.monotonic() - start_time
+                remaining = max_wait - elapsed
+
+                if remaining <= 0:
+                    self.logger.error(
+                        f"Failed to get firmware versions for {self.pci_id} "
+                        f"after {attempt} attempts ({elapsed:.0f}s elapsed): {str(e)}"
+                    )
                     return None, None
-                self.logger.info(f"Unable to get firmware versions (attempt {query_retry_count + 1}/{query_retry_count_max}): {str(e)}, retrying...")
 
-            query_retry_count += 1
-            time.sleep(1)
+                sleep_time = min(delay, remaining)
+                error_str = str(e)
 
-        return None, None
+                if 'rc = 523' in error_str:
+                    self.logger.info(
+                        f"ASIC management interface not ready for {self.pci_id} "
+                        f"(MCAM rc=523): {error_str} "
+                        f"(retrying in {sleep_time:.0f}s, {remaining:.0f}s remaining)"
+                    )
+                else:
+                    self.logger.info(
+                        f"Unable to get firmware versions for {self.pci_id} "
+                        f"(attempt {attempt}): {error_str} "
+                        f"(retrying in {sleep_time:.0f}s, {remaining:.0f}s remaining)"
+                    )
+
+                time.sleep(sleep_time)
+                delay = min(delay * 2, max_delay)
 
     @abstractmethod
     def _get_available_firmware_version(self, psid: str) -> Optional[str]:

--- a/platform/mellanox/platform-utils/mellanox_fw_manager/firmware_base.py
+++ b/platform/mellanox/platform-utils/mellanox_fw_manager/firmware_base.py
@@ -316,7 +316,7 @@ class FirmwareManagerBase(Process):
 
                 if 'rc = 523' in error_str:
                     self.logger.info(
-                        f"ASIC management interface not ready for {self.pci_id} "
+                        f"ASIC not ready for {self.pci_id} "
                         f"(rc=523): {error_str} "
                         f"(retrying in {sleep_time:.0f}s, {remaining:.0f}s remaining)"
                     )

--- a/platform/mellanox/platform-utils/mellanox_fw_manager/firmware_base.py
+++ b/platform/mellanox/platform-utils/mellanox_fw_manager/firmware_base.py
@@ -320,17 +320,14 @@ class FirmwareManagerBase(Process):
                 error_str = str(e)
 
                 if 'rc = 523' in error_str:
-                    self.logger.info(
-                        f"ASIC not ready for {self.pci_id} "
-                        f"(rc=523): {error_str} "
-                        f"(retrying in {sleep_time:.0f}s, {remaining:.0f}s remaining)"
-                    )
+                    prefix = f"ASIC not ready for {self.pci_id} (rc=523)"
                 else:
-                    self.logger.info(
-                        f"Unable to get firmware versions for {self.pci_id} "
-                        f"(attempt {attempt}): {error_str} "
-                        f"(retrying in {sleep_time:.0f}s, {remaining:.0f}s remaining)"
-                    )
+                    prefix = f"Unable to get firmware versions for {self.pci_id} (attempt {attempt})"
+
+                self.logger.info(
+                    f"{prefix}: {error_str} "
+                    f"(retrying in {sleep_time:.0f}s, {remaining:.0f}s remaining)"
+                )
 
                 time.sleep(sleep_time)
                 delay = min(delay * 2, max_delay)

--- a/platform/mellanox/platform-utils/mellanox_fw_manager/firmware_base.py
+++ b/platform/mellanox/platform-utils/mellanox_fw_manager/firmware_base.py
@@ -289,7 +289,7 @@ class FirmwareManagerBase(Process):
         return current_version, available_version
 
     def _get_firmware_versions(self) -> Tuple[Optional[str], Optional[str]]:
-        """Get current and available firmware versions with exponential backoff retry."""
+        """Get current and available firmware versions with exponential back off retry."""
         max_wait = 60
         delay = 1
         max_delay = 16
@@ -317,7 +317,7 @@ class FirmwareManagerBase(Process):
                 if 'rc = 523' in error_str:
                     self.logger.info(
                         f"ASIC management interface not ready for {self.pci_id} "
-                        f"(MCAM rc=523): {error_str} "
+                        f"(rc=523): {error_str} "
                         f"(retrying in {sleep_time:.0f}s, {remaining:.0f}s remaining)"
                     )
                 else:

--- a/platform/mellanox/platform-utils/mellanox_fw_manager/firmware_base.py
+++ b/platform/mellanox/platform-utils/mellanox_fw_manager/firmware_base.py
@@ -267,15 +267,19 @@ class FirmwareManagerBase(Process):
         result = self._run_command(cmd, env=env, capture_output=True, text=True)
 
         output = result.stdout or ''
+        error_output = result.stderr or ''
+        stderr_suffix = f", stderr={error_output}" if error_output else ""
 
         if result.returncode != 0:
-            raise FirmwareManagerError(f"Query returned non-zero exit code: {output}")
+            raise FirmwareManagerError(
+                f"Query returned non-zero exit code: stdout={output}{stderr_suffix}")
 
         # Extract XML block from potentially verbose debug output
         xml_start = output.find('<Devices>')
         xml_end = output.find('</Devices>')
         if xml_start < 0 or xml_end < 0:
-            raise FirmwareManagerError(f"No XML device data found in query output: {output}")
+            raise FirmwareManagerError(
+                f"No XML device data found in query output: stdout={output}{stderr_suffix}")
 
         xml_str = output[xml_start:xml_end + len('</Devices>')]
         root = ET.fromstring(xml_str)
@@ -283,7 +287,8 @@ class FirmwareManagerBase(Process):
         psid = root.find('.//Device').get('psid')
 
         if not current_version or current_version == '--' or not psid:
-            raise FirmwareManagerError(f"Version or PSID not found in response: {output}")
+            raise FirmwareManagerError(
+                f"Version or PSID not found in response: stdout={output}{stderr_suffix}")
 
         available_version = self._get_available_firmware_version(psid)
         return current_version, available_version

--- a/platform/mellanox/platform-utils/tests/test_firmware_base.py
+++ b/platform/mellanox/platform-utils/tests/test_firmware_base.py
@@ -586,7 +586,7 @@ class TestFirmwareManagerBase(unittest.TestCase):
     @patch('mellanox_fw_manager.firmware_base.time.sleep')
     @patch('mellanox_fw_manager.firmware_base.subprocess.run')
     def test_get_firmware_versions_success_on_retry(self, mock_run, mock_sleep, mock_monotonic):
-        """Test _get_firmware_versions succeeds on third attempt with backoff"""
+        """Test _get_firmware_versions succeeds on third attempt with back off"""
         with patch.object(ConcreteFirmwareManager, '_initialize_asic'):
             manager = ConcreteFirmwareManager(
                 asic_index=0,
@@ -841,7 +841,7 @@ class TestFirmwareManagerBase(unittest.TestCase):
     @patch('mellanox_fw_manager.firmware_base.time.monotonic')
     @patch('mellanox_fw_manager.firmware_base.time.sleep')
     def test_get_firmware_versions_rc523_logging(self, mock_sleep, mock_monotonic):
-        """Test rc=523 error uses MCAM-specific log message"""
+        """Test rc=523 error uses management-interface-specific log message"""
         with patch.object(ConcreteFirmwareManager, '_initialize_asic'):
             manager = ConcreteFirmwareManager(
                 asic_index=0,
@@ -858,7 +858,7 @@ class TestFirmwareManagerBase(unittest.TestCase):
                     manager._get_firmware_versions()
 
                     info_msgs = [call[0][0] for call in mock_info.call_args_list]
-                    self.assertTrue(any("MCAM rc=523" in msg for msg in info_msgs))
+                    self.assertTrue(any("rc=523" in msg for msg in info_msgs))
                     self.assertTrue(
                         any("ASIC management interface not ready" in msg for msg in info_msgs)
                     )
@@ -866,7 +866,7 @@ class TestFirmwareManagerBase(unittest.TestCase):
     @patch('mellanox_fw_manager.firmware_base.time.monotonic')
     @patch('mellanox_fw_manager.firmware_base.time.sleep')
     def test_get_firmware_versions_exponential_backoff_timing(self, mock_sleep, mock_monotonic):
-        """Test exponential backoff delays double each retry and cap at 16s"""
+        """Test exponential back off delays double each retry and cap at 16s"""
         with patch.object(ConcreteFirmwareManager, '_initialize_asic'):
             manager = ConcreteFirmwareManager(
                 asic_index=0,

--- a/platform/mellanox/platform-utils/tests/test_firmware_base.py
+++ b/platform/mellanox/platform-utils/tests/test_firmware_base.py
@@ -520,10 +520,11 @@ class TestFirmwareManagerBase(unittest.TestCase):
         self.assertEqual(available, "2.0.0")
         mock_sleep.assert_not_called()
 
+    @patch('mellanox_fw_manager.firmware_base.time.monotonic')
     @patch('mellanox_fw_manager.firmware_base.time.sleep')
     @patch('mellanox_fw_manager.firmware_base.subprocess.run')
-    def test_get_firmware_versions_command_failure(self, mock_run, mock_sleep):
-        """Test _get_firmware_versions when command fails with retry logic"""
+    def test_get_firmware_versions_command_failure(self, mock_run, mock_sleep, mock_monotonic):
+        """Test _get_firmware_versions when command fails with time-bounded retry"""
         with patch.object(ConcreteFirmwareManager, '_initialize_asic'):
             manager = ConcreteFirmwareManager(
                 asic_index=0,
@@ -531,7 +532,8 @@ class TestFirmwareManagerBase(unittest.TestCase):
                 asic_type="test"
             )
 
-        mock_run.return_value = MagicMock(returncode=1)
+        mock_run.return_value = MagicMock(returncode=1, stdout='')
+        mock_monotonic.side_effect = [0, 20, 45, 61]
 
         with patch.object(manager.logger, 'info') as mock_info:
             with patch.object(manager.logger, 'error') as mock_error:
@@ -539,16 +541,23 @@ class TestFirmwareManagerBase(unittest.TestCase):
 
                 self.assertIsNone(current)
                 self.assertIsNone(available)
-                self.assertEqual(mock_run.call_count, 10)
-                self.assertEqual(mock_sleep.call_count, 9)
-                # 10 "Executing" logs from run_command + 9 "Unable to query" logs = 19 total
-                self.assertEqual(mock_info.call_count, 19)
-                mock_error.assert_called_once_with("Failed to get firmware versions after 10 attempts: Query returned non-zero exit code")
+                self.assertEqual(mock_run.call_count, 3)
+                self.assertEqual(mock_sleep.call_count, 2)
+                mock_sleep.assert_any_call(1)
+                mock_sleep.assert_any_call(2)
+                self.assertEqual(mock_info.call_count, 5)
+                mock_error.assert_called_once()
+                error_msg = mock_error.call_args[0][0]
+                self.assertIn("Failed to get firmware versions", error_msg)
+                self.assertIn("01:00.0", error_msg)
+                self.assertIn("3 attempts", error_msg)
+                self.assertIn("61s elapsed", error_msg)
 
+    @patch('mellanox_fw_manager.firmware_base.time.monotonic')
     @patch('mellanox_fw_manager.firmware_base.time.sleep')
     @patch('mellanox_fw_manager.firmware_base.subprocess.run')
-    def test_get_firmware_versions_xml_parsing_error(self, mock_run, mock_sleep):
-        """Test _get_firmware_versions with XML parsing error and retry logic"""
+    def test_get_firmware_versions_xml_parsing_error(self, mock_run, mock_sleep, mock_monotonic):
+        """Test _get_firmware_versions with missing XML tags and time-bounded retry"""
         with patch.object(ConcreteFirmwareManager, '_initialize_asic'):
             manager = ConcreteFirmwareManager(
                 asic_index=0,
@@ -557,6 +566,7 @@ class TestFirmwareManagerBase(unittest.TestCase):
             )
 
         mock_run.return_value = MagicMock(returncode=0, stdout="invalid xml")
+        mock_monotonic.side_effect = [0, 20, 45, 61]
 
         with patch.object(manager.logger, 'info') as mock_info:
             with patch.object(manager.logger, 'error') as mock_error:
@@ -564,16 +574,19 @@ class TestFirmwareManagerBase(unittest.TestCase):
 
                 self.assertIsNone(current)
                 self.assertIsNone(available)
-                self.assertEqual(mock_run.call_count, 10)
-                self.assertEqual(mock_sleep.call_count, 9)
-                # 10 "Executing" logs from run_command + 9 "Unable to..." logs = 19 total
-                self.assertEqual(mock_info.call_count, 19)
+                self.assertEqual(mock_run.call_count, 3)
+                self.assertEqual(mock_sleep.call_count, 2)
+                self.assertEqual(mock_info.call_count, 5)
                 mock_error.assert_called_once()
+                error_msg = mock_error.call_args[0][0]
+                self.assertIn("No XML device data found", error_msg)
+                self.assertIn("01:00.0", error_msg)
 
+    @patch('mellanox_fw_manager.firmware_base.time.monotonic')
     @patch('mellanox_fw_manager.firmware_base.time.sleep')
     @patch('mellanox_fw_manager.firmware_base.subprocess.run')
-    def test_get_firmware_versions_success_on_retry(self, mock_run, mock_sleep):
-        """Test _get_firmware_versions succeeds on third attempt"""
+    def test_get_firmware_versions_success_on_retry(self, mock_run, mock_sleep, mock_monotonic):
+        """Test _get_firmware_versions succeeds on third attempt with backoff"""
         with patch.object(ConcreteFirmwareManager, '_initialize_asic'):
             manager = ConcreteFirmwareManager(
                 asic_index=0,
@@ -591,10 +604,11 @@ class TestFirmwareManagerBase(unittest.TestCase):
         </Devices>'''
 
         mock_run.side_effect = [
-            MagicMock(returncode=1),
-            MagicMock(returncode=1),
+            MagicMock(returncode=1, stdout=''),
+            MagicMock(returncode=1, stdout=''),
             MagicMock(returncode=0, stdout=xml_output)
         ]
+        mock_monotonic.side_effect = [0, 1, 3]
 
         with patch.object(manager.logger, 'info') as mock_info:
             current, available = manager._get_firmware_versions()
@@ -603,12 +617,14 @@ class TestFirmwareManagerBase(unittest.TestCase):
             self.assertEqual(available, "2.0.0")
             self.assertEqual(mock_run.call_count, 3)
             self.assertEqual(mock_sleep.call_count, 2)
-            # 3 "Executing" logs from run_command + 2 "Unable to query" logs = 5 total
+            mock_sleep.assert_any_call(1)
+            mock_sleep.assert_any_call(2)
             self.assertEqual(mock_info.call_count, 5)
 
+    @patch('mellanox_fw_manager.firmware_base.time.monotonic')
     @patch('mellanox_fw_manager.firmware_base.time.sleep')
     @patch('mellanox_fw_manager.firmware_base.subprocess.run')
-    def test_get_firmware_versions_missing_version_field(self, mock_run, mock_sleep):
+    def test_get_firmware_versions_missing_version_field(self, mock_run, mock_sleep, mock_monotonic):
         """Test _get_firmware_versions when version field is missing"""
         with patch.object(ConcreteFirmwareManager, '_initialize_asic'):
             manager = ConcreteFirmwareManager(
@@ -627,6 +643,7 @@ class TestFirmwareManagerBase(unittest.TestCase):
         </Devices>'''
 
         mock_run.return_value = MagicMock(returncode=0, stdout=xml_output)
+        mock_monotonic.side_effect = [0, 20, 45, 61]
 
         with patch.object(manager.logger, 'info') as mock_info:
             with patch.object(manager.logger, 'error') as mock_error:
@@ -634,15 +651,18 @@ class TestFirmwareManagerBase(unittest.TestCase):
 
                 self.assertIsNone(current)
                 self.assertIsNone(available)
-                self.assertEqual(mock_run.call_count, 10)
-                self.assertEqual(mock_sleep.call_count, 9)
-                # 10 "Executing" logs from run_command + 9 "Unable to parse" logs = 19 total
-                self.assertEqual(mock_info.call_count, 19)
-                mock_error.assert_called_once_with("Failed to get firmware versions after 10 attempts: Version or PSID not found in response")
+                self.assertEqual(mock_run.call_count, 3)
+                self.assertEqual(mock_sleep.call_count, 2)
+                self.assertEqual(mock_info.call_count, 5)
+                mock_error.assert_called_once()
+                error_msg = mock_error.call_args[0][0]
+                self.assertIn("Version or PSID not found", error_msg)
+                self.assertIn("01:00.0", error_msg)
 
+    @patch('mellanox_fw_manager.firmware_base.time.monotonic')
     @patch('mellanox_fw_manager.firmware_base.time.sleep')
     @patch('mellanox_fw_manager.firmware_base.subprocess.run')
-    def test_get_firmware_versions_missing_psid_field(self, mock_run, mock_sleep):
+    def test_get_firmware_versions_missing_psid_field(self, mock_run, mock_sleep, mock_monotonic):
         """Test _get_firmware_versions when psid field is missing"""
         with patch.object(ConcreteFirmwareManager, '_initialize_asic'):
             manager = ConcreteFirmwareManager(
@@ -661,6 +681,7 @@ class TestFirmwareManagerBase(unittest.TestCase):
         </Devices>'''
 
         mock_run.return_value = MagicMock(returncode=0, stdout=xml_output)
+        mock_monotonic.side_effect = [0, 20, 45, 61]
 
         with patch.object(manager.logger, 'info') as mock_info:
             with patch.object(manager.logger, 'error') as mock_error:
@@ -668,11 +689,13 @@ class TestFirmwareManagerBase(unittest.TestCase):
 
                 self.assertIsNone(current)
                 self.assertIsNone(available)
-                self.assertEqual(mock_run.call_count, 10)
-                self.assertEqual(mock_sleep.call_count, 9)
-                # 10 "Executing" logs from run_command + 9 "Unable to parse" logs = 19 total
-                self.assertEqual(mock_info.call_count, 19)
-                mock_error.assert_called_once_with("Failed to get firmware versions after 10 attempts: Version or PSID not found in response")
+                self.assertEqual(mock_run.call_count, 3)
+                self.assertEqual(mock_sleep.call_count, 2)
+                self.assertEqual(mock_info.call_count, 5)
+                mock_error.assert_called_once()
+                error_msg = mock_error.call_args[0][0]
+                self.assertIn("Version or PSID not found", error_msg)
+                self.assertIn("01:00.0", error_msg)
 
     def test_get_env_verbose_mode(self):
         """Test _get_env with verbose mode"""
@@ -760,6 +783,108 @@ class TestFirmwareManagerBase(unittest.TestCase):
         result = manager.clear_semaphore()
 
         self.assertFalse(result)
+
+    @patch('mellanox_fw_manager.firmware_base.subprocess.run')
+    def test_query_firmware_versions_current_version_dashes(self, mock_run):
+        """Test _query_firmware_versions rejects current_version='--' as invalid"""
+        with patch.object(ConcreteFirmwareManager, '_initialize_asic'):
+            manager = ConcreteFirmwareManager(
+                asic_index=0,
+                pci_id="01:00.0",
+                asic_type="test"
+            )
+
+        xml_output = '''<?xml version="1.0"?>
+        <Devices>
+            <Device psid="MT_0000001187">
+                <Versions>
+                    <FW current="--"/>
+                </Versions>
+            </Device>
+        </Devices>'''
+        mock_run.return_value = MagicMock(returncode=0, stdout=xml_output)
+
+        with self.assertRaises(FirmwareManagerError) as context:
+            manager._query_firmware_versions()
+
+        self.assertIn("Version or PSID not found", str(context.exception))
+
+    @patch('mellanox_fw_manager.firmware_base.subprocess.run')
+    def test_query_firmware_versions_mixed_debug_xml(self, mock_run):
+        """Test _query_firmware_versions extracts XML from mixed debug output"""
+        with patch.object(ConcreteFirmwareManager, '_initialize_asic'):
+            manager = ConcreteFirmwareManager(
+                asic_index=0,
+                pci_id="01:00.0",
+                asic_type="test"
+            )
+
+        mixed_output = (
+            'DEBUG: some debug line\n'
+            'FLASH_ACCESS: reading register 0x1234\n'
+            '<Devices>\n'
+            '    <Device psid="MT_0000001187">\n'
+            '        <Versions>\n'
+            '            <FW current="1.0.0"/>\n'
+            '        </Versions>\n'
+            '    </Device>\n'
+            '</Devices>\n'
+            'DEBUG: done\n'
+        )
+        mock_run.return_value = MagicMock(returncode=0, stdout=mixed_output)
+
+        current, available = manager._query_firmware_versions()
+
+        self.assertEqual(current, "1.0.0")
+        self.assertEqual(available, "2.0.0")
+
+    @patch('mellanox_fw_manager.firmware_base.time.monotonic')
+    @patch('mellanox_fw_manager.firmware_base.time.sleep')
+    def test_get_firmware_versions_rc523_logging(self, mock_sleep, mock_monotonic):
+        """Test rc=523 error uses MCAM-specific log message"""
+        with patch.object(ConcreteFirmwareManager, '_initialize_asic'):
+            manager = ConcreteFirmwareManager(
+                asic_index=0,
+                pci_id="01:00.0",
+                asic_type="test"
+            )
+
+        mock_monotonic.side_effect = [0, 5, 61]
+        rc523_error = FirmwareManagerError("Query failed rc = 523 details")
+
+        with patch.object(manager, '_query_firmware_versions', side_effect=rc523_error):
+            with patch.object(manager.logger, 'info') as mock_info:
+                with patch.object(manager.logger, 'error'):
+                    manager._get_firmware_versions()
+
+                    info_msgs = [call[0][0] for call in mock_info.call_args_list]
+                    self.assertTrue(any("MCAM rc=523" in msg for msg in info_msgs))
+                    self.assertTrue(
+                        any("ASIC management interface not ready" in msg for msg in info_msgs)
+                    )
+
+    @patch('mellanox_fw_manager.firmware_base.time.monotonic')
+    @patch('mellanox_fw_manager.firmware_base.time.sleep')
+    def test_get_firmware_versions_exponential_backoff_timing(self, mock_sleep, mock_monotonic):
+        """Test exponential backoff delays double each retry and cap at 16s"""
+        with patch.object(ConcreteFirmwareManager, '_initialize_asic'):
+            manager = ConcreteFirmwareManager(
+                asic_index=0,
+                pci_id="01:00.0",
+                asic_type="test"
+            )
+
+        mock_monotonic.side_effect = [0, 1, 2, 4, 8, 16, 32, 48, 61]
+
+        with patch.object(manager, '_query_firmware_versions',
+                          side_effect=FirmwareManagerError("test error")):
+            with patch.object(manager.logger, 'info'):
+                with patch.object(manager.logger, 'error'):
+                    manager._get_firmware_versions()
+
+        expected_sleeps = [1, 2, 4, 8, 16, 16, 12]
+        actual_sleeps = [call[0][0] for call in mock_sleep.call_args_list]
+        self.assertEqual(actual_sleeps, expected_sleeps)
 
 
 if __name__ == '__main__':

--- a/platform/mellanox/platform-utils/tests/test_firmware_base.py
+++ b/platform/mellanox/platform-utils/tests/test_firmware_base.py
@@ -841,7 +841,7 @@ class TestFirmwareManagerBase(unittest.TestCase):
     @patch('mellanox_fw_manager.firmware_base.time.monotonic')
     @patch('mellanox_fw_manager.firmware_base.time.sleep')
     def test_get_firmware_versions_rc523_logging(self, mock_sleep, mock_monotonic):
-        """Test rc=523 error uses management-interface-specific log message"""
+        """Test rc=523 error uses ASIC-not-ready log message"""
         with patch.object(ConcreteFirmwareManager, '_initialize_asic'):
             manager = ConcreteFirmwareManager(
                 asic_index=0,
@@ -860,7 +860,7 @@ class TestFirmwareManagerBase(unittest.TestCase):
                     info_msgs = [call[0][0] for call in mock_info.call_args_list]
                     self.assertTrue(any("rc=523" in msg for msg in info_msgs))
                     self.assertTrue(
-                        any("ASIC management interface not ready" in msg for msg in info_msgs)
+                        any("ASIC not ready" in msg for msg in info_msgs)
                     )
 
     @patch('mellanox_fw_manager.firmware_base.time.monotonic')


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The firmware version query (`mlxfwmanager --query-format XML`) can fail transiently when the FW initiliazation of the ASIC is not yet complete and MCAM register is not accessible (MCAM rc=523). The previous fixed 1s retry over 10 attempts (~10s) was insufficient for slow-initializing ASICs, and lacked diagnostic output to understand failures.

#### How I did it

- Pass `_get_env()` to the query command so `FLASH_ACCESS_DEBUG` / `FW_COMPS_DEBUG` are set when verbose mode is enabled.
- Extract `<Devices>...</Devices>` XML from stdout to handle verbose debug output mixed with the XML response.
- Replace fixed-interval retry with exponential backoff (1s -> 2s -> 4s -> 8s -> 16s cap) bounded by 60s total wall-clock time.
- Add specific log message when MCAM rc=523 is detected, identifying the ASIC management interface as not ready.
- Treat `current_version == '--'` as an invalid response (indicates device failed to open).
- Include `stderr` from `mlxfwmanager` in `FirmwareManagerError` messages (only when non-empty) so retry/error logs surface failure context from the underlying tool that was previously dropped.

#### How to verify it

- Deploy to a switch and trigger FW query during ASIC init (rc=523 window) i.e this is automatically triggered on a reboot. Verify logs show the MCAM-specific message with backoff timing.
- On a healthy switch, verify query succeeds on first attempt with debug output correctly parsed.
- Enable `--verbose` flag and confirm `FLASH_ACCESS_DEBUG`/`FW_COMPS_DEBUG` output does not break XML parsing.
- Force a query failure (e.g. invalid PCI id) and confirm the resulting error log includes the `stderr=` suffix with the underlying tool error.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

[Mellanox] Improve mlxfwmanager FW query diagnostics: pass debug env flags in verbose mode, extract XML from mixed debug output, retry with exponential backoff (60s budget) on transient MCAM rc=523, log stderr on failure, and reject '--' as a valid current version.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

N/A - no YANG / config_db schema changes.

#### A picture of a cute animal (not mandatory but encouraged)