### PR TITLE
ci: fix YAML indentation in docker-sonic-mgmt.yml

### DIFF
--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -134,14 +134,14 @@ stages:
       condition: always()
       continueOnError: true
 
-    - template: .azure-pipelines/pr_test_template.yml@sonic-mgmt
-      parameters:
-        CHECKOUT_SONIC_MGMT: true
-        # todo: enable vpp build in sonic-mgmt docker image build pipeline, and add vpp test pipeline back.
-        INCLUDE_JOBS: "t0_job,t1_job,t2_job,t0_2vlans_job,t0_sonic_job,dpu_job,t1_multi_asic_job"
-        OVERRIDE_PARAMS:
-          REPO_NAME: "sonic-mgmt"
-          SETUP_CONTAINER_PARAMS: "-i ${{ parameters.registry_url }}/docker-sonic-mgmt:lastbuild"
+  - template: .azure-pipelines/pr_test_template.yml@sonic-mgmt
+    parameters:
+      CHECKOUT_SONIC_MGMT: true
+      # todo: enable vpp build in sonic-mgmt docker image build pipeline, and add vpp test pipeline back.
+      INCLUDE_JOBS: "t0_job,t1_job,t2_job,t0_2vlans_job,t0_sonic_job,dpu_job,t1_multi_asic_job"
+      OVERRIDE_PARAMS:
+        REPO_NAME: "sonic-mgmt"
+        SETUP_CONTAINER_PARAMS: "-i ${{ parameters.registry_url }}/docker-sonic-mgmt:lastbuild"
 
 - stage: Publish
   dependsOn: Test


### PR DESCRIPTION
#### Why I did it

Fix a YAML parse error introduced by #27079. The `pr_test_template` reference was indented as a `step` inside the `trivy_scan` job rather than as a sibling `job` in the `jobs` list, causing:

```
/.azure-pipelines/pr_test_template.yml@sonic-mgmt (Line: 74, Col: 1): Unexpected value 'jobs'
```

##### Work item tracking
- Microsoft ADO:

#### How I did it

Fix indentation: move `- template: .azure-pipelines/pr_test_template.yml@sonic-mgmt` from step level (4-space) to job level (2-space) in the `Test` stage `jobs` list.

#### How to verify it

The `docker-sonic-mgmt.yml` pipeline should parse without YAML errors and run both jobs (`trivy_scan` and the `pr_test_template`) in parallel in the Test stage.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch

- [ ]

#### Description for the changelog

Fix YAML indentation in docker-sonic-mgmt.yml Trivy scan job.

#### Link to config_db schema for YANG module changes

N/A
