### PR TITLE
[build] Fix docker-syncd-mlnx build failure by removing obsolete pip upgrade step

### DIFF
--- a/platform/mellanox/docker-syncd-mlnx-rpc/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx-rpc/Dockerfile.j2
@@ -50,8 +50,6 @@ RUN apt-get update        \
     python3-thrift        \
     pciutils
 
-RUN pip3 install --upgrade pip
-
 {% if docker_syncd_mlnx_rpc_debs.strip() -%}
 # Copy locally-built Debian package dependencies
 {{ copy_files("debs/", docker_syncd_mlnx_rpc_debs.split(' '), "/debs/") }}

--- a/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
@@ -41,9 +41,6 @@ RUN apt-get update && \
         pciutils \
         linuxptp
 
-RUN pip3 install --upgrade pip
-RUN apt-get purge -y python-pip
-
 {% if docker_syncd_mlnx_debs.strip() -%}
 # Copy locally-built Debian package dependencies
 {{ copy_files("debs/", docker_syncd_mlnx_debs.split(' '), "/debs/") }}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The `docker-syncd-mlnx` (and `docker-syncd-mlnx-rpc`) image build fails on Trixie with:
 

```
#12 [base  8/30] RUN pip3 install --upgrade pip
#12 1.152 Requirement already satisfied: pip in /usr/lib/python3/dist-packages (25.1.1)
#12 1.270 Collecting pip
#12 1.317   Downloading pip-26.1.1-py3-none-any.whl.metadata (4.6 kB)
#12 1.342 Downloading pip-26.1.1-py3-none-any.whl (1.8 MB)
#12 1.438    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.8/1.8 MB 23.8 MB/s eta 0:00:00
#12 1.543 Installing collected packages: pip
#12 1.543   Attempting uninstall: pip
#12 1.554     Found existing installation: pip 25.1.1
#12 1.565 error: uninstall-no-record-file
#12 1.565 
#12 1.565 × Cannot uninstall pip 25.1.1
#12 1.565 ╰─> The package's contents are unknown: no RECORD file was found for pip.
#12 1.565 
#12 1.565 hint: The package was installed by debian. You should check if it can uninstall the package.
#12 ERROR: process "/bin/sh -c pip3 install --upgrade pip" did not complete successfully: exit code: 1
```
After the Mellanox syncd containers were migrated from Bookworm to Trixie, the Debian-packaged `python3-pip` is now version 25.1.1. Pip refuses to uninstall a distro-managed pip that lacks a `RECORD` file. The `RUN pip3 install --upgrade pip` line is therefore broken on Trixie. The follow-on `RUN apt-get purge -y python-pip` is also obsolete: `python-pip` is the Python 2 package and no longer exists on Trixie.
```
#13 [base  9/30] RUN apt-get purge -y python-pip
#13 0.236 Reading package lists...
#13 0.766 Building dependency tree...
#13 0.874 Reading state information...
#13 1.038 Package 'python-pip' is not installed, so not removed
#13 1.038 0 upgraded, 0 newly installed, 0 to remove and 4 not upgraded.
#13 DONE 1.1s
```
 Trixie's stock pip 25.1.1 is sufficient thus removing the pip upgrade step. (It has also been removed in `docker-base-trixie`)
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

