### PR TITLE
[ragile] Replace os.popen with subprocess.Popen and add unit tests

### DIFF
--- a/platform/broadcom/sonic-platform-modules-ragile/common/script/platform_util.py
+++ b/platform/broadcom/sonic-platform-modules-ragile/common/script/platform_util.py
@@ -214,7 +214,8 @@ def getonieplatform(path):
 def getplatform_config_db():
     if not os.path.isfile(CONFIG_DB_PATH):
         return ""
-    val = os.popen("sonic-cfggen -j %s -v DEVICE_METADATA.localhost.platform" % CONFIG_DB_PATH).read().strip()
+    val = subprocess.Popen(["sonic-cfggen", "-j", CONFIG_DB_PATH, "-v", "DEVICE_METADATA.localhost.platform"],
+                           stdout=subprocess.PIPE, universal_newlines=True).stdout.read().strip()
     if len(val) <= 0:
         return ""
     return val

--- a/platform/broadcom/sonic-platform-modules-ragile/common/script/platform_util.py
+++ b/platform/broadcom/sonic-platform-modules-ragile/common/script/platform_util.py
@@ -214,8 +214,8 @@ def getonieplatform(path):
 def getplatform_config_db():
     if not os.path.isfile(CONFIG_DB_PATH):
         return ""
-    val = subprocess.Popen(["sonic-cfggen", "-j", CONFIG_DB_PATH, "-v", "DEVICE_METADATA.localhost.platform"],
-                           stdout=subprocess.PIPE, universal_newlines=True).stdout.read().strip()
+    val = subprocess.run(["sonic-cfggen", "-j", CONFIG_DB_PATH, "-v", "DEVICE_METADATA.localhost.platform"],
+                         stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True).stdout.strip()
     if len(val) <= 0:
         return ""
     return val

