### PR TITLE
[restapi-sidecar] cleanup native container, fix sync order, add jitter

### DIFF
--- a/dockers/docker-restapi-sidecar/cli-plugin-tests/test_systemd_stub.py
+++ b/dockers/docker-restapi-sidecar/cli-plugin-tests/test_systemd_stub.py
@@ -1,6 +1,7 @@
 # tests/test_systemd_stub.py
 import sys
 import os
+import time
 import types
 import importlib
 
@@ -900,3 +901,74 @@ def test_date_extract_pattern_extracts_correctly(ss):
     # Should not match
     match = systemd_stub._DATE_EXTRACT_PATTERN.search("SONiC.master.123456-abcdef12")
     assert not match
+
+
+# ─────────────────────────── Tests for POST_COPY_ACTIONS docker rm --force ───────────────────────────
+
+def test_post_copy_actions_use_docker_rm_force(ss):
+    """POST_COPY_ACTIONS for restapi.sh should use 'docker rm --force' instead of plain 'docker rm'."""
+    ss_mod, *_ = ss
+    # Re-import to get the real POST_COPY_ACTIONS (fixture clears them)
+    if "systemd_stub" in sys.modules:
+        del sys.modules["systemd_stub"]
+    ss_fresh = importlib.import_module("systemd_stub")
+
+    actions = ss_fresh.POST_COPY_ACTIONS["/usr/bin/restapi.sh"]
+    # Should have docker stop, docker rm --force, daemon-reload, restart
+    assert ["sudo", "docker", "stop", "restapi"] in actions
+    assert ["sudo", "docker", "rm", "--force", "restapi"] in actions
+    # Old plain 'docker rm' should NOT be present
+    assert ["sudo", "docker", "rm", "restapi"] not in actions
+
+
+# ─────────────────────────── Tests for sync ordering (k8s_pod_control before restapi.sh) ───────────────
+
+def test_sync_order_k8s_pod_control_before_restapi(ss):
+    """k8s_pod_control.sh must be synced before restapi.sh to avoid 'No such file' errors."""
+    ss_mod, container_fs, host_fs, commands, config_db = ss
+
+    container_fs["/usr/share/sonic/systemd_scripts/restapi.sh"] = b"NEW-RESTAPI"
+    container_fs["/usr/share/sonic/systemd_scripts/container_checker_202311"] = b"NEW-CHECKER"
+    container_fs["/usr/share/sonic/scripts/k8s_pod_control.sh"] = b"NEW-K8S"
+
+    host_fs["/usr/bin/restapi.sh"] = b"OLD"
+    host_fs["/bin/container_checker"] = b"OLD"
+    host_fs["/usr/share/sonic/scripts/docker-restapi-sidecar/k8s_pod_control.sh"] = b"OLD"
+
+    ok = ss_mod.ensure_sync()
+    assert ok is True
+
+    # Extract the order of file writes by looking at /bin/mv commands (atomic write pattern)
+    mv_dsts = [args[3] for _, args in commands if args[:1] == ("/bin/mv",) and len(args) == 4]
+    # k8s_pod_control.sh dest must appear before restapi.sh dest
+    k8s_dst = "/usr/share/sonic/scripts/docker-restapi-sidecar/k8s_pod_control.sh"
+    restapi_dst = "/usr/bin/restapi.sh"
+    if k8s_dst in mv_dsts and restapi_dst in mv_dsts:
+        assert mv_dsts.index(k8s_dst) < mv_dsts.index(restapi_dst), \
+            f"k8s_pod_control.sh must be synced before restapi.sh, but order was: {mv_dsts}"
+
+
+# ─────────────────────────── Tests for main() jitter ───────────────────────────
+
+def test_main_loop_uses_jitter(ss, monkeypatch):
+    """The sync loop sleep should include jitter (interval ± 10%)."""
+    ss_mod, container_fs, host_fs, commands, config_db = ss
+
+    sleep_values = []
+    original_sleep = time.sleep
+
+    def mock_sleep(secs):
+        sleep_values.append(secs)
+        raise KeyboardInterrupt  # break out of loop after first sleep
+
+    monkeypatch.setattr(time, "sleep", mock_sleep)
+    monkeypatch.setattr(ss_mod, "ensure_sync", lambda: True)
+    monkeypatch.setattr(sys, "argv", ["systemd_stub.py", "--interval", "100"])
+
+    # main() will do initial sync, then enter loop, sleep with jitter, then KeyboardInterrupt
+    with pytest.raises(KeyboardInterrupt):
+        ss_mod.main()
+
+    assert len(sleep_values) == 1
+    # With 10% jitter on interval=100, sleep should be in [90, 110]
+    assert 90 <= sleep_values[0] <= 110, f"Sleep value {sleep_values[0]} outside jitter range [90, 110]"

