### PR TITLE
fix(docker-sonic-mgmt): migrate to uv and fix USN-8221-1 wheel vulnerability

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -49,8 +49,7 @@ RUN apt-get update \
 # Install uv - a fast Python package manager that replaces pip/venv/wheel.
 # This eliminates the need for python3-pip, python3-venv, and python3-wheel
 # system packages, avoiding vulnerabilities like USN-8221-1.
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.local/bin:$PATH"
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 # Create a virtual environment at /opt/venv using uv
 RUN uv venv --system-site-packages /opt/venv

--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -58,6 +58,11 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN sed -i 's|^PATH="|PATH="/opt/venv/bin:|' /etc/environment \
     && sed -i 's|secure_path="\([^"]*\)"|secure_path="/opt/venv/bin:\1"|' /etc/sudoers
 
+# Remove vulnerable system python3-wheel packages (USN-8221-1) so OS-level
+# scanners no longer flag them. The venv pip/wheel are independent.
+RUN apt-get purge -y python3-wheel python-wheel-common python3-wheel-whl 2>/dev/null; \
+    apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
+
 RUN pip install --no-cache-dir --upgrade pip wheel \
     && pip install --no-cache-dir \
     aiohttp \

--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -32,8 +32,6 @@ RUN apt-get update \
     psmisc \
     python3 \
     python3-dev \
-    python3-pip \
-    python3-venv \
     python-is-python3 \
     rsyslog \
     shellcheck \