--- a/platform/broadcom/sonic-platform-modules-ragile/common/script/tests/test_platform_util.py
+++ b/platform/broadcom/sonic-platform-modules-ragile/common/script/tests/test_platform_util.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+"""
+Unit tests for platform_util.py — focused on getplatform_config_db and getonieplatform
+"""
+
+import os
+import sys
+import pytest
+from unittest.mock import patch, mock_open, MagicMock
+
+# Mock heavy platform imports
+sys.modules['platform_config'] = MagicMock()
+
+import platform_util as pu
+
+
+class TestGetplatformConfigDb:
+    """Tests for getplatform_config_db()"""
+
+    @patch('os.path.isfile', return_value=False)
+    def test_returns_empty_when_config_db_missing(self, mock_isfile):
+        result = pu.getplatform_config_db()
+        assert result == ""
+
+    @patch('subprocess.Popen')
+    @patch('os.path.isfile', return_value=True)
+    def test_returns_platform_name(self, mock_isfile, mock_popen):
+        mock_stdout = MagicMock()
+        mock_stdout.read.return_value = "x86_64-mlnx_msn2700-r0"
+        mock_popen.return_value.stdout = mock_stdout
+
+        result = pu.getplatform_config_db()
+        assert result == "x86_64-mlnx_msn2700-r0"
+
+    @patch('subprocess.Popen')
+    @patch('os.path.isfile', return_value=True)
+    def test_returns_empty_when_command_returns_empty(self, mock_isfile, mock_popen):
+        mock_stdout = MagicMock()
+        mock_stdout.read.return_value = ""
+        mock_popen.return_value.stdout = mock_stdout
+
+        result = pu.getplatform_config_db()
+        assert result == ""
+
+    @patch('subprocess.Popen')
+    @patch('os.path.isfile', return_value=True)
+    def test_strips_whitespace(self, mock_isfile, mock_popen):
+        mock_stdout = MagicMock()
+        mock_stdout.read.return_value = "  x86_64-ragile-r0  \n"
+        mock_popen.return_value.stdout = mock_stdout
+
+        result = pu.getplatform_config_db()
+        assert result == "x86_64-ragile-r0"
+
+
+class TestGetonieplatform:
+    """Tests for getonieplatform()"""
+
+    def test_returns_platform_from_machine_conf(self):
+        content = "onie_machine=ragile\nonie_platform=x86_64-ragile-r0\nonie_arch=x86_64\n"
+        with patch('os.path.isfile', return_value=True), \
+             patch("builtins.open", mock_open(read_data=content)):
+            result = pu.getonieplatform("/host/machine.conf")
+        assert result == "x86_64-ragile-r0"
+
+    def test_returns_none_when_no_onie_platform(self):
+        content = "onie_machine=ragile\nonie_arch=x86_64\n"
+        with patch('os.path.isfile', return_value=True), \
+             patch("builtins.open", mock_open(read_data=content)):
+            result = pu.getonieplatform("/host/machine.conf")
+        assert result is None
+
+    def test_returns_empty_when_file_missing(self):
+        with patch('os.path.isfile', return_value=False):
+            result = pu.getonieplatform("/host/machine.conf")
+        assert result == ""
+
+    def test_skips_malformed_lines(self):
+        content = "badline\nonie_platform=x86_64-ragile-r0\nanother_bad\n"
+        with patch('os.path.isfile', return_value=True), \
+             patch("builtins.open", mock_open(read_data=content)):
+            result = pu.getonieplatform("/host/machine.conf")
+        assert result == "x86_64-ragile-r0"
+
+
+class TestGetplatformName:
+    """Tests for getplatform_name()"""
+
+    @patch.object(pu, 'getonieplatform', return_value="x86_64-ragile-r0")
+    @patch('os.path.isfile', return_value=True)
+    def test_returns_from_machine_conf(self, mock_isfile, mock_onie):
+        result = pu.getplatform_name()
+        assert result == "x86_64-ragile-r0"
+
+    @patch.object(pu, 'getplatform_config_db', return_value="x86_64-ragile-r0")
+    @patch('os.path.isfile', return_value=False)
+    def test_falls_back_to_config_db(self, mock_isfile, mock_cfgdb):
+        result = pu.getplatform_name()
+        assert result == "x86_64-ragile-r0"
+
+
+class TestByteTostr:
+    """Tests for byteTostr()"""
+
+    def test_bytes_to_str(self):
+        result = pu.byteTostr(b'\x48\x65\x6c\x6c\x6f')
+        assert result == "Hello"
+
+    def test_empty_bytes(self):
+        result = pu.byteTostr(b'')
+        assert result == ""
+
+
+class TestInttostr:
+    """Tests for inttostr()"""
+
+    def test_basic(self):
+        result = pu.inttostr(0x41424344, 4)
+        assert len(result) == 4
+
+    def test_single_byte(self):
+        result = pu.inttostr(0x41, 1)
+        assert len(result) == 1

--- a/platform/broadcom/sonic-platform-modules-ragile/common/script/tests/test_platform_util.py
+++ b/platform/broadcom/sonic-platform-modules-ragile/common/script/tests/test_platform_util.py
@@ -12,6 +12,9 @@ from unittest.mock import patch, mock_open, MagicMock
 # Mock heavy platform imports
 sys.modules['platform_config'] = MagicMock()
 
+# Ensure platform_util is importable from any working directory
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+
 import platform_util as pu
 
 
@@ -23,32 +26,26 @@ class TestGetplatformConfigDb:
         result = pu.getplatform_config_db()
         assert result == ""
 
-    @patch('subprocess.Popen')
+    @patch('subprocess.run')
     @patch('os.path.isfile', return_value=True)
-    def test_returns_platform_name(self, mock_isfile, mock_popen):
-        mock_stdout = MagicMock()
-        mock_stdout.read.return_value = "x86_64-mlnx_msn2700-r0"
-        mock_popen.return_value.stdout = mock_stdout
+    def test_returns_platform_name(self, mock_isfile, mock_run):
+        mock_run.return_value.stdout = "x86_64-mlnx_msn2700-r0"
 
         result = pu.getplatform_config_db()
         assert result == "x86_64-mlnx_msn2700-r0"
 
