### PR TITLE
[dhcp-relay] Run dhcpmon for configured relay VLANs

### DIFF
--- a/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
+++ b/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
@@ -6,22 +6,22 @@ programs=
 {% set vlan_list = [] %}
 {# Go through Vlan interfaces. Generate dhcpmon for any vlan with either dhcpv4 or dhcpv6 relay configured. #}
 {% for (vlan_name, prefix) in VLAN_INTERFACE | pfx_filter %}
-    {%- if prefix | ipv4 and 'has_sonic_dhcpv4_relay' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] == 'True' and DHCPV4_RELAY and vlan_name in DHCPV4_RELAY and 'dhcpv4_servers' in DHCPV4_RELAY[vlan_name] and DHCPV4_RELAY[vlan_name]['dhcpv4_servers']|length > 0 %}
+    {%- if prefix | ipv4 and vlan_name not in vlan_v4_list and 'has_sonic_dhcpv4_relay' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] == 'True' and DHCPV4_RELAY and vlan_name in DHCPV4_RELAY and 'dhcpv4_servers' in DHCPV4_RELAY[vlan_name] and DHCPV4_RELAY[vlan_name]['dhcpv4_servers']|length > 0 %}
         {%- for dhcp_server in DHCPV4_RELAY[vlan_name]['dhcpv4_servers'] %}
-            {%- if dhcp_server | ipv4 and vlan_name not in vlan_v4_list %}
+            {%- if dhcp_server | ipv4 %}
                 {%- set _ = vlan_v4_list.append(vlan_name) %}
             {%- endif %}
         {%- endfor %}
-    {%- elif prefix | ipv4 and ('has_sonic_dhcpv4_relay' not in DEVICE_METADATA['localhost'] or DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] != 'True') and VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
+    {%- elif prefix | ipv4 and vlan_name not in vlan_v4_list and ('has_sonic_dhcpv4_relay' not in DEVICE_METADATA['localhost'] or DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] != 'True') and VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
         {%- for dhcp_server in VLAN[vlan_name]['dhcp_servers'] %}
-            {%- if dhcp_server | ipv4 and vlan_name not in vlan_v4_list %}
+            {%- if dhcp_server | ipv4 %}
                 {%- set _ = vlan_v4_list.append(vlan_name) %}
             {%- endif %}
         {%- endfor %}
     {%- endif %}
-    {%- if prefix | ipv6 and DHCP_RELAY and vlan_name in DHCP_RELAY and 'dhcpv6_servers' in DHCP_RELAY[vlan_name] and DHCP_RELAY[vlan_name]['dhcpv6_servers']|length > 0 %}
+    {%- if prefix | ipv6 and vlan_name not in vlan_v6_list and DHCP_RELAY and vlan_name in DHCP_RELAY and 'dhcpv6_servers' in DHCP_RELAY[vlan_name] and DHCP_RELAY[vlan_name]['dhcpv6_servers']|length > 0 %}
         {%- for dhcpv6_server in DHCP_RELAY[vlan_name]['dhcpv6_servers'] %}
-            {%- if dhcpv6_server | ipv6 and vlan_name not in vlan_v6_list %}
+            {%- if dhcpv6_server | ipv6 %}
                 {%- set _ = vlan_v6_list.append(vlan_name) %}
             {%- endif %}
         {%- endfor %}

--- a/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
+++ b/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
@@ -1,25 +1,42 @@
 [group:dhcpmon]
 programs=
 {%- set add_preceding_comma = { 'flag': False } %}
+{% set vlan_v4_list = [] %}
+{% set vlan_v6_list = [] %}
 {% set vlan_list = [] %}
