### PR TITLE
[bgpcfgd][frrcfgd][yang] Add BFD custom timer parameters and BFD profile support for BGP

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/dynamic/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/dynamic/instance.conf.j2
@@ -27,6 +27,14 @@
   neighbor {{ bgp_session['name'] }} update-source {{ get_ipv4_loopback_address(CONFIG_DB__LOOPBACK_INTERFACE, "Loopback1") | ip }}
 {% endif %}
 !
+{% if 'bfd' in bgp_session and bgp_session['bfd'] == 'true' %}
+{%   if 'bfd_detect_multiplier' in bgp_session and 'bfd_min_rx' in bgp_session and 'bfd_min_tx' in bgp_session %}
+  neighbor {{ bgp_session['name'] }} bfd {{ bgp_session['bfd_detect_multiplier'] }} {{ bgp_session['bfd_min_rx'] }} {{ bgp_session['bfd_min_tx'] }}
+{%   else %}
+  neighbor {{ bgp_session['name'] }} bfd
+{%   endif %}
+{% endif %}
+!
   address-family ipv4
     neighbor {{ bgp_session['name'] }} activate
   exit-address-family

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/dynamic/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/dynamic/instance.conf.j2
@@ -28,7 +28,10 @@
 {% endif %}
 !
 {% if 'bfd' in bgp_session and bgp_session['bfd'] == 'true' %}
-{%   if 'bfd_detect_multiplier' in bgp_session and 'bfd_min_rx' in bgp_session and 'bfd_min_tx' in bgp_session %}
+{%   if 'bfd_profile' in bgp_session %}
+  neighbor {{ bgp_session['name'] }} bfd
+  neighbor {{ bgp_session['name'] }} bfd profile {{ bgp_session['bfd_profile'] }}
+{%   elif 'bfd_detect_multiplier' in bgp_session and 'bfd_min_rx' in bgp_session and 'bfd_min_tx' in bgp_session %}
   neighbor {{ bgp_session['name'] }} bfd {{ bgp_session['bfd_detect_multiplier'] }} {{ bgp_session['bfd_min_rx'] }} {{ bgp_session['bfd_min_tx'] }}
 {%   else %}
   neighbor {{ bgp_session['name'] }} bfd

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
@@ -14,6 +14,14 @@
   neighbor {{ neighbor_addr }} shutdown
 {% endif %}
 !
+{% if 'bfd' in bgp_session and bgp_session['bfd'] == 'true' %}
+{%   if 'bfd_detect_multiplier' in bgp_session and 'bfd_min_rx' in bgp_session and 'bfd_min_tx' in bgp_session %}
+  neighbor {{ neighbor_addr }} bfd {{ bgp_session['bfd_detect_multiplier'] }} {{ bgp_session['bfd_min_rx'] }} {{ bgp_session['bfd_min_tx'] }}
+{%   else %}
+  neighbor {{ neighbor_addr }} bfd
+{%   endif %}
+{% endif %}
+!
 {% if neighbor_addr | ipv4 %}
   address-family ipv4
     neighbor {{ neighbor_addr }} peer-group PEER_V4

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
@@ -15,7 +15,10 @@
 {% endif %}
 !
 {% if 'bfd' in bgp_session and bgp_session['bfd'] == 'true' %}
-{%   if 'bfd_detect_multiplier' in bgp_session and 'bfd_min_rx' in bgp_session and 'bfd_min_tx' in bgp_session %}
+{%   if 'bfd_profile' in bgp_session %}
+  neighbor {{ neighbor_addr }} bfd
+  neighbor {{ neighbor_addr }} bfd profile {{ bgp_session['bfd_profile'] }}
+{%   elif 'bfd_detect_multiplier' in bgp_session and 'bfd_min_rx' in bgp_session and 'bfd_min_tx' in bgp_session %}
   neighbor {{ neighbor_addr }} bfd {{ bgp_session['bfd_detect_multiplier'] }} {{ bgp_session['bfd_min_rx'] }} {{ bgp_session['bfd_min_tx'] }}
 {%   else %}
   neighbor {{ neighbor_addr }} bfd

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/internal/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/internal/instance.conf.j2
@@ -7,7 +7,10 @@
   neighbor {{ neighbor_addr }} timers connect 10
 !
 {% if 'bfd' in bgp_session and bgp_session['bfd'] == 'true' %}
-{%   if 'bfd_detect_multiplier' in bgp_session and 'bfd_min_rx' in bgp_session and 'bfd_min_tx' in bgp_session %}
+{%   if 'bfd_profile' in bgp_session %}
+  neighbor {{ neighbor_addr }} bfd
+  neighbor {{ neighbor_addr }} bfd profile {{ bgp_session['bfd_profile'] }}
+{%   elif 'bfd_detect_multiplier' in bgp_session and 'bfd_min_rx' in bgp_session and 'bfd_min_tx' in bgp_session %}
   neighbor {{ neighbor_addr }} bfd {{ bgp_session['bfd_detect_multiplier'] }} {{ bgp_session['bfd_min_rx'] }} {{ bgp_session['bfd_min_tx'] }}
 {%   else %}
   neighbor {{ neighbor_addr }} bfd

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/internal/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/internal/instance.conf.j2
@@ -6,6 +6,14 @@
   neighbor {{ neighbor_addr }} timers 3 10
   neighbor {{ neighbor_addr }} timers connect 10
 !
+{% if 'bfd' in bgp_session and bgp_session['bfd'] == 'true' %}
+{%   if 'bfd_detect_multiplier' in bgp_session and 'bfd_min_rx' in bgp_session and 'bfd_min_tx' in bgp_session %}
+  neighbor {{ neighbor_addr }} bfd {{ bgp_session['bfd_detect_multiplier'] }} {{ bgp_session['bfd_min_rx'] }} {{ bgp_session['bfd_min_tx'] }}
+{%   else %}
+  neighbor {{ neighbor_addr }} bfd
+{%   endif %}
+{% endif %}
+!
 {% if neighbor_addr | ipv4 %}
   address-family ipv4
     neighbor {{ neighbor_addr }} peer-group INTERNAL_PEER_V4

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/monitors/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/monitors/instance.conf.j2
@@ -6,7 +6,10 @@
   neighbor {{ neighbor_addr }} description {{ bgp_session['name'] }}
 !
 {% if 'bfd' in bgp_session and bgp_session['bfd'] == 'true' %}
-{%   if 'bfd_detect_multiplier' in bgp_session and 'bfd_min_rx' in bgp_session and 'bfd_min_tx' in bgp_session %}
+{%   if 'bfd_profile' in bgp_session %}
+  neighbor {{ neighbor_addr }} bfd
+  neighbor {{ neighbor_addr }} bfd profile {{ bgp_session['bfd_profile'] }}
+{%   elif 'bfd_detect_multiplier' in bgp_session and 'bfd_min_rx' in bgp_session and 'bfd_min_tx' in bgp_session %}
   neighbor {{ neighbor_addr }} bfd {{ bgp_session['bfd_detect_multiplier'] }} {{ bgp_session['bfd_min_rx'] }} {{ bgp_session['bfd_min_tx'] }}
 {%   else %}
   neighbor {{ neighbor_addr }} bfd

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/monitors/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/monitors/instance.conf.j2
@@ -4,6 +4,15 @@
   neighbor {{ neighbor_addr }} remote-as {{ bgp_asn }}
   neighbor {{ neighbor_addr }} peer-group BGPMON
   neighbor {{ neighbor_addr }} description {{ bgp_session['name'] }}
+!
+{% if 'bfd' in bgp_session and bgp_session['bfd'] == 'true' %}
+{%   if 'bfd_detect_multiplier' in bgp_session and 'bfd_min_rx' in bgp_session and 'bfd_min_tx' in bgp_session %}
+  neighbor {{ neighbor_addr }} bfd {{ bgp_session['bfd_detect_multiplier'] }} {{ bgp_session['bfd_min_rx'] }} {{ bgp_session['bfd_min_tx'] }}
+{%   else %}
+  neighbor {{ neighbor_addr }} bfd
+{%   endif %}
+{% endif %}
+!
   neighbor {{ neighbor_addr }} activate
   address-family ipv6
     neighbor {{ neighbor_addr }} activate

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/sentinels/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/sentinels/instance.conf.j2
@@ -10,6 +10,14 @@
   bgp listen range {{ ip_range }} peer-group {{ bgp_session['name'] }}
 {% endfor %}
 !
+{% if 'bfd' in bgp_session and bgp_session['bfd'] == 'true' %}
+{%   if 'bfd_detect_multiplier' in bgp_session and 'bfd_min_rx' in bgp_session and 'bfd_min_tx' in bgp_session %}
+  neighbor {{ bgp_session['name'] }} bfd {{ bgp_session['bfd_detect_multiplier'] }} {{ bgp_session['bfd_min_rx'] }} {{ bgp_session['bfd_min_tx'] }}
+{%   else %}
+  neighbor {{ bgp_session['name'] }} bfd
+{%   endif %}
+{% endif %}
+!
   address-family ipv4
     neighbor {{ bgp_session['name'] }} activate
     neighbor {{ bgp_session['name'] }} addpath-tx-all-paths

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/sentinels/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/sentinels/instance.conf.j2
@@ -11,7 +11,10 @@
 {% endfor %}
 !
 {% if 'bfd' in bgp_session and bgp_session['bfd'] == 'true' %}
-{%   if 'bfd_detect_multiplier' in bgp_session and 'bfd_min_rx' in bgp_session and 'bfd_min_tx' in bgp_session %}
+{%   if 'bfd_profile' in bgp_session %}
+  neighbor {{ bgp_session['name'] }} bfd
+  neighbor {{ bgp_session['name'] }} bfd profile {{ bgp_session['bfd_profile'] }}
+{%   elif 'bfd_detect_multiplier' in bgp_session and 'bfd_min_rx' in bgp_session and 'bfd_min_tx' in bgp_session %}
   neighbor {{ bgp_session['name'] }} bfd {{ bgp_session['bfd_detect_multiplier'] }} {{ bgp_session['bfd_min_rx'] }} {{ bgp_session['bfd_min_tx'] }}
 {%   else %}
   neighbor {{ bgp_session['name'] }} bfd

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/voq_chassis/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/voq_chassis/instance.conf.j2
@@ -17,6 +17,14 @@
   neighbor {{ neighbor_addr }} shutdown
 {% endif %}
 !
+{% if 'bfd' in bgp_session and bgp_session['bfd'] == 'true' %}
+{%   if 'bfd_detect_multiplier' in bgp_session and 'bfd_min_rx' in bgp_session and 'bfd_min_tx' in bgp_session %}
+  neighbor {{ neighbor_addr }} bfd {{ bgp_session['bfd_detect_multiplier'] }} {{ bgp_session['bfd_min_rx'] }} {{ bgp_session['bfd_min_tx'] }}
+{%   else %}
+  neighbor {{ neighbor_addr }} bfd
+{%   endif %}
+{% endif %}
+!
   address-family ipv4
 {% if constants.bgp.maximum_paths.enabled is defined and constants.bgp.maximum_paths.enabled %}
     maximum-paths ibgp {{ constants.bgp.maximum_paths.ipv4 | default(64) }}

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/voq_chassis/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/voq_chassis/instance.conf.j2
@@ -18,7 +18,10 @@
 {% endif %}
 !
 {% if 'bfd' in bgp_session and bgp_session['bfd'] == 'true' %}
-{%   if 'bfd_detect_multiplier' in bgp_session and 'bfd_min_rx' in bgp_session and 'bfd_min_tx' in bgp_session %}
+{%   if 'bfd_profile' in bgp_session %}
+  neighbor {{ neighbor_addr }} bfd
+  neighbor {{ neighbor_addr }} bfd profile {{ bgp_session['bfd_profile'] }}
+{%   elif 'bfd_detect_multiplier' in bgp_session and 'bfd_min_rx' in bgp_session and 'bfd_min_tx' in bgp_session %}
   neighbor {{ neighbor_addr }} bfd {{ bgp_session['bfd_detect_multiplier'] }} {{ bgp_session['bfd_min_rx'] }} {{ bgp_session['bfd_min_tx'] }}
 {%   else %}
   neighbor {{ neighbor_addr }} bfd

--- a/src/sonic-bgpcfgd/bgpcfgd/main.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/main.py
@@ -27,6 +27,7 @@ from .managers_rm import RouteMapMgr
 from .managers_device_global import DeviceGlobalCfgMgr
 from .managers_chassis_app_db import ChassisAppDbMgr
 from .managers_bfd import BfdMgr
+from .managers_bfd_profile import BfdProfileMgr, BFD_PROFILE_TABLE_NAME
 from .managers_srv6 import SRv6Mgr
 from .managers_prefix_list import PrefixListMgr
 from .managers_as_path import AsPathMgr
@@ -81,6 +82,8 @@ def do_work():
         InterfaceMgr(common_objs, "CONFIG_DB", swsscommon.CFG_LAG_INTF_TABLE_NAME),
         InterfaceMgr(common_objs, "CONFIG_DB", swsscommon.CFG_VOQ_INBAND_INTERFACE_TABLE_NAME),
         InterfaceMgr(common_objs, "CONFIG_DB", swsscommon.CFG_VLAN_SUB_INTF_TABLE_NAME),