-    @patch('subprocess.Popen')
+    @patch('subprocess.run')
     @patch('os.path.isfile', return_value=True)
-    def test_returns_empty_when_command_returns_empty(self, mock_isfile, mock_popen):
-        mock_stdout = MagicMock()
-        mock_stdout.read.return_value = ""
-        mock_popen.return_value.stdout = mock_stdout
+    def test_returns_empty_when_command_returns_empty(self, mock_isfile, mock_run):
+        mock_run.return_value.stdout = ""
 
         result = pu.getplatform_config_db()
         assert result == ""
 
-    @patch('subprocess.Popen')
+    @patch('subprocess.run')
     @patch('os.path.isfile', return_value=True)
-    def test_strips_whitespace(self, mock_isfile, mock_popen):
-        mock_stdout = MagicMock()
-        mock_stdout.read.return_value = "  x86_64-ragile-r0  \n"
-        mock_popen.return_value.stdout = mock_stdout
+    def test_strips_whitespace(self, mock_isfile, mock_run):
+        mock_run.return_value.stdout = "  x86_64-ragile-r0  \n"
 
         result = pu.getplatform_config_db()
         assert result == "x86_64-ragile-r0"

--- a/platform/broadcom/sonic-platform-modules-ragile/ra-b6510-32c/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-ragile/ra-b6510-32c/sonic_platform/sfp.py
@@ -34,6 +34,7 @@
 #############################################################################
 import sys
 import time
+import subprocess
 import syslog
 import traceback
 from abc import abstractmethod
@@ -67,7 +68,8 @@ def getonieplatform(path):
 def getplatform_config_db():
     if not os.path.isfile(CONFIG_DB_PATH):
         return ""
-    val = os.popen("sonic-cfggen -j %s -v DEVICE_METADATA.localhost.platform" % CONFIG_DB_PATH).read().strip()
+    val = subprocess.Popen(["sonic-cfggen", "-j", CONFIG_DB_PATH, "-v", "DEVICE_METADATA.localhost.platform"],
+                           stdout=subprocess.PIPE, universal_newlines=True).stdout.read().strip()
     if len(val) <= 0:
         return ""
     else:

--- a/platform/broadcom/sonic-platform-modules-ragile/ra-b6510-32c/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-ragile/ra-b6510-32c/sonic_platform/sfp.py
@@ -68,8 +68,8 @@ def getonieplatform(path):
 def getplatform_config_db():
     if not os.path.isfile(CONFIG_DB_PATH):
         return ""
-    val = subprocess.Popen(["sonic-cfggen", "-j", CONFIG_DB_PATH, "-v", "DEVICE_METADATA.localhost.platform"],
-                           stdout=subprocess.PIPE, universal_newlines=True).stdout.read().strip()
+    val = subprocess.run(["sonic-cfggen", "-j", CONFIG_DB_PATH, "-v", "DEVICE_METADATA.localhost.platform"],
+                         stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True).stdout.strip()
     if len(val) <= 0:
         return ""
     else:

