### PR TITLE
[docker-sonic-mgmt] unpin ansible version

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -62,7 +62,7 @@ RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir \
     aiohttp \
     allure-pytest \
-    ansible==11.10.0 \
+    ansible==12.2.0 \
     azure-storage-blob \
     azure-kusto-data \
     azure-kusto-ingest \

--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -62,7 +62,7 @@ RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir \
     aiohttp \
     allure-pytest \
-    ansible==12.2.0 \
+    ansible \
     azure-storage-blob \
     azure-kusto-data \
     azure-kusto-ingest \


### PR DESCRIPTION
#### Why I did it

Un-pin ansible version in docker-sonic-mgmt to enable using latest version

##### Work item tracking
- Microsoft ADO **(number only)**: 37905505

#### How I did it

Unpin version of ansible

#### How to verify it

Verified testing manually. Requires changes from https://github.com/sonic-net/sonic-mgmt/pull/24477 which is now merged.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

NA

#### Description for the changelog

[docker-sonic-mgmt] unpin ansible version
- Un-pin ansible version in docker-sonic-mgmt to enable using latest version

#### Link to config_db schema for YANG module changes

NA

#### A picture of a cute animal (not mandatory but encouraged)

NA