### PR TITLE
ASPEED BMC: Improve net-install payload transport and safe sparse eMMC writes

### DIFF
--- a/platform/aspeed/build-emmc-image-installer.sh
+++ b/platform/aspeed/build-emmc-image-installer.sh
@@ -165,7 +165,8 @@ PART_START_SECTOR=$(sgdisk -i 1 "$DISK_IMAGE" | sed -n 's/^First sector: *\([0-9
 log_info "Partition 1 starts at sector $PART_START_SECTOR"
 
 log_info "Copying SONiC installation to SONiC-OS partition..."
-dd if="$RAW_IMAGE" of="$DISK_IMAGE" bs=512 seek="$PART_START_SECTOR" conv=sparse status=progress
+# notrunc: without it dd ftruncates DISK_IMAGE to (seek + input_size) at EOF, dropping the partition tail.
+dd if="$RAW_IMAGE" of="$DISK_IMAGE" bs=512 seek="$PART_START_SECTOR" conv=notrunc,fsync status=progress
 
 rm -f "$RAW_IMAGE"
 RAW_IMAGE=""

--- a/platform/aspeed/installer/create_tftp_image.sh
+++ b/platform/aspeed/installer/create_tftp_image.sh
@@ -1,14 +1,20 @@
 #!/bin/bash
 #
-# Build the Aspeed U-Boot / TFTP install bundle (FIT + initramfs + optional raw eMMC image).
+# Build the Aspeed U-Boot net-install bundle (FIT + initramfs + optional raw eMMC image).
+#
+# Transport layout:
+#   - FIT: U-Boot loads via TFTP (`tftp $loadaddr sonic_tftp_install.fit`). Small, one-shot.
+#   - eMMC payload (*.img.gz): the initramfs picks transport by scheme of sonic_install.bmc_image=
+#       * http://... or https://...  -> curl
+#       * plain path / filename       -> TFTP, server from sonic_install.tftp_server=
 #
 # Platform-local installer orchestration under platform/<name>/installer/ (same structural role as
-# other platforms' installer scripts). Differences: output is a FIT for TFTP boot, and second-stage
+# other platforms' installer scripts). Difference: output is a FIT for TFTP boot, and second-stage
 # logic lives in ../tftp-installer-init/.
 #
 # This script is not wired as a second SONIC_INSTALLERS entry: that would create a second RFS
-# squashfs target (see slave.mk rfs_define_target). The TFTP bundle reuses the rootfs built for
-# sonic-aspeed-arm64.bin (see recipes/installer-tftp.mk).
+# squashfs target (see slave.mk rfs_define_target). The bundle reuses the rootfs built for
+# sonic-aspeed-arm64.bin (see recipes/installer-tftp.mk) and injects curl from it.
 #
 # Usage (from sonic-buildimage root):
 #   ./platform/aspeed/installer/create_tftp_image.sh [output_dir]
@@ -143,10 +149,31 @@ inject_fsroot_extras_into_initrd() {
         /usr/sbin/sfdisk /sbin/sfdisk \
         /usr/bin/fw_printenv /usr/sbin/fw_printenv \
         /usr/bin/fw_setenv /usr/sbin/fw_setenv \
-        /usr/bin/fw_getenv /usr/sbin/fw_getenv; do
+        /usr/bin/fw_getenv /usr/sbin/fw_getenv \
+        /usr/bin/curl /bin/curl \
+        /usr/bin/dd /bin/dd \
+        /usr/sbin/blkdiscard /sbin/blkdiscard; do
         [ -e "$FILESYSTEM_ROOT/$p" ] || continue
         copy_fsroot_binary_to_initrd "$FILESYSTEM_ROOT/$p" "$dir"
     done
+}
+
+# NSS modules are dlopen'd (not DT_NEEDED), so copy_fsroot_binary_to_initrd does not pull them in;
+# without them, getaddrinfo() cannot resolve hostnames for HTTP/HTTPS sonic_install.bmc_image=.
+inject_fsroot_nss_into_initrd() {
+    local dir="$1"
+    local d="/lib/aarch64-linux-gnu"
+    local lib src
+    for lib in libnss_dns.so.2 libnss_files.so.2 libresolv.so.2; do
+        src="$FILESYSTEM_ROOT$d/$lib"
+        [ -f "$src" ] || continue
+        mkdir -p "$dir$d"
+        cp -L "$src" "$dir$d/$lib"
+    done
+    if [ -f "$FILESYSTEM_ROOT/etc/nsswitch.conf" ]; then
+        mkdir -p "$dir/etc"
+        cp -L "$FILESYSTEM_ROOT/etc/nsswitch.conf" "$dir/etc/nsswitch.conf"
+    fi
 }
 
 repack_sonic_initrd_for_tftp_installer() {
@@ -178,6 +205,7 @@ repack_sonic_initrd_for_tftp_installer() {
     fi
     unset _aspeed_repo_root
     inject_fsroot_extras_into_initrd "$d"
+    inject_fsroot_nss_into_initrd "$d"
     if [ ! -f "$d/lib/modules/ftgmac100.ko" ] && [ -d "$d/lib/modules" ]; then
         ko=$(find "$d/lib/modules" -name ftgmac100.ko 2>/dev/null | head -1)
         if [ -n "$ko" ]; then
@@ -347,15 +375,24 @@ cp -v "$EMMC_RAW_IMAGE" "$OUTPUT_DIR/$TFTP_IMAGE_NAME"
 fit_addr=0x432000000
 
 cat > "$OUTPUT_DIR/uboot-tftp-commands.txt" << EOF
-# Aspeed TFTP initramfs: /init brings up network, can TFTP the eMMC image and run install-to-emmc.sh.
+# Aspeed net-install: /init brings up network, fetches the eMMC image, and runs
+# install-to-emmc.sh. U-Boot still fetches the FIT via TFTP (small, one-shot); the large eMMC
+# payload transport is selected from sonic_install.bmc_image= (HTTP/HTTPS or TFTP).
 #
-# 1. On TFTP server: sonic_tftp_install.fit and $TFTP_IMAGE_NAME (same directory as FIT is typical).
+# 1. Layout:
+#    - sonic_tftp_install.fit   -> on the TFTP server (U-Boot boots this).
+#    - $TFTP_IMAGE_NAME  -> served by an HTTP/HTTPS server, OR placed on the TFTP server.
 #
-# 2. In U-Boot — auto install to eMMC (DHCP + TFTP from serverip):
+# 2. In U-Boot — auto install to eMMC (DHCP + TFTP for FIT; payload by sonic_install.bmc_image=):
 dhcp
 setenv serverip <tftp-server-ip>
 setenv loadaddr $fit_addr
-setenv bootargs "console=ttyS12,115200n8 earlycon=uart8250,mmio32,0x14c33b00 root=/dev/ram0 rw sonic_install.tftp_server=\${serverip} sonic_install.tftp_image=$TFTP_IMAGE_NAME"
+# HTTP example (payload served over HTTP, e.g. on same host as TFTP, default port 80):
+setenv bootargs "console=ttyS12,115200n8 earlycon=uart8250,mmio32,0x14c33b00 root=/dev/ram0 rw sonic_install.bmc_image=http://\${serverip}/$TFTP_IMAGE_NAME"
+# HTTPS example:
+#   setenv bootargs "console=ttyS12,115200n8 ... root=/dev/ram0 rw sonic_install.bmc_image=https://images.example.com/sonic/$TFTP_IMAGE_NAME"
+# TFTP example (plain path/filename triggers TFTP; pair with sonic_install.tftp_server=):
+#   setenv bootargs "console=ttyS12,115200n8 ... root=/dev/ram0 rw sonic_install.bmc_image=$TFTP_IMAGE_NAME sonic_install.tftp_server=\${serverip}"
 tftp \$loadaddr sonic_tftp_install.fit
 # bootconf must match a "configurations" entry in platform/aspeed/sonic_fit.its (name without conf- prefix).
 setenv bootconf <fit-configuration>
@@ -363,9 +400,12 @@ bootm \$loadaddr#conf-\$bootconf
 #
 #    Optional bootargs: sonic_install.reboot=1  (reboot after flash; network is always eth0)
 #    Static IP instead of DHCP: add e.g. ip=192.168.1.50::192.168.1.1:255.255.255.0::eth0:off
+#    Static IP has no DHCP, so hostname URLs won't resolve — use an IP-literal URL.
 #
-# 3. Manual install (no sonic_install.tftp_server in bootargs): shell then
+# 3. Manual install (no sonic_install.bmc_image in bootargs): shell then
 #      /sbin/install-to-emmc.sh /tmp/$TFTP_IMAGE_NAME
+#    (after fetching the image yourself — curl http(s)://.../$TFTP_IMAGE_NAME -o /tmp/$TFTP_IMAGE_NAME
+#     or tftp -g -r $TFTP_IMAGE_NAME -l /tmp/$TFTP_IMAGE_NAME <tftp-server-ip>)
 #    If you use gunzip|dd manually, run sync (and blockdev --flushbufs /dev/mmcblk0) before reboot
 #    or the eMMC root fs may be corrupt (EXT4 journal / I/O errors on first boot).
 EOF
@@ -375,20 +415,23 @@ if [ -n "${OUTPUT_TFTP_INSTALL_TAR:-}" ]; then
     rm -f "$OUTPUT_TFTP_INSTALL_TAR"
     tar -chf "$OUTPUT_TFTP_INSTALL_TAR" -C "$OUTPUT_DIR" \
         "$FIT_NAME" uboot-tftp-commands.txt "$TFTP_IMAGE_NAME"
-    echo "TFTP install archive: $OUTPUT_TFTP_INSTALL_TAR"
+    echo "Net-install archive: $OUTPUT_TFTP_INSTALL_TAR"
 fi
 
 echo ""
-echo "TFTP initramfs image ready in: $OUTPUT_DIR"
-echo "  - $FIT_NAME (boot from TFTP → initramfs shell)"
-echo "  - $TFTP_IMAGE_NAME (optional on TFTP if you pull it manually from the shell)"
+echo "Net-install bundle ready in: $OUTPUT_DIR"
+echo "  - $FIT_NAME (U-Boot loads this via TFTP)"
+echo "  - $TFTP_IMAGE_NAME (serve via HTTP/HTTPS, or place on the TFTP server)"
 echo "  - uboot-tftp-commands.txt (U-Boot commands)"
 echo ""
-echo "Put $FIT_NAME and $TFTP_IMAGE_NAME on your TFTP server, then in U-Boot:"
+echo "Put $FIT_NAME on your TFTP server. Pick a transport for $TFTP_IMAGE_NAME, then in U-Boot:"
 echo "  setenv serverip <tftp-server-ip>"
-echo "  setenv bootargs \"console=... root=/dev/ram0 rw sonic_install.tftp_server=\${serverip} sonic_install.tftp_image=$TFTP_IMAGE_NAME\""
+echo "  # HTTP/HTTPS payload:"
+echo "  setenv bootargs \"console=... root=/dev/ram0 rw sonic_install.bmc_image=http(s)://<host>/<path>/$TFTP_IMAGE_NAME\""
+echo "  # OR TFTP payload (plain path/filename + tftp_server):"
+echo "  setenv bootargs \"console=... root=/dev/ram0 rw sonic_install.bmc_image=$TFTP_IMAGE_NAME sonic_install.tftp_server=\${serverip}\""
 echo "  tftp $fit_addr sonic_tftp_install.fit"
 echo "  setenv bootconf <fit-configuration>   # see configurations in platform/aspeed/sonic_fit.its (no conf- prefix)"
 echo "  bootm $fit_addr#conf-\$bootconf"
 echo ""
-echo "Without sonic_install.tftp_server=: shell, then /sbin/install-to-emmc.sh /tmp/$TFTP_IMAGE_NAME"
+echo "Without sonic_install.bmc_image=: shell, then /sbin/install-to-emmc.sh /tmp/$TFTP_IMAGE_NAME"

--- a/platform/aspeed/tftp-installer-init/init
+++ b/platform/aspeed/tftp-installer-init/init
@@ -1,8 +1,15 @@
 #!/bin/sh
-# TFTP installer initramfs: minimal bring-up, then same driver load path as stock SONiC initramfs
+# Net-install initramfs: minimal bring-up, then same driver load path as stock SONiC initramfs
 # (init-top + /conf/modules + init-premount/udev) so MDIO/I2C/GPIO/PHY deps match full initramfs.
-# If cmdline has sonic_install.tftp_server=, DHCP (or existing ip=) + TFTP + /sbin/install-to-emmc.sh;
-# else interactive shell. Optional: sonic_install.tftp_image= sonic_install.reboot=1 (network: always eth0)
+# If cmdline has sonic_install.bmc_image=, DHCP (or existing ip=) + fetch + /sbin/install-to-emmc.sh;
+# else interactive shell. Optional: sonic_install.reboot=1 (network: always eth0)
+#
+# Transport is selected from the bmc_image value:
+#   http://… or https://…  -> curl
+#   plain path / filename  -> TFTP, server from sonic_install.tftp_server=
+#
+# The FIT is still TFTP-loaded by U-Boot (U-Boot-side transport unchanged); only the large eMMC
+# payload fetch inside this initramfs picks per-scheme.
 
 export PATH=/sbin:/usr/sbin:/bin:/usr/bin
 
@@ -101,29 +108,25 @@ refresh_machine_conf_for_installer
 
 cd /tmp
 
-DEFAULT_TFTP_IMAGE=sonic-aspeed-arm64-emmc.img.gz
-TFTP_SERVER=
-TFTP_IMAGE="$DEFAULT_TFTP_IMAGE"
+INSTALL_BMC_IMAGE=
+INSTALL_TFTP_SERVER=
 INSTALL_REBOOT=
 for x in $(cat /proc/cmdline); do
     case $x in
-    sonic_install.tftp_server=*) TFTP_SERVER="${x#sonic_install.tftp_server=}" ;;
-    sonic_install.tftp_image=*) TFTP_IMAGE="${x#sonic_install.tftp_image=}" ;;
+    sonic_install.bmc_image=*) INSTALL_BMC_IMAGE="${x#sonic_install.bmc_image=}" ;;
+    sonic_install.tftp_server=*) INSTALL_TFTP_SERVER="${x#sonic_install.tftp_server=}" ;;
     sonic_install.reboot=1|sonic_install.reboot=yes|sonic_install.reboot=true)
         INSTALL_REBOOT=y ;;
     esac
 done
 
 drop_shell() {
-    echo "Aspeed TFTP installer: dropping to shell."
+    echo "Aspeed net-install: dropping to shell."
     echo "  Manual install: /sbin/install-to-emmc.sh /tmp/<image.img.gz>"
-    echo "  Auto install: add to bootargs, e.g. sonic_install.tftp_server=<tftp-ip> [sonic_install.tftp_image=$DEFAULT_TFTP_IMAGE]"
-    echo ""
+    echo "  Auto install (HTTP/HTTPS): sonic_install.bmc_image=http(s)://<host>/<path>/<image.img.gz>"
+    echo "  Auto install (TFTP):       sonic_install.bmc_image=<path-or-filename> sonic_install.tftp_server=<ip>"
     if [ -x /bin/bash ]; then
         exec /bin/bash
-    fi
-    if [ -x /usr/bin/bash ]; then
-        exec /usr/bin/bash
     fi
     exec /bin/sh
 }