--- a/platform/broadcom/sonic-platform-modules-ragile/ra-b6510-32c/sonic_platform/tests/test_sfp.py
+++ b/platform/broadcom/sonic-platform-modules-ragile/ra-b6510-32c/sonic_platform/tests/test_sfp.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+"""
+Unit tests for sfp.py — focused on getplatform_config_db and getonieplatform
+"""
+
+import os
+import sys
+import pytest
+from unittest.mock import patch, mock_open, MagicMock
+
+# Mock platform-specific imports BEFORE importing sfp
+sys.modules['sonic_platform_base'] = MagicMock()
+sys.modules['sonic_platform_base.sonic_sfp'] = MagicMock()
+sys.modules['sonic_platform_base.sonic_sfp.sfputilhelper'] = MagicMock()
+sys.modules['sonic_platform_base.sfp_base'] = MagicMock()
+sys.modules['sonic_platform_base.sonic_xcvr'] = MagicMock()
+sys.modules['sonic_platform_base.sonic_xcvr.sfp_optoe_base'] = MagicMock()
+
+# Add the sfp.py directory to path and create a fake package
+sfp_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
+sys.path.insert(0, sfp_dir)
+
+# Create a fake package so relative imports work
+import types
+sonic_platform_pkg = types.ModuleType('sonic_platform')
+sonic_platform_pkg.__path__ = [sfp_dir]
+sonic_platform_pkg.sfp_config = MagicMock()
+sys.modules['sonic_platform'] = sonic_platform_pkg
+sys.modules['sonic_platform.sfp_config'] = sonic_platform_pkg.sfp_config
+
+# Now import sfp as part of the package
+import importlib.util
+spec = importlib.util.spec_from_file_location("sonic_platform.sfp", os.path.join(sfp_dir, "sfp.py"),
+                                               submodule_search_locations=[])
+sfp = importlib.util.module_from_spec(spec)
+sys.modules['sonic_platform.sfp'] = sfp
+spec.loader.exec_module(sfp)
+
+
+class TestGetplatformConfigDb:
+    """Tests for getplatform_config_db() in sfp.py"""
+
+    @patch('os.path.isfile', return_value=False)
+    def test_returns_empty_when_config_db_missing(self, mock_isfile):
+        result = sfp.getplatform_config_db()
+        assert result == ""
+
+    @patch('subprocess.Popen')
+    @patch('os.path.isfile', return_value=True)
+    def test_returns_platform_name(self, mock_isfile, mock_popen):
+        mock_stdout = MagicMock()
+        mock_stdout.read.return_value = "x86_64-ragile_ra-b6510-32c-r0"
+        mock_popen.return_value.stdout = mock_stdout
+
+        result = sfp.getplatform_config_db()
+        assert result == "x86_64-ragile_ra-b6510-32c-r0"
+
+    @patch('subprocess.Popen')
+    @patch('os.path.isfile', return_value=True)
+    def test_returns_empty_when_command_returns_empty(self, mock_isfile, mock_popen):
+        mock_stdout = MagicMock()
+        mock_stdout.read.return_value = ""
+        mock_popen.return_value.stdout = mock_stdout
+
+        result = sfp.getplatform_config_db()
+        assert result == ""
+
+    @patch('subprocess.Popen')
+    @patch('os.path.isfile', return_value=True)
+    def test_strips_whitespace(self, mock_isfile, mock_popen):
+        mock_stdout = MagicMock()
+        mock_stdout.read.return_value = "  x86_64-ragile-r0  \n"
+        mock_popen.return_value.stdout = mock_stdout
+
+        result = sfp.getplatform_config_db()
+        assert result == "x86_64-ragile-r0"
+
+
+class TestGetonieplatform:
+    """Tests for getonieplatform() in sfp.py"""
+
+    def test_returns_platform_from_machine_conf(self):
+        content = "onie_machine=ragile\nonie_platform=x86_64-ragile_ra-b6510-32c-r0\nonie_arch=x86_64\n"
+        with patch('os.path.isfile', return_value=True), \
+             patch("builtins.open", mock_open(read_data=content)):
+            result = sfp.getonieplatform("/host/machine.conf")
+        assert result == "x86_64-ragile_ra-b6510-32c-r0"
+
+    def test_returns_none_when_no_onie_platform(self):
+        content = "onie_machine=ragile\nonie_arch=x86_64\n"
+        with patch('os.path.isfile', return_value=True), \
+             patch("builtins.open", mock_open(read_data=content)):
+            result = sfp.getonieplatform("/host/machine.conf")
+        assert result is None
+
+    def test_returns_empty_when_file_missing(self):
+        with patch('os.path.isfile', return_value=False):
+            result = sfp.getonieplatform("/host/machine.conf")
+        assert result == ""
+
+
+class TestGetplatformName:
+    """Tests for getplatform_name() in sfp.py"""
+
+    @patch.object(sfp, 'getonieplatform', return_value="x86_64-ragile-r0")
+    @patch('os.path.isfile', return_value=True)
+    def test_returns_from_machine_conf(self, mock_isfile, mock_onie):
+        result = sfp.getplatform_name()
+        assert result == "x86_64-ragile-r0"
+
+    @patch.object(sfp, 'getplatform_config_db', return_value="x86_64-ragile-r0")
+    @patch('os.path.isfile', return_value=False)
+    def test_falls_back_to_config_db(self, mock_isfile, mock_cfgdb):
+        result = sfp.getplatform_name()
+        assert result == "x86_64-ragile-r0"