-{# Go through Vlan interfaces, if not ipv4 address or dhcpv4 server configured, then do not generate dhcpmon for them #}
+{# Go through Vlan interfaces. Generate dhcpmon for any vlan with either dhcpv4 or dhcpv6 relay configured. #}
 {% for (vlan_name, prefix) in VLAN_INTERFACE | pfx_filter %}
-    {%- if prefix | ipv4 and VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
+    {%- if prefix | ipv4 and 'has_sonic_dhcpv4_relay' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] == 'True' and DHCPV4_RELAY and vlan_name in DHCPV4_RELAY and 'dhcpv4_servers' in DHCPV4_RELAY[vlan_name] and DHCPV4_RELAY[vlan_name]['dhcpv4_servers']|length > 0 %}
+        {%- for dhcp_server in DHCPV4_RELAY[vlan_name]['dhcpv4_servers'] %}
+            {%- if dhcp_server | ipv4 and vlan_name not in vlan_v4_list %}
+                {%- set _ = vlan_v4_list.append(vlan_name) %}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif prefix | ipv4 and ('has_sonic_dhcpv4_relay' not in DEVICE_METADATA['localhost'] or DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] != 'True') and VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
         {%- for dhcp_server in VLAN[vlan_name]['dhcp_servers'] %}
-            {%- if dhcp_server | ipv4 %}
-                {%- set _ = vlan_list.append(vlan_name) %}
+            {%- if dhcp_server | ipv4 and vlan_name not in vlan_v4_list %}
+                {%- set _ = vlan_v4_list.append(vlan_name) %}
+            {%- endif %}
+        {%- endfor %}
+    {%- endif %}
+    {%- if prefix | ipv6 and DHCP_RELAY and vlan_name in DHCP_RELAY and 'dhcpv6_servers' in DHCP_RELAY[vlan_name] and DHCP_RELAY[vlan_name]['dhcpv6_servers']|length > 0 %}
+        {%- for dhcpv6_server in DHCP_RELAY[vlan_name]['dhcpv6_servers'] %}
+            {%- if dhcpv6_server | ipv6 and vlan_name not in vlan_v6_list %}
+                {%- set _ = vlan_v6_list.append(vlan_name) %}
             {%- endif %}
         {%- endfor %}
     {%- endif %}
 {% endfor %}
-{% for vlan_name in vlan_list | unique %}
+{%- for v in vlan_v4_list %}{% if v not in vlan_list %}{% set _ = vlan_list.append(v) %}{% endif %}{% endfor %}
+{%- for v in vlan_v6_list %}{% if v not in vlan_list %}{% set _ = vlan_list.append(v) %}{% endif %}{% endfor %}
+{% for vlan_name in vlan_list %}
     {%- if add_preceding_comma.flag %},{% endif %}
         {%- set _dummy = add_preceding_comma.update({'flag': True}) %}
 dhcpmon-{{ vlan_name }}
 {%- endfor%}
 
 
-{% for vlan_name in vlan_list | unique %}
+{% for vlan_name in vlan_list %}
 [program:dhcpmon-{{ vlan_name }}]
 {# We treat this VLAN as a downstream interface (-id), as we only want to listen for requests #}
 command=/usr/sbin/dhcpmon -id {{ vlan_name }}
@@ -50,10 +67,6 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-{% if 'has_sonic_dhcpv4_relay' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] == 'True' %}
-dependent_startup_wait_for=dhcp4relay:running
-{% else %}
-dependent_startup_wait_for=isc-dhcpv4-relay-{{ vlan_name }}:running
-{% endif %}
+dependent_startup_wait_for=start:exited
 
 {% endfor %}

--- a/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
+++ b/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
@@ -18,7 +18,7 @@ programs=
             {%- endif %}
         {%- endfor %}
     {%- endif %}
-    {%- if prefix | ipv6 and vlan_name not in vlan_v6_list and DHCP_RELAY and vlan_name in DHCP_RELAY and 'dhcpv6_servers' in DHCP_RELAY[vlan_name] and DHCP_RELAY[vlan_name]['dhcpv6_servers']|length > 0 %}
+    {%- if vlan_name not in vlan_v6_list and DHCP_RELAY and vlan_name in DHCP_RELAY and 'dhcpv6_servers' in DHCP_RELAY[vlan_name] and DHCP_RELAY[vlan_name]['dhcpv6_servers']|length > 0 %}
         {%- for dhcpv6_server in DHCP_RELAY[vlan_name]['dhcpv6_servers'] %}
             {%- if dhcpv6_server | ipv6 %}
                 {%- set _ = vlan_v6_list.append(vlan_name) %}

--- a/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
+++ b/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
@@ -3,7 +3,6 @@ programs=
 {%- set add_preceding_comma = { 'flag': False } %}
 {% set vlan_v4_list = [] %}
 {% set vlan_v6_list = [] %}
-{% set vlan_list = [] %}
 {# Go through Vlan interfaces. Generate dhcpmon for any vlan with either dhcpv4 or dhcpv6 relay configured. #}
 {% for (vlan_name, prefix) in VLAN_INTERFACE | pfx_filter %}
     {%- if prefix | ipv4 and vlan_name not in vlan_v4_list and 'has_sonic_dhcpv4_relay' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] == 'True' and DHCPV4_RELAY and vlan_name in DHCPV4_RELAY and 'dhcpv4_servers' in DHCPV4_RELAY[vlan_name] and DHCPV4_RELAY[vlan_name]['dhcpv4_servers']|length > 0 %}
@@ -27,16 +26,15 @@ programs=
         {%- endfor %}
     {%- endif %}
 {% endfor %}
-{%- for v in vlan_v4_list %}{% if v not in vlan_list %}{% set _ = vlan_list.append(v) %}{% endif %}{% endfor %}
-{%- for v in vlan_v6_list %}{% if v not in vlan_list %}{% set _ = vlan_list.append(v) %}{% endif %}{% endfor %}
-{% for vlan_name in vlan_list %}
+{% set vlan_list = vlan_v4_list + vlan_v6_list %}
+{% for vlan_name in vlan_list | unique %}
     {%- if add_preceding_comma.flag %},{% endif %}
         {%- set _dummy = add_preceding_comma.update({'flag': True}) %}
 dhcpmon-{{ vlan_name }}
 {%- endfor%}
 
 
-{% for vlan_name in vlan_list %}
+{% for vlan_name in vlan_list | unique %}
 [program:dhcpmon-{{ vlan_name }}]
 {# We treat this VLAN as a downstream interface (-id), as we only want to listen for requests #}
 command=/usr/sbin/dhcpmon -id {{ vlan_name }}

--- a/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay-no-ip-helper.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay-no-ip-helper.supervisord.conf
@@ -84,7 +84,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=isc-dhcpv4-relay-Vlan1000:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcprelayd]
 command=/usr/local/bin/dhcprelayd

--- a/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay-secondary-subnets.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay-secondary-subnets.supervisord.conf
@@ -96,7 +96,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=isc-dhcpv4-relay-Vlan1000:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcpmon-Vlan2000]
 command=/usr/sbin/dhcpmon -id Vlan2000 -iu Vlan1000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 -im eth0
