### PR TITLE
[nvidia-bluefield] Remove legacy console=hvc0 from BF3 DPU kernel command line to fix IRQ open request error

### DIFF
--- a/device/nvidia-bluefield/arm64-nvda_bf-bf3comdpu/installer.conf
+++ b/device/nvidia-bluefield/arm64-nvda_bf-bf3comdpu/installer.conf
@@ -1,2 +1,2 @@
-GRUB_CMDLINE_LINUX="console=ttyAMA1 console=hvc0 console=ttyAMA0 earlycon=pl011,0x13010000 quiet"
+GRUB_CMDLINE_LINUX="console=ttyAMA1 console=ttyAMA0 earlycon=pl011,0x13010000 quiet"
 ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="isolcpus=1-10 nohz_full=1-10 rcu_nocbs=1-10"

--- a/platform/nvidia-bluefield/installer/create_sonic_image
+++ b/platform/nvidia-bluefield/installer/create_sonic_image
@@ -41,7 +41,7 @@ GRUB_AA64=grubnetaa64.efi
 GRUB_CFG="" # Common Grub Config
 BF2_BOOT_ARGS="console=ttyAMA1 console=hvc0 console=ttyAMA0 earlycon=pl011,0x01000000 earlycon=pl011,0x01800000"
 BF2_GRUB_CFG="$BF2_BOOT_ARGS isolcpus=1-7 nohz_full=1-7 rcu_nocbs=1-7"
-BF3_BOOT_ARGS="console=ttyAMA1 console=hvc0 console=ttyAMA0 earlycon=pl011,0x13010000"
+BF3_BOOT_ARGS="console=ttyAMA1 console=ttyAMA0 earlycon=pl011,0x13010000"
 BF3_GRUB_CFG="$BF3_BOOT_ARGS isolcpus=1-10 nohz_full=1-10 rcu_nocbs=1-10"
 
 usage() {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Remove the legacy `console=hvc0` virtual console from the BlueField-3 (BF3) DPU
kernel command line. With recent kernels, registering `hvc0` on this platform
triggers an IRQ open request error during boot (no real hypervisor backend
exists for this console on bare-metal BF3 SoC), producing noisy errors and
serving no functional purpose: real serial output already goes through
`ttyAMA1` (rshim/UART) and `ttyAMA0`.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Dropped `console=hvc0` from the BF3 kernel command line in two places that
must stay in sync:

1. `device/nvidia-bluefield/arm64-nvda_bf-bf3comdpu/installer.conf` —
   `GRUB_CMDLINE_LINUX` used by the installed SONiC image's GRUB config.
2. `platform/nvidia-bluefield/installer/create_sonic_image` — `BF3_BOOT_ARGS`
   used when building the BFB / BF3 GRUB config at image creation time.

BF2 boot args are intentionally left unchanged.

#### How to verify it

1. Build a BlueField-3 (BF3) SONiC BFB and install it on a BF3 DPU.
2. After boot, confirm:
   - `cat /proc/cmdline` shows `console=ttyAMA1 console=ttyAMA0 ...` and
     **no** `console=hvc0`.
   - `dmesg | grep -iE "hvc|irq.*open"` no longer shows the IRQ open
     request error previously seen for `hvc0`.
   - Console output on rshim / `ttyAMA1` and `ttyAMA0` still works
     normally (login prompt, kernel logs).

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

[nvidia-bluefield] Remove legacy `console=hvc0` from BF3 DPU kernel command line to fix IRQ open request error.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

N/A — no YANG / config_db changes.

#### A picture of a cute animal (not mandatory but encouraged)