### PR TITLE
[Mellanox] Remove redundancy "_SIMX" suffix string from product name in platform.json of SIMX platform

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4700_simx-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn4700_simx-r0/platform.json
@@ -1,6 +1,6 @@
 {
     "chassis": {
-        "name": "MSN4700_SIMX",
+        "name": "MSN4700",
         "components": [
             {
                 "name": "ONIE"

--- a/device/mellanox/x86_64-nvidia_sn4280_simx-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn4280_simx-r0/platform.json
@@ -1,6 +1,6 @@
 {
     "chassis": {
-        "name": "SN4280_SIMX",
+        "name": "SN4280",
         "components": [
             {
                 "name": "ONIE"

--- a/device/mellanox/x86_64-nvidia_sn5400_simx-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn5400_simx-r0/platform.json
@@ -1,6 +1,6 @@
 {
     "chassis": {
-        "name": "SN5400_SIMX",
+        "name": "SN5400",
         "components": [
             {
                 "name": "ONIE"

--- a/device/mellanox/x86_64-nvidia_sn5600_simx-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn5600_simx-r0/platform.json
@@ -1,6 +1,6 @@
 {
     "chassis": {
-        "name": "SN5600_SIMX",
+        "name": "SN5600",
         "components": [
             {
                 "name": "ONIE"

--- a/device/mellanox/x86_64-nvidia_sn5640_simx-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn5640_simx-r0/platform.json
@@ -1,6 +1,6 @@
 {
     "chassis": {
-        "name": "SN5640_SIMX",
+        "name": "SN5640",
         "components": [
             {
                 "name": "ONIE"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Previously, we relay on the product name string of platform.json to identify a setup is simx or not, this no long stand. So to align the sys-eeprom and platform.json product name, remove the suffix from product name of platform.json accordingly.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
delete the "_SIMX" suffix

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
run the platform_tests.api.test_chassis.TestChassisApi#test_get_name test case.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] 202511
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

