### PR TITLE
Disable in-PR testing of docker-ptf image change

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -127,7 +127,9 @@ stages:
   - name: testbed_file
     value: vtestbed.csv
   - name: PTF_MODIFIED
-    value: $[ coalesce(stageDependencies.BuildVS.vs.outputs['PublishAndSetPtfTag.PTF_MODIFIED'], stageDependencies.BuildVS.vs.outputs['script.PTF_MODIFIED'], stageDependencies.BuildVS.vs.outputs['script1.PTF_MODIFIED'], 'False') ]
+    # $[ coalesce(stageDependencies.BuildVS.vs.outputs['PublishAndSetPtfTag.PTF_MODIFIED'], stageDependencies.BuildVS.vs.outputs['script.PTF_MODIFIED'], stageDependencies.BuildVS.vs.outputs['script1.PTF_MODIFIED'], 'False') ]
+    # Disable in-PR testing of docker-ptf image; To be re-enabled after image can be uploaded to approved ACR
+    value: 'False' 
 
 # For every test job:
 # continueOnError: false means it's a required test job and will block merge if it fails


### PR DESCRIPTION
#### Why I did it

Temporarily disable in-PR testing of changes to `docker-ptf` image until the built image can be uploaded to an approved ACR.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Disable detection of `docker-ptf` image change. The test pipelines will always use the latest image from the registry.

#### How to verify it

NA.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

NA

#### Description for the changelog

Temporarily disable in-PR testing of changes to `docker-ptf` image until the built image can be uploaded to an approved ACR.

- Hard-code PTF_MODIFIED to 'False' to disable testing pipeline from pre-loading PR built image.

#### A picture of a cute animal (not mandatory but encouraged)

NA