### PR TITLE
[BMC] Disable swss and syncd features on NetworkBmc devices

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -67,8 +67,8 @@
 {%- set features = [("bgp", "{% if not DEVICE_RUNTIME_METADATA['ETHERNET_PORTS_PRESENT'] or ('CHASSIS_METADATA' in DEVICE_RUNTIME_METADATA and DEVICE_RUNTIME_METADATA['CHASSIS_METADATA']['module_type'] in ['supervisor']) %}disabled{% else %}enabled{% endif %}", false, "enabled"),
                    ("database", "always_enabled", false, "always_enabled"),
                    ("pmon", "enabled", "{% if 'type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'SpineRouter' %}False{% else %}True{% endif %}", "enabled"),
-                   ("swss", "enabled", false, "enabled"),
-                   ("syncd", "enabled", false, "enabled")] %}
+                   ("swss", "{% if 'type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'NetworkBmc' %}disabled{% else %}enabled{% endif %}", false, "enabled"),
+                   ("syncd", "{% if 'type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'NetworkBmc' %}disabled{% else %}enabled{% endif %}", false, "enabled")] %}
 {%- if include_router_advertiser == "y" %}{% do features.append(("radv", "enabled", false, "enabled")) %}{% endif %}
 {%- if include_lldp == "y" %}{% do features.append(("lldp", "enabled", true, "enabled")) %}{% endif %}
 {%- if include_snmp == "y" %}{% do features.append(("snmp", "enabled", true, "enabled")) %}{% endif %}


### PR DESCRIPTION
#### Why I did it

A `NetworkBmc` device (e.g. an Aspeed BMC such as Komodo NH-B27) has no front-side ASIC. The ASIC sits on the separate front-side switch. The swss / syncd services therefore have nothing to manage and never start in practice — but the feature manifest was still declaring them as `enabled`.

This mismatch (feature `enabled` ↔ systemd unit `inactive`) breaks any test or tool that uses `feature_status` or `swss.service ActiveState` as a readiness gate. Concrete example: `config_system_checks_passed()` in `sonic-mgmt` (used by `platform_tests/test_reload_config.py`) waits up to 360 s for `swss.service` to become `active`; on a BMC it never does, and the test fails 100 % of the time on Komodo BMC.

##### Work item tracking
- Microsoft ADO **(number only)**: 37906237

#### How I did it

In `files/build_templates/init_cfg.json.j2`, gate the `swss` and `syncd` feature state on:
```jinja2
{% if 'type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'NetworkBmc' %}disabled{% else %}enabled{% endif %}
```
so that on `NetworkBmc` devices both features render as `disabled` in CONFIG_DB, and on every other device type they remain `enabled` (existing behavior). `hostcfgd` will then `systemctl disable` the units instead of leaving them enabled-but-inactive, and any test that already honors `feature_status` will skip cleanly on BMC.

The conditional pattern mirrors the existing one on the same line for `pmon` (which is gated on `DEVICE_METADATA['localhost']['type'] == 'SpineRouter'`), so no new mechanism is introduced.

Diff:
```diff
-                   ("swss", "enabled", false, "enabled"),
-                   ("syncd", "enabled", false, "enabled")] %}
+                   ("swss", "{% if 'type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'NetworkBmc' %}disabled{% else %}enabled{% endif %}", false, "enabled"),
+                   ("syncd", "{% if 'type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'NetworkBmc' %}disabled{% else %}enabled{% endif %}", false, "enabled")] %}
```

#### How to verify it

On a non-BMC device (`DEVICE_METADATA['localhost']['type'] != 'NetworkBmc'`):
- `show feature status` continues to list `swss` and `syncd` as `enabled` (no behavior change).

On a `NetworkBmc` device (e.g. Komodo NH-B27 BMC):
- `show feature status` now lists `swss` and `syncd` as `disabled`.
- `systemctl is-enabled swss.service` returns `disabled` (was `enabled` before).
- `platform_tests/test_reload_config.py::test_reload_configuration[host1-komodo-bmc]` and `test_reload_configuration_checks[host1-komodo-bmc]` will skip via the existing feature-disabled path instead of timing out at the swss readiness check (companion sonic-mgmt change to honor feature_status in `config_system_checks_passed()` may also be needed; tracked separately).

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] master (image build pending)

#### Description for the changelog

Disable `swss` and `syncd` feature state on `NetworkBmc` devices so feature manifest matches actual systemd state.

#### Link to config_db schema for YANG module changes

N/A — no schema change. Only modifies generated default values in `FEATURE` table for `NetworkBmc` devices.