--- a/platform/broadcom/sonic-platform-modules-ragile/ra-b6510-32c/sonic_platform/tests/test_sfp.py
+++ b/platform/broadcom/sonic-platform-modules-ragile/ra-b6510-32c/sonic_platform/tests/test_sfp.py
@@ -46,32 +46,26 @@ class TestGetplatformConfigDb:
         result = sfp.getplatform_config_db()
         assert result == ""
 
-    @patch('subprocess.Popen')
+    @patch('subprocess.run')
     @patch('os.path.isfile', return_value=True)
-    def test_returns_platform_name(self, mock_isfile, mock_popen):
-        mock_stdout = MagicMock()
-        mock_stdout.read.return_value = "x86_64-ragile_ra-b6510-32c-r0"
-        mock_popen.return_value.stdout = mock_stdout
+    def test_returns_platform_name(self, mock_isfile, mock_run):
+        mock_run.return_value.stdout = "x86_64-ragile_ra-b6510-32c-r0"
 
         result = sfp.getplatform_config_db()
         assert result == "x86_64-ragile_ra-b6510-32c-r0"
 
-    @patch('subprocess.Popen')
+    @patch('subprocess.run')
     @patch('os.path.isfile', return_value=True)
-    def test_returns_empty_when_command_returns_empty(self, mock_isfile, mock_popen):
-        mock_stdout = MagicMock()
-        mock_stdout.read.return_value = ""
-        mock_popen.return_value.stdout = mock_stdout
+    def test_returns_empty_when_command_returns_empty(self, mock_isfile, mock_run):
+        mock_run.return_value.stdout = ""
 
         result = sfp.getplatform_config_db()
         assert result == ""
 
-    @patch('subprocess.Popen')
+    @patch('subprocess.run')
     @patch('os.path.isfile', return_value=True)
-    def test_strips_whitespace(self, mock_isfile, mock_popen):
-        mock_stdout = MagicMock()
-        mock_stdout.read.return_value = "  x86_64-ragile-r0  \n"
-        mock_popen.return_value.stdout = mock_stdout
+    def test_strips_whitespace(self, mock_isfile, mock_run):
+        mock_run.return_value.stdout = "  x86_64-ragile-r0  \n"
 
         result = sfp.getplatform_config_db()
         assert result == "x86_64-ragile-r0"


### PR DESCRIPTION
#### Why I did it
Fix Semgrep reported findings on master branch

`os.popen()` is deprecated and unsafe. Replace with `subprocess.Popen()` (shell=False) per Python docs recommendation.

#### How I did it

- Replace `os.popen()` with `subprocess.Popen([...], stdout=subprocess.PIPE, universal_newlines=True).stdout` in `platform_util.py` and `sfp.py`
- Add 23 unit tests (14 for `platform_util.py`, 9 for `sfp.py`)

#### How to verify it

```bash
cd platform/broadcom/sonic-platform-modules-ragile/common/script
python3 -m pytest tests/test_platform_util.py -v

cd /path/to/sonic-buildimage
python3 -m pytest platform/broadcom/sonic-platform-modules-ragile/ra-b6510-32c/sonic_platform/tests/test_sfp.py -v
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] N/A — no functional change, security fix with unit tests

#### Description for the changelog

Replace os.popen with subprocess.Popen in ragile platform scripts and add unit tests.

#### A picture of a cute animal (not mandatory but encouraged)

🐾