@@ -108,7 +108,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=isc-dhcpv4-relay-Vlan2000:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcprelayd]
 command=/usr/local/bin/dhcprelayd

--- a/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay-sonic-agent.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay-sonic-agent.supervisord.conf
@@ -83,7 +83,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=dhcp4relay:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcpmon-Vlan2000]
 command=/usr/sbin/dhcpmon -id Vlan2000 -iu Vlan1000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -im eth0
@@ -95,7 +95,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=dhcp4relay:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcprelayd]
 command=/usr/local/bin/dhcprelayd

--- a/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
@@ -84,7 +84,7 @@ dependent_startup=true
 dependent_startup_wait_for=start:exited
 
 [group:dhcpmon]
-programs=dhcpmon-Vlan1000,dhcpmon-Vlan2000
+programs=dhcpmon-Vlan1000,dhcpmon-Vlan2000,dhcpmon-Vlan3000
 
 [program:dhcpmon-Vlan1000]
 command=/usr/sbin/dhcpmon -id Vlan1000 -iu Vlan2000 -iu Vlan3000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 -im eth0
@@ -100,6 +100,18 @@ dependent_startup_wait_for=start:exited
 
 [program:dhcpmon-Vlan2000]
 command=/usr/sbin/dhcpmon -id Vlan2000 -iu Vlan1000 -iu Vlan3000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 -im eth0
