### PR TITLE
[ragile] Replace os.system with subprocess.call and add unit tests

### DIFF
--- a/platform/broadcom/sonic-platform-modules-ragile/common/script/dev_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-ragile/common/script/dev_monitor.py
@@ -108,18 +108,20 @@ class DevMonitor():
         return ret
 
     def removeDev(self, bus, loc):
-        cmd = "echo  0x%02x > /sys/bus/i2c/devices/i2c-%d/delete_device" % (loc, bus)
         devpath = "/sys/bus/i2c/devices/%d-%04x" % (bus, loc)
         if os.path.exists(devpath):
-            os.system(cmd)
+            delete_file = "/sys/bus/i2c/devices/i2c-%d/delete_device" % bus
+            with open(delete_file, 'w') as f:
+                f.write("0x%02x\n" % loc)
 
     def addDev(self, name, bus, loc):
         if name == "lm75":
             time.sleep(0.1)
-        cmd = "echo  %s 0x%02x > /sys/bus/i2c/devices/i2c-%d/new_device" % (name, loc, bus)
         devpath = "/sys/bus/i2c/devices/%d-%04x" % (bus, loc)
         if os.path.exists(devpath) is False:
-            os.system(cmd)
+            new_device_file = "/sys/bus/i2c/devices/i2c-%d/new_device" % bus
+            with open(new_device_file, 'w') as f:
+                f.write("%s 0x%02x\n" % (name, loc))
 
     def checkattr(self, bus, loc, attr):
         try:

--- a/platform/broadcom/sonic-platform-modules-ragile/common/script/generate_airflow.py
+++ b/platform/broadcom/sonic-platform-modules-ragile/common/script/generate_airflow.py
@@ -16,6 +16,7 @@ write resulet to AIRFLOW_RESULT_FILE, file format:
 }
 '''
 import os
+import subprocess
 import syslog
 import json
 from platform_config import AIR_FLOW_CONF, AIRFLOW_RESULT_FILE
@@ -222,12 +223,11 @@ def generate_airflow():
 
     out_file_dir = os.path.dirname(AIRFLOW_RESULT_FILE)
     if len(out_file_dir) != 0:
-        cmd = "mkdir -p %s" % out_file_dir
-        os.system(cmd)
-        os.system("sync")
+        subprocess.call(["mkdir", "-p", out_file_dir])
+        subprocess.call(["sync"])
     with open(AIRFLOW_RESULT_FILE, "w") as fd:
         fd.write(ret_json)
-    os.system("sync")
+    subprocess.call(["sync"])
 
 
 if __name__ == '__main__':

--- a/platform/broadcom/sonic-platform-modules-ragile/common/script/intelligent_monitor/monitor_fan.py
+++ b/platform/broadcom/sonic-platform-modules-ragile/common/script/intelligent_monitor/monitor_fan.py
@@ -2,6 +2,7 @@
 # -*- coding: UTF-8 -*-
 
 import os
+import subprocess
 import time
 import logging
 from logging.handlers import RotatingFileHandler
@@ -19,8 +20,8 @@ E2_NAME = "ONIE_E2"
 
 def _init_logger():
     if not os.path.exists(LOG_FILE):
-        os.system("mkdir -p %s" % os.path.dirname(LOG_FILE))
-        os.system("sync")
+        subprocess.call(["mkdir", "-p", os.path.dirname(LOG_FILE)])
+        subprocess.call(["sync"])
     handler = RotatingFileHandler(filename=LOG_FILE, maxBytes=5 * 1024 * 1024, backupCount=1)
     formatter = logging.Formatter("%(asctime)s %(levelname)s %(filename)s[%(funcName)s][%(lineno)s]: %(message)s")
     handler.setFormatter(formatter)

--- a/platform/broadcom/sonic-platform-modules-ragile/common/script/intelligent_monitor/tests/test_monitor_fan.py
+++ b/platform/broadcom/sonic-platform-modules-ragile/common/script/intelligent_monitor/tests/test_monitor_fan.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+"""
+Unit tests for monitor_fan.py
+"""
+
+import os
+import sys
+import time
+import pytest
+from unittest.mock import patch, MagicMock, PropertyMock
+
+# Mock platform-specific imports
+sys.modules['plat_hal'] = MagicMock()
+sys.modules['plat_hal.interface'] = MagicMock()
+sys.modules['plat_hal.baseutil'] = MagicMock()
+
+import monitor_fan as mf
+
+
+class TestInitLogger:
+    """Tests for _init_logger()"""
+
+    @patch('monitor_fan.RotatingFileHandler')
+    @patch('subprocess.call')
+    @patch('os.path.exists', return_value=False)
+    def test_creates_log_directory_when_missing(self, mock_exists, mock_call, mock_handler):
+        logger = mf._init_logger()
+        mock_call.assert_any_call(["mkdir", "-p", os.path.dirname(mf.LOG_FILE)])
+        mock_call.assert_any_call(["sync"])
+        assert logger is not None
+
+    @patch('monitor_fan.RotatingFileHandler')
+    @patch('os.path.exists', return_value=True)
+    def test_skips_mkdir_when_log_exists(self, mock_exists, mock_handler):
+        with patch('subprocess.call') as mock_call:
+            logger = mf._init_logger()
+        mock_call.assert_not_called()
+        assert logger is not None
+
+
+class TestFan:
+    """Tests for Fan class"""
+
+    def setup_method(self):
+        self.mock_interface = MagicMock()
+        self.fan = mf.Fan("FAN1", self.mock_interface)
+
+    def test_init(self):
+        assert self.fan.name == "FAN1"
+        assert self.fan.pre_present is False
+        assert self.fan.pre_status is True
+        assert self.fan.plugin_cnt == 0
+        assert self.fan.plugout_cnt == 0
+
+    def test_fan_dict_update_caches(self):
+        self.mock_interface.get_fan_info.return_value = {"NAME": "FAN-A", "SN": "123"}
+        self.fan.fan_dict_update()
+        self.fan.fan_dict_update()  # second call should use cache
+        self.mock_interface.get_fan_info.assert_called_once()
+
+    def test_fan_dict_update_refreshes_after_interval(self):
+        self.mock_interface.get_fan_info.return_value = {"NAME": "FAN-A", "SN": "123"}
+        self.fan.fan_dict_update()
+        self.fan.update_time = time.time() - 2  # simulate 2 seconds ago
+        self.fan.fan_dict_update()
+        assert self.mock_interface.get_fan_info.call_count == 2
+
+    def test_get_model(self):
+        self.mock_interface.get_fan_info.return_value = {"NAME": "FAN-MODEL-A", "SN": "123"}
+        assert self.fan.get_model() == "FAN-MODEL-A"
+
+    def test_get_serial(self):
+        self.mock_interface.get_fan_info.return_value = {"NAME": "FAN-A", "SN": "SN12345"}
+        assert self.fan.get_serial() == "SN12345"
+
+    def test_get_presence(self):
+        self.mock_interface.get_fan_presence.return_value = True
+        assert self.fan.get_presence() is True
+        self.mock_interface.get_fan_presence.assert_called_with("FAN1")
+
+    def test_get_rotor_speed_normal(self):
+        self.mock_interface.get_fan_info_rotor.return_value = {
+            "Rotor1": {"Speed": 8000, "SpeedMax": 10000}
+        }
+        assert self.fan.get_rotor_speed("Rotor1") == 80
+
+    def test_get_rotor_speed_over_100_capped(self):
+        self.mock_interface.get_fan_info_rotor.return_value = {
+            "Rotor1": {"Speed": 12000, "SpeedMax": 10000}
+        }
+        assert self.fan.get_rotor_speed("Rotor1") == 100
+
+    def test_get_rotor_speed_string_value_returns_zero(self):
+        self.mock_interface.get_fan_info_rotor.return_value = {
+            "Rotor1": {"Speed": "N/A", "SpeedMax": 10000}
+        }
+        assert self.fan.get_rotor_speed("Rotor1") == 0
+
+    def test_get_rotor_speed_none_value_returns_zero(self):
+        self.mock_interface.get_fan_info_rotor.return_value = {
+            "Rotor1": {"Speed": None, "SpeedMax": 10000}
+        }
+        assert self.fan.get_rotor_speed("Rotor1") == 0
+
+    def test_get_rotor_speed_tolerance_normal(self):
+        self.mock_interface.get_fan_info_rotor.return_value = {
+            "Rotor1": {"Tolerance": 25}
+        }
+        assert self.fan.get_rotor_speed_tolerance("Rotor1") == 25
+
+    def test_get_rotor_speed_tolerance_string_returns_default(self):
+        self.mock_interface.get_fan_info_rotor.return_value = {
+            "Rotor1": {"Tolerance": "N/A"}
+        }
+        assert self.fan.get_rotor_speed_tolerance("Rotor1") == 30
+
+    def test_get_rotor_speed_tolerance_none_returns_default(self):
+        self.mock_interface.get_fan_info_rotor.return_value = {
+            "Rotor1": {"Tolerance": None}
+        }
+        assert self.fan.get_rotor_speed_tolerance("Rotor1") == 30
+
+    def test_get_target_speed(self):
+        self.mock_interface.get_fan_speed_pwm.return_value = 75
+        assert self.fan.get_target_speed() == 75
+
+    def test_get_status_not_present(self):
+        self.mock_interface.get_fan_presence.return_value = False
+        assert self.fan.get_status() is False
+
+    def test_get_status_speed_within_tolerance(self):
+        self.mock_interface.get_fan_presence.return_value = True
+        self.mock_interface.get_fan_rotor_number.return_value = 1
+        self.mock_interface.get_fan_info_rotor.return_value = {
+            "Rotor1": {"Speed": 7500, "SpeedMax": 10000, "Tolerance": 30}
+        }
+        self.mock_interface.get_fan_speed_pwm.return_value = 75
+        assert self.fan.get_status() is True
+
+    def test_get_status_speed_too_high(self):
+        self.mock_interface.get_fan_presence.return_value = True
+        self.mock_interface.get_fan_rotor_number.return_value = 1
+        self.mock_interface.get_fan_info_rotor.return_value = {
+            "Rotor1": {"Speed": 10000, "SpeedMax": 10000, "Tolerance": 10}
+        }
+        self.mock_interface.get_fan_speed_pwm.return_value = 50  # target 50%, actual 100%
+        assert self.fan.get_status() is False
+
+    def test_get_status_speed_too_low(self):
+        self.mock_interface.get_fan_presence.return_value = True
+        self.mock_interface.get_fan_rotor_number.return_value = 1
+        self.mock_interface.get_fan_info_rotor.return_value = {
+            "Rotor1": {"Speed": 1000, "SpeedMax": 10000, "Tolerance": 10}
+        }
+        self.mock_interface.get_fan_speed_pwm.return_value = 80  # target 80%, actual 10%
+        assert self.fan.get_status() is False
+
+    def test_get_status_multiple_rotors(self):
+        self.mock_interface.get_fan_presence.return_value = True
+        self.mock_interface.get_fan_rotor_number.return_value = 2
+        self.mock_interface.get_fan_info_rotor.return_value = {
+            "Rotor1": {"Speed": 7500, "SpeedMax": 10000, "Tolerance": 30},
+            "Rotor2": {"Speed": 7500, "SpeedMax": 10000, "Tolerance": 30},
+        }
+        self.mock_interface.get_fan_speed_pwm.return_value = 75
+        assert self.fan.get_status() is True
+
+    def test_get_direction(self):
+        self.mock_interface.get_fan_info.return_value = {"NAME": "FAN-A", "SN": "123", "AirFlow": "intake"}
+        assert self.fan.get_direction() == "intake"
+
+
+class TestMonitorFan:
+    """Tests for MonitorFan class"""
+
+    def setup_method(self):
+        self.mock_baseutil = MagicMock()
+        self.mock_baseutil.get_monitor_config.return_value = {
+            "monitor_fan_para": {
+                "present_interval": 0.5,
+                "status_interval": 5,
+                "present_check_cnt": 3,
+                "status_check_cnt": 3,
+            }
+        }
+        with patch.object(mf, 'baseutil', self.mock_baseutil), \
+             patch.object(mf, 'interface', MagicMock()), \
+             patch.object(mf, '_init_logger', return_value=MagicMock()):
+            self.monitor = mf.MonitorFan()
+
+    def test_debug_init_debug_mode(self):
+        with patch('os.path.exists', return_value=True):
+            self.monitor.debug_init()
+        self.monitor.logger.setLevel.assert_called_with(mf.logging.DEBUG)
+
+    def test_debug_init_info_mode(self):
+        with patch('os.path.exists', return_value=False):
+            self.monitor.debug_init()
+        self.monitor.logger.setLevel.assert_called_with(mf.logging.INFO)
+
+    def test_fan_obj_init(self):
+        self.monitor.int_case.get_fan_total_number.return_value = 3
+        self.monitor.fan_obj_init()
+        assert len(self.monitor.fan_obj_list) == 3
+        assert self.monitor.fan_obj_list[0].name == "FAN1"
+        assert self.monitor.fan_obj_list[2].name == "FAN3"
+
+    def test_fan_airflow_check_match(self):
+        fan_obj = MagicMock()
+        fan_obj.name = "FAN1"
+        fan_obj.get_direction.return_value = "intake"
+        self.monitor.int_case.get_device_airflow.return_value = "intake"
+
+        self.monitor.fan_airflow_check(fan_obj)
+        self.monitor.logger.debug.assert_called()
+
+    def test_fan_airflow_check_mismatch(self):
+        fan_obj = MagicMock()
+        fan_obj.name = "FAN1"
+        fan_obj.get_direction.return_value = "intake"
+        self.monitor.int_case.get_device_airflow.return_value = "exhaust"
+
+        self.monitor.fan_airflow_check(fan_obj)
+        self.monitor.logger.error.assert_called()
+
+    def test_fan_plug_in_detected(self):
+        fan_obj = mf.Fan("FAN1", MagicMock())
+        fan_obj.pre_present = False
+        fan_obj.int_case.get_fan_presence.return_value = True
+        # Need 3 consecutive detections
+        for _ in range(3):
+            self.monitor.fan_plug_in_out_check(fan_obj)
+        assert fan_obj.pre_present is True
+
+    def test_fan_plug_out_detected(self):
+        fan_obj = mf.Fan("FAN1", MagicMock())
+        fan_obj.pre_present = True
+        fan_obj.int_case.get_fan_presence.return_value = False
+        for _ in range(3):
+            self.monitor.fan_plug_in_out_check(fan_obj)
+        assert fan_obj.pre_present is False
+
+    def test_fan_plug_in_not_enough_count(self):
+        fan_obj = mf.Fan("FAN1", MagicMock())
+        fan_obj.pre_present = False
+        fan_obj.int_case.get_fan_presence.return_value = True
+        self.monitor.fan_plug_in_out_check(fan_obj)  # only 1 detection
+        assert fan_obj.pre_present is False  # not yet confirmed
+
+    def test_fan_status_normal_to_error(self):
+        fan_obj = mf.Fan("FAN1", MagicMock())
+        fan_obj.pre_status = True
+        fan_obj.int_case.get_fan_presence.return_value = True
+        fan_obj.int_case.get_fan_rotor_number.return_value = 1
+        fan_obj.int_case.get_fan_info_rotor.return_value = {
+            "Rotor1": {"Speed": 1000, "SpeedMax": 10000, "Tolerance": 10}
+        }
+        fan_obj.int_case.get_fan_speed_pwm.return_value = 80  # way off
+        for _ in range(3):
+            self.monitor.fan_status_check(fan_obj)
+        assert fan_obj.pre_status is False
+
+    def test_fan_status_error_to_normal(self):
+        fan_obj = mf.Fan("FAN1", MagicMock())
+        fan_obj.pre_status = False
+        fan_obj.int_case.get_fan_presence.return_value = True
+        fan_obj.int_case.get_fan_rotor_number.return_value = 1
+        fan_obj.int_case.get_fan_info_rotor.return_value = {
+            "Rotor1": {"Speed": 7500, "SpeedMax": 10000, "Tolerance": 30}
+        }
+        fan_obj.int_case.get_fan_speed_pwm.return_value = 75
+        for _ in range(3):
+            self.monitor.fan_status_check(fan_obj)
+        assert fan_obj.pre_status is True
+
+    def test_checkFanPresence_iterates_all(self):
+        fan1 = MagicMock()
+        fan2 = MagicMock()
+        self.monitor.fan_obj_list = [fan1, fan2]
+        with patch.object(self.monitor, 'fan_plug_in_out_check') as mock_check:
+            self.monitor.checkFanPresence()
+        assert mock_check.call_count == 2
+
+    def test_checkFanStatus_iterates_all(self):
+        fan1 = MagicMock()
+        fan2 = MagicMock()
+        self.monitor.fan_obj_list = [fan1, fan2]
+        with patch.object(self.monitor, 'fan_status_check') as mock_check:
+            self.monitor.checkFanStatus()
+        assert mock_check.call_count == 2

--- a/platform/broadcom/sonic-platform-modules-ragile/common/script/platform_driver.py
+++ b/platform/broadcom/sonic-platform-modules-ragile/common/script/platform_driver.py
@@ -55,10 +55,11 @@ def check_driver():
 
 
 def removeDev(bus, loc):
-    cmd = "echo  0x%02x > /sys/bus/i2c/devices/i2c-%d/delete_device" % (loc, bus)
     devpath = "/sys/bus/i2c/devices/%d-%04x" % (bus, loc)
     if os.path.exists(devpath):
-        log_os_system(cmd)
+        delete_file = "/sys/bus/i2c/devices/i2c-%d/delete_device" % bus
+        with open(delete_file, 'w') as f:
+            f.write("0x%02x\n" % loc)
 
 
 def addDev(name, bus, loc):
@@ -72,10 +73,11 @@ def addDev(name, bus, loc):
         if i % 10 == 0:
             click.echo("%%WB_PLATFORM_DRIVER-INIT: %s not found, wait 0.1 second ! i %d " % (pdevpath, i))
 
-    cmd = "echo  %s 0x%02x > /sys/bus/i2c/devices/i2c-%d/new_device" % (name, loc, bus)
     devpath = "/sys/bus/i2c/devices/%d-%04x" % (bus, loc)
     if os.path.exists(devpath) is False:
-        os.system(cmd)
+        new_device_file = "/sys/bus/i2c/devices/i2c-%d/new_device" % bus
+        with open(new_device_file, 'w') as f:
+            f.write("%s 0x%02x\n" % (name, loc))
 
 
 def removeOPTOE(startbus, endbus):

--- a/platform/broadcom/sonic-platform-modules-ragile/common/script/tests/test_dev_monitor.py
+++ b/platform/broadcom/sonic-platform-modules-ragile/common/script/tests/test_dev_monitor.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+"""
+Unit tests for dev_monitor.py — focused on removeDev and addDev
+"""
+
+import os
+import sys
+import pytest
+from unittest.mock import patch, mock_open, MagicMock, call
+
+# Mock platform-specific imports
+mock_config = MagicMock()
+mock_config.DEV_MONITOR_PARAM = {}
+sys.modules['platform_config'] = mock_config
+sys.modules['platform_util'] = MagicMock()
+sys.modules['click'] = MagicMock()
+
+import dev_monitor as dm
+
+
+class TestDevMonitorRemoveDev:
+    """Tests for DevMonitor.removeDev()"""
+
+    def setup_method(self):
+
+        self.monitor = dm.DevMonitor.__new__(dm.DevMonitor)
+        self.monitor.logger = MagicMock()
+
+    @patch('os.path.exists', return_value=True)
+    def test_removes_existing_device(self, mock_exists):
+        m = mock_open()
+        with patch("builtins.open", m):
+            self.monitor.removeDev(10, 0x56)
+        m.assert_called_once_with("/sys/bus/i2c/devices/i2c-10/delete_device", 'w')
+        m().write.assert_called_once_with("0x56\n")
+
+    @patch('os.path.exists', return_value=False)
+    def test_skips_nonexistent_device(self, mock_exists):
+        m = mock_open()
+        with patch("builtins.open", m):
+            self.monitor.removeDev(10, 0x56)
+        m.assert_not_called()
+
+    @patch('os.path.exists', return_value=True)
+    def test_correct_devpath_format(self, mock_exists):
+        m = mock_open()
+        with patch("builtins.open", m):
+            self.monitor.removeDev(5, 0x48)
+        mock_exists.assert_called_with("/sys/bus/i2c/devices/5-0048")
+
+
+class TestDevMonitorAddDev:
+    """Tests for DevMonitor.addDev()"""
+
+    def setup_method(self):
+
+        self.monitor = dm.DevMonitor.__new__(dm.DevMonitor)
+        self.monitor.logger = MagicMock()
+
+    @patch('os.path.exists', return_value=False)
+    def test_adds_new_device(self, mock_exists):
+        m = mock_open()
+        with patch("builtins.open", m):
+            self.monitor.addDev("tmp75", 10, 0x48)
+        m.assert_called_once_with("/sys/bus/i2c/devices/i2c-10/new_device", 'w')
+        m().write.assert_called_once_with("tmp75 0x48\n")
+
+    @patch('os.path.exists', return_value=True)
+    def test_skips_existing_device(self, mock_exists):
+        m = mock_open()
+        with patch("builtins.open", m):
+            self.monitor.addDev("tmp75", 10, 0x48)
+        m.assert_not_called()
+
+    @patch('time.sleep')
+    @patch('os.path.exists', return_value=False)
+    def test_lm75_sleeps_before_add(self, mock_exists, mock_sleep):
+        m = mock_open()
+        with patch("builtins.open", m):
+            self.monitor.addDev("lm75", 10, 0x48)
+        mock_sleep.assert_called_once_with(0.1)
+
+    @patch('os.path.exists', return_value=False)
+    def test_non_lm75_no_sleep(self, mock_exists):
+        m = mock_open()
+        with patch("builtins.open", m), \
+             patch('time.sleep') as mock_sleep:
+            self.monitor.addDev("tmp75", 10, 0x48)
+        mock_sleep.assert_not_called()

--- a/platform/broadcom/sonic-platform-modules-ragile/common/script/tests/test_generate_airflow.py
+++ b/platform/broadcom/sonic-platform-modules-ragile/common/script/tests/test_generate_airflow.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+"""
+Unit tests for generate_airflow.py
+"""
+
+import os
+import sys
+import json
+import pytest
+from unittest.mock import patch, mock_open, MagicMock
+
+# Mock platform-specific imports before importing the module under test
+sys.modules['platform_config'] = MagicMock()
+sys.modules['platform_util'] = MagicMock()
+sys.modules['eepromutil'] = MagicMock()
+sys.modules['eepromutil.fru'] = MagicMock()
+sys.modules['eepromutil.fantlv'] = MagicMock()
+
+# Now we can import
+import generate_airflow as ga
+
+
+class TestGetBoardAirFlow:
+    """Tests for get_board_air_flow()"""
+
+    def test_all_zeros_returns_na(self):
+        with patch.object(ga, 'airflow_error'):
+            result = ga.get_board_air_flow(0, 0, 0, 0)
+        assert result == "N/A"
+
+    def test_more_intake_fans_returns_intake(self):
+        result = ga.get_board_air_flow(3, 1, 0, 0)
+        assert result == "intake"
+
+    def test_more_exhaust_fans_returns_exhaust(self):
+        result = ga.get_board_air_flow(1, 3, 0, 0)
+        assert result == "exhaust"
+
+    def test_equal_fans_more_intake_psus_returns_intake(self):
+        result = ga.get_board_air_flow(2, 2, 2, 1)
+        assert result == "intake"
+
+    def test_equal_fans_more_exhaust_psus_returns_exhaust(self):
+        result = ga.get_board_air_flow(2, 2, 1, 2)
+        assert result == "exhaust"
+
+    def test_all_equal_returns_intake(self):
+        result = ga.get_board_air_flow(2, 2, 2, 2)
+        assert result == "intake"
+
+    def test_only_fans_intake(self):
+        result = ga.get_board_air_flow(4, 0, 0, 0)
+        assert result == "intake"
+
+    def test_only_fans_exhaust(self):
+        result = ga.get_board_air_flow(0, 4, 0, 0)
+        assert result == "exhaust"
+
+    def test_only_psus_intake(self):
+        result = ga.get_board_air_flow(0, 0, 2, 0)
+        assert result == "intake"
+
+    def test_only_psus_exhaust(self):
+        result = ga.get_board_air_flow(0, 0, 0, 2)
+        assert result == "exhaust"
+
+    def test_fans_override_psus(self):
+        result = ga.get_board_air_flow(3, 1, 0, 4)
+        assert result == "intake"
+
+
+class TestGetModelFru:
+    """Tests for get_model_fru()"""
+
+    def test_success(self):
+        device = {"name": "FAN1", "area": "boardInfoArea", "field": "boardPartNumber"}
+        mock_fru = MagicMock()
+        mock_area = MagicMock()
+        mock_area.boardPartNumber = "M1HFAN-I-F"
+        mock_fru.boardInfoArea = mock_area
+
+        with patch.object(ga, 'ipmifru', return_value=mock_fru):
+            status, model = ga.get_model_fru(device, b'\x00' * 256)
+        assert status is True
+        assert model == "M1HFAN-I-F"
+
+    def test_invalid_area(self):
+        device = {"name": "FAN1", "area": "nonExistentArea", "field": "boardPartNumber"}
+        mock_fru = MagicMock()
+        mock_fru.nonExistentArea = None
+
+        with patch.object(ga, 'ipmifru', return_value=mock_fru):
+            status, msg = ga.get_model_fru(device, b'\x00' * 256)
+        assert status is False
+        assert "area config error" in msg
+
+    def test_invalid_field(self):
+        device = {"name": "FAN1", "area": "boardInfoArea", "field": "nonExistentField"}
+        mock_fru = MagicMock()
+        mock_area = MagicMock(spec=[])
+        mock_fru.boardInfoArea = mock_area
+
+        with patch.object(ga, 'ipmifru', return_value=mock_fru):
+            status, msg = ga.get_model_fru(device, b'\x00' * 256)
+        assert status is False
+        assert "get model error" in msg
+
+    def test_exception(self):
+        device = {"name": "FAN1", "area": "boardInfoArea", "field": "boardPartNumber"}
+
+        with patch.object(ga, 'ipmifru', side_effect=Exception("decode error")):
+            status, msg = ga.get_model_fru(device, b'\x00' * 256)
+        assert status is False
+        assert "decode error" in msg
+
+
+class TestGetModelFantlv:
+    """Tests for get_model_fantlv()"""
+
+    def test_success(self):
+        device = {"name": "FAN1", "field": "Model"}
+        mock_tlv = MagicMock()
+        mock_tlv.decode.return_value = [{"name": "Model", "value": "FAN-INTAKE-001"}]
+
+        with patch.object(ga, 'fan_tlv', return_value=mock_tlv):
+            status, model = ga.get_model_fantlv(device, b'\x00' * 256)
+        assert status is True
+        assert model == "FAN-INTAKE-001"
+
+    def test_empty_decode(self):
+        device = {"name": "FAN1", "field": "Model"}
+        mock_tlv = MagicMock()
+        mock_tlv.decode.return_value = []
+
+        with patch.object(ga, 'fan_tlv', return_value=mock_tlv):
+            status, msg = ga.get_model_fantlv(device, b'\x00' * 256)
+        assert status is False
+        assert "decode fantlv eeprom info error" in msg
+
+    def test_field_not_found(self):
+        device = {"name": "FAN1", "field": "Model"}
+        mock_tlv = MagicMock()
+        mock_tlv.decode.return_value = [{"name": "Serial", "value": "123"}]
+
+        with patch.object(ga, 'fan_tlv', return_value=mock_tlv):
+            status, msg = ga.get_model_fantlv(device, b'\x00' * 256)
+        assert status is False
+        assert "not found" in msg
+
+    def test_exception(self):
+        device = {"name": "FAN1", "field": "Model"}
+        mock_tlv = MagicMock()
+        mock_tlv.decode.side_effect = Exception("tlv error")
+
+        with patch.object(ga, 'fan_tlv', return_value=mock_tlv):
+            status, msg = ga.get_model_fantlv(device, b'\x00' * 256)
+        assert status is False
+        assert "tlv error" in msg
+
+
+class TestGetDeviceModele:
+    """Tests for get_device_modele()"""
+
+    def test_unsupported_e2_type(self):
+        device = {"name": "FAN1", "e2_type": "unknown"}
+        status, msg = ga.get_device_modele(device)
+        assert status is False
+        assert "unsupport e2_type" in msg
+
+    def test_eeprom_read_failure(self):
+        device = {"name": "FAN1", "e2_type": "fru", "e2_path": "/dev/fake", "e2_size": 256}
+
+        with patch.object(ga, 'dev_file_read', return_value=(False, "read error")):
+            status, msg = ga.get_device_modele(device)
+        assert status is False
+        assert "eeprom read error" in msg
+
+    def test_fru_type_calls_get_model_fru(self):
+        device = {"name": "FAN1", "e2_type": "fru", "e2_path": "/dev/fake", "e2_size": 256,
+                  "area": "boardInfoArea", "field": "boardPartNumber"}
+
+        with patch.object(ga, 'dev_file_read', return_value=(True, b'\x00' * 256)), \
+             patch.object(ga, 'byteTostr', return_value="eeprom_data"), \
+             patch.object(ga, 'get_model_fru', return_value=(True, "MODEL-A")) as mock_fru:
+            status, model = ga.get_device_modele(device)
+        assert status is True
+        assert model == "MODEL-A"
+        mock_fru.assert_called_once()
+
+    def test_fantlv_type_calls_get_model_fantlv(self):
+        device = {"name": "FAN1", "e2_type": "fantlv", "e2_path": "/dev/fake", "e2_size": 256,
+                  "field": "Model"}
+
+        with patch.object(ga, 'dev_file_read', return_value=(True, b'\x00' * 256)), \
+             patch.object(ga, 'byteTostr', return_value="eeprom_data"), \
+             patch.object(ga, 'get_model_fantlv', return_value=(True, "MODEL-B")) as mock_fantlv:
+            status, model = ga.get_device_modele(device)
+        assert status is True
+        assert model == "MODEL-B"
+        mock_fantlv.assert_called_once()
+
+    def test_default_e2_size(self):
+        device = {"name": "FAN1", "e2_type": "fru", "e2_path": "/dev/fake",
+                  "area": "boardInfoArea", "field": "boardPartNumber"}
+
+        with patch.object(ga, 'dev_file_read', return_value=(True, b'\x00' * 256)) as mock_read, \
+             patch.object(ga, 'byteTostr', return_value="data"), \
+             patch.object(ga, 'get_model_fru', return_value=(True, "MODEL")):
+            ga.get_device_modele(device)
+        mock_read.assert_called_once_with("/dev/fake", 0, 256)
+
+
+class TestDebugInit:
+    """Tests for debug_init()"""
+
+    def test_sets_debuglevel_from_file(self):
+        with patch("builtins.open", mock_open(read_data="3")):
+            ga.debug_init()
+        assert ga.debuglevel == 3
+
+    def test_defaults_to_zero_on_missing_file(self):
+        with patch("builtins.open", side_effect=FileNotFoundError):
+            ga.debug_init()
+        assert ga.debuglevel == 0
+
+    def test_defaults_to_zero_on_invalid_content(self):
+        with patch("builtins.open", mock_open(read_data="abc")):
+            ga.debug_init()
+        assert ga.debuglevel == 0
+
+
+class TestGenerateAirflow:
+    """Tests for generate_airflow()"""
+
+    def setup_method(self):
+        self.air_flow_conf = {
+            "fans": [
+                {"name": "FAN1", "e2_type": "fru", "e2_path": "/dev/fan1",
+                 "e2_size": 256, "area": "boardInfoArea", "field": "boardPartNumber",
+                 "decode": "fan_airflow"},
+                {"name": "FAN2", "e2_type": "fru", "e2_path": "/dev/fan2",
+                 "e2_size": 256, "area": "boardInfoArea", "field": "boardPartNumber",
+                 "decode": "fan_airflow"},
+            ],
+            "psus": [
+                {"name": "PSU1", "e2_type": "fru", "e2_path": "/dev/psu1",
+                 "e2_size": 256, "area": "boardInfoArea", "field": "boardPartNumber",
+                 "decode": "psu_airflow"},
+            ],
+            "fan_airflow": {
+                "intake": ["MODEL-INTAKE"],
+                "exhaust": ["MODEL-EXHAUST"],
+            },
+            "psu_airflow": {
+                "intake": ["PSU-INTAKE"],
+                "exhaust": ["PSU-EXHAUST"],
+            },
+        }
+
+    @patch.object(ga, 'AIRFLOW_RESULT_FILE', '/tmp/test_airflow_result.json')
+    def test_all_intake(self):
+        ga.AIR_FLOW_CONF = self.air_flow_conf
+
+        with patch.object(ga, 'get_device_modele') as mock_model, \
+             patch('os.system'):
+            mock_model.side_effect = [
+                (True, "MODEL-INTAKE"),
+                (True, "MODEL-INTAKE"),
+                (True, "PSU-INTAKE"),
+            ]
+            ga.generate_airflow()
+
+        with open('/tmp/test_airflow_result.json', 'r') as f:
+            result = json.load(f)
+
+        assert result["FAN1"]["airflow"] == "intake"
+        assert result["FAN2"]["airflow"] == "intake"
+        assert result["PSU1"]["airflow"] == "intake"
+        assert result["board"] == "intake"
+        os.remove('/tmp/test_airflow_result.json')
+
+    @patch.object(ga, 'AIRFLOW_RESULT_FILE', '/tmp/test_airflow_result.json')
+    def test_mixed_airflow(self):
+        ga.AIR_FLOW_CONF = self.air_flow_conf
+
+        with patch.object(ga, 'get_device_modele') as mock_model, \
+             patch('os.system'):
+            mock_model.side_effect = [
+                (True, "MODEL-INTAKE"),
+                (True, "MODEL-EXHAUST"),
+                (True, "PSU-INTAKE"),
+            ]
+            ga.generate_airflow()
+
+        with open('/tmp/test_airflow_result.json', 'r') as f:
+            result = json.load(f)
+
+        assert result["FAN1"]["airflow"] == "intake"
+        assert result["FAN2"]["airflow"] == "exhaust"
+        assert result["board"] == "intake"
+        os.remove('/tmp/test_airflow_result.json')
+
+    @patch.object(ga, 'AIRFLOW_RESULT_FILE', '/tmp/test_airflow_result.json')
+    def test_fan_eeprom_read_failure(self):
+        ga.AIR_FLOW_CONF = self.air_flow_conf
+
+        with patch.object(ga, 'get_device_modele') as mock_model, \
+             patch('os.system'):
+            mock_model.side_effect = [
+                (False, "read error"),
+                (True, "MODEL-EXHAUST"),
+                (True, "PSU-EXHAUST"),
+            ]
+            ga.generate_airflow()
+
+        with open('/tmp/test_airflow_result.json', 'r') as f:
+            result = json.load(f)
+
+        assert result["FAN1"]["model"] == "N/A"
+        assert result["FAN1"]["airflow"] == "N/A"
+        assert result["board"] == "exhaust"
+        os.remove('/tmp/test_airflow_result.json')
+
+    @patch.object(ga, 'AIRFLOW_RESULT_FILE', '/tmp/test_airflow_result.json')
+    def test_unknown_model(self):
+        ga.AIR_FLOW_CONF = self.air_flow_conf
+
+        with patch.object(ga, 'get_device_modele') as mock_model, \
+             patch('os.system'):
+            mock_model.side_effect = [
+                (True, "UNKNOWN-MODEL"),
+                (True, "UNKNOWN-MODEL"),
+                (True, "UNKNOWN-MODEL"),
+            ]
+            ga.generate_airflow()
+
+        with open('/tmp/test_airflow_result.json', 'r') as f:
+            result = json.load(f)
+
+        assert result["FAN1"]["airflow"] == "N/A"
+        assert result["board"] == "N/A"
+        os.remove('/tmp/test_airflow_result.json')
+
+    @patch.object(ga, 'AIRFLOW_RESULT_FILE', '/tmp/test_airflow_subdir/test_airflow.json')
+    def test_creates_output_directory(self):
+        ga.AIR_FLOW_CONF = {"fans": [], "psus": []}
+
+        ga.generate_airflow()
+
+        assert os.path.exists('/tmp/test_airflow_subdir/test_airflow.json')
+        os.remove('/tmp/test_airflow_subdir/test_airflow.json')
+        os.rmdir('/tmp/test_airflow_subdir')
+
+
+class TestLogging:
+    """Tests for logging functions"""
+
+    @patch('syslog.openlog')
+    @patch('syslog.syslog')
+    def test_airflow_info(self, mock_syslog, mock_openlog):
+        ga.airflow_info("test message")
+        mock_openlog.assert_called_once_with("AIRFLOW", ga.syslog.LOG_PID)
+        mock_syslog.assert_called_once_with(ga.syslog.LOG_INFO, "test message")
+
+    @patch('syslog.openlog')
+    @patch('syslog.syslog')
+    def test_airflow_error(self, mock_syslog, mock_openlog):
+        ga.airflow_error("error message")
+        mock_openlog.assert_called_once_with("AIRFLOW", ga.syslog.LOG_PID)
+        mock_syslog.assert_called_once_with(ga.syslog.LOG_ERR, "error message")
+
+    @patch('syslog.openlog')
+    @patch('syslog.syslog')
+    def test_airflow_debug_when_enabled(self, mock_syslog, mock_openlog):
+        ga.debuglevel = ga.AIRFLOWDEBUG
+        ga.airflow_debug("debug msg")
+        mock_syslog.assert_called_once()
+        ga.debuglevel = 0
+
+    @patch('syslog.syslog')
+    def test_airflow_debug_when_disabled(self, mock_syslog):
+        ga.debuglevel = 0
+        ga.airflow_debug("debug msg")
+        mock_syslog.assert_not_called()

--- a/platform/broadcom/sonic-platform-modules-ragile/common/script/tests/test_generate_airflow.py
+++ b/platform/broadcom/sonic-platform-modules-ragile/common/script/tests/test_generate_airflow.py
@@ -258,12 +258,13 @@ class TestGenerateAirflow:
             },
         }
 
-    @patch.object(ga, 'AIRFLOW_RESULT_FILE', '/tmp/test_airflow_result.json')
-    def test_all_intake(self):
+    def test_all_intake(self, tmp_path):
+        result_file = str(tmp_path / "airflow_result.json")
         ga.AIR_FLOW_CONF = self.air_flow_conf
 
-        with patch.object(ga, 'get_device_modele') as mock_model, \
-             patch('os.system'):
+        with patch.object(ga, 'AIRFLOW_RESULT_FILE', result_file), \
+             patch.object(ga, 'get_device_modele') as mock_model, \
+             patch('subprocess.call') as mock_call:
             mock_model.side_effect = [
                 (True, "MODEL-INTAKE"),
                 (True, "MODEL-INTAKE"),
@@ -271,21 +272,22 @@ class TestGenerateAirflow:
             ]
             ga.generate_airflow()
 
-        with open('/tmp/test_airflow_result.json', 'r') as f:
+        with open(result_file, 'r') as f:
             result = json.load(f)
 
         assert result["FAN1"]["airflow"] == "intake"
         assert result["FAN2"]["airflow"] == "intake"
         assert result["PSU1"]["airflow"] == "intake"
         assert result["board"] == "intake"
-        os.remove('/tmp/test_airflow_result.json')
+        mock_call.assert_any_call(["sync"])
 
-    @patch.object(ga, 'AIRFLOW_RESULT_FILE', '/tmp/test_airflow_result.json')
-    def test_mixed_airflow(self):
+    def test_mixed_airflow(self, tmp_path):
+        result_file = str(tmp_path / "airflow_result.json")
         ga.AIR_FLOW_CONF = self.air_flow_conf
 
-        with patch.object(ga, 'get_device_modele') as mock_model, \
-             patch('os.system'):
+        with patch.object(ga, 'AIRFLOW_RESULT_FILE', result_file), \
+             patch.object(ga, 'get_device_modele') as mock_model, \
+             patch('subprocess.call') as mock_call:
             mock_model.side_effect = [
                 (True, "MODEL-INTAKE"),
                 (True, "MODEL-EXHAUST"),
@@ -293,20 +295,21 @@ class TestGenerateAirflow:
             ]
             ga.generate_airflow()
 
-        with open('/tmp/test_airflow_result.json', 'r') as f:
+        with open(result_file, 'r') as f:
             result = json.load(f)
 
         assert result["FAN1"]["airflow"] == "intake"
         assert result["FAN2"]["airflow"] == "exhaust"
         assert result["board"] == "intake"
-        os.remove('/tmp/test_airflow_result.json')
+        mock_call.assert_any_call(["sync"])
 
-    @patch.object(ga, 'AIRFLOW_RESULT_FILE', '/tmp/test_airflow_result.json')
-    def test_fan_eeprom_read_failure(self):
+    def test_fan_eeprom_read_failure(self, tmp_path):
+        result_file = str(tmp_path / "airflow_result.json")
         ga.AIR_FLOW_CONF = self.air_flow_conf
 
-        with patch.object(ga, 'get_device_modele') as mock_model, \
-             patch('os.system'):
+        with patch.object(ga, 'AIRFLOW_RESULT_FILE', result_file), \
+             patch.object(ga, 'get_device_modele') as mock_model, \
+             patch('subprocess.call'):
             mock_model.side_effect = [
                 (False, "read error"),
                 (True, "MODEL-EXHAUST"),
@@ -314,20 +317,20 @@ class TestGenerateAirflow:
             ]
             ga.generate_airflow()
 
-        with open('/tmp/test_airflow_result.json', 'r') as f:
+        with open(result_file, 'r') as f:
             result = json.load(f)
 
         assert result["FAN1"]["model"] == "N/A"
         assert result["FAN1"]["airflow"] == "N/A"
         assert result["board"] == "exhaust"
-        os.remove('/tmp/test_airflow_result.json')
 
-    @patch.object(ga, 'AIRFLOW_RESULT_FILE', '/tmp/test_airflow_result.json')
-    def test_unknown_model(self):
+    def test_unknown_model(self, tmp_path):
+        result_file = str(tmp_path / "airflow_result.json")
         ga.AIR_FLOW_CONF = self.air_flow_conf
 
-        with patch.object(ga, 'get_device_modele') as mock_model, \
-             patch('os.system'):
+        with patch.object(ga, 'AIRFLOW_RESULT_FILE', result_file), \
+             patch.object(ga, 'get_device_modele') as mock_model, \
+             patch('subprocess.call'):
             mock_model.side_effect = [
                 (True, "UNKNOWN-MODEL"),
                 (True, "UNKNOWN-MODEL"),
@@ -335,22 +338,21 @@ class TestGenerateAirflow:
             ]
             ga.generate_airflow()
 
-        with open('/tmp/test_airflow_result.json', 'r') as f:
+        with open(result_file, 'r') as f:
             result = json.load(f)
 
         assert result["FAN1"]["airflow"] == "N/A"
         assert result["board"] == "N/A"
-        os.remove('/tmp/test_airflow_result.json')
 
-    @patch.object(ga, 'AIRFLOW_RESULT_FILE', '/tmp/test_airflow_subdir/test_airflow.json')
-    def test_creates_output_directory(self):
+    def test_creates_output_directory(self, tmp_path):
+        subdir = tmp_path / "subdir"
+        result_file = str(subdir / "airflow_result.json")
         ga.AIR_FLOW_CONF = {"fans": [], "psus": []}
 
-        ga.generate_airflow()
+        with patch.object(ga, 'AIRFLOW_RESULT_FILE', result_file):
+            ga.generate_airflow()
 
-        assert os.path.exists('/tmp/test_airflow_subdir/test_airflow.json')
-        os.remove('/tmp/test_airflow_subdir/test_airflow.json')
-        os.rmdir('/tmp/test_airflow_subdir')
+        assert os.path.exists(result_file)
 
 
 class TestLogging:

--- a/platform/broadcom/sonic-platform-modules-ragile/common/script/tests/test_platform_driver.py
+++ b/platform/broadcom/sonic-platform-modules-ragile/common/script/tests/test_platform_driver.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+"""
+Unit tests for platform_driver.py — focused on removeDev and addDev
+"""
+
+import os
+import sys
+import pytest
+from unittest.mock import patch, mock_open, MagicMock, call
+
+# Mock platform-specific imports
+import types
+mock_config = types.ModuleType('platform_config')
+mock_config.GLOBALCONFIG = {"DRIVERLISTS": [], "DEVS": [], "OPTOE": []}
+mock_config.WARM_UPGRADE_STARTED_FLAG = "/tmp/.warm_upgrade_started"
+mock_config.WARM_UPG_FLAG = "/tmp/.warm_upg_flag"
+sys.modules['platform_config'] = mock_config
+
+# Mock click
+sys.modules['click'] = MagicMock()
+
+import platform_driver as pd
+
+
+class TestRemoveDev:
+    """Tests for removeDev()"""
+
+    @patch('os.path.exists', return_value=True)
+    def test_removes_existing_device(self, mock_exists):
+        m = mock_open()
+        with patch("builtins.open", m):
+            pd.removeDev(10, 0x56)
+        m.assert_called_once_with("/sys/bus/i2c/devices/i2c-10/delete_device", 'w')
+        m().write.assert_called_once_with("0x56\n")
+
+    @patch('os.path.exists', return_value=False)
+    def test_skips_nonexistent_device(self, mock_exists):
+        m = mock_open()
+        with patch("builtins.open", m):
+            pd.removeDev(10, 0x56)
+        m.assert_not_called()
+
+    @patch('os.path.exists', return_value=True)
+    def test_correct_devpath_format(self, mock_exists):
+        m = mock_open()
+        with patch("builtins.open", m):
+            pd.removeDev(5, 0x48)
+        mock_exists.assert_called_with("/sys/bus/i2c/devices/5-0048")
+
+
+class TestAddDev:
+    """Tests for addDev()"""
+
+    @patch('os.path.exists')
+    def test_adds_new_device(self, mock_exists):
+        # pdevpath exists, devpath does not
+        mock_exists.side_effect = lambda p: p.endswith("/")
+        m = mock_open()
+        with patch("builtins.open", m):
+            pd.addDev("tmp75", 10, 0x48)
+        m.assert_called_once_with("/sys/bus/i2c/devices/i2c-10/new_device", 'w')
+        m().write.assert_called_once_with("tmp75 0x48\n")
+
+    @patch('os.path.exists', return_value=True)
+    def test_skips_existing_device(self, mock_exists):
+        m = mock_open()
+        with patch("builtins.open", m):
+            pd.addDev("tmp75", 10, 0x48)
+        m.assert_not_called()
+
+    @patch('time.sleep')
+    @patch('os.path.exists')
+    def test_lm75_sleeps_before_add(self, mock_exists, mock_sleep):
+        mock_exists.side_effect = lambda p: p.endswith("/")
+        m = mock_open()
+        with patch("builtins.open", m):
+            pd.addDev("lm75", 10, 0x48)
+        mock_sleep.assert_any_call(0.1)
+
+    @patch('os.path.exists')
+    def test_waits_for_parent_bus(self, mock_exists):
+        # Simulate parent bus appearing after 3 attempts
+        call_count = [0]
+        def side_effect(path):
+            if path.endswith("/"):
+                call_count[0] += 1
+                return call_count[0] >= 3
+            return False  # devpath doesn't exist
+
+        mock_exists.side_effect = side_effect
+        m = mock_open()
+        with patch("builtins.open", m), \
+             patch('time.sleep'):
+            pd.addDev("tmp75", 10, 0x48)
+        m.assert_called_once()
+
+
+class TestCheckDriver:
+    """Tests for check_driver()"""
+
+    @patch.object(pd, 'log_os_system', return_value=(0, "3"))
+    def test_driver_loaded(self, mock_log):
+        assert pd.check_driver() is True
+
+    @patch.object(pd, 'log_os_system', return_value=(0, "0"))
+    def test_driver_not_loaded(self, mock_log):
+        assert pd.check_driver() is False
+
+    @patch.object(pd, 'log_os_system', return_value=(1, ""))
+    def test_command_fails(self, mock_log):
+        assert pd.check_driver() is False
+
+
+class TestChecksignaldriver:
+    """Tests for checksignaldriver()"""
+
+    @patch.object(pd, 'log_os_system', return_value=(0, "1"))
+    def test_module_loaded(self, mock_log):
+        assert pd.checksignaldriver("wb_io_dev") is True
+
+    @patch.object(pd, 'log_os_system', return_value=(0, "0"))
+    def test_module_not_loaded(self, mock_log):
+        assert pd.checksignaldriver("wb_io_dev") is False
+
+    @patch.object(pd, 'log_os_system', return_value=(1, ""))
+    def test_command_fails(self, mock_log):
+        assert pd.checksignaldriver("wb_io_dev") is False
+
+
+class TestAddRemoveDriver:
+    """Tests for adddriver() and removedriver()"""
+
+    @patch.object(pd, 'log_os_system')
+    @patch.object(pd, 'checksignaldriver', return_value=False)
+    def test_adddriver_loads_module(self, mock_check, mock_log):
+        pd.adddriver("wb_io_dev", 0)
+        mock_log.assert_called_once_with("modprobe wb_io_dev")
+
+    @patch.object(pd, 'log_os_system')
+    @patch.object(pd, 'checksignaldriver', return_value=True)
+    def test_adddriver_skips_loaded_module(self, mock_check, mock_log):
+        pd.adddriver("wb_io_dev", 0)
+        mock_log.assert_not_called()
+
+    @patch.object(pd, 'log_os_system')
+    @patch.object(pd, 'checksignaldriver', return_value=True)
+    def test_removedriver_removes_module(self, mock_check, mock_log):
+        pd.removedriver("wb_io_dev", 0)
+        mock_log.assert_called_once_with("rmmod -f wb_io_dev")
+
+    @patch.object(pd, 'log_os_system')
+    @patch.object(pd, 'checksignaldriver', return_value=False)
+    def test_removedriver_skips_unloaded_module(self, mock_check, mock_log):
+        pd.removedriver("wb_io_dev", 0)
+        mock_log.assert_not_called()


### PR DESCRIPTION
#### Why I did it

`os.system()` is unsafe as it invokes a shell and is vulnerable to shell injection. Replace with `subprocess.call()` or direct file writes per Python docs recommendation.

#### How I did it

- Replace `os.system()` with `subprocess.call()` in `generate_airflow.py` and `monitor_fan.py`
- Replace `os.system("echo ... > /sys/bus/i2c/...")` with direct `open()/write()` in `dev_monitor.py` and `platform_driver.py`
- Add 94 unit tests:
  - `generate_airflow.py`: 36 tests
  - `monitor_fan.py`: 34 tests
  - `dev_monitor.py`: 7 tests
  - `platform_driver.py`: 17 tests

#### How to verify it

```bash
cd platform/broadcom/sonic-platform-modules-ragile/common/script
python3 -m pytest tests/ -v

cd intelligent_monitor
python3 -m pytest tests/ -v
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] N/A — no functional change, security fix with unit tests

#### Description for the changelog

Replace os.system with subprocess.call and direct file writes in ragile platform scripts, add 94 unit tests.

#### A picture of a cute animal (not mandatory but encouraged)

🦔