+        # BFD Profile Manager (must be before Peer Managers so profiles exist first)
+        BfdProfileMgr(common_objs, "CONFIG_DB", BFD_PROFILE_TABLE_NAME),
         # State DB managers
         ZebraSetSrc(common_objs, "STATE_DB", swsscommon.STATE_INTERFACE_TABLE_NAME),
         # Peer Managers

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bfd_profile.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bfd_profile.py
@@ -1,0 +1,107 @@
+from .log import log_err, log_info
+from .manager import Manager
+from .utils import run_command
+
+BFD_PROFILE_TABLE_NAME = "BFD_PROFILE"
+
+# Maps CONFIG_DB field names to FRR command names
+FIELD_TO_FRR_CMD = {
+    'detect_multiplier': 'detect-multiplier',
+    'receive_interval': 'receive-interval',
+    'transmit_interval': 'transmit-interval',
+    'echo_interval': 'echo-interval',
+    'minimum_ttl': 'minimum-ttl',
+}
+
+# Boolean fields that render as "command" / "no command"
+BOOLEAN_FIELDS = {
+    'echo_mode': 'echo-mode',
+    'passive_mode': 'passive-mode',
+}
+
+
+class BfdProfileMgr(Manager):
+    """This class manages BFD profiles in FRR based on CONFIG_DB BFD_PROFILE table."""
+
+    def __init__(self, common_objs, db, table):
+        """
+        Initialize the object
+        :param common_objs: common object dictionary
+        :param db: name of the db
+        :param table: name of the table in the db
+        """
+        super(BfdProfileMgr, self).__init__(
+            common_objs,
+            [],  # no dependencies
+            db,
+            table,
+        )
+        self.profiles = {}  # name -> data dict, tracks current state
+
+    def set_handler(self, key, data):
+        """Implementation of 'SET' command."""
+        if not key:
+            log_err("BFD profile name is empty")
+            return True  # don't re-queue an invalid key
+
+        prev = self.profiles.get(key, {})
+        cmds = self._build_profile_cmds(key, data, prev)
+        command = ["vtysh", "-c", "conf t", "-c", "bfd"] + cmds
+        ret_code, out, err = run_command(command)
+        if ret_code != 0:
+            log_err("Can't configure BFD profile '%s': %s" % (key, err))
+            return False
+
+        self.profiles[key] = dict(data)
+        log_info("BFD profile '%s' configured" % key)
+        return True
+
+    def del_handler(self, key):
+        """Implementation of 'DEL' command."""
+        command = ["vtysh", "-c", "conf t", "-c", "bfd",
+                   "-c", "no profile %s" % key]
+        ret_code, out, err = run_command(command)
+        if ret_code != 0:
+            log_err("Can't remove BFD profile '%s': %s" % (key, err))
+            return
+
+        if key in self.profiles:
+            del self.profiles[key]
+        log_info("BFD profile '%s' removed" % key)
+
+    def _build_profile_cmds(self, name, data, prev=None):
+        """
+        Build vtysh commands for a BFD profile configuration.
+        :param name: profile name
+        :param data: dict of profile fields from CONFIG_DB
+        :param prev: dict of previously applied fields, for diff-based cleanup
+        :return: list of vtysh command arguments
+        """
+        prev = prev or {}
+        cmds = ["-c", "profile %s" % name]
+
+        # Clear fields that existed previously but were removed in this update.
+        # Without this, FRR retains stale values when a field is deleted from
+        # CONFIG_DB while the profile itself still exists.
+        for db_field, frr_cmd in FIELD_TO_FRR_CMD.items():
+            if db_field in prev and db_field not in data:
+                cmds.extend(["-c", "no %s" % frr_cmd])
+        for db_field, frr_cmd in BOOLEAN_FIELDS.items():
+            if db_field in prev and db_field not in data:
+                cmds.extend(["-c", "no %s" % frr_cmd])
+
+        # Numeric fields: render if present in data
+        for db_field, frr_cmd in FIELD_TO_FRR_CMD.items():
+            if db_field in data:
+                cmds.extend(["-c", "%s %s" % (frr_cmd, data[db_field])])
+
+        # Boolean fields: render as "cmd" or "no cmd"
+        for db_field, frr_cmd in BOOLEAN_FIELDS.items():
+            if db_field in data:
+                if data[db_field].lower() == 'true':
+                    cmds.extend(["-c", frr_cmd])
+                else:
+                    cmds.extend(["-c", "no %s" % frr_cmd])
+
+        cmds.extend(["-c", "exit"])  # exit profile
+        return cmds

--- a/src/sonic-bgpcfgd/staticroutebfd/main.py
+++ b/src/sonic-bgpcfgd/staticroutebfd/main.py
@@ -98,7 +98,7 @@ def check_ip(ip):
 class StaticRouteBfd(object):
 
     SELECT_TIMEOUT = 1000
-    BFD_DEFAULT_CFG = {"multihop": "false", "rx_interval": "50", "tx_interval": "50"}
+    BFD_DEFAULT_CFG = {"multihop": "false", "rx_interval": "50", "tx_interval": "50", "multiplier": "3"}
 
     def __init__(self):
         self.local_db = defaultdict(dict)
@@ -220,18 +220,31 @@ class StaticRouteBfd(object):
     def update_bfd_pending(self, if_name):
         del_list=[]
         for k, v in self.local_db[LOCAL_BFD_PENDING_TABLE].items():
-            if len(v) == 3 and v[0] == if_name:
+            # Support both old format (3 elements) and new format (6 elements with timer params)
+            if len(v) >= 3 and v[0] == if_name:
                 intf, nh_ip, bfd_key = v[0], v[1], v[2]
+                # Extract timer parameters if available (new format)
+                bfd_multiplier_val = v[3] if len(v) > 3 else None
+                bfd_rx_interval_val = v[4] if len(v) > 4 else None
+                bfd_tx_interval_val = v[5] if len(v) > 5 else None
+
                 valid, local_addr = self.find_interface_ip(intf, nh_ip)
                 if not valid: #IP address might not be available for this type of nh_ip (IPv4 or IPv6) yet
                     continue
                 log_notice("bfd_pending: get ip for interface: %s, create bfd session for %s"%(intf, bfd_key))
                 bfd_entry_cfg = self.BFD_DEFAULT_CFG.copy()
+                # Override hardcoded defaults with values from vars.py
                 if all([bfd_rx_interval, bfd_tx_interval, bfd_multiplier, bfd_multihop]):
                     bfd_entry_cfg["multihop"] = bfd_multihop
                     bfd_entry_cfg["rx_interval"] = bfd_rx_interval
                     bfd_entry_cfg["tx_interval"] = bfd_tx_interval
                     bfd_entry_cfg["multiplier"] = bfd_multiplier
+
+                # Override with custom timer parameters from CONFIG_DB if provided
+                if bfd_multiplier_val and bfd_rx_interval_val and bfd_tx_interval_val:
+                    bfd_entry_cfg["rx_interval"] = bfd_rx_interval_val
+                    bfd_entry_cfg["tx_interval"] = bfd_tx_interval_val
+                    bfd_entry_cfg["multiplier"] = bfd_multiplier_val
 
                 bfd_entry_cfg["local_addr"] = local_addr
                 self.set_bfd_session_into_appl_db(bfd_key, bfd_entry_cfg)
@@ -351,10 +364,17 @@ class StaticRouteBfd(object):
         key = vrf + ":" + ip_prefix
         log_debug("SRT_BFD: handle_bfd_change. key %s, data %s, to_bfd_enable %s"%(key, str(data), str(to_bfd_enable)))
         if to_bfd_enable:
-            #write route with full_nh_list to appl_db, let StaticRouteMgr(appl_db) install this route to update its cache
-            data['bfd'] = "false"
-            data['expiry'] = "false"
-            self.set_static_route_into_appl_db(key, data)
+            # Filter out custom BFD timer parameters before writing the static route to APPL_DB
+            filtered_data = {}
+            for k, v in data.items():
+                if k in ["bfd_detect_multiplier", "bfd_min_rx", "bfd_min_tx"]:
+                    # Skip custom BFD timer parameters
+                    continue
+                filtered_data[k] = v
+
+            filtered_data['bfd'] = "false"
+            filtered_data['expiry'] = "false"
+            self.set_static_route_into_appl_db(key, filtered_data)
             log_debug("SRT_BFD: bfd toggle to true. write the route to appl_db, update StaticRouteMgr(appl_db), key %s"%(key))
         else:
             self.del_static_route_from_appl_db(key)
@@ -423,6 +443,12 @@ class StaticRouteBfd(object):
         bkh_list    = arg_list(data['blackhole']) if 'blackhole' in data else None
         intf_list   = arg_list(data['ifname']) if 'ifname' in data else None
         dist_list   = arg_list(data['distance']) if 'distance' in data else None
+
+        # Extract BFD custom timer parameters (per-nexthop lists)
+        bfd_multiplier_list = arg_list(data['bfd_detect_multiplier']) if 'bfd_detect_multiplier' in data else None
+        bfd_rx_interval_list = arg_list(data['bfd_min_rx']) if 'bfd_min_rx' in data else None
+        bfd_tx_interval_list = arg_list(data['bfd_min_tx']) if 'bfd_min_tx' in data else None
+
         if bkh_list is not None and 'true' in bkh_list:
             log_info("Blackholing static route encountered, skipping it")
             return True
@@ -468,6 +494,11 @@ class StaticRouteBfd(object):
             nh_vrf = nh_vrf_list[index]
             nh_key = nh_vrf + "|" + nh_ip
 
+            # Get per-nexthop BFD timer parameters if available
+            bfd_multiplier_val = bfd_multiplier_list[index] if bfd_multiplier_list and index < len(bfd_multiplier_list) else None
+            bfd_rx_interval_val = bfd_rx_interval_list[index] if bfd_rx_interval_list and index < len(bfd_rx_interval_list) else None
+            bfd_tx_interval_val = bfd_tx_interval_list[index] if bfd_tx_interval_list and index < len(bfd_tx_interval_list) else None
+
             #check if the bfd session is already created
             bfd_key = nh_vrf  + ":default:" + nh_ip
             bfd_session = self.get_local_db(LOCAL_BFD_TABLE, bfd_key)
@@ -477,18 +508,26 @@ class StaticRouteBfd(object):
             if len(self.get_local_db(LOCAL_NEXTHOP_TABLE, nh_key)) == 0 and len(bfd_session) == 0:
                 valid, local_addr = self.find_interface_ip(intf, nh_ip)
                 if not valid:
-                    #interface IP is not available yet, put this request to cache
-                    self.set_local_db(LOCAL_BFD_PENDING_TABLE, intf+"_"+bfd_key, [intf, nh_ip, bfd_key])
+                    #interface IP is not available yet, put this request to cache with timer parameters
+                    pending_entry = [intf, nh_ip, bfd_key, bfd_multiplier_val, bfd_rx_interval_val, bfd_tx_interval_val]
+                    self.set_local_db(LOCAL_BFD_PENDING_TABLE, intf+"_"+bfd_key, pending_entry)
                     self.append_to_nh_table_entry(nh_key, vrf + "|" + ip_prefix)
                     log_warn("bfd_pending: cannot find ip for interface: %s, postpone bfd session creation" %intf)
                     continue
 
                 bfd_entry_cfg = self.BFD_DEFAULT_CFG.copy()
+                # Override with values from vars.py only if all are set
                 if all([bfd_rx_interval, bfd_tx_interval, bfd_multiplier, bfd_multihop]):
                     bfd_entry_cfg["multihop"] = bfd_multihop
                     bfd_entry_cfg["rx_interval"] = bfd_rx_interval
                     bfd_entry_cfg["tx_interval"] = bfd_tx_interval
                     bfd_entry_cfg["multiplier"] = bfd_multiplier
+
+                # Override with custom timer parameters from CONFIG_DB if provided
+                if bfd_multiplier_val and bfd_rx_interval_val and bfd_tx_interval_val:
+                    bfd_entry_cfg["rx_interval"] = bfd_rx_interval_val
+                    bfd_entry_cfg["tx_interval"] = bfd_tx_interval_val
+                    bfd_entry_cfg["multiplier"] = bfd_multiplier_val
 
                 bfd_entry_cfg["local_addr"] = local_addr
                 self.set_bfd_session_into_appl_db(bfd_key, bfd_entry_cfg)
@@ -620,6 +659,8 @@ class StaticRouteBfd(object):
             if key == "bfd":
                 continue
             if key == "bfd_nh_hold":