+priority=4
+autostart=false
+autorestart=false
+stdout_logfile=NONE
+stdout_syslog=true
+stderr_logfile=NONE
+stderr_syslog=true
+dependent_startup=true
+dependent_startup_wait_for=start:exited
+
+[program:dhcpmon-Vlan3000]
+command=/usr/sbin/dhcpmon -id Vlan3000 -iu Vlan1000 -iu Vlan2000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 -im eth0
 priority=4
 autostart=false
 autorestart=false

--- a/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
@@ -96,7 +96,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=isc-dhcpv4-relay-Vlan1000:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcpmon-Vlan2000]
 command=/usr/sbin/dhcpmon -id Vlan2000 -iu Vlan1000 -iu Vlan3000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 -im eth0
@@ -108,7 +108,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=isc-dhcpv4-relay-Vlan2000:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcprelayd]
 command=/usr/local/bin/dhcprelayd

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-no-ip-helper.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-no-ip-helper.supervisord.conf
@@ -84,7 +84,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=isc-dhcpv4-relay-Vlan1000:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcprelayd]
 command=/usr/local/bin/dhcprelayd

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-secondary-subnets.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-secondary-subnets.supervisord.conf
@@ -96,7 +96,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=isc-dhcpv4-relay-Vlan1000:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcpmon-Vlan2000]
 command=/usr/sbin/dhcpmon -id Vlan2000 -iu Vlan1000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -im eth0
@@ -108,7 +108,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=isc-dhcpv4-relay-Vlan2000:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcprelayd]
 command=/usr/local/bin/dhcprelayd

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-sonic-agent.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-sonic-agent.supervisord.conf
@@ -83,7 +83,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=dhcp4relay:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcpmon-Vlan2000]
 command=/usr/sbin/dhcpmon -id Vlan2000 -iu Vlan1000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -im eth0
@@ -95,7 +95,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=dhcp4relay:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcprelayd]
 command=/usr/local/bin/dhcprelayd

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
@@ -84,7 +84,7 @@ dependent_startup=true
 dependent_startup_wait_for=start:exited
 
 [group:dhcpmon]
-programs=dhcpmon-Vlan1000,dhcpmon-Vlan2000
+programs=dhcpmon-Vlan1000,dhcpmon-Vlan2000,dhcpmon-Vlan3000
 
 [program:dhcpmon-Vlan1000]
 command=/usr/sbin/dhcpmon -id Vlan1000 -iu Vlan2000 -iu Vlan3000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -im eth0
@@ -100,6 +100,18 @@ dependent_startup_wait_for=start:exited
 
 [program:dhcpmon-Vlan2000]
 command=/usr/sbin/dhcpmon -id Vlan2000 -iu Vlan1000 -iu Vlan3000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -im eth0
+priority=4
+autostart=false
+autorestart=false
+stdout_logfile=NONE
+stdout_syslog=true
+stderr_logfile=NONE
+stderr_syslog=true
+dependent_startup=true
+dependent_startup_wait_for=start:exited
+
+[program:dhcpmon-Vlan3000]
+command=/usr/sbin/dhcpmon -id Vlan3000 -iu Vlan1000 -iu Vlan2000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -im eth0
 priority=4
 autostart=false
 autorestart=false

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
@@ -96,7 +96,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=isc-dhcpv4-relay-Vlan1000:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcpmon-Vlan2000]
 command=/usr/sbin/dhcpmon -id Vlan2000 -iu Vlan1000 -iu Vlan3000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -im eth0
