### PR TITLE
Change the IP address to use 169.254.100 

### DIFF
--- a/device/nexthop/arm64-nexthop_b27-r0/bmc.json
+++ b/device/nexthop/arm64-nexthop_b27-r0/bmc.json
@@ -1,5 +1,5 @@
 {
     "bmc_if_name": "bmc0",
-    "bmc_if_addr": "192.168.100.1",
-    "bmc_net_mask": "255.255.255.0"
+    "bmc_if_addr": "169.254.100.1",
+    "bmc_net_mask": "255.255.255.252"
 }


### PR DESCRIPTION
Change the IP address to use 169.254.100 as outlined in https://github.com/sonic-net/SONiC/blob/master/doc/bmc/sonicBMC/pmon-bmc-design.md#213-host-bmc-link

#### Why I did it
fix the IP address to use the one outlined in the document.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Updated the .json file

#### How to verify it
Image upon boot should have this address on the bmc0 interface

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