+                continue
+            if key in ["bfd_detect_multiplier", "bfd_min_rx", "bfd_min_tx"]:
                 continue
             if key == "blackhole":
                 new_config[key] = bkh_candidate[1:]

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/param_bfd_profile.json
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/param_bfd_profile.json
@@ -1,0 +1,20 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {}
+    },
+    "neighbor_addr": "10.10.10.10",
+    "bgp_session": {
+        "asn": "555",
+        "name": "remote_peer",
+        "bfd": "true",
+        "bfd_profile": "fast-failover",
+        "bfd_detect_multiplier": "5",
+        "bfd_min_rx": "300",
+        "bfd_min_tx": "300"
+    },
+    "constants": {
+        "deployment_id_asn_map": {
+            "5": "51111"
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/param_bfd_timers.json
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/param_bfd_timers.json
@@ -1,0 +1,19 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {}
+    },
+    "neighbor_addr": "10.10.10.10",
+    "bgp_session": {
+        "asn": "555",
+        "name": "remote_peer",
+        "bfd": "true",
+        "bfd_detect_multiplier": "5",
+        "bfd_min_rx": "300",
+        "bfd_min_tx": "300"
+    },
+    "constants": {
+        "deployment_id_asn_map": {
+            "5": "51111"
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_bfd_profile.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_bfd_profile.conf
@@ -1,0 +1,18 @@
+!
+! template: bgpd/templates/general/instance.conf.j2
+!
+  neighbor 10.10.10.10 remote-as 555
+  neighbor 10.10.10.10 description remote_peer
+  neighbor 10.10.10.10 timers connect 10
+!
+  neighbor 10.10.10.10 bfd
+  neighbor 10.10.10.10 bfd profile fast-failover
+!
+  address-family ipv4
+    neighbor 10.10.10.10 peer-group PEER_V4
+!
+    neighbor 10.10.10.10 activate
+  exit-address-family
+!
+! end of template: bgpd/templates/general/instance.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_bfd_timers.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_bfd_timers.conf
@@ -1,0 +1,17 @@
+!
+! template: bgpd/templates/general/instance.conf.j2
+!
+  neighbor 10.10.10.10 remote-as 555
+  neighbor 10.10.10.10 description remote_peer
+  neighbor 10.10.10.10 timers connect 10
+!
+  neighbor 10.10.10.10 bfd 5 300 300
+!
+  address-family ipv4
+    neighbor 10.10.10.10 peer-group PEER_V4
+!
+    neighbor 10.10.10.10 activate
+  exit-address-family
+!
+! end of template: bgpd/templates/general/instance.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/test_bfd_profile_mgr.py
+++ b/src/sonic-bgpcfgd/tests/test_bfd_profile_mgr.py
@@ -1,0 +1,318 @@
+from unittest.mock import MagicMock, patch
+
+from bgpcfgd.directory import Directory
+from bgpcfgd.template import TemplateFabric
+from . import swsscommon_test
+import pytest
+
+import sys
+sys.modules["swsscommon"] = swsscommon_test
+
+from bgpcfgd.managers_bfd_profile import BfdProfileMgr
+
+
+@pytest.fixture
+def bfd_profile_mgr():
+    cfg_mgr = MagicMock()
+    common_objs = {
+        'directory': Directory(),
+        'cfg_mgr':   cfg_mgr,
+        'tf':        TemplateFabric(),
+        'constants': {},
+    }
+    return BfdProfileMgr(common_objs, "CONFIG_DB", "BFD_PROFILE")
+
+
+def test_constructor(bfd_profile_mgr):
+    assert len(bfd_profile_mgr.profiles) == 0
+
+
+@patch('bgpcfgd.managers_bfd_profile.run_command', return_value=(0, '', ''))
+def test_set_handler_basic(mocked_run_command, bfd_profile_mgr):
+    """Test creating a profile with only required fields."""
+    key = "fast-bfd"
+    data = {
+        "detect_multiplier": "3",
+        "receive_interval": "300",
+        "transmit_interval": "300",
+    }
+    expected_cmd = [
+        'vtysh', '-c', 'conf t', '-c', 'bfd',
+        '-c', 'profile fast-bfd',
+        '-c', 'detect-multiplier 3',
+        '-c', 'receive-interval 300',
+        '-c', 'transmit-interval 300',
+        '-c', 'exit',
+    ]
+    assert bfd_profile_mgr.set_handler(key, data) == True
+    mocked_run_command.assert_called_once_with(expected_cmd)
+    assert 'fast-bfd' in bfd_profile_mgr.profiles
+
+
+@patch('bgpcfgd.managers_bfd_profile.run_command', return_value=(0, '', ''))
+def test_set_handler_all_fields(mocked_run_command, bfd_profile_mgr):
+    """Test creating a profile with all fields."""
+    key = "full-profile"
+    data = {
+        "detect_multiplier": "5",
+        "receive_interval": "500",
+        "transmit_interval": "500",
+        "echo_interval": "100",
+        "minimum_ttl": "250",
+        "echo_mode": "true",
+        "passive_mode": "false",
+    }
+    assert bfd_profile_mgr.set_handler(key, data) == True
+    args = mocked_run_command.call_args[0][0]
+    assert 'profile full-profile' in args
+    assert 'detect-multiplier 5' in args
+    assert 'receive-interval 500' in args
+    assert 'transmit-interval 500' in args
+    assert 'echo-interval 100' in args
+    assert 'minimum-ttl 250' in args
+    assert 'echo-mode' in args
+    assert 'no passive-mode' in args
+    assert 'full-profile' in bfd_profile_mgr.profiles
+
+
+@patch('bgpcfgd.managers_bfd_profile.run_command', return_value=(1, '', 'Error'))
+@patch('bgpcfgd.managers_bfd_profile.log_err')
+def test_set_handler_failure(mocked_log_err, mocked_run_command, bfd_profile_mgr):
+    """Test vtysh command failure."""
+    key = "fail-profile"
+    data = {
+        "detect_multiplier": "3",
+        "receive_interval": "300",
+        "transmit_interval": "300",
+    }
+    assert bfd_profile_mgr.set_handler(key, data) == False
+    assert 'fail-profile' not in bfd_profile_mgr.profiles
+    mocked_log_err.assert_called_with("Can't configure BFD profile 'fail-profile': Error")
+
+
+@patch('bgpcfgd.managers_bfd_profile.run_command', return_value=(0, '', ''))
+def test_set_handler_partial_profile_accepted(mocked_run_command, bfd_profile_mgr):
+    """A profile with only a subset of fields is accepted; FRR fills in defaults
+    for the rest. YANG does not mark detect_multiplier/receive_interval/
+    transmit_interval as mandatory, so the manager must not reject these."""
+    key = "echo-only"
+    data = {"echo_interval": "100", "echo_mode": "true"}
+    assert bfd_profile_mgr.set_handler(key, data) is True
+    args = mocked_run_command.call_args[0][0]
+    assert "profile echo-only" in args
+    assert "echo-interval 100" in args
+    assert "echo-mode" in args
+    # No 'detect-multiplier'/'receive-interval'/'transmit-interval' lines
+    for arg in args:
+        assert "detect-multiplier" not in arg
+        assert "receive-interval" not in arg
+        assert "transmit-interval" not in arg
+    assert "echo-only" in bfd_profile_mgr.profiles
+
+
+@patch('bgpcfgd.managers_bfd_profile.log_err')
+def test_set_handler_empty_key(mocked_log_err, bfd_profile_mgr):
+    """Test empty profile name is rejected."""
+    data = {
+        "detect_multiplier": "3",
+        "receive_interval": "300",
+        "transmit_interval": "300",
+    }
+    assert bfd_profile_mgr.set_handler("", data) == True
+    assert len(bfd_profile_mgr.profiles) == 0
+    mocked_log_err.assert_called_with("BFD profile name is empty")
+
+
+@patch('bgpcfgd.managers_bfd_profile.run_command', return_value=(0, '', ''))
+def test_del_handler(mocked_run_command, bfd_profile_mgr):
+    """Test deleting a profile."""
+    bfd_profile_mgr.profiles['test-profile'] = {"detect_multiplier": "3"}
+    bfd_profile_mgr.del_handler('test-profile')
+    expected_cmd = [
+        'vtysh', '-c', 'conf t', '-c', 'bfd',
+        '-c', 'no profile test-profile',
+    ]
+    mocked_run_command.assert_called_once_with(expected_cmd)
+    assert 'test-profile' not in bfd_profile_mgr.profiles
+
+
+@patch('bgpcfgd.managers_bfd_profile.run_command', return_value=(1, '', 'Error'))
+@patch('bgpcfgd.managers_bfd_profile.log_err')
+def test_del_handler_failure(mocked_log_err, mocked_run_command, bfd_profile_mgr):
+    """Test delete failure preserves profile in tracking."""
+    bfd_profile_mgr.profiles['test-profile'] = {"detect_multiplier": "3"}
+    bfd_profile_mgr.del_handler('test-profile')
+    assert 'test-profile' in bfd_profile_mgr.profiles
+    mocked_log_err.assert_called_with("Can't remove BFD profile 'test-profile': Error")
+
+
+@patch('bgpcfgd.managers_bfd_profile.run_command', return_value=(0, '', ''))
+def test_del_handler_not_tracked(mocked_run_command, bfd_profile_mgr):
+    """Test deleting a profile that isn't tracked still sends vtysh command."""
+    bfd_profile_mgr.del_handler('unknown-profile')
+    expected_cmd = [
+        'vtysh', '-c', 'conf t', '-c', 'bfd',
+        '-c', 'no profile unknown-profile',
+    ]
+    mocked_run_command.assert_called_once_with(expected_cmd)
+
+
+@patch('bgpcfgd.managers_bfd_profile.run_command', return_value=(0, '', ''))
+def test_set_handler_update(mocked_run_command, bfd_profile_mgr):
+    """Test updating an existing profile."""
+    bfd_profile_mgr.profiles['update-profile'] = {
+        "detect_multiplier": "3",
+        "receive_interval": "300",
+        "transmit_interval": "300",
+    }
+    data = {
+        "detect_multiplier": "5",
+        "receive_interval": "500",
+        "transmit_interval": "500",
+    }
+    assert bfd_profile_mgr.set_handler('update-profile', data) == True
+    assert bfd_profile_mgr.profiles['update-profile']['detect_multiplier'] == '5'
+    assert bfd_profile_mgr.profiles['update-profile']['receive_interval'] == '500'
+
+
+@patch('bgpcfgd.managers_bfd_profile.run_command', return_value=(0, '', ''))
+def test_set_handler_echo_mode_false(mocked_run_command, bfd_profile_mgr):
+    """Test echo_mode=false renders 'no echo-mode'."""
+    data = {
+        "detect_multiplier": "3",
+        "receive_interval": "300",
+        "transmit_interval": "300",
+        "echo_mode": "false",
+    }
+    assert bfd_profile_mgr.set_handler('echo-test', data) == True
+    args = mocked_run_command.call_args[0][0]
+    assert 'no echo-mode' in args
+
+
+@patch('bgpcfgd.managers_bfd_profile.run_command', return_value=(0, '', ''))
+def test_set_handler_passive_mode_true(mocked_run_command, bfd_profile_mgr):
+    """Test passive_mode=true renders 'passive-mode' (not 'no passive-mode')."""
+    data = {
+        "detect_multiplier": "3",
+        "receive_interval": "300",
+        "transmit_interval": "300",
+        "passive_mode": "true",
+    }
+    assert bfd_profile_mgr.set_handler('passive-test', data) == True
+    args = mocked_run_command.call_args[0][0]
+    assert 'passive-mode' in args
+    # Ensure 'no passive-mode' is NOT present
+    assert 'no passive-mode' not in args
+
+
+@patch('bgpcfgd.managers_bfd_profile.run_command', return_value=(0, '', ''))
+def test_set_handler_update_removes_stale_fields(mocked_run_command, bfd_profile_mgr):
+    """Test that fields dropped between updates are explicitly cleared in FRR."""
+    # Initial state: profile has echo_mode and echo_interval
+    bfd_profile_mgr.profiles['clean-profile'] = {
+        "detect_multiplier": "3",
+        "receive_interval": "300",
+        "transmit_interval": "300",
+        "echo_interval": "100",
+        "echo_mode": "true",
+    }
+    # Update removes echo_interval and echo_mode
+    data = {
+        "detect_multiplier": "3",
+        "receive_interval": "300",
+        "transmit_interval": "300",
+    }
+    assert bfd_profile_mgr.set_handler('clean-profile', data) is True
+    args = mocked_run_command.call_args[0][0]
+    # Stale fields must be explicitly cleared
+    assert 'no echo-interval' in args
+    assert 'no echo-mode' in args
+
+
+@patch('bgpcfgd.managers_bfd_profile.run_command', return_value=(0, '', ''))
+def test_set_handler_optional_fields_only_when_present(mocked_run_command, bfd_profile_mgr):
+    """Test that echo_interval and minimum_ttl are only rendered when present."""
+    data = {
+        "detect_multiplier": "3",
+        "receive_interval": "300",
+        "transmit_interval": "300",
+    }
+    assert bfd_profile_mgr.set_handler('minimal', data) == True
+    args = mocked_run_command.call_args[0][0]
+    # These should NOT appear since they're not in data
+    for arg in args:
+        assert 'echo-interval' not in arg
+        assert 'minimum-ttl' not in arg
+        assert 'echo-mode' not in arg
+        assert 'passive-mode' not in arg
+
+
+@patch('bgpcfgd.managers_bfd_profile.run_command', return_value=(0, '', ''))
+def test_set_handler_boolean_flip_true_to_false(mocked_run_command, bfd_profile_mgr):
+    """Boolean field flipped from 'true' (in prev) to 'false' (in data) takes
+    the boolean-render branch, not the cleanup-on-absent branch. Both branches
+    converge on emitting 'no echo-mode', but they are distinct code paths and
+    must each be exercised."""
+    bfd_profile_mgr.profiles['flip-profile'] = {
+        "detect_multiplier": "3",
+        "receive_interval": "300",
+        "transmit_interval": "300",
+        "echo_mode": "true",
+    }
+    data = {
+        "detect_multiplier": "3",
+        "receive_interval": "300",
+        "transmit_interval": "300",
+        "echo_mode": "false",
+    }
+    assert bfd_profile_mgr.set_handler('flip-profile', data) is True
+    args = mocked_run_command.call_args[0][0]
+    assert 'no echo-mode' in args
+    # 'echo-mode' as a bare set must NOT also be emitted in the same call
+    assert args.count('echo-mode') == 0
+    # And the renderer must not duplicate 'no echo-mode' (cleanup loop is
+    # skipped because echo_mode is in data; only the boolean-render branch fires).
+    assert args.count('no echo-mode') == 1
+
+
+@patch('bgpcfgd.managers_bfd_profile.run_command', return_value=(0, '', ''))
+def test_set_handler_boolean_flip_false_to_true(mocked_run_command, bfd_profile_mgr):
+    """Symmetric to the true→false flip: 'false' in prev to 'true' in data
+    emits 'echo-mode' (without 'no')."""
+    bfd_profile_mgr.profiles['flip-profile'] = {
+        "detect_multiplier": "3",
+        "receive_interval": "300",
+        "transmit_interval": "300",
+        "echo_mode": "false",
+    }
+    data = {
+        "detect_multiplier": "3",
+        "receive_interval": "300",
+        "transmit_interval": "300",
+        "echo_mode": "true",
+    }
+    assert bfd_profile_mgr.set_handler('flip-profile', data) is True
+    args = mocked_run_command.call_args[0][0]
+    assert 'echo-mode' in args
+    assert 'no echo-mode' not in args
+
+
+@patch('bgpcfgd.managers_bfd_profile.run_command', return_value=(0, '', ''))
+def test_set_handler_numeric_value_change(mocked_run_command, bfd_profile_mgr):
+    """Updating a numeric field's value (no field added/dropped) emits the
+    new value without a stale-cleanup 'no <field>' line — the cleanup loop
+    only fires for fields present in prev but absent in data."""
+    bfd_profile_mgr.profiles['retune'] = {
+        "detect_multiplier": "3",
+        "receive_interval": "100",
+        "transmit_interval": "100",
+    }
+    data = {
+        "detect_multiplier": "3",
+        "receive_interval": "200",
+        "transmit_interval": "100",
+    }
+    assert bfd_profile_mgr.set_handler('retune', data) is True
+    args = mocked_run_command.call_args[0][0]
+    assert 'receive-interval 200' in args
+    assert 'no receive-interval' not in args

--- a/src/sonic-bgpcfgd/tests/test_static_rt_bfd.py
+++ b/src/sonic-bgpcfgd/tests/test_static_rt_bfd.py
@@ -750,3 +750,226 @@ def test_set_del_ifname_only_route():
 
     assert "Static route bfd set Failed, nexthop, interface and vrf lists do not match or some of them is empty."\
         in test_set_del_ifname_only_route.logs
+
+
+def test_bfd_custom_timers():
+    """Test BFD with custom timer parameters"""
+    dut = constructor()
+    intf_setup(dut)
+
+    # Test static route with custom BFD timer parameters (single nexthop)
+    set_del_test(dut, "srt",
+        "SET",
+        ("2.2.2.0/24", {
+            "nexthop": "192.168.1.2",
+            "ifname": "if1",
+            "bfd": "true",
+            "bfd_detect_multiplier": "5",
+            "bfd_min_rx": "300",
+            "bfd_min_tx": "300"
+        }),
+        {
+            "set_default:default:192.168.1.2": {
+                "multihop": "false",
+                "rx_interval": "300",
+                "tx_interval": "300",
+                "multiplier": "5",
+                "local_addr": "192.168.1.1"
+            }
+        },
+        {}
+    )
+
+    # BFD session comes UP - static route should be written with the UP nexthop
+    set_del_test(dut, "bfd",
+        "SET",
+        ("192.168.1.2", {
+            "state": "Up"
+        }),
+        {},
+        {'set_default:2.2.2.0/24': {'nexthop': '192.168.1.2', 'ifname': 'if1', 'nexthop-vrf': 'default', 'expiry': 'false'}}
+    )
+
+    # Test another route with different custom timer parameters
+    set_del_test(dut, "srt",
+        "SET",
+        ("3.3.3.0/24", {
+            "nexthop": "192.168.2.2",
+            "ifname": "if2",
+            "bfd": "true",
+            "bfd_detect_multiplier": "10",
+            "bfd_min_rx": "500",
+            "bfd_min_tx": "500"
+        }),
+        {
+            "set_default:default:192.168.2.2": {
+                "multihop": "false",
+                "rx_interval": "500",
+                "tx_interval": "500",
+                "multiplier": "10",
+                "local_addr": "192.168.2.1"
+            }
+        },
+        {}
+    )
+
+    # Delete the first route
+    set_del_test(dut, "srt",
+        "DEL",
+        ("2.2.2.0/24", {}),
+        {
+            "del_default:default:192.168.1.2": {}
+        },
+        {
+            "del_default:2.2.2.0/24": {}
+        }
+    )
+
+    # Delete the second route
+    set_del_test(dut, "srt",
+        "DEL",
+        ("3.3.3.0/24", {}),
+        {
+            "del_default:default:192.168.2.2": {}
+        },
+        {
+            "del_default:3.3.3.0/24": {}
+        }
+    )
+
+
+def test_bfd_vrf_based_key():
+    """Test BFD with VRF-based key format (unified mode)"""
+    dut = constructor()
+    intf_setup(dut)
+
+    # Test static route with VRF in key (Vrf-BLUE|prefix format)
+    set_del_test(dut, "srt",
+        "SET",
+        ("Vrf-BLUE|3.3.3.0/24", {
+            "nexthop": "192.168.1.2",
+            "ifname": "if1",
+            "bfd": "true",
+            "bfd_detect_multiplier": "7",
+            "bfd_min_rx": "400",
+            "bfd_min_tx": "400"
+        }),
+        {
+            "set_Vrf-BLUE:default:192.168.1.2": {
+                "multihop": "false",
+                "rx_interval": "400",
+                "tx_interval": "400",
+                "multiplier": "7",
+                "local_addr": "192.168.1.1"
+            }
+        },
+        {}
+    )
+
+    # BFD session comes UP - static route should be written
+    set_del_test(dut, "bfd",
+        "SET",
+        ("Vrf-BLUE|default|192.168.1.2", {
+            "state": "Up"
+        }),
+        {},
+        {'set_Vrf-BLUE:3.3.3.0/24': {'nexthop': '192.168.1.2', 'ifname': 'if1', 'nexthop-vrf': 'Vrf-BLUE', 'expiry': 'false'}}
+    )
+
+    # Delete the route
+    set_del_test(dut, "srt",
+        "DEL",
+        ("Vrf-BLUE|3.3.3.0/24", {}),
+        {
+            "del_Vrf-BLUE:default:192.168.1.2": {}
+        },
+        {
+            "del_Vrf-BLUE:3.3.3.0/24": {}
+        }
+    )
+
+
+def test_bfd_vrf_based_key_custom_timers():
+    """Test BFD with VRF-based key and custom timer parameters (unified mode)"""
+    dut = constructor()
+    intf_setup(dut)
+
+    # Test static route with VRF in key and custom BFD timer parameters (single nexthop)
+    set_del_test(dut, "srt",
+        "SET",
+        ("Vrf-RED|4.4.4.0/24", {
+            "nexthop": "192.168.1.2",
+            "ifname": "if1",
+            "bfd": "true",
+            "bfd_detect_multiplier": "3",
+            "bfd_min_rx": "250",
+            "bfd_min_tx": "250"
+        }),
+        {
+            "set_Vrf-RED:default:192.168.1.2": {
+                "multihop": "false",
+                "rx_interval": "250",
+                "tx_interval": "250",
+                "multiplier": "3",
+                "local_addr": "192.168.1.1"
+            }
+        },
+        {}
+    )
+
+    # BFD session comes UP - static route should be written with the UP nexthop
+    set_del_test(dut, "bfd",
+        "SET",
+        ("Vrf-RED|default|192.168.1.2", {
+            "state": "Up"
+        }),
+        {},
+        {'set_Vrf-RED:4.4.4.0/24': {'nexthop': '192.168.1.2', 'ifname': 'if1', 'nexthop-vrf': 'Vrf-RED', 'expiry': 'false'}}
+    )
+
+    # Test another route with different custom timer parameters
+    set_del_test(dut, "srt",
+        "SET",
+        ("Vrf-RED|5.5.5.0/24", {
+            "nexthop": "192.168.2.2",
+            "ifname": "if2",
+            "bfd": "true",
+            "bfd_detect_multiplier": "8",
+            "bfd_min_rx": "600",
+            "bfd_min_tx": "600"
+        }),
+        {
+            "set_Vrf-RED:default:192.168.2.2": {
+                "multihop": "false",
+                "rx_interval": "600",
+                "tx_interval": "600",
+                "multiplier": "8",
+                "local_addr": "192.168.2.1"
+            }
+        },
+        {}
+    )
+
+    # Delete the first route
+    set_del_test(dut, "srt",
+        "DEL",
+        ("Vrf-RED|4.4.4.0/24", {}),
+        {
+            "del_Vrf-RED:default:192.168.1.2": {}
+        },
+        {
+            "del_Vrf-RED:4.4.4.0/24": {}
+        }
+    )
+
+    # Delete the second route
+    set_del_test(dut, "srt",
+        "DEL",
+        ("Vrf-RED|5.5.5.0/24", {}),
+        {
+            "del_Vrf-RED:default:192.168.2.2": {}
+        },
+        {
+            "del_Vrf-RED:5.5.5.0/24": {}
+        }
+    )

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -104,6 +104,7 @@ class BgpdClientMgr(threading.Thread):
             'BFD_PEER': ['bfdd'],
             'BFD_PEER_SINGLE_HOP': ['bfdd'],
             'BFD_PEER_MULTI_HOP': ['bfdd'],
+            'BFD_PROFILE': ['bfdd'],
             'IP_SLA': ['iptrackd'],
             'OSPFV2_ROUTER': ['ospfd'],
             'OSPFV2_ROUTER_AREA': ['ospfd'],
@@ -1505,9 +1506,12 @@ def hdl_admin_status_shutdown_msg(daemon, cmd_str, op, st_idx, args, data):
 
 def hdl_bfd_timers(daemon, cmd_str, op, st_idx, args, data):
     """
-    Handler for BGP neighbor/peer-group BFD with optional custom timer parameters.
-    Generates 'neighbor X bfd' if no timers are present, or
-    'neighbor X bfd <multiplier> <rx> <tx>' if all three timer parameters are present.
+    Handler for BGP neighbor/peer-group BFD configuration.
+
+    Precedence (matches bgpcfgd Jinja templates):
+      1. bfd_profile  -> 'neighbor X bfd' + 'neighbor X bfd profile <name>'
+      2. all three legacy timer fields -> 'neighbor X bfd <m> <rx> <tx>'
+      3. otherwise -> 'neighbor X bfd' (bare enable)
     """
     if op == CachedDataWithOp.OP_DELETE:
         # For delete, just use 'no neighbor X bfd'
@@ -1518,6 +1522,22 @@ def hdl_bfd_timers(daemon, cmd_str, op, st_idx, args, data):
     # Check if BFD is enabled
     if args[st_idx] != 'true':
         return None
+
+    # bfd_profile takes priority over the legacy per-peer timer fields. FRR
+    # treats 'neighbor X bfd profile <name>' and 'neighbor X bfd' as separate
+    # commands; the bare enable is required because older FRR versions reject
+    # the profile command if BFD is not already enabled on the neighbor.
+    bfd_profile = args[st_idx + 4] if len(args) > st_idx + 4 else None
+    if bfd_profile:
+        enable_args = [CommandArgument(daemon, True, args[0]),
+                       CommandArgument(daemon, True, 'bfd')]
+        enable_cmd = '{no:no-prefix}neighbor {} {}'.format(
+            *enable_args, no=CommandArgument(daemon, True))
+        profile_args = [CommandArgument(daemon, True, args[0]),
+                        CommandArgument(daemon, True, bfd_profile)]
+        profile_cmd = '{no:no-prefix}neighbor {} bfd profile {}'.format(
+            *profile_args, no=CommandArgument(daemon, True))
+        return [enable_cmd, profile_cmd]
 
     # Check if all three timer parameters are present and non-empty
     if (len(args) > st_idx + 3 and
@@ -1918,7 +1938,7 @@ class BGPConfigDaemon:
                    ('enforce_first_as',                     '{no:no-prefix}neighbor {} enforce-first-as', ['true', 'false']),
                    ('solo_peer',                            '{no:no-prefix}neighbor {} solo', ['true', 'false']),
                    ('ttl_security_hops',                    '{no:no-prefix}neighbor {} ttl-security hops {}'),
-                   (['bfd', '+bfd_detect_multiplier', '+bfd_min_rx', '+bfd_min_tx'], '{no:no-prefix}neighbor {} bfd {} {} {}', hdl_bfd_timers),
+                   (['bfd', '++bfd_detect_multiplier', '++bfd_min_rx', '++bfd_min_tx', '++bfd_profile'], '{no:no-prefix}neighbor {} bfd {} {} {}', hdl_bfd_timers),
                    ('bfd_check_ctrl_plane_failure',         '{no:no-prefix}neighbor {} bfd check-control-plane-failure', ['true', 'false']),
                    ('capability_dynamic',                   '{no:no-prefix}neighbor {} capability dynamic', ['true', 'false']),
                    ('dont_negotiate_capability',            '{no:no-prefix}neighbor {} dont-capability-negotiate', ['true', 'false']),
@@ -2311,6 +2331,10 @@ class BGPConfigDaemon:
             if 'vni' in entry:
                 self.vrf_vni_map[key] = entry['vni']
 
+        # BFD_PROFILE name -> last-applied data dict, for diff-based cleanup
+        # of fields removed across updates (mirrors bgpcfgd BfdProfileMgr).
+        self._bfd_profile_state = {}
+
         # VRF ==> ip_prefix ==> nexthop list
         self.static_route_list = {}
         sroute_table = self.config_db.get_table('STATIC_ROUTE')
@@ -2347,6 +2371,7 @@ class BGPConfigDaemon:
             ('BGP_GLOBALS_EVPN_RT', self.bgp_table_handler_common),
             ('BGP_GLOBALS_EVPN_VNI_RT', self.bgp_table_handler_common),
             ('BFD_PEER', self.bfd_handler),
+            ('BFD_PROFILE', self.bfd_profile_handler),
             ('NEIGHBOR_SET', self.bgp_table_handler_common),
             ('NEXTHOP_SET', self.bgp_table_handler_common),
             ('TAG_SET', self.bgp_table_handler_common),
@@ -2447,6 +2472,61 @@ class BGPConfigDaemon:
                 elif param == 'admin_status' and data[param] == 'down':
                     command += ['-c', 'shutdown']
             self.__run_command(table, command)
+
+    # CONFIG_DB BFD_PROFILE field name -> FRR command name (numeric values).
+    _BFD_PROFILE_NUMERIC = {
+        'detect_multiplier':  'detect-multiplier',
+        'receive_interval':   'receive-interval',
+        'transmit_interval':  'transmit-interval',
+        'echo_interval':      'echo-interval',
+        'minimum_ttl':        'minimum-ttl',
+    }
+    # CONFIG_DB BFD_PROFILE field name -> FRR command name (boolean values).
+    _BFD_PROFILE_BOOLEAN = {
+        'echo_mode':    'echo-mode',
+        'passive_mode': 'passive-mode',
+    }
+
+    def bfd_profile_handler(self, table, key, data):
+        """Handler for CONFIG_DB BFD_PROFILE table.
+
+        Pushes 'bfd / profile <name> / ...' commands to FRR via vtysh.
+        Mirrors bgpcfgd's BfdProfileMgr semantics so 'separated' and
+        'unified' routing modes produce the same FRR config.
+        """
+        syslog.syslog(syslog.LOG_INFO,
+            '[bgp cfgd](bfd_profile) value for {} changed to {}'.format(key, data))
+
+        if not data:
+            # delete
+            command = "vtysh -c 'configure terminal' -c 'bfd' -c 'no profile {}'".format(key)
+            if self.__run_command(table, command):
+                self._bfd_profile_state.pop(key, None)
+            return
+
+        # create/update — single vtysh invocation
+        prev = self._bfd_profile_state.get(key, {})
+        command = "vtysh -c 'configure terminal' -c 'bfd' -c 'profile {}'".format(key)
+        # Clear fields present in the previous update but absent now, otherwise
+        # FRR retains stale values for fields the operator removed.
+        for db_field, frr_cmd in self._BFD_PROFILE_NUMERIC.items():
+            if db_field in prev and db_field not in data:
+                command += " -c 'no {}'".format(frr_cmd)
+        for db_field, frr_cmd in self._BFD_PROFILE_BOOLEAN.items():
+            if db_field in prev and db_field not in data:
+                command += " -c 'no {}'".format(frr_cmd)
+        for db_field, frr_cmd in self._BFD_PROFILE_NUMERIC.items():
+            if db_field in data:
+                command += " -c '{} {}'".format(frr_cmd, data[db_field])
+        for db_field, frr_cmd in self._BFD_PROFILE_BOOLEAN.items():
+            if db_field in data:
+                if str(data[db_field]).lower() == 'true':
+                    command += " -c '{}'".format(frr_cmd)
+                else:
+                    command += " -c 'no {}'".format(frr_cmd)
+        command += " -c 'exit'"
+        if self.__run_command(table, command):
+            self._bfd_profile_state[key] = dict(data)
 
     def vrf_handler(self, table, key, data):
         syslog.syslog(syslog.LOG_INFO, '[bgp cfgd](vrf) value for {} changed to {}'.format(key, data))

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -1503,6 +1503,44 @@ def hdl_admin_status_shutdown_msg(daemon, cmd_str, op, st_idx, args, data):
 
     return cmd_list
 
+def hdl_bfd_timers(daemon, cmd_str, op, st_idx, args, data):
+    """
+    Handler for BGP neighbor/peer-group BFD with optional custom timer parameters.
+    Generates 'neighbor X bfd' if no timers are present, or
+    'neighbor X bfd <multiplier> <rx> <tx>' if all three timer parameters are present.
+    """
+    if op == CachedDataWithOp.OP_DELETE:
+        # For delete, just use 'no neighbor X bfd'
+        cmd_args = [CommandArgument(daemon, False, args[0]), CommandArgument(daemon, False, 'bfd')]
+        simple_cmd = '{no:no-prefix}neighbor {} {}'
+        return [simple_cmd.format(*cmd_args, no=CommandArgument(daemon, False))]
+
+    # Check if BFD is enabled
+    if args[st_idx] != 'true':
+        return None
+
+    # Check if all three timer parameters are present and non-empty
+    if (len(args) > st_idx + 3 and
+        args[st_idx + 1] and args[st_idx + 2] and args[st_idx + 3]):
+        # All timer parameters present - include them in the command
+        cmd_args = [
+            CommandArgument(daemon, True, args[0]),  # neighbor IP/name
+            CommandArgument(daemon, True, 'bfd'),
+            CommandArgument(daemon, True, args[st_idx + 1]),  # multiplier
+            CommandArgument(daemon, True, args[st_idx + 2]),  # rx_interval
+            CommandArgument(daemon, True, args[st_idx + 3])   # tx_interval
+        ]
+        full_cmd = '{no:no-prefix}neighbor {} {} {} {} {}'
+        return [full_cmd.format(*cmd_args, no=CommandArgument(daemon, True))]
+    else:
+        # No timer parameters - just use 'neighbor X bfd'
+        cmd_args = [
+            CommandArgument(daemon, True, args[0]),  # neighbor IP/name
+            CommandArgument(daemon, True, 'bfd')
+        ]
+        simple_cmd = '{no:no-prefix}neighbor {} {}'
+        return [simple_cmd.format(*cmd_args, no=CommandArgument(daemon, True))]
+
 class ExtConfigDBConnector(ConfigDBConnector):
     def __init__(self, ns_attrs = None):
         super(ExtConfigDBConnector, self).__init__()
@@ -1880,7 +1918,7 @@ class BGPConfigDaemon:
                    ('enforce_first_as',                     '{no:no-prefix}neighbor {} enforce-first-as', ['true', 'false']),
                    ('solo_peer',                            '{no:no-prefix}neighbor {} solo', ['true', 'false']),
                    ('ttl_security_hops',                    '{no:no-prefix}neighbor {} ttl-security hops {}'),
-                   ('bfd',                                  '{no:no-prefix}neighbor {} bfd', ['true', 'false']),
+                   (['bfd', '+bfd_detect_multiplier', '+bfd_min_rx', '+bfd_min_tx'], '{no:no-prefix}neighbor {} bfd {} {} {}', hdl_bfd_timers),
                    ('bfd_check_ctrl_plane_failure',         '{no:no-prefix}neighbor {} bfd check-control-plane-failure', ['true', 'false']),
                    ('capability_dynamic',                   '{no:no-prefix}neighbor {} capability dynamic', ['true', 'false']),
                    ('dont_negotiate_capability',            '{no:no-prefix}neighbor {} dont-capability-negotiate', ['true', 'false']),

--- a/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.nbr_or_peer.j2
+++ b/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.nbr_or_peer.j2
@@ -38,7 +38,11 @@
 {% endif %}
 {% endif %}
 {% if 'bfd' in nbr_or_peer and nbr_or_peer['bfd'] == 'true' %}
+{% if 'bfd_detect_multiplier' in nbr_or_peer and 'bfd_min_rx' in nbr_or_peer and 'bfd_min_tx' in nbr_or_peer %}
+ neighbor {{name_or_ip}} bfd {{nbr_or_peer['bfd_detect_multiplier']}} {{nbr_or_peer['bfd_min_rx']}} {{nbr_or_peer['bfd_min_tx']}}
+{% else %}
  neighbor {{name_or_ip}} bfd
+{% endif %}
 {% endif %}
 {% if 'ttl_security_hops' in nbr_or_peer %}
  neighbor {{name_or_ip}} ttl-security hops {{nbr_or_peer['ttl_security_hops']}}

--- a/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.nbr_or_peer.j2
+++ b/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.nbr_or_peer.j2
@@ -38,7 +38,10 @@
 {% endif %}
 {% endif %}
 {% if 'bfd' in nbr_or_peer and nbr_or_peer['bfd'] == 'true' %}
-{% if 'bfd_detect_multiplier' in nbr_or_peer and 'bfd_min_rx' in nbr_or_peer and 'bfd_min_tx' in nbr_or_peer %}
+{% if 'bfd_profile' in nbr_or_peer %}
+ neighbor {{name_or_ip}} bfd
+ neighbor {{name_or_ip}} bfd profile {{nbr_or_peer['bfd_profile']}}
+{% elif 'bfd_detect_multiplier' in nbr_or_peer and 'bfd_min_rx' in nbr_or_peer and 'bfd_min_tx' in nbr_or_peer %}
  neighbor {{name_or_ip}} bfd {{nbr_or_peer['bfd_detect_multiplier']}} {{nbr_or_peer['bfd_min_rx']}} {{nbr_or_peer['bfd_min_tx']}}
 {% else %}
  neighbor {{name_or_ip}} bfd

--- a/src/sonic-frr-mgmt-framework/tests/test_bfd_profile.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_bfd_profile.py
@@ -1,0 +1,350 @@
+"""Tests for BFD profile handling in frrcfgd.
+
+Covers:
+  - hdl_bfd_timers precedence: bfd_profile > legacy timers > bare bfd
+  - BGPConfigDaemon.bfd_profile_handler vtysh command construction
+"""
+from unittest.mock import MagicMock, NonCallableMagicMock, patch
+
+# Mock external modules that frrcfgd imports at module load time
+swsscommon_module_mock = MagicMock(ConfigDBConnector=NonCallableMagicMock)
+mockmapping = {
+    'swsscommon.swsscommon': swsscommon_module_mock,
+    'bgpcfgd': MagicMock(),
+    'bgpcfgd.managers_bfd': MagicMock(),
+    'bgpcfgd.directory': MagicMock(),
+    'bgpcfgd.log': MagicMock(),
+    'bgpcfgd.utils': MagicMock(),
+}
+
+with patch.dict('sys.modules', **mockmapping):
+    from frrcfgd.frrcfgd import (
+        BGPConfigDaemon,
+        CachedDataWithOp,
+        hdl_bfd_timers,
+    )
+
+
+# ---------------------------------------------------------------------------
+# hdl_bfd_timers precedence
+# ---------------------------------------------------------------------------
+
+def _call(args):
+    """Invoke hdl_bfd_timers with SET op and the given (neighbor, *fields)."""
+    # st_idx=1: args[0] is neighbor, args[1..] are field values matching the
+    # key_map order ['bfd', '+detect_mult', '+min_rx', '+min_tx', '+bfd_profile']
+    return hdl_bfd_timers('bgpd', '', CachedDataWithOp.OP_ADD, 1, args, {})
+
+
+def test_bfd_profile_takes_priority_over_legacy_timers():
+    """When bfd_profile is set, emit two commands and ignore legacy timers."""
+    cmds = _call(['10.0.0.1', 'true', '5', '300', '300', 'fast-failover'])
+    assert len(cmds) == 2
+    assert 'neighbor 10.0.0.1 bfd' in cmds[0]
+    assert '5' not in cmds[0]  # legacy timers must NOT be in the bare enable line
+    assert 'neighbor 10.0.0.1 bfd profile fast-failover' in cmds[1]
+
+
+def test_bfd_profile_alone_no_timers():
+    """Profile set, no timer fields — still emits both enable + profile."""
+    cmds = _call(['10.0.0.1', 'true', '', '', '', 'fast-failover'])
+    assert len(cmds) == 2
+    assert 'neighbor 10.0.0.1 bfd' in cmds[0]
+    assert 'neighbor 10.0.0.1 bfd profile fast-failover' in cmds[1]
+
+
+def test_legacy_timers_when_no_profile():
+    """Profile absent, all three timers present — emits the legacy combined form."""
+    cmds = _call(['10.0.0.1', 'true', '5', '300', '300', None])
+    assert len(cmds) == 1
+    assert 'neighbor 10.0.0.1 bfd 5 300 300' in cmds[0]
+
+
+def test_bare_bfd_when_no_profile_no_timers():
+    """No profile, no timers — bare enable."""
+    cmds = _call(['10.0.0.1', 'true', '', '', '', None])
+    assert len(cmds) == 1
+    assert cmds[0].rstrip().endswith('neighbor 10.0.0.1 bfd')
+
+
+def test_bfd_disabled_returns_none():
+    """bfd=false short-circuits."""
+    assert _call(['10.0.0.1', 'false', '', '', '', 'fast-failover']) is None
+
+
+def test_delete_op_returns_no_neighbor_bfd():
+    cmds = hdl_bfd_timers('bgpd', '', CachedDataWithOp.OP_DELETE, 1,
+                          ['10.0.0.1', 'true', '', '', '', 'fast-failover'], {})
+    assert len(cmds) == 1
+    assert 'no neighbor 10.0.0.1 bfd' in cmds[0]
+
+
+def test_backward_compat_no_bfd_profile_field():
+    """Old key_map shape with only 4 fields (no +bfd_profile) still works."""
+    cmds = _call(['10.0.0.1', 'true', '5', '300', '300'])  # no 6th arg
+    assert len(cmds) == 1
+    assert 'neighbor 10.0.0.1 bfd 5 300 300' in cmds[0]
+
+
+# ---------------------------------------------------------------------------
+# bfd_profile_handler — vtysh command construction
+# ---------------------------------------------------------------------------
+
+def _make_daemon_for_handler():
+    """Construct a minimal BGPConfigDaemon-like object for handler testing."""
+    daemon = BGPConfigDaemon.__new__(BGPConfigDaemon)
+    daemon._BGPConfigDaemon__run_command = MagicMock(return_value=True)
+    daemon._bfd_profile_state = {}
+    return daemon
+
+
+def _all_commands(daemon):
+    """Return list of vtysh command strings passed across all __run_command calls."""
+    return [c.args[1] for c in daemon._BGPConfigDaemon__run_command.call_args_list]
+
+
+def _last_command(daemon):
+    """Return the vtysh command string passed to the most recent __run_command."""
+    return daemon._BGPConfigDaemon__run_command.call_args[0][1]
+
+
+def test_handler_set_with_required_fields_only():
+    daemon = _make_daemon_for_handler()
+    daemon.bfd_profile_handler('BFD_PROFILE', 'fast-failover', {
+        'detect_multiplier': '3',
+        'receive_interval': '100',
+        'transmit_interval': '100',
+    })
+    cmd = _last_command(daemon)
+    assert "'profile fast-failover'" in cmd
+    assert "'detect-multiplier 3'" in cmd
+    assert "'receive-interval 100'" in cmd
+    assert "'transmit-interval 100'" in cmd
+    assert "'exit'" in cmd
+
+
+def test_handler_set_with_all_fields():
+    daemon = _make_daemon_for_handler()
+    daemon.bfd_profile_handler('BFD_PROFILE', 'full-profile', {
+        'detect_multiplier': '5',
+        'receive_interval': '500',
+        'transmit_interval': '500',
+        'echo_interval': '100',
+        'minimum_ttl': '250',
+        'echo_mode': 'true',
+        'passive_mode': 'false',
+    })
+    cmd = _last_command(daemon)
+    assert "'profile full-profile'" in cmd
+    assert "'echo-interval 100'" in cmd
+    assert "'minimum-ttl 250'" in cmd
+    assert "'echo-mode'" in cmd
+    assert "'no passive-mode'" in cmd
+
+
+def test_handler_delete():
+    daemon = _make_daemon_for_handler()
+    daemon.bfd_profile_handler('BFD_PROFILE', 'fast-failover', None)
+    cmd = _last_command(daemon)
+    assert "'no profile fast-failover'" in cmd
+
+
+def test_handler_partial_profile_accepted():
+    """A profile with only a subset of fields is accepted; FRR fills in defaults
+    for the rest. YANG does not mark detect_multiplier/receive_interval/
+    transmit_interval as mandatory."""
+    daemon = _make_daemon_for_handler()
+    daemon.bfd_profile_handler('BFD_PROFILE', 'echo-only', {
+        'echo_interval': '100',
+        'echo_mode': 'true',
+    })
+    cmd = _last_command(daemon)
+    assert "'profile echo-only'" in cmd
+    assert "'echo-interval 100'" in cmd
+    assert "'echo-mode'" in cmd
+    assert "detect-multiplier" not in cmd
+    assert "receive-interval" not in cmd
+    assert "transmit-interval" not in cmd
+    assert 'echo-only' in daemon._bfd_profile_state
+
+
+def test_handler_passive_mode_true():
+    daemon = _make_daemon_for_handler()
+    daemon.bfd_profile_handler('BFD_PROFILE', 'passive-test', {
+        'detect_multiplier': '3',
+        'receive_interval': '300',
+        'transmit_interval': '300',
+        'passive_mode': 'true',
+    })
+    cmd = _last_command(daemon)
+    assert "'passive-mode'" in cmd
+    assert "'no passive-mode'" not in cmd
+
+
+def test_handler_clears_dropped_numeric_field_on_update():
+    """Removing echo_interval across an update emits 'no echo-interval'."""
+    daemon = _make_daemon_for_handler()
+    daemon.bfd_profile_handler('BFD_PROFILE', 'p1', {
+        'detect_multiplier': '3',
+        'receive_interval': '100',
+        'transmit_interval': '100',
+        'echo_interval': '200',
+    })
+    daemon.bfd_profile_handler('BFD_PROFILE', 'p1', {
+        'detect_multiplier': '3',
+        'receive_interval': '100',
+        'transmit_interval': '100',
+    })
+    cmd = _all_commands(daemon)[-1]
+    assert "'no echo-interval'" in cmd
+
+
+def test_handler_clears_dropped_boolean_field_on_update():
+    """Removing echo_mode across an update emits 'no echo-mode'."""
+    daemon = _make_daemon_for_handler()
+    daemon.bfd_profile_handler('BFD_PROFILE', 'p1', {
+        'detect_multiplier': '3',
+        'receive_interval': '100',
+        'transmit_interval': '100',
+        'echo_mode': 'true',
+    })
+    daemon.bfd_profile_handler('BFD_PROFILE', 'p1', {
+        'detect_multiplier': '3',
+        'receive_interval': '100',
+        'transmit_interval': '100',
+    })
+    cmd = _all_commands(daemon)[-1]
+    # Order: 'no <removed>' precedes the rendered fields, but both forms of
+    # 'no echo-mode' (cleanup and explicit-false) collapse to the same string;
+    # only the cleanup branch fires here because echo_mode is absent in data.
+    assert "'no echo-mode'" in cmd
+
+
+def test_handler_delete_clears_state():
+    """After a delete the state is forgotten and a later set has no 'no' lines."""
+    daemon = _make_daemon_for_handler()
+    daemon.bfd_profile_handler('BFD_PROFILE', 'p1', {
+        'detect_multiplier': '3',
+        'receive_interval': '100',
+        'transmit_interval': '100',
+        'echo_interval': '200',
+    })
+    daemon.bfd_profile_handler('BFD_PROFILE', 'p1', None)
+    daemon.bfd_profile_handler('BFD_PROFILE', 'p1', {
+        'detect_multiplier': '3',
+        'receive_interval': '100',
+        'transmit_interval': '100',
+    })
+    cmd = _all_commands(daemon)[-1]
+    assert "'no echo-interval'" not in cmd
+
+
+def test_handler_set_failure_does_not_cache_state():
+    """A vtysh failure must not poison the state cache. The next successful
+    update should still see the FRR-applied prev state, not the failed one."""
+    daemon = _make_daemon_for_handler()
+    daemon._BGPConfigDaemon__run_command.return_value = False
+    daemon.bfd_profile_handler('BFD_PROFILE', 'p1', {
+        'detect_multiplier': '3',
+        'receive_interval': '100',
+        'transmit_interval': '100',
+        'echo_interval': '200',
+    })
+    assert 'p1' not in daemon._bfd_profile_state
+
+
+def test_handler_delete_failure_does_not_drop_state():
+    """A vtysh failure on delete must not drop the state — the next set call
+    needs the prev mapping to compute correct cleanup commands."""
+    daemon = _make_daemon_for_handler()
+    daemon._bfd_profile_state['p1'] = {'echo_interval': '200'}
+    daemon._BGPConfigDaemon__run_command.return_value = False
+    daemon.bfd_profile_handler('BFD_PROFILE', 'p1', None)
+    assert 'p1' in daemon._bfd_profile_state
+
+
+def test_handler_boolean_flip_true_to_false():
+    """Boolean field flipped from 'true' (in prev) to 'false' (in data) hits
+    the boolean-render branch (emits 'no echo-mode'), not the cleanup-on-absent
+    branch — both converge on the same vtysh fragment but are distinct paths."""
+    daemon = _make_daemon_for_handler()
+    daemon._bfd_profile_state['p1'] = {
+        'detect_multiplier': '3',
+        'receive_interval': '100',
+        'transmit_interval': '100',
+        'echo_mode': 'true',
+    }
+    daemon.bfd_profile_handler('BFD_PROFILE', 'p1', {
+        'detect_multiplier': '3',
+        'receive_interval': '100',
+        'transmit_interval': '100',
+        'echo_mode': 'false',
+    })
+    cmd = _last_command(daemon)
+    assert "'no echo-mode'" in cmd
+    # The cleanup loop must NOT also fire (echo_mode is in data),
+    # so 'no echo-mode' appears exactly once.
+    assert cmd.count("'no echo-mode'") == 1
+    # And the bare 'echo-mode' setter must NOT appear.
+    assert "'echo-mode'" not in cmd.replace("'no echo-mode'", '')
+
+
+def test_handler_boolean_flip_false_to_true():
+    """Symmetric flip false→true emits 'echo-mode' (without 'no')."""
+    daemon = _make_daemon_for_handler()
+    daemon._bfd_profile_state['p1'] = {
+        'detect_multiplier': '3',
+        'receive_interval': '100',
+        'transmit_interval': '100',
+        'echo_mode': 'false',
+    }
+    daemon.bfd_profile_handler('BFD_PROFILE', 'p1', {
+        'detect_multiplier': '3',
+        'receive_interval': '100',
+        'transmit_interval': '100',
+        'echo_mode': 'true',
+    })
+    cmd = _last_command(daemon)
+    assert "'echo-mode'" in cmd
+    assert "'no echo-mode'" not in cmd
+
+
+def test_handler_numeric_value_change():
+    """Changing a numeric field's value emits the new line without a stale
+    'no receive-interval' — cleanup only fires for prev-only fields."""
+    daemon = _make_daemon_for_handler()
+    daemon._bfd_profile_state['p1'] = {
+        'detect_multiplier': '3',
+        'receive_interval': '100',
+        'transmit_interval': '100',
+    }
+    daemon.bfd_profile_handler('BFD_PROFILE', 'p1', {
+        'detect_multiplier': '3',
+        'receive_interval': '200',
+        'transmit_interval': '100',
+    })
+    cmd = _last_command(daemon)
+    assert "'receive-interval 200'" in cmd
+    assert "'no receive-interval'" not in cmd
+
+
+# ---------------------------------------------------------------------------
+# hdl_bfd_timers — additional edge cases
+# ---------------------------------------------------------------------------
+
+def test_hdl_bfd_timers_empty_string_profile_falls_through():
+    """An empty-string bfd_profile must NOT trigger the two-step emission;
+    it should fall through to the legacy/timers branch. The handler relies
+    on Python truthiness ('' is falsy) — pin that behavior."""
+    cmds = _call(['10.0.0.1', 'true', '5', '300', '300', ''])
+    assert len(cmds) == 1
+    assert 'neighbor 10.0.0.1 bfd 5 300 300' in cmds[0]
+    assert 'profile' not in cmds[0]
+
+
+def test_hdl_bfd_timers_profile_without_timers_emits_two_steps():
+    """bfd_profile present, all three timers absent — still two-step."""
+    cmds = _call(['10.0.0.1', 'true', None, None, None, 'fast-failover'])
+    assert len(cmds) == 2
+    assert cmds[0].rstrip().endswith('neighbor 10.0.0.1 bfd')
+    assert cmds[1].rstrip().endswith('neighbor 10.0.0.1 bfd profile fast-failover')

--- a/src/sonic-frr-mgmt-framework/tests/test_config.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_config.py
@@ -307,3 +307,50 @@ def test_bgp_neighbor_description_injection(run_cmd):
         if any('description' in arg for arg in cmd):
             assert any(injection_payload in arg for arg in cmd), \
                 "injection payload not found as literal arg: {}".format(cmd)
+
+
+# BGP neighbor BFD with custom timer parameters test data
+bgp_neighbor_bfd_timers_data = [
+    # Set up BGP globals first
+    CmdMapTestInfo('BGP_GLOBALS', 'default',
+                  {'local_asn': '100'},
+                  conf_bgp_dft_cmd('default', 100),
+                  True, None, None, None, None),  # no_del=True, rest=None
+    # BGP neighbor with BFD and custom timer parameters
+    CmdMapTestInfo('BGP_NEIGHBOR', 'default|10.1.1.1',
+                  {'bfd': 'true', 'bfd_detect_multiplier': '5', 'bfd_min_rx': '500', 'bfd_min_tx': '500'},
+                  conf_bgp_cmd('default', 100) + ['{}neighbor 10.1.1.1 bfd 5 500 500'],
+                  False,
+                  conf_bgp_cmd('default', 100) + ['{}neighbor 10.1.1.1 bfd']),
+    # BGP neighbor with BFD but no custom timers (should use default command)
+    CmdMapTestInfo('BGP_NEIGHBOR', 'default|10.1.1.2',
+                  {'bfd': 'true'},
+                  conf_bgp_cmd('default', 100) + ['{}neighbor 10.1.1.2 bfd']),
+]
+
+# BGP peer group BFD with custom timer parameters test data
+bgp_peer_group_bfd_timers_data = [
+    # Set up BGP globals first
+    CmdMapTestInfo('BGP_GLOBALS', 'default',
+                  {'local_asn': '100'},
+                  conf_bgp_dft_cmd('default', 100),
+                  True, None, None, None, None),  # no_del=True, rest=None
+    # BGP peer group with BFD and custom timer parameters
+    CmdMapTestInfo('BGP_PEER_GROUP', 'default|TEST_PG',
+                  {'bfd': 'true', 'bfd_detect_multiplier': '10', 'bfd_min_rx': '1000', 'bfd_min_tx': '1000'},
+                  conf_bgp_cmd('default', 100) + ['{}neighbor TEST_PG bfd 10 1000 1000'],
+                  False,
+                  conf_bgp_cmd('default', 100) + ['{}neighbor TEST_PG bfd']),
+    # BGP peer group with BFD but no custom timers
+    CmdMapTestInfo('BGP_PEER_GROUP', 'default|TEST_PG2',
+                  {'bfd': 'true'},
+                  conf_bgp_cmd('default', 100) + ['{}neighbor TEST_PG2 bfd']),
+]
+
+def test_bgp_neighbor_bfd_custom_timers():
+    """Test BGP neighbor with BFD custom timer parameters (SET and DELETE)"""
+    data_set_del_test(bgp_neighbor_bfd_timers_data)
+
+def test_bgp_peer_group_bfd_custom_timers():
+    """Test BGP peer group with BFD custom timer parameters (SET and DELETE)"""
+    data_set_del_test(bgp_peer_group_bfd_timers_data)

--- a/src/sonic-frr-mgmt-framework/tests/test_config.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_config.py
@@ -354,3 +354,94 @@ def test_bgp_neighbor_bfd_custom_timers():
 def test_bgp_peer_group_bfd_custom_timers():
     """Test BGP peer group with BFD custom timer parameters (SET and DELETE)"""
     data_set_del_test(bgp_peer_group_bfd_timers_data)
+
+
+# BGP neighbor / peer-group with BFD profile binding (unified mode).
+#
+# bfd_profile triggers two separate vtysh invocations:
+#   1. neighbor X bfd                    (enable BFD)
+#   2. neighbor X bfd profile <name>     (apply profile)
+# matching the priority order rendered by
+# templates/bgpd/bgpd.conf.db.nbr_or_peer.j2 and the separated-mode
+# fixtures in sonic-bgpcfgd/tests/data/general/instance.conf/{param,result}_bfd_profile.*
+
+def hdl_bfd_profile_cmd(is_del, cmd_list, chk_data):
+    """Validator for the two-step bfd + bfd-profile emission.
+    chk_data is a tuple (peer_or_pg_name, profile_name).
+
+    g_run_command is called with shell=False (a list of args:
+    ['vtysh', '-c', '<vtysh cmd>', '-c', '<vtysh cmd>', ...]). The last
+    ``-c <cmd>`` pair is the leaf vtysh command; that's the one we want
+    to assert against."""
+    peer, profile = chk_data
+    bfd_calls = []
+    for cmd in cmd_list:
+        # cmd is a list when shell=False, a string when shell=True.
+        if isinstance(cmd, list):
+            last = None
+            for i, arg in enumerate(cmd):
+                if arg == '-c' and i + 1 < len(cmd):
+                    last = cmd[i + 1]
+            if last is None:
+                continue
+        else:
+            matches = re.findall(r"-c\s+'([^']+)'\s*", cmd)
+            if not matches:
+                continue
+            last = matches[-1]
+        if 'neighbor %s bfd' % peer in last:
+            bfd_calls.append(last)
+
+    if is_del:
+        assert len(bfd_calls) >= 1, "no bfd-related vtysh on delete: %s" % cmd_list
+        # Last bfd-related call should be `no neighbor X bfd` (collapse)
+        assert bfd_calls[-1] == 'no neighbor %s bfd' % peer, bfd_calls[-1]
+        return
+
+    # Set: expect exactly the two-step emission
+    assert len(bfd_calls) == 2, \
+        "expected 2 bfd-related vtysh calls, got %d: %s" % (len(bfd_calls), bfd_calls)
+    assert bfd_calls[0] == 'neighbor %s bfd' % peer, bfd_calls[0]
+    assert bfd_calls[1] == 'neighbor %s bfd profile %s' % (peer, profile), bfd_calls[1]
+
+bgp_neighbor_bfd_profile_data = [
+    # Set up BGP globals first
+    CmdMapTestInfo('BGP_GLOBALS', 'default',
+                  {'local_asn': '100'},
+                  conf_bgp_dft_cmd('default', 100),
+                  True, None, None, None, None),
+    # BGP neighbor with bfd=true and bfd_profile — emits two-step bfd + bfd profile
+    CmdMapTestInfo('BGP_NEIGHBOR', 'default|10.2.2.1',
+                  {'bfd': 'true', 'bfd_profile': 'fast-failover'},
+                  hdl_bfd_profile_cmd, False, None,
+                  ('10.2.2.1', 'fast-failover')),
+    # bfd_profile takes precedence over inline custom timers
+    CmdMapTestInfo('BGP_NEIGHBOR', 'default|10.2.2.2',
+                  {'bfd': 'true', 'bfd_profile': 'fast-failover',
+                   'bfd_detect_multiplier': '5', 'bfd_min_rx': '500', 'bfd_min_tx': '500'},
+                  hdl_bfd_profile_cmd, False, None,
+                  ('10.2.2.2', 'fast-failover')),
+]
+
+bgp_peer_group_bfd_profile_data = [
+    CmdMapTestInfo('BGP_GLOBALS', 'default',
+                  {'local_asn': '100'},
+                  conf_bgp_dft_cmd('default', 100),
+                  True, None, None, None, None),
+    CmdMapTestInfo('BGP_PEER_GROUP', 'default|TEST_PG_PROFILE',
+                  {'bfd': 'true', 'bfd_profile': 'slow-stable'},
+                  hdl_bfd_profile_cmd, False, None,
+                  ('TEST_PG_PROFILE', 'slow-stable')),
+]
+
+def test_bgp_neighbor_bfd_profile():
+    """Test BGP neighbor with bfd_profile binding.
+
+    Mirrors the separated-mode test fixtures in
+    sonic-bgpcfgd/tests/data/general/instance.conf/{param,result}_bfd_profile.*
+    so that both routing-config modes are covered."""
+    data_set_del_test(bgp_neighbor_bfd_profile_data)
+
+def test_bgp_peer_group_bfd_profile():
+    """Test BGP peer group with bfd_profile binding."""
+    data_set_del_test(bgp_peer_group_bfd_profile_data)

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -81,6 +81,7 @@ yang_files = [
     'sonic-asic-sensors.yang',
     'sonic-auto_techsupport.yang',
     'sonic-banner.yang',
+    'sonic-bfd-profile.yang',
     'sonic-bgp-aggregate-address.yang',
     'sonic-bgp-allowed-prefix.yang',
     'sonic-bgp-bbr.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1832,6 +1832,16 @@
                 "local_ip": "12.12.0.2"
             }
         },
+        "BFD_PROFILE": {
+            "fast-failover": {
+                "detect_multiplier": "3",
+                "receive_interval": "100",
+                "transmit_interval": "100",
+                "echo_mode": "true",
+                "passive_mode": "false",
+                "minimum_ttl": "253"
+            }
+        },
         "BGP_AGGREGATE_ADDRESS": {
             "192.168.0.0/24": {
                 "bbr-required": "true",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bfd_profile.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bfd_profile.json
@@ -1,0 +1,43 @@
+{
+    "BFD_PROFILE_VALID": {
+        "desc": "Configure a valid BFD_PROFILE entry."
+    },
+    "BFD_PROFILE_NAME_WITH_QUOTE": {
+        "desc": "Profile name containing a single quote must be rejected by the name pattern; otherwise it would mis-parse in vtysh command construction.",
+        "eStrKey": "Pattern"
+    },
+    "BFD_PROFILE_NAME_WITH_SPACE": {
+        "desc": "Profile name containing whitespace must be rejected by the name pattern; FRR does not accept whitespace in profile names.",
+        "eStrKey": "Pattern"
+    },
+    "BFD_PROFILE_RECEIVE_INTERVAL_TOO_LOW": {
+        "desc": "receive_interval below 10ms must be rejected (FRR floor is 10ms per frr-bfdd.yang range \"10000..max\" microseconds).",
+        "eStrKey": "Range"
+    },
+    "BFD_PROFILE_TRANSMIT_INTERVAL_TOO_HIGH": {
+        "desc": "transmit_interval above 60000ms must be rejected.",
+        "eStrKey": "Range"
+    },
+    "BFD_PROFILE_DETECT_MULTIPLIER_TOO_LOW": {
+        "desc": "detect_multiplier below 2 must be rejected (BFD requires at least 2 to tolerate a single packet loss).",
+        "eStrKey": "Range"
+    },
+    "BFD_PROFILE_MINIMUM_TTL_TOO_HIGH": {
+        "desc": "minimum_ttl above 254 must be rejected.",
+        "eStrKey": "Range"
+    },
+    "BFD_PROFILE_BIND_VALID": {
+        "desc": "BGP_NEIGHBOR.bfd_profile referencing an existing BFD_PROFILE entry is accepted by the leafref."
+    },
+    "BFD_PROFILE_BIND_GHOST_REJECTED": {
+        "desc": "BGP_NEIGHBOR.bfd_profile referencing a non-existent BFD_PROFILE entry must be rejected by the leafref. This is the symmetric protection for delete-while-bound: any final state in which a peer references a missing profile is invalid, regardless of how it was reached.",
+        "eStrKey": "LeafRef"
+    },
+    "BFD_PROFILE_BIND_VALID_PEER_GROUP": {
+        "desc": "BGP_PEER_GROUP.bfd_profile referencing an existing BFD_PROFILE entry is accepted by the leafref. The bfd_profile leaf lives in the shared sonic-bgp-common grouping; both BGP_NEIGHBOR_LIST and BGP_PEER_GROUP_LIST inherit it, so the leafref must work on either."
+    },
+    "BFD_PROFILE_BIND_GHOST_REJECTED_PEER_GROUP": {
+        "desc": "BGP_PEER_GROUP.bfd_profile referencing a non-existent BFD_PROFILE entry must be rejected by the leafref — the same symmetric protection as the BGP_NEIGHBOR case.",
+        "eStrKey": "LeafRef"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bfd_profile.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bfd_profile.json
@@ -1,0 +1,225 @@
+{
+    "BFD_PROFILE_VALID": {
+        "sonic-bfd-profile:sonic-bfd-profile": {
+            "sonic-bfd-profile:BFD_PROFILE": {
+                "BFD_PROFILE_LIST": [
+                    {
+                        "name": "fast-failover",
+                        "detect_multiplier": "3",
+                        "receive_interval": "100",
+                        "transmit_interval": "100",
+                        "echo_interval": "100",
+                        "echo_mode": true,
+                        "passive_mode": false,
+                        "minimum_ttl": "253"
+                    }
+                ]
+            }
+        }
+    },
+    "BFD_PROFILE_NAME_WITH_QUOTE": {
+        "sonic-bfd-profile:sonic-bfd-profile": {
+            "sonic-bfd-profile:BFD_PROFILE": {
+                "BFD_PROFILE_LIST": [
+                    {
+                        "name": "fast'failover",
+                        "detect_multiplier": "3",
+                        "receive_interval": "100",
+                        "transmit_interval": "100"
+                    }
+                ]
+            }
+        }
+    },
+    "BFD_PROFILE_NAME_WITH_SPACE": {
+        "sonic-bfd-profile:sonic-bfd-profile": {
+            "sonic-bfd-profile:BFD_PROFILE": {
+                "BFD_PROFILE_LIST": [
+                    {
+                        "name": "fast failover",
+                        "detect_multiplier": "3",
+                        "receive_interval": "100",
+                        "transmit_interval": "100"
+                    }
+                ]
+            }
+        }
+    },
+    "BFD_PROFILE_RECEIVE_INTERVAL_TOO_LOW": {
+        "sonic-bfd-profile:sonic-bfd-profile": {
+            "sonic-bfd-profile:BFD_PROFILE": {
+                "BFD_PROFILE_LIST": [
+                    {
+                        "name": "too-fast",
+                        "detect_multiplier": "3",
+                        "receive_interval": "5",
+                        "transmit_interval": "100"
+                    }
+                ]
+            }
+        }
+    },
+    "BFD_PROFILE_TRANSMIT_INTERVAL_TOO_HIGH": {
+        "sonic-bfd-profile:sonic-bfd-profile": {
+            "sonic-bfd-profile:BFD_PROFILE": {
+                "BFD_PROFILE_LIST": [
+                    {
+                        "name": "too-slow",
+                        "detect_multiplier": "3",
+                        "receive_interval": "100",
+                        "transmit_interval": "70000"
+                    }
+                ]
+            }
+        }
+    },
+    "BFD_PROFILE_DETECT_MULTIPLIER_TOO_LOW": {
+        "sonic-bfd-profile:sonic-bfd-profile": {
+            "sonic-bfd-profile:BFD_PROFILE": {
+                "BFD_PROFILE_LIST": [
+                    {
+                        "name": "single-loss",
+                        "detect_multiplier": "1",
+                        "receive_interval": "100",
+                        "transmit_interval": "100"
+                    }
+                ]
+            }
+        }
+    },
+    "BFD_PROFILE_MINIMUM_TTL_TOO_HIGH": {
+        "sonic-bfd-profile:sonic-bfd-profile": {
+            "sonic-bfd-profile:BFD_PROFILE": {
+                "BFD_PROFILE_LIST": [
+                    {
+                        "name": "ttl-overflow",
+                        "detect_multiplier": "3",
+                        "receive_interval": "100",
+                        "transmit_interval": "100",
+                        "minimum_ttl": "255"
+                    }
+                ]
+            }
+        }
+    },
+    "BFD_PROFILE_BIND_VALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "local_asn": 65001
+                    }
+                ]
+            }
+        },
+        "sonic-bfd-profile:sonic-bfd-profile": {
+            "sonic-bfd-profile:BFD_PROFILE": {
+                "BFD_PROFILE_LIST": [
+                    {
+                        "name": "fast-failover",
+                        "detect_multiplier": "3",
+                        "receive_interval": "100",
+                        "transmit_interval": "100"
+                    }
+                ]
+            }
+        },
+        "sonic-bgp-neighbor:sonic-bgp-neighbor": {
+            "sonic-bgp-neighbor:BGP_NEIGHBOR": {
+                "BGP_NEIGHBOR_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "neighbor": "10.0.0.1",
+                        "asn": 65002,
+                        "bfd_profile": "fast-failover"
+                    }
+                ]
+            }
+        }
+    },
+    "BFD_PROFILE_BIND_GHOST_REJECTED": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "local_asn": 65001
+                    }
+                ]
+            }
+        },
+        "sonic-bgp-neighbor:sonic-bgp-neighbor": {
+            "sonic-bgp-neighbor:BGP_NEIGHBOR": {
+                "BGP_NEIGHBOR_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "neighbor": "10.0.0.1",
+                        "asn": 65002,
+                        "bfd_profile": "ghost-profile"
+                    }
+                ]
+            }
+        }
+    },
+    "BFD_PROFILE_BIND_VALID_PEER_GROUP": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "local_asn": 65001
+                    }
+                ]
+            }
+        },
+        "sonic-bfd-profile:sonic-bfd-profile": {
+            "sonic-bfd-profile:BFD_PROFILE": {
+                "BFD_PROFILE_LIST": [
+                    {
+                        "name": "fast-failover",
+                        "detect_multiplier": "3",
+                        "receive_interval": "100",
+                        "transmit_interval": "100"
+                    }
+                ]
+            }
+        },
+        "sonic-bgp-peergroup:sonic-bgp-peergroup": {
+            "sonic-bgp-peergroup:BGP_PEER_GROUP": {
+                "BGP_PEER_GROUP_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "peer_group_name": "PG_FAST_BFD",
+                        "asn": 65002,
+                        "bfd_profile": "fast-failover"
+                    }
+                ]
+            }
+        }
+    },
+    "BFD_PROFILE_BIND_GHOST_REJECTED_PEER_GROUP": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "local_asn": 65001
+                    }
+                ]
+            }
+        },
+        "sonic-bgp-peergroup:sonic-bgp-peergroup": {
+            "sonic-bgp-peergroup:BGP_PEER_GROUP": {
+                "BGP_PEER_GROUP_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "peer_group_name": "PG_FAST_BFD",
+                        "asn": 65002,
+                        "bfd_profile": "ghost-profile"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-bfd-profile.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bfd-profile.yang
@@ -1,0 +1,83 @@
+module sonic-bfd-profile {
+    namespace "http://github.com/sonic-net/sonic-bfd-profile";
+    prefix bfdprofile;
+    yang-version 1.1;
+
+    organization
+        "SONiC";
+
+    contact
+        "SONiC";
+
+    description
+        "SONIC BFD Profile configuration for CONFIG_DB";
+
+    revision 2026-04-21 {
+        description
+            "Initial revision.";
+    }
+
+    container sonic-bfd-profile {
+        container BFD_PROFILE {
+            description "BFD_PROFILE part of config_db.json";
+
+            list BFD_PROFILE_LIST {
+                key "name";
+                description "BFD profile configuration entries";
+
+                leaf name {
+                    type string {
+                        length "1..64";
+                        pattern "[a-zA-Z0-9_-]+";
+                    }
+                    description "BFD profile name.";
+                }
+
+                leaf detect_multiplier {
+                    type uint8 {
+                        range "2..255";
+                    }
+                    description "BFD detection multiplier";
+                }
+
+                leaf receive_interval {
+                    type uint32 {
+                        range "10..60000";
+                    }
+                    description "BFD minimum receive interval in milliseconds";
+                }
+
+                leaf transmit_interval {
+                    type uint32 {
+                        range "10..60000";
+                    }
+                    description "BFD minimum transmit interval in milliseconds";
+                }
+
+                leaf echo_interval {
+                    type uint32 {
+                        range "10..60000";
+                    }
+                    description "BFD echo interval in milliseconds";
+                }
+
+                leaf echo_mode {
+                    type boolean;
+                    description "Enable or disable BFD echo mode";
+                }
+
+                leaf passive_mode {
+                    type boolean;
+                    description "Enable or disable BFD passive mode";
+                }
+
+                leaf minimum_ttl {
+                    type uint8 {
+                        range "1..254";
+                    }
+                    description "Minimum expected TTL on received multihop packets";
+                }
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
@@ -40,6 +40,10 @@ module sonic-bgp-common {
         prefix ext;
     }
 
+    import sonic-bfd-profile {
+        prefix bfdprof;
+    }
+
     organization
         "SONiC";
 
@@ -48,6 +52,11 @@ module sonic-bgp-common {
 
     description
         "SONIC BGP common YANG attributes for Neighbors and Peer group";
+
+    revision 2026-04-29 {
+        description
+            "Add bfd_profile leafref into sonic-bfd-profile/BFD_PROFILE/name; align bfd_min_rx and bfd_min_tx ranges with BFD_PROFILE timer ranges.";
+    }
 
     revision 2025-12-09 {
         description
@@ -288,21 +297,28 @@ module sonic-bgp-common {
 
         leaf bfd_min_rx {
             type uint32 {
-                range 50..60000;
+                range 10..60000;
             }
-            description "BFD minimum receive interval in milliseconds";
+            description "BFD minimum receive interval in milliseconds. Range matches sonic-bfd-profile receive_interval so per-peer and profile-bound timers are interchangeable.";
         }
 
         leaf bfd_min_tx {
             type uint32 {
-                range 50..60000;
+                range 10..60000;
             }
-            description "BFD minimum transmit interval in milliseconds";
+            description "BFD minimum transmit interval in milliseconds. Range matches sonic-bfd-profile transmit_interval so per-peer and profile-bound timers are interchangeable.";
         }
 
         leaf bfd_check_ctrl_plane_failure {
             type boolean;
             description "Trigger BGP session reset when a BFD control plane failure is detected.";
+        }
+
+        leaf bfd_profile {
+            type leafref {
+                path "/bfdprof:sonic-bfd-profile/bfdprof:BFD_PROFILE/bfdprof:BFD_PROFILE_LIST/bfdprof:name";
+            }
+            description "BFD profile applied to this peer. References an entry in the BFD_PROFILE table.";
         }
 
         leaf capability_dynamic {

--- a/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
@@ -49,6 +49,11 @@ module sonic-bgp-common {
     description
         "SONIC BGP common YANG attributes for Neighbors and Peer group";
 
+    revision 2025-12-09 {
+        description
+            "Add BFD custom timer parameters: bfd_detect_multiplier, bfd_min_rx, bfd_min_tx";
+    }
+
     revision 2021-02-26 {
         description
             "Initial revision.";
@@ -272,6 +277,27 @@ module sonic-bgp-common {
         leaf bfd {
             type boolean;
             description "Enable Bidirectional Forwarding Detection (BFD) for rapid link failure detection on this peer.";
+        }
+
+        leaf bfd_detect_multiplier {
+            type uint8 {
+                range 2..255;
+            }
+            description "BFD detection multiplier";
+        }
+
+        leaf bfd_min_rx {
+            type uint32 {
+                range 50..60000;
+            }
+            description "BFD minimum receive interval in milliseconds";
+        }
+
+        leaf bfd_min_tx {
+            type uint32 {
+                range 50..60000;
+            }
+            description "BFD minimum transmit interval in milliseconds";
         }
 
         leaf bfd_check_ctrl_plane_failure {

--- a/src/sonic-yang-models/yang-models/sonic-static-route.yang
+++ b/src/sonic-yang-models/yang-models/sonic-static-route.yang
@@ -12,6 +12,11 @@ module sonic-static-route {
   description
     "STATIC ROUTE yang Module for SONiC OS";
 
+  revision 2025-12-09 {
+    description
+      "Add BFD custom timer parameters: bfd_detect_multiplier, bfd_min_rx, bfd_min_tx";
+  }
+
   revision 2022-03-17 {
     description
       "First Revision";
@@ -53,6 +58,27 @@ module sonic-static-route {
           }
           default "false";
           description "Enable BFD monitoring for each nexthop, comma-separated per nexthop.";
+        }
+        leaf bfd_detect_multiplier {
+          type string {
+            pattern "(([2-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]),)*([2-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])";
+          }
+          description
+            "BFD detection multiplier (2-255), comma-separated for multiple nexthops";
+        }
+        leaf bfd_min_rx {
+          type string {
+            pattern "(([5-9][0-9]|[1-9][0-9]{2,3}|[1-5][0-9]{4}|60000),)*([5-9][0-9]|[1-9][0-9]{2,3}|[1-5][0-9]{4}|60000)";
+          }
+          description
+            "BFD minimum receive interval in milliseconds (50-60000), comma-separated for multiple nexthops";
+        }
+        leaf bfd_min_tx {
+          type string {
+            pattern "(([5-9][0-9]|[1-9][0-9]{2,3}|[1-5][0-9]{4}|60000),)*([5-9][0-9]|[1-9][0-9]{2,3}|[1-5][0-9]{4}|60000)";
+          }
+          description
+            "BFD minimum transmit interval in milliseconds (50-60000), comma-separated for multiple nexthops";
         }
       }
       list STATIC_ROUTE_LIST {
@@ -124,6 +150,33 @@ module sonic-static-route {
           default "false";
           description
             "blackhole refers to a route that, if matched, discards the message silently.";
+        }
+        leaf bfd {
+          type string {
+            pattern "((true|false),)*(true|false)";
+          }
+          default "false";
+        }
+        leaf bfd_detect_multiplier {
+          type string {
+            pattern "(([2-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]),)*([2-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])";
+          }
+          description
+            "BFD detection multiplier (2-255), comma-separated for multiple nexthops";
+        }
+        leaf bfd_min_rx {
+          type string {
+            pattern "(([5-9][0-9]|[1-9][0-9]{2,3}|[1-5][0-9]{4}|60000),)*([5-9][0-9]|[1-9][0-9]{2,3}|[1-5][0-9]{4}|60000)";
+          }
+          description
+            "BFD minimum receive interval in milliseconds (50-60000), comma-separated for multiple nexthops";
+        }
+        leaf bfd_min_tx {
+          type string {
+            pattern "(([5-9][0-9]|[1-9][0-9]{2,3}|[1-5][0-9]{4}|60000),)*([5-9][0-9]|[1-9][0-9]{2,3}|[1-5][0-9]{4}|60000)";
+          }
+          description
+            "BFD minimum transmit interval in milliseconds (50-60000), comma-separated for multiple nexthops";
         }
       } /* end of list STATIC_ROUTE_LIST */
     } /* end of container STATIC_ROUTE */


### PR DESCRIPTION
#### Why I did it

Two related improvements to BGP BFD configuration that complement SONiC's existing `BFD_PEER`-only BFD plumbing:

1. **Custom BFD timer parameters per BGP neighbor / peer-group / static route** (`bfd_detect_multiplier`, `bfd_min_rx`, `bfd_min_tx`). Today SONiC's bgp templates emit `neighbor X bfd` only — no way to pin per-session detection timers from CONFIG_DB without writing a full `BFD_PEER` row by hand for every neighbor.

2. **`BFD_PROFILE` table + `bfd_profile` leafref on BGP neighbor / peer-group**. Lets operators define named BFD timing profiles once (`detect_multiplier`, `receive_interval`, `transmit_interval`, plus optional `echo_interval` / `echo_mode` / `passive_mode` / `minimum_ttl`) and bind them to many neighbors / peer-groups, matching FRR's first-class `bfd / profile <name>` support. GCU-friendly since it's a separate table with a leafref from BGP.

The two together give CONFIG_DB-driven BFD tuning without forcing operators to drop into vtysh or maintain external `BFD_PEER` rows.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

**Custom BFD timers (commit 1):**
- YANG: added `bfd_detect_multiplier`, `bfd_min_rx`, `bfd_min_tx` to `BGP_NEIGHBOR`, `BGP_PEER_GROUP` (in `sonic-bgp-common.yang`) and `STATIC_ROUTE` (in `sonic-static-route.yang`).
- bgpcfgd (separated mode): all six bgpd Jinja2 templates (`general`, `internal`, `dynamic`, `monitors`, `sentinels`, `voq_chassis`) now emit `neighbor X bfd <mult> <rx> <tx>` when all three timer fields are present, falling back to `neighbor X bfd` when not.
- frrcfgd (unified mode): new `hdl_bfd_timers()` handler.
- staticroutebfd: per-nexthop timer overrides take precedence over the global defaults from `vars.py`.

**BFD profile (commit 2):**
- New YANG model `sonic-bfd-profile.yang` defining a `BFD_PROFILE` table keyed by profile name (`detect_multiplier` 2..255, `receive_interval` / `transmit_interval` 10..60000 ms, optional `echo_interval`, `echo_mode`, `passive_mode`, `minimum_ttl`).
- `bfd_profile` field added to `BGP_NEIGHBOR` / `BGP_PEER_GROUP` as a leafref into `sonic-bfd-profile/BFD_PROFILE/name`.
- bgpcfgd: new `BfdProfileMgr` watches `BFD_PROFILE` and renders FRR `bfd / profile <name> / detect-multiplier ... / receive-interval ... / transmit-interval ...`.
- bgpcfgd templates: when `bfd_profile` is set, emit two-step `neighbor X bfd` + `neighbor X bfd profile <name>` (FRR's canonical apply form). When both timers and a profile are set, profile wins.
- frrcfgd (unified mode): `BFD_PROFILE` registered as a `bfdd`-handled table; new `bfd_profile_handler`.
- `bfd_min_rx` / `bfd_min_tx` ranges in `sonic-bgp-common.yang` aligned with the `BFD_PROFILE` ranges so values stay portable when migrating from inline timers to a profile binding.

#### How to verify it

```
# Unit tests (sonic-bgpcfgd)
cd src/sonic-bgpcfgd
python3 -m pytest tests/test_bfd_profile_mgr.py tests/test_static_rt_bfd.py -q

# Unit tests (sonic-frr-mgmt-framework, unified mode)
cd src/sonic-frr-mgmt-framework
python3 -m pytest tests/test_bfd_profile.py tests/test_config.py -q

# YANG model tests
cd src/sonic-yang-models
python3 -m pytest tests/yang_model_tests/yang_model_tests.py -q
```

Functional verification done on a KVM virtual testbed with cEOS neighbors and a vSONiC DUT:
1. Configured `BFD_PROFILE|fast-test` with `detect_multiplier=3, receive_interval=100, transmit_interval=100`. `show running-config bfdd` showed the profile materialised under `bfd / profile fast-test`.
2. Bound `BGP_NEIGHBOR|10.0.0.57` to `bfd: true, bfd_profile: fast-test` → bgpcfgd emitted the two-step `neighbor 10.0.0.57 bfd` + `neighbor 10.0.0.57 bfd profile fast-test`.
3. `show bfd peers` listed the session with timers exactly matching the profile.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [x] master — verified on a sonic-mgmt KVM testbed

#### Description for the changelog

Add CONFIG_DB-driven custom BFD timer parameters and `BFD_PROFILE` table for BGP neighbors, peer groups, and static routes.

#### Link to config_db schema for YANG module changes

- `BGP_NEIGHBOR` / `BGP_PEER_GROUP`: new `bfd_detect_multiplier`, `bfd_min_rx`, `bfd_min_tx`, `bfd_profile`. See `src/sonic-yang-models/yang-models/sonic-bgp-common.yang`.
- `STATIC_ROUTE`: new `bfd_detect_multiplier`, `bfd_min_rx`, `bfd_min_tx`. See `src/sonic-yang-models/yang-models/sonic-static-route.yang`.
- `BFD_PROFILE`: new top-level table. See `src/sonic-yang-models/yang-models/sonic-bfd-profile.yang`.