--- a/dockers/docker-restapi-sidecar/systemd_stub.py
+++ b/dockers/docker-restapi-sidecar/systemd_stub.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import random
 import re
 import subprocess
 import time
@@ -12,7 +13,7 @@ from typing import List
 from sonic_py_common.sidecar_common import (
     get_bool_env_var, logger, SyncItem, run_nsenter,
     read_file_bytes_local, host_read_bytes, host_write_atomic,
-    sync_items, SYNC_INTERVAL_S
+    sync_items, cleanup_native_container, SYNC_INTERVAL_S
 )
 
 # ───────────── restapi.service paths ─────────────
@@ -97,7 +98,7 @@ def _get_branch_name() -> str:
 POST_COPY_ACTIONS = {
     "/usr/bin/restapi.sh": [
         ["sudo", "docker", "stop", "restapi"],
-        ["sudo", "docker", "rm", "restapi"],
+        ["sudo", "docker", "rm", "--force", "restapi"],
         ["sudo", "systemctl", "daemon-reload"],
         ["sudo", "systemctl", "restart", "restapi"],
     ],
@@ -202,6 +203,7 @@ def _cleanup_stale_service_unit() -> None:
 
 def ensure_sync() -> bool:
     _cleanup_stale_service_unit()
+    cleanup_native_container("restapi", IS_V1_ENABLED)
     # Evaluate branch and source paths each time to allow retry on runtime failures
     detected_branch = _get_branch_name()
 
@@ -217,10 +219,14 @@ def ensure_sync() -> bool:
     container_checker_src = f"/usr/share/sonic/systemd_scripts/container_checker_{branch_name}"
     
     # Construct SYNC_ITEMS with evaluated paths
+    # k8s_pod_control.sh must be synced before restapi.sh because the new
+    # restapi.sh is a thin wrapper that exec's k8s_pod_control.sh.  If
+    # restapi.sh is synced first its post-copy action (systemctl restart
+    # restapi) would fail with "No such file or directory".
     sync_items_list: List[SyncItem] = [
+        SyncItem("/usr/share/sonic/scripts/k8s_pod_control.sh", "/usr/share/sonic/scripts/docker-restapi-sidecar/k8s_pod_control.sh", mode=0o755),
         SyncItem(restapi_src, "/usr/bin/restapi.sh", mode=0o755),
         SyncItem(container_checker_src, "/bin/container_checker", mode=0o755),
-        SyncItem("/usr/share/sonic/scripts/k8s_pod_control.sh", "/usr/share/sonic/scripts/docker-restapi-sidecar/k8s_pod_control.sh", mode=0o755),
     ]
     return sync_items(sync_items_list, POST_COPY_ACTIONS)
 
@@ -245,6 +251,7 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
+    jitter_pct = 0.1  # ±10% jitter applied to sync loop interval
     if args.no_post_actions:
         POST_COPY_ACTIONS.clear()
         logger.log_info("Post-copy host actions DISABLED for this run")
@@ -262,7 +269,8 @@ def main() -> int:
         return 0 if ok else 1
     while True:
         try:
-            time.sleep(args.interval)
+            jitter = args.interval * random.uniform(-jitter_pct, jitter_pct)
+            time.sleep(args.interval + jitter)
             ok = ensure_sync()
             if not ok:
                 logger.log_error("Sync failed. Will retry in next iteration.")

--- a/src/sonic-py-common/sonic_py_common/sidecar_common.py
+++ b/src/sonic-py-common/sonic_py_common/sidecar_common.py
@@ -274,3 +274,25 @@ def _run_host_actions_for(path_on_host: str, post_copy_actions: Dict[str, List[L
             logger.log_info(f"Post-copy action succeeded: {' '.join(cmd)}")
         else:
             logger.log_error(f"Post-copy action FAILED (rc={rc}): {' '.join(cmd)}; stderr={str(err).strip()}")
+
+
+def cleanup_native_container(container_name: str, is_v1_enabled: bool) -> None:
+    """In V2 mode, check for and remove any native container.
+
+    Post-copy actions only fire when a synced file changes, so on subsequent
+    sidecar restarts (files already in sync) or after a race with the
+    container framework, the native container may persist.  Called every
+    sync cycle to guarantee it is eventually cleaned up.
+    """
+    if is_v1_enabled:
+        return
+    rc, out, _ = run_nsenter(
+        ["sudo", "docker", "inspect", "--format", "{{.State.Status}}", container_name]
+    )
+    if rc != 0:
+        logger.log_info(f"No native {container_name} container found")
+        return
+    status = out.strip()
+    logger.log_notice(f"Native {container_name} container found (status={status}); removing")
+    run_nsenter(["sudo", "docker", "stop", container_name])
+    run_nsenter(["sudo", "docker", "rm", "--force", container_name])

--- a/src/sonic-py-common/tests/test_sidecar_common.py
+++ b/src/sonic-py-common/tests/test_sidecar_common.py
@@ -193,3 +193,90 @@ def test_sync_items_with_post_actions(fake_logger, mock_nsenter, monkeypatch):
     sudo_cmds = [args for _, args in commands if args and args[0] == "sudo"]
     assert ("sudo", "systemctl", "daemon-reload") in sudo_cmds
     assert ("sudo", "systemctl", "restart", "myservice") in sudo_cmds
+
+
+# ─────────────────────────── Tests for cleanup_native_container ───────────────────────────
+
+@pytest.fixture
+def docker_nsenter(monkeypatch):
+    """Mock run_nsenter with configurable docker inspect response."""
+    commands = []
+    inspect_result = {"rc": 1, "out": "", "err": ""}
+
+    def fake_run_nsenter(args, *, text=True, input_bytes=None):
+        commands.append(("nsenter", tuple(args)))
+        if args[:2] == ["sudo", "docker"] and "inspect" in args:
+            return inspect_result["rc"], inspect_result["out"], inspect_result["err"]
+        if args[:1] == ["sudo"]:
+            return 0, "" if text else b"", "" if text else b""
+        return 1, "" if text else b"", "unsupported" if text else b"unsupported"
+
+    monkeypatch.setattr(sidecar_common, "run_nsenter", fake_run_nsenter)
+    return commands, inspect_result
+
+
+def test_cleanup_native_container_removes_running(fake_logger, docker_nsenter):
+    """When a native container is running, it is stopped and force-removed."""
+    commands, inspect_result = docker_nsenter
+    inspect_result.update(rc=0, out="running\n", err="")
+
+    sidecar_common.cleanup_native_container("mycontainer", False)
+
+    sudo_cmds = [args for _, args in commands if args and args[0] == "sudo"]
+    assert ("sudo", "docker", "inspect", "--format", "{{.State.Status}}", "mycontainer") in sudo_cmds
+    assert ("sudo", "docker", "stop", "mycontainer") in sudo_cmds
+    assert ("sudo", "docker", "rm", "--force", "mycontainer") in sudo_cmds
+
+
+def test_cleanup_native_container_removes_exited(fake_logger, docker_nsenter):
+    """When a native container exists but is exited, it is still removed."""
+    commands, inspect_result = docker_nsenter
+    inspect_result.update(rc=0, out="exited\n", err="")
+
+    sidecar_common.cleanup_native_container("mycontainer", False)
+
+    sudo_cmds = [args for _, args in commands if args and args[0] == "sudo"]
+    assert ("sudo", "docker", "stop", "mycontainer") in sudo_cmds
+    assert ("sudo", "docker", "rm", "--force", "mycontainer") in sudo_cmds
+
+
+def test_cleanup_native_container_noop_when_absent(fake_logger, docker_nsenter):
+    """When no native container exists, cleanup is a no-op."""
+    commands, inspect_result = docker_nsenter
+    inspect_result.update(rc=1, out="", err="No such object: mycontainer")
+
+    sidecar_common.cleanup_native_container("mycontainer", False)
+
+    sudo_cmds = [args for _, args in commands if args and args[0] == "sudo"]
+    assert ("sudo", "docker", "stop", "mycontainer") not in sudo_cmds
+    assert ("sudo", "docker", "rm", "--force", "mycontainer") not in sudo_cmds
+
+
+def test_cleanup_native_container_skipped_when_v1(fake_logger, docker_nsenter):
+    """When is_v1_enabled=True, native container cleanup is skipped entirely."""
+    commands, _ = docker_nsenter
+
+    sidecar_common.cleanup_native_container("mycontainer", True)
+
+    assert len(commands) == 0
+
+
+def test_cleanup_native_container_uses_container_name(fake_logger, docker_nsenter):
+    """Container name parameter is correctly passed to all docker commands."""
+    commands, inspect_result = docker_nsenter
+    inspect_result.update(rc=0, out="running\n", err="")
+
+    sidecar_common.cleanup_native_container("restapi", False)
+
+    sudo_cmds = [args for _, args in commands if args and args[0] == "sudo"]
+    assert ("sudo", "docker", "stop", "restapi") in sudo_cmds
+    assert ("sudo", "docker", "rm", "--force", "restapi") in sudo_cmds
+
+    commands.clear()
+    inspect_result.update(rc=0, out="running\n", err="")
+
+    sidecar_common.cleanup_native_container("acms", False)
+
+    sudo_cmds = [args for _, args in commands if args and args[0] == "sudo"]
+    assert ("sudo", "docker", "stop", "acms") in sudo_cmds
+    assert ("sudo", "docker", "rm", "--force", "acms") in sudo_cmds


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md
-->

#### Why I did it

Three issues in the restapi sidecar sync logic that surface during V1→V2 migration and at steady-state:

1. The native `restapi` container can persist after V2 takeover because `POST_COPY_ACTIONS` only fires when a synced file changes. On subsequent sidecar restarts (files already in sync) or after a race with the container framework, the leftover container is never cleaned up.
2. The first `systemctl restart restapi` after a fresh sync can fail with `No such file or directory` because the new `restapi.sh` is a thin wrapper that `exec`s `k8s_pod_control.sh`, but the sync ordering placed `k8s_pod_control.sh` last.
3. Many sidecars on the same fleet wake up and call into the host at the same instant, producing periodic load spikes.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Add `cleanup_native_container(name, is_v1_enabled)` helper in `sonic_py_common.sidecar_common`. In V2 mode it `docker inspect`s the named container and, if present, runs `docker stop` then `docker rm --force`. Called every sync cycle from `ensure_sync()` so a leftover container is eventually removed even when post-copy actions do not fire.
- Switch `POST_COPY_ACTIONS` for `/usr/bin/restapi.sh` from plain `docker rm` to `docker rm --force` so we never leave the container behind because it is still considered running.
- Reorder `SYNC_ITEMS` so `k8s_pod_control.sh` is synced before `restapi.sh`. This guarantees the wrapper target exists when the post-copy `systemctl restart restapi` runs.
- Add ±10% jitter to the sync loop sleep in `main()` to spread sidecar wake-ups across the fleet.

#### How to verify it

Unit tests added and run locally inside `sonic-slave-bookworm`:

- `src/sonic-py-common/tests/test_sidecar_common.py` — 11/11 pass (5 new tests for `cleanup_native_container` covering: running, exited, absent, V1 skip, container-name parameterization).
- `dockers/docker-restapi-sidecar/cli-plugin-tests/test_systemd_stub.py` — 74/74 pass (3 new tests covering `docker rm --force` in `POST_COPY_ACTIONS`, sync ordering of `k8s_pod_control.sh` before `restapi.sh`, and ±10% jitter on the loop interval).

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

Restapi sidecar: cleanup leftover native container, fix sync order, force-rm, and add jitter to the sync loop.

#### Link to config_db schema for YANG module changes

N/A (no YANG / config_db schema changes)

#### A picture of a cute animal (not mandatory but encouraged)