### PR TITLE
[SN-4700] Fix issue: align LED color in system_health_monitoring_conf…

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4700-r0/system_health_monitoring_config.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/system_health_monitoring_config.json
@@ -4,8 +4,8 @@
     "user_defined_checkers": [],
     "polling_interval": 60,
     "led_color": {
-        "fault": "amber",
+        "fault": "red",
         "normal": "green",
-        "booting": "amber_blink"
+        "booting": "red_blink"
     }
 }

--- a/device/mellanox/x86_64-mlnx_msn4700_simx-r0/system_health_monitoring_config.json
+++ b/device/mellanox/x86_64-mlnx_msn4700_simx-r0/system_health_monitoring_config.json
@@ -4,8 +4,8 @@
     "user_defined_checkers": [],
     "polling_interval": 60,
     "led_color": {
-        "fault": "amber",
+        "fault": "red",
         "normal": "green",
-        "booting": "amber_blink"
+        "booting": "red_blink"
     }
 }


### PR DESCRIPTION
…ig.json with physical capability

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Align LED color in system_health_monitoring_config.json with physical capability

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
SN4700 supports Red Led. so updated the system_health_monitoring_config.json file.

#### How to verify it
Manual test
sonic-mgmt regression

The discussion is going under https://github.com/sonic-net/sonic-mgmt/issues/23055#issuecomment-4393016465
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

