### PR TITLE
Add RUST_BACKTRACE=full ENV for hamgrd and swbusd

### DIFF
--- a/dockers/docker-dash-ha/supervisord.conf
+++ b/dockers/docker-dash-ha/supervisord.conf
@@ -45,7 +45,7 @@ dependent_startup_wait_for=rsyslogd:running
 
 [program:swbusd]
 command=/bin/bash -c 'SLOT=${DEV: -1}; exec /usr/bin/swbusd -s "$SLOT"'
-environment=RUST_BACKTRACE=1
+environment=RUST_BACKTRACE=full
 priority=3
 autostart=false
 autorestart=true
@@ -58,7 +58,7 @@ dependent_startup_wait_for=wait-for-loopback:exited
 
 [program:hamgrd]
 command=/bin/bash -c 'SLOT=${DEV: -1}; exec /usr/bin/hamgrd -s "$SLOT"'
-environment=RUST_BACKTRACE=1
+environment=RUST_BACKTRACE=full
 priority=4
 autostart=false
 autorestart=false

--- a/dockers/docker-dash-ha/supervisord.conf
+++ b/dockers/docker-dash-ha/supervisord.conf
@@ -45,6 +45,7 @@ dependent_startup_wait_for=rsyslogd:running
 
 [program:swbusd]
 command=/bin/bash -c 'SLOT=${DEV: -1}; exec /usr/bin/swbusd -s "$SLOT"'
+environment=RUST_BACKTRACE=1
 priority=3
 autostart=false
 autorestart=true
@@ -57,6 +58,7 @@ dependent_startup_wait_for=wait-for-loopback:exited
 
 [program:hamgrd]
 command=/bin/bash -c 'SLOT=${DEV: -1}; exec /usr/bin/hamgrd -s "$SLOT"'
+environment=RUST_BACKTRACE=1
 priority=4
 autostart=false
 autorestart=false


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Add RUST_BACKTRACE=full ENV for hamgrd and swbusd

#### Why I did it

Enable back trace when hamgrd or swbusd panics.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

Verify on a device.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

