### PR TITLE
[Backport] NH platform: Use state db transceiver temperature

### DIFF
--- a/device/nexthop/common/pmon_daemon_control.json
+++ b/device/nexthop/common/pmon_daemon_control.json
@@ -5,5 +5,8 @@
     "thermalctld": {
         "thermal_monitor_update_interval": 10,
         "thermal_monitor_update_elapsed_threshold": 9
+    },
+    "xcvrd": {
+        "dom_temperature_poll_interval": 5
     }
 }

--- a/platform/broadcom/sonic-platform-modules-nexthop/common/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/common/sonic_platform/thermal.py
@@ -325,6 +325,8 @@ class NexthopFpgaAsicThermal(ThermalBase, MinMaxTempMixin, PidThermalMixin):
 class SfpThermal(ThermalBase, MinMaxTempMixin, PidThermalMixin):
     """SFP thermal interface class"""
     THRESHOLDS_CACHE_INTERVAL_SEC = 5
+    TEMP_CACHE_INTERVAL_SEC = 1
+    TEMP_STALE_SEC = 30
     MIN_VALID_SETPOINT = 30.0
     DEFAULT_SETPOINT = 62.0
 
@@ -334,6 +336,9 @@ class SfpThermal(ThermalBase, MinMaxTempMixin, PidThermalMixin):
         self._max_temperature = None
         self._threshold_info = {}
         self._threshold_info_time = 0
+        self._intf_name = None
+        self._temp = None
+        self._temp_read_time = 0
         self._invalid_setpoint_logged = False
         self._state_db = None
         ThermalBase.__init__(self)
@@ -380,10 +385,63 @@ class SfpThermal(ThermalBase, MinMaxTempMixin, PidThermalMixin):
     def is_replaceable(self):
         return True
 
+    def _resolve_intf_name(self):
+        if self._intf_name:
+            return self._intf_name
+        self._intf_name = PortIndexMapper().get_interface_name(
+            self._sfp.get_position_in_parent()
+        )
+        return self._intf_name
+
     def get_temperature(self):
         if not self.get_presence():
+            self._intf_name = None
             return None
-        temp = self._sfp.get_temperature()
+
+        if time.monotonic() - self._temp_read_time < self.TEMP_CACHE_INTERVAL_SEC:
+            self._update_min_max_temp(self._temp)
+            return self._temp
+
+        intf_name = self._resolve_intf_name()
+        if not intf_name:
+            thermal_syslogger.log_warning(
+                f"Failed to get interface name for port {self._sfp.get_position_in_parent()}; "
+                f"temperature will not be available."
+            )
+            return None
+
+        db = self._get_state_db()
+        key = f"TRANSCEIVER_DOM_TEMPERATURE|{intf_name}"
+        data = db.get_all(db.STATE_DB, key) or {}
+
+        temp_str = data.get("temperature")
+        try:
+            temp = float(temp_str) if temp_str not in (None, "", "N/A") else None
+        except (TypeError, ValueError):
+            temp = None
+
+        last_update = data.get("last_update_time")
+        if temp is not None and last_update:
+            try:
+                age = time.time() - time.mktime(time.strptime(last_update, "%a %b %d %H:%M:%S %Y"))
+                if age > self.TEMP_STALE_SEC:
+                    thermal_syslogger.log_warning(
+                        f"Stale TRANSCEIVER_DOM_TEMPERATURE for {intf_name} "
+                        f"(age={age:.0f}s); ignoring"
+                    )
+                    temp = None
+            except ValueError:
+                thermal_syslogger.log_error(
+                    f"Failed to parse last_update_time '{last_update}' for {intf_name}"
+                )
+        elif temp is not None:
+            thermal_syslogger.log_warning(
+                f"TRANSCEIVER_DOM_TEMPERATURE for {intf_name} missing last_update_time; "
+                f"accepting without staleness check"
+            )
+
+        self._temp = temp
+        self._temp_read_time = time.monotonic()
         self._update_min_max_temp(temp)
         return temp
 


### PR DESCRIPTION
#### Why I did it

Rely on STATE_DB read for transceiver stats for thermal PID algorithm instead of sfp object read for NH platform.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
1. Enable fast polling of temperature on NH platform.
2. Update nh_thermal monitoring script.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

- TRANSCEIVER_DOM_TEMPERATURE updated in STATE_DB every 5 seconds from xcvrd
- show platform temperature reads every 10 seconds via thermalctld
- nh_thermal reads every 5 seconds from STATE_DB
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Backport of https://github.com/sonic-net/sonic-buildimage/pull/27153

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

