### PR TITLE
marvell-prestera sai 1.17.1-13

### DIFF
--- a/platform/marvell-prestera/sai.mk
+++ b/platform/marvell-prestera/sai.mk
@@ -2,11 +2,11 @@
 
 BRANCH = master
 ifeq ($(CONFIGURED_ARCH),arm64)
-MRVL_SAI_VERSION = 1.17.1-12
+MRVL_SAI_VERSION = 1.17.1-13
 else ifeq ($(CONFIGURED_ARCH),armhf)
-MRVL_SAI_VERSION = 1.17.1-12
+MRVL_SAI_VERSION = 1.17.1-13
 else
-MRVL_SAI_VERSION = 1.17.1-12
+MRVL_SAI_VERSION = 1.17.1-13
 endif
 
 MRVL_SAI_URL_PREFIX = https://github.com/Marvell-switching/sonic-marvell-binaries/raw/master/$(CONFIGURED_ARCH)/sai-plugin/$(BRANCH)/


### PR DESCRIPTION
#### Why I did it
Fix: do not call on_switch_shutdown_request() in RemoveSwitch (reboot) sequence.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Remove the callback from the sequence

#### How to verify it
$ reboot
$ warm-reboot
Check pass and check syslog has no message
 "INFO swss#supervisord 2026-04-08 13:42:28,163 WARN exited: orchagent (exit status 1; not expected)"
---------
The files could be downloaded from:
https://github.com/Marvell-switching/sonic-marvell-binaries/raw/master/amd64/sai-plugin/master/mrvllibsai_1.17.1-13_amd64.deb
https://github.com/Marvell-switching/sonic-marvell-binaries/raw/master/arm64/sai-plugin/master/mrvllibsai_1.17.1-13_arm64.deb
https://github.com/Marvell-switching/sonic-marvell-binaries/raw/master/armhf/sai-plugin/master/mrvllibsai_1.17.1-13_armhf.deb

#### Which release branch to backport (provide reason below if selected)
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

#### Tested branch (Please provide the tested image version)

#### Description for the changelog

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