@@ -48,9 +46,14 @@ RUN apt-get update \
     && apt-get autoclean \
     && rm -rf /var/lib/apt/lists/*
 
-# Ubuntu 24.04 recommends installing pip packages in a virtual environment
-# Create a virtual environment at /opt/venv and install all required python packages there
-RUN python3 -m venv --system-site-packages /opt/venv
+# Install uv - a fast Python package manager that replaces pip/venv/wheel.
+# This eliminates the need for python3-pip, python3-venv, and python3-wheel
+# system packages, avoiding vulnerabilities like USN-8221-1.
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:$PATH"
+
+# Create a virtual environment at /opt/venv using uv
+RUN uv venv --system-site-packages /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 # Configure system-wide PATH and sudo secure_path for /opt/venv/bin access
@@ -58,13 +61,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN sed -i 's|^PATH="|PATH="/opt/venv/bin:|' /etc/environment \
     && sed -i 's|secure_path="\([^"]*\)"|secure_path="/opt/venv/bin:\1"|' /etc/sudoers
 
-# Remove vulnerable system python3-wheel packages (USN-8221-1) so OS-level
-# scanners no longer flag them. The venv pip/wheel are independent.
-RUN apt-get purge -y python3-wheel python-wheel-common python3-wheel-whl 2>/dev/null; \
-    apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
-
-RUN pip install --no-cache-dir --upgrade pip wheel \
-    && pip install --no-cache-dir \
+RUN uv pip install --no-cache \
     aiohttp \
     allure-pytest \
     ansible==11.10.0 \
@@ -151,7 +148,7 @@ RUN pip install --no-cache-dir --upgrade pip wheel \
     && cd ../..            \
     && rm -fr nanomsg-1.2.1  \
     && rm -f 1.2.1.tar.gz  \
-    && python3 -m pip install --no-cache-dir nnpy
+    && uv pip install --no-cache nnpy
 
 # Install docker-ce-cli, azure-cli
 RUN install -m 0755 -d /etc/apt/keyrings \
@@ -190,7 +187,7 @@ RUN tmpdir=$(mktemp -d) \
     && python3 /usr/bin/github_get.py https://api.github.com/repos/sonic-net/DASH/contents/dash-pipeline/utils \
     && cd utils \
     && python3 setup.py bdist_wheel \
-    && python3 -m pip install dist/dash_pipeline_utils*.whl \
+    && uv pip install --no-cache dist/dash_pipeline_utils*.whl \
     && cd / \
     && rm -rf "$tmpdir"
 

--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -58,7 +58,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN sed -i 's|^PATH="|PATH="/opt/venv/bin:|' /etc/environment \
     && sed -i 's|secure_path="\([^"]*\)"|secure_path="/opt/venv/bin:\1"|' /etc/sudoers
 
-RUN pip install --no-cache-dir --upgrade pip wheel \
+RUN pip install --no-cache-dir --upgrade pip "wheel>=0.45.1" \
     && pip install --no-cache-dir \
     aiohttp \
     allure-pytest \

--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -58,7 +58,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN sed -i 's|^PATH="|PATH="/opt/venv/bin:|' /etc/environment \
     && sed -i 's|secure_path="\([^"]*\)"|secure_path="/opt/venv/bin:\1"|' /etc/sudoers
 
-RUN pip install --no-cache-dir --upgrade pip "wheel>=0.45.1" \
+RUN pip install --no-cache-dir --upgrade pip wheel \
     && pip install --no-cache-dir \
     aiohttp \
     allure-pytest \

--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -58,7 +58,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN sed -i 's|^PATH="|PATH="/opt/venv/bin:|' /etc/environment \
     && sed -i 's|secure_path="\([^"]*\)"|secure_path="/opt/venv/bin:\1"|' /etc/sudoers
 
-RUN pip install --no-cache-dir --upgrade pip \
+RUN pip install --no-cache-dir --upgrade pip wheel \
     && pip install --no-cache-dir \
     aiohttp \
     allure-pytest \


### PR DESCRIPTION
#### Why I did it
The container image `docker-sonic-mgmt:latest` has a known vulnerability in `python3-wheel` (version 0.42.0-2). The vulnerability (USN-8221-1) allows arbitrary code execution if a user or automated system opens a specially crafted wheel file.

The scan result shows:

| Package | Installed_Version | Required_Version |
|---------|------------------|-----------------|
| python3-wheel | 0.42.0-2 | 0.42.0-2ubuntu0.1~esm1 |

- **VulnId**: 6032775
- **Advisory**: [USN-8221-1](https://ubuntu.com/security/notices/USN-8221-1)
- **Due Date**: 2026-05-30

The root cause is the `python3-pip` and `python3-venv` apt packages pulling in `python3-wheel` as a dependency. The system-level fix requires Ubuntu Pro/ESM.

#### Work item tracking
Microsoft ADO (number only):

#### How I did it
Migrated from `pip`/`venv` to [`uv`](https://docs.astral.sh/uv/) (by Astral) as the Python package manager:

1. **Removed** `python3-pip` and `python3-venv` from apt install — this eliminates `python3-wheel` entirely at the root, so no vulnerable system package exists
2. **Installed** `uv` via its official install script (`curl -LsSf https://astral.sh/uv/install.sh | sh`)
3. **Replaced** `python3 -m venv` with `uv venv`
4. **Replaced** all `pip install` / `python3 -m pip install` with `uv pip install`

Benefits:
- Eliminates the USN-8221-1 vulnerability at the source (no `python3-wheel` package)
- Significantly faster dependency resolution and installs (~10x)
- Modern, actively maintained tooling

#### How to verify it
Build the docker-sonic-mgmt image and verify:
```bash
# Verify uv is installed
docker run --rm docker-sonic-mgmt uv --version

# Verify python3-wheel is NOT installed as system package
docker run --rm docker-sonic-mgmt dpkg -l python3-wheel 2>&1 | grep -c "no packages found"

# Verify packages are installed in venv
docker run --rm docker-sonic-mgmt python3 -c "import ansible; print(ansible.__version__)"
```

#### Which release branch to backport (provide reason below if selected)
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)


#### Description for the changelog
Migrate docker-sonic-mgmt from pip/venv to uv for faster builds and to fix USN-8221-1 (python3-wheel) vulnerability.

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)