@@ -164,7 +167,7 @@ bringup_network() {
         return 0
     fi
     if [ ! -x /sbin/udhcpc.script ]; then
-        echo "Error: /sbin/udhcpc.script missing (TFTP initrd must ship udhcpc.script next to install-to-emmc.sh)."
+        echo "Error: /sbin/udhcpc.script missing (net-install initrd must ship udhcpc.script next to install-to-emmc.sh)."
         return 1
     fi
     echo "Running DHCP on $IFACE..."
@@ -176,24 +179,63 @@ bringup_network() {
     return 1
 }
 
+http_fetch_image() {
+    url="$1"
+    name=${url%%\?*}; name=${name%%#*}; name=${name##*/}
+    [ -n "$name" ] || name=sonic-aspeed-arm64-emmc.img.gz
+    dest="/tmp/$name"
+    rm -f "$dest"
+    echo "HTTP/HTTPS: $url -> $dest"
+    if curl -fkL --retry 3 --connect-timeout 10 -o "$dest" "$url" && [ -s "$dest" ]; then
+        FETCHED_IMAGE="$dest"
+        return 0
+    fi
+    rm -f "$dest"
+    echo "Error: curl failed or empty file (check URL, server, DNS)."
+    return 1
+}
+
 tftp_fetch_image() {
     srv="$1"
     img="$2"
-    dest="/tmp/$(basename "$img")"
+    name=${img##*/}
+    [ -n "$name" ] || name=sonic-aspeed-arm64-emmc.img.gz
+    dest="/tmp/$name"
     rm -f "$dest"
-    echo "TFTP: $srv -> $dest ($img)"
+    echo "TFTP: $srv:$img -> $dest"
     if command -v tftp >/dev/null 2>&1 && tftp -g -r "$img" -l "$dest" "$srv" && [ -s "$dest" ]; then
+        FETCHED_IMAGE="$dest"
         return 0
     fi
     if command -v busybox >/dev/null 2>&1 && busybox tftp -g -r "$img" -l "$dest" "$srv" && [ -s "$dest" ]; then
+        FETCHED_IMAGE="$dest"
         return 0
     fi
+    rm -f "$dest"
     echo "Error: tftp failed or empty file (check server, filename, firewall)."
     return 1
 }
 
-if [ -z "$TFTP_SERVER" ]; then
-    echo "Aspeed TFTP installer: no sonic_install.tftp_server= in cmdline — interactive shell."
+fetch_image_by_scheme() {
+    case "$INSTALL_BMC_IMAGE" in
+    http://*|https://*)
+        http_fetch_image "$INSTALL_BMC_IMAGE"
+        return $?
+        ;;
+    *)
+        if [ -z "$INSTALL_TFTP_SERVER" ]; then
+            echo "Error: TFTP transport selected (sonic_install.bmc_image=$INSTALL_BMC_IMAGE has no http/https scheme),"
+            echo "       but sonic_install.tftp_server= is missing from bootargs."
+            return 1
+        fi
+        tftp_fetch_image "$INSTALL_TFTP_SERVER" "$INSTALL_BMC_IMAGE"
+        return $?
+        ;;
+    esac
+}
+
+if [ -z "$INSTALL_BMC_IMAGE" ]; then
+    echo "Aspeed net-install: no sonic_install.bmc_image= in cmdline — interactive shell."
     echo "  eMMC helper: /sbin/install-to-emmc.sh <path-to-raw-image>"
     echo ""
     drop_shell
@@ -203,7 +245,7 @@ if ! bringup_network; then
     drop_shell
 fi
 
-if ! tftp_fetch_image "$TFTP_SERVER" "$TFTP_IMAGE"; then
+if ! fetch_image_by_scheme; then
     drop_shell
 fi
 
@@ -212,7 +254,7 @@ if [ ! -x /sbin/install-to-emmc.sh ]; then
     drop_shell
 fi
 
-if ! /sbin/install-to-emmc.sh "/tmp/$(basename "$TFTP_IMAGE")"; then
+if ! /sbin/install-to-emmc.sh "$FETCHED_IMAGE"; then
     echo "Install script failed."
     drop_shell
 fi

--- a/platform/aspeed/tftp-installer-init/install-to-emmc.sh
+++ b/platform/aspeed/tftp-installer-init/install-to-emmc.sh
@@ -4,7 +4,8 @@
 # Default: /tmp/sonic-aspeed-arm64-emmc.img.gz
 # After running, reboot to boot from eMMC.
 # Initramfs must provide: sgdisk, wipefs, blockdev, partprobe, e2fsck,
-# gunzip, dd, blkid, mount. (TFTP installer ramfs has no swap and no eMMC mounts.)
+# gunzip, dd (with conv=sparse — coreutils, not BusyBox's), blkdiscard,
+# blkid, mount. (TFTP installer ramfs has no swap and no eMMC mounts.)
 
 IMG="${1:-/tmp/sonic-aspeed-arm64-emmc.img.gz}"
 EMMC="/dev/mmcblk0"
@@ -33,11 +34,18 @@ sync
 blockdev --rereadpt "$EMMC" 2>/dev/null || true
 partprobe "$EMMC" 2>/dev/null || true
 
+# -z (BLKZEROOUT): the sparse dd below assumes skipped regions read as zero;
+# plain discard does not guarantee that on this eMMC (discard_zeroes_data=0).
+echo "Zeroing all blocks on $EMMC..."
+blkdiscard -z "$EMMC"
+sync
+
 echo "Writing $IMG to $EMMC..."
-# Smaller bs + full pipe reads: fewer phys_seg per I/O on some MMC hosts than bs=1M; conv=fsync at end.
+# Smaller bs + full pipe reads: fewer phys_seg per I/O on some MMC hosts than bs=1M; conv=sparse,fsync at end.
+# sparse: lseek() over all-zero source blocks instead of writing them.
 # Pipeline exit status is only from dd; corrupt/truncated gzip can still yield dd exit 0, so require gunzip success.
 gz_ok=$(mktemp) || exit 1
-(gunzip -c "$IMG" && echo ok >"$gz_ok") | dd of="$EMMC" bs=128k iflag=fullblock conv=fsync
+(gunzip -c "$IMG" && echo ok >"$gz_ok") | dd of="$EMMC" bs=128k iflag=fullblock conv=sparse,fsync
 DD_RC=$?
 if [ "$DD_RC" -ne 0 ] || [ ! -s "$gz_ok" ]; then
     rm -f "$gz_ok"

--- a/platform/aspeed/tftp-installer-init/udhcpc.script
+++ b/platform/aspeed/tftp-installer-init/udhcpc.script
@@ -1,5 +1,5 @@
 #!/bin/sh
-# BusyBox udhcpc handler: apply lease (address + default route). Bundled as /sbin/udhcpc.script
+# BusyBox udhcpc handler: apply lease (address + default route + DNS). Bundled as /sbin/udhcpc.script
 # because minimal initramfs has no /usr/share/udhcpc/default.script.
 
 case "$1" in
@@ -29,6 +29,14 @@ renew|bound)
                 route add default gw "$gw" dev "$interface" 2>/dev/null && break
             fi
         done
+    fi
+    if [ -n "$dns" ] || [ -n "$domain" ]; then
+        {
+            [ -n "$domain" ] && echo "search $domain"
+            for ns in $dns; do
+                echo "nameserver $ns"
+            done
+        } > /etc/resolv.conf
     fi
     ;;
 esac


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Improve ASPEED BMC net-install reliability and speed.

The large eMMC payload can now be fetched over HTTP/HTTPS instead of only TFTP, while the FIT image is still loaded by U-Boot via TFTP. The eMMC flashing path also uses sparse writes to skip all-zero image regions, but first zero-fills the
target eMMC so skipped regions are safe.

Fix raw disk image generation where `dd` could truncate the preallocated disk image without `conv=notrunc`.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Added `sonic_install.bmc_image=` as the single payload selector:
  - `http://` or `https://` uses `curl`
  - plain path/filename uses TFTP with `sonic_install.tftp_server=`
- Injected `curl`, coreutils `dd`, `blkdiscard`, and required glibc NSS DNS files into the net-install initramfs.
- Updated DHCP handling to write DNS servers to `/etc/resolv.conf`.
- Changed eMMC flashing flow to:
  - zero-fill eMMC with `blkdiscard -z`
  - write the gzip payload using `dd conv=sparse,fsync`
  - keep gzip completion validation
- Fixed eMMC image build to use `dd conv=notrunc,fsync` when copying the raw SONiC partition into the preallocated disk image.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

- Build ASPEED BMC image and net-install bundle:
- Boot `sonic_tftp_install.fit` from U-Boot via TFTP.
- Verify HTTP/HTTPS payload install:
  - Set `sonic_install.bmc_image=http://<server>/sonic-aspeed-arm64-emmc.img.gz`
  - Confirm initramfs fetches the payload and flashes `/dev/mmcblk0`.
- Verify TFTP payload install:
  - Set `sonic_install.bmc_image=sonic-aspeed-arm64-emmc.img.gz sonic_install.tftp_server=<server-ip>`
- After reboot, verify:
  - SONiC boots from eMMC
  - `sgdisk -v /dev/mmcblk0` reports no GPT problems

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

