### PR TITLE
Validate kubelet client cert before skipping join

### DIFF
--- a/src/sonic-ctrmgrd/ctrmgr/kube_commands.py
+++ b/src/sonic-ctrmgrd/ctrmgr/kube_commands.py
@@ -24,6 +24,7 @@ from swsscommon import swsscommon
 
 KUBE_ADMIN_CONF = "/etc/sonic/kube_admin.conf"
 KUBELET_YAML = "/var/lib/kubelet/config.yaml"
+KUBELET_CLIENT_CERT = "/var/lib/kubelet/pki/kubelet-client-current.pem"
 SERVER_ADMIN_URL = "https://{}/admin.conf"
 LOCK_FILE = "/var/lock/kube_join.lock"
 FLANNEL_CONF_FILE = "/usr/share/sonic/templates/kube_cni.10-flannel.conflist"
@@ -189,7 +190,9 @@ def func_get_labels(args):
 def is_connected(server=""):
     """ Check if we are currently connected """
 
-    if (os.path.exists(KUBELET_YAML) and os.path.exists(KUBE_ADMIN_CONF)):
+    if (os.path.exists(KUBELET_YAML) and
+            os.path.exists(KUBE_ADMIN_CONF) and
+            os.path.exists(KUBELET_CLIENT_CERT)):
         with open(KUBE_ADMIN_CONF, 'r') as s:
             d = yaml.load(s, yaml.SafeLoader)
             d = d['clusters'] if 'clusters' in d else []

--- a/src/sonic-ctrmgrd/tests/kube_commands_test.py
+++ b/src/sonic-ctrmgrd/tests/kube_commands_test.py
@@ -13,10 +13,12 @@ import kube_commands
 
 
 KUBE_ADMIN_CONF = "/tmp/kube_admin.conf"
+KUBELET_CLIENT_CERT = "/tmp/kubelet-client-current.pem"
 FLANNEL_CONF_FILE = "/tmp/flannel.conf"
 CNI_DIR = "/tmp/cni/net.d"
 AME_CRT = "/tmp/restapiserver.crt"
 AME_KEY = "/tmp/restapiserver.key"
+REMOVE_KUBELET_CLIENT_CERT = "remove_kubelet_client_cert"
 
 # kube_commands test cases
 # NOTE: Ensure state-db entry is complete in PRE as we need to
@@ -160,6 +162,32 @@ none".format(KUBE_ADMIN_CONF),
         ]
     },
     3: {
+        common_test.DESCR: "Regular join when stale config exists without kubelet client cert",
+        common_test.RETVAL: 0,
+        common_test.ARGS: ["10.3.157.24", 6443, True, False],
+        common_test.NO_INIT: True,
+        REMOVE_KUBELET_CLIENT_CERT: True,
+        common_test.PROC_CMD: [
+            "kubectl --kubeconfig {} --request-timeout 20s drain none \
+--ignore-daemonsets".format(KUBE_ADMIN_CONF),
+            "kubectl --kubeconfig {} --request-timeout 20s delete node \
+none".format(KUBE_ADMIN_CONF),
+            "kubeadm reset -f",
+            "rm -rf {}".format(CNI_DIR),
+            "systemctl stop kubelet",
+            "modprobe br_netfilter",
+            "mkdir -p {}".format(CNI_DIR),
+            "cp {} {}".format(FLANNEL_CONF_FILE, CNI_DIR),
+            "systemctl start kubelet",
+            "kubeadm join --discovery-file {} --node-name none".format(
+                KUBE_ADMIN_CONF)
+        ],
+        common_test.PROC_RUN: [True, True],
+        common_test.REQ: {
+            "data": {"ca.crt": "test"}
+        }
+    },
+    4: {
         common_test.DESCR: "Regular join: fail due to unable to lock",
         common_test.RETVAL: -1,
         common_test.ARGS: ["10.3.157.24", 6443, False, False],
@@ -439,7 +467,10 @@ clusters:\n\
             s.close()
         with open(AME_KEY, "w") as s:
             s.close()
+        with open(KUBELET_CLIENT_CERT, "w") as s:
+            s.close()
         kube_commands.KUBELET_YAML = kubelet_yaml
+        kube_commands.KUBELET_CLIENT_CERT = KUBELET_CLIENT_CERT
         kube_commands.CNI_DIR = CNI_DIR
         kube_commands.FLANNEL_CONF_FILE = FLANNEL_CONF_FILE
         kube_commands.SERVER_ADMIN_URL = "file://{}".format(self.admin_conf_file)
@@ -527,6 +558,9 @@ clusters:\n\
             if ct_data.get(common_test.FAIL_LOCK, False):
                 lock_file = kube_commands.LOCK_FILE
                 kube_commands.LOCK_FILE = "/xxx/yyy/zzz"
+
+            if ct_data.get(REMOVE_KUBELET_CLIENT_CERT, False):
+                os.system("rm -f {}".format(KUBELET_CLIENT_CERT))
 
             args = ct_data[common_test.ARGS]
             (ret, _, _) = kube_commands.kube_join_master(


### PR DESCRIPTION
Require kubelet-client-current.pem to exist before ctrmgrd treats a node as already connected to the Kubernetes master. This prevents stale kubelet/admin config from bypassing rejoin when kubelet client auth material is missing.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

