### PR TITLE
[BMC][aspeed] Disable eventd/snmp/radv/restapi FEATURE entries on Aspeed BMC

### DIFF
--- a/platform/aspeed/one-image.mk
+++ b/platform/aspeed/one-image.mk
@@ -16,6 +16,16 @@ DISABLED_PACKAGES_LOCAL = $(DOCKER_DHCP_RELAY) $(DOCKER_SFLOW) $(DOCKER_MGMT_FRA
 $(info [aspeed] Filtering out packages: $(DISABLED_PACKAGES_LOCAL))
 SONIC_PACKAGES_LOCAL := $(filter-out $(DISABLED_PACKAGES_LOCAL), $(SONIC_PACKAGES_LOCAL))
 
+# Aspeed BMC does not ship eventd / snmp / radv / restapi (their dockers are
+# already filtered out above). Override the include flags so the rendered
+# init_cfg.json FEATURE table does not advertise them as enabled, which would
+# otherwise cause "show feature status" and tests/tools that trust it to try
+# to operate on systemd units that do not exist.
+INCLUDE_SYSTEM_EVENTD = n
+INCLUDE_SNMP = n
+INCLUDE_ROUTER_ADVERTISER = n
+INCLUDE_RESTAPI = n
+
 $(SONIC_ONE_IMAGE)_INSTALLS += $(SYSTEMD_SONIC_GENERATOR)
 $(SONIC_ONE_IMAGE)_INSTALLS += $(ASPEED_PLATFORM_SERVICES)
 $(SONIC_ONE_IMAGE)_LAZY_INSTALLS += $(ASPEED_EVB_AST2700_PLATFORM_MODULE)

--- a/platform/aspeed/one-image.mk
+++ b/platform/aspeed/one-image.mk
@@ -13,18 +13,21 @@ DISABLED_PACKAGES_LOCAL = $(DOCKER_DHCP_RELAY) $(DOCKER_SFLOW) $(DOCKER_MGMT_FRA
                           $(DOCKER_EVENTD) $(DOCKER_DASH_HA) $(DOCKER_STP) \
                           $(DOCKER_RESTAPI)
 
-$(info [aspeed] Filtering out packages: $(DISABLED_PACKAGES_LOCAL))
-SONIC_PACKAGES_LOCAL := $(filter-out $(DISABLED_PACKAGES_LOCAL), $(SONIC_PACKAGES_LOCAL))
+# Aspeed BMC does not ship eventd / snmp / radv / restapi as features. Disable
+# their INCLUDE_* flags so the rendered init_cfg.json FEATURE table does not
+# advertise them as enabled, which would otherwise cause "show feature status"
+# and tools/tests that trust it to try to operate on systemd units that do not
+# exist on BMC.
+DISABLED_FEATURE_FLAGS = INCLUDE_SYSTEM_EVENTD \
+                         INCLUDE_SNMP \
+                         INCLUDE_ROUTER_ADVERTISER \
+                         INCLUDE_RESTAPI
 
-# Aspeed BMC does not ship eventd / snmp / radv / restapi (their dockers are
-# already filtered out above). Override the include flags so the rendered
-# init_cfg.json FEATURE table does not advertise them as enabled, which would
-# otherwise cause "show feature status" and tests/tools that trust it to try
-# to operate on systemd units that do not exist.
-INCLUDE_SYSTEM_EVENTD = n
-INCLUDE_SNMP = n
-INCLUDE_ROUTER_ADVERTISER = n
-INCLUDE_RESTAPI = n
+$(info [aspeed] Filtering out packages: $(DISABLED_PACKAGES_LOCAL))
+$(info [aspeed] Disabling feature flags: $(DISABLED_FEATURE_FLAGS))
+
+SONIC_PACKAGES_LOCAL := $(filter-out $(DISABLED_PACKAGES_LOCAL), $(SONIC_PACKAGES_LOCAL))
+$(foreach feature, $(DISABLED_FEATURE_FLAGS), $(eval override $(feature)=n))
 
 $(SONIC_ONE_IMAGE)_INSTALLS += $(SYSTEMD_SONIC_GENERATOR)
 $(SONIC_ONE_IMAGE)_INSTALLS += $(ASPEED_PLATFORM_SERVICES)


### PR DESCRIPTION
#### Why I did it

The Aspeed BMC one-image already filters out the dockers for `eventd`, `snmp`, `radv` (router-advertiser) and `restapi` via `DISABLED_PACKAGES_LOCAL` in `platform/aspeed/one-image.mk`, so the matching systemd units are not installed on the BMC image.

However, the rendered `init_cfg.json` FEATURE table still advertises these features as `enabled` because the `INCLUDE_*` build flags default to `y` in `rules/config`:

| Flag | Default in `rules/config` |
|---|---|
| `INCLUDE_SYSTEM_EVENTD` | `y` (line 166) |
| `INCLUDE_SNMP` | `?= y` (line 178) |
| `INCLUDE_ROUTER_ADVERTISER` | `?= y` (line 238) |
| `INCLUDE_RESTAPI` | `?= n` (line 194) — already n; pinned for consistency |

Result on Aspeed BMC today:
- `show feature status` reports `eventd`, `snmp`, `radv`, `restapi` as `enabled`.
- Any tool / test that consults `feature_status` before acting on the unit (e.g. `systemctl restart eventd`) hits `Failed to restart eventd.service: Unit eventd.service not found.`

Concrete failures observed on Komodo BMC second-round Sonic-Mgmt run (R1 == R2):
- `telemetry.test_events::test_events[host1-komodo-bmc-False]` — setup error: `systemctl restart eventd` → *Unit eventd.service not found.*
- `telemetry.test_events::test_events_cache_overflow[host1-komodo-bmc-False]` — failure: `systemctl reset-failed eventd` → *Unit eventd.service not loaded.*

Both call sites (`tests/telemetry/conftest.py:88-90` and `tests/telemetry/events/event_utils.py:85-87`) already short-circuit on `'eventd' not in features_dict or features_dict['eventd']=='disabled'` — the skip just never fires today because the FEATURE table lies.

##### Work item tracking
- Microsoft ADO **(number only)**: 37908132

#### How I did it

Override the four `INCLUDE_*` flags in `platform/aspeed/one-image.mk` (which `slave.mk` reads after `rules/config`, so plain `=` reassignments win):

```make
INCLUDE_SYSTEM_EVENTD = n
INCLUDE_SNMP = n
INCLUDE_ROUTER_ADVERTISER = n
INCLUDE_RESTAPI = n
```

This causes `files/build_templates/init_cfg.json.j2` to skip the `features.append(...)` lines for these four features (lines 72, 74, 84-87, 96-98), so they are absent from the FEATURE table on Aspeed BMC builds.

Companion of #27302, which addressed the same FEATURE-vs-systemd-mismatch class for `swss`/`syncd`. swss/syncd are kept in the FEATURE table (state=disabled via a `NetworkBmc` jinja gate) because their dockers are still shipped; eventd/radv/snmp/restapi are removed entirely from the FEATURE table because their dockers are not shipped.

#### How to verify it

After building an Aspeed BMC image (e.g. `arm64-nexthop_b27-r0`) with this change:

1. On the BMC DUT:
   ```bash
   show feature status | grep -E 'eventd|snmp|radv|restapi'
   ```
   → should produce no output (entries gone from FEATURE table).

2. `cat /etc/sonic/init_cfg.json | jq '.FEATURE | keys[]' | grep -E 'eventd|snmp|radv|restapi'` → no matches.

3. Re-run sonic-mgmt `telemetry/test_events.py` on a Komodo BMC testbed:
   - `test_events[host1-komodo-bmc-False]` → SKIPPED ("eventd is disabled on the system")
   - `test_events_cache_overflow[host1-komodo-bmc-False]` → SKIPPED (same reason)

4. Sanity: non-BMC platforms must not be affected. Quick check that the override is scoped to `platform/aspeed/one-image.mk` only — no change to `rules/config`. A standard switch image build (e.g. `vs`, `broadcom`) continues to render the FEATURE entries for these features.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

(No backport requested — Aspeed BMC support is master-only.)

#### Tested branch (Please provide the tested image version)

- [ ] master (image build pending — will update once verified on Komodo BMC testbed)

#### Description for the changelog

[BMC][aspeed] Drop eventd/snmp/radv/restapi from FEATURE table on Aspeed BMC images