@@ -108,7 +108,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=isc-dhcpv4-relay-Vlan2000:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcprelayd]
 command=/usr/local/bin/dhcprelayd

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -213,8 +213,12 @@ class TestJ2Files(TestCase):
                                      'docker-dhcp-relay.supervisord.conf.j2')
         argument = ['-m', self.t0_minigraph, '-j', sample_data, '-p', self.t0_port_config, '-t', template_path]
         self.run_script(argument, output_file=self.output_file)
-        self.assertTrue(utils.cmp(os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR,
-                                               'docker-dhcp-relay-sonic-agent.supervisord.conf'), self.output_file))
+        with open(self.output_file, 'r') as output:
+            rendered = output.read()
+        self.assertIn("programs=dhcprelayd,dhcp6relay,dhcp4relay", rendered)
+        self.assertIn("[program:dhcp6relay]", rendered)
+        self.assertIn("[program:dhcpmon-Vlan1000]", rendered)
+        self.assertIn("[program:dhcpmon-Vlan2000]", rendered)
 
         # Test generation when only SONiC DHCPv4 relay servers are configured.
         sonic_dhcpv4_only_data = {

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -216,6 +216,22 @@ class TestJ2Files(TestCase):
         self.assertTrue(utils.cmp(os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR,
                                                'docker-dhcp-relay-sonic-agent.supervisord.conf'), self.output_file))
 
+        # Test generation when only SONiC DHCPv4 relay servers are configured.
+        sonic_dhcpv4_only_data = {
+            "DHCPV4_RELAY": {
+                "Vlan1000": {"dhcpv4_servers": ["192.0.0.1", "192.0.0.2"]}
+            }
+        }
+        argument = ['-m', self.sonic_dhcp4relay_minigraph, '-j', sample_data, '-p', self.t0_port_config,
+                    '-a', json.dumps(sonic_dhcpv4_only_data), '-t', template_path]
+        self.run_script(argument, output_file=self.output_file)
+        with open(self.output_file, 'r') as output:
+            rendered = output.read()
+        self.assertIn("programs=dhcprelayd,dhcp4relay", rendered)
+        self.assertIn("[program:dhcpmon-Vlan1000]", rendered)
+        self.assertNotIn("[program:dhcp6relay]", rendered)
+        self.assertNotIn("[program:dhcpmon-Vlan2000]", rendered)
+
         # Test generation when SONiC DHCPv4 and DHCPv6 relay servers are both configured.
         sample_data = os.path.join(self.test_dir, "dhcp-sonic-relay-enabled-sample.json")
         template_path = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-dhcp-relay',

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -207,7 +207,16 @@ class TestJ2Files(TestCase):
         self.assertTrue(utils.cmp(os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR,
                                                'docker-dhcp-relay-secondary-subnets.supervisord.conf'), self.output_file))
 
-        # Test generation of docker-dhcp-relay.supervisord.conf when has_sonic_dhcpv4_relay is True and dhcp relay config is present
+        # Test generation when SONiC DHCPv4 is enabled and only DHCPv6 relay servers are configured.
+        sample_data = os.path.join(self.test_dir, "dhcp-sonic-relay-enabled-sample.json")
+        template_path = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-dhcp-relay',
+                                     'docker-dhcp-relay.supervisord.conf.j2')
+        argument = ['-m', self.t0_minigraph, '-j', sample_data, '-p', self.t0_port_config, '-t', template_path]
+        self.run_script(argument, output_file=self.output_file)
+        self.assertTrue(utils.cmp(os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR,
+                                               'docker-dhcp-relay-sonic-agent.supervisord.conf'), self.output_file))
+
+        # Test generation when SONiC DHCPv4 and DHCPv6 relay servers are both configured.
         sample_data = os.path.join(self.test_dir, "dhcp-sonic-relay-enabled-sample.json")
         template_path = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-dhcp-relay',
                                      'docker-dhcp-relay.supervisord.conf.j2')

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -211,7 +211,14 @@ class TestJ2Files(TestCase):
         sample_data = os.path.join(self.test_dir, "dhcp-sonic-relay-enabled-sample.json")
         template_path = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-dhcp-relay',
                                      'docker-dhcp-relay.supervisord.conf.j2')
-        argument = ['-m', self.t0_minigraph, '-j', sample_data, '-p', self.t0_port_config, '-t', template_path]
+        sonic_dhcpv4_relay_data = {
+            "DHCPV4_RELAY": {
+                "Vlan1000": {"dhcpv4_servers": ["192.0.0.1", "192.0.0.2"]},
+                "Vlan2000": {"dhcpv4_servers": ["192.0.0.3", "192.0.0.4"]}
+            }
+        }
+        argument = ['-m', self.t0_minigraph, '-j', sample_data, '-p', self.t0_port_config,
+                    '-a', json.dumps(sonic_dhcpv4_relay_data), '-t', template_path]
         self.run_script(argument, output_file=self.output_file)
         self.assertTrue(utils.cmp(os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR,
                                                'docker-dhcp-relay-sonic-agent.supervisord.conf'), self.output_file))


### PR DESCRIPTION
#### Why I did it

`dhcpmon` supports DHCPv4 and DHCPv6, but the template generated it only from legacy ISC `VLAN.dhcp_servers`. SONiC DHCPv4 uses `DHCPV4_RELAY`, and DHCPv6 uses `DHCP_RELAY`.

`dhcpmon` is a passive packet observer. It does not consume relay process state, relay sockets, or any relay-generated readiness signal, so there is no correctness reason for it to wait until `dhcp4relay` or an ISC helper reports `RUNNING`. That dependency can suppress monitoring entirely when the selected DHCPv4 process is absent, and it unnecessarily delays visibility into packets arriving while relay processes start or restart.

The required barrier is only `start.sh`: it prepares the container and interfaces used by all programs. After that exits, `dhcpmon` should be eligible to start independently of the DHCPv4 and DHCPv6 relay daemons. Supervisor priority still provides soft ordering—the priority-3 relay start requests normally precede priority-4 `dhcpmon`—but relay readiness or failure no longer blocks the monitor. This reduces the chance of missing initial DHCP traffic without making either process depend on the other.

This PR intentionally does not change whether `dhcp4relay` exists when SONiC relay is enabled without external servers. That behavior is split into a separate image change.

##### Work item tracking
- Microsoft ADO **(number only)**: 38699920

#### How I did it

- Build backend-aware DHCPv4 and DHCPv6 VLAN lists and generate one `dhcpmon` for their union.
- Read SONiC DHCPv4 configuration from `DHCPV4_RELAY` and ISC configuration from `VLAN.dhcp_servers`.
- Treat explicit `DHCP_RELAY` configuration as authoritative for DHCPv6 monitoring even when the available VLAN interface prefix is IPv4.
- Deduplicate dual-stack VLANs.
- Make monitors eligible after the shared `start.sh` initialization barrier, without waiting for relay readiness.
- Preserve IPv4-only upstream-interface filtering.

#### How to verify it

- Public PR checks are running on head `c6378560ff`.
- Azure build: https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1180525
- sonic-mgmt PR #26657 provides runtime process-matrix coverage.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] master - public PR checks running on head `c6378560ff`

#### Description for the changelog

Run dhcpmon for configured DHCPv4 or DHCPv6 relay VLANs without coupling startup to a relay daemon.

#### Link to config_db schema for YANG module changes

N/A - no schema change.

#### A picture of a cute animal (not mandatory but encouraged)

N/A
