### PR TITLE
update host_write_atomic to use mktemp in dest dir

### DIFF
--- a/dockers/docker-gnmi-sidecar/cli-plugin-tests/test_systemd_stub.py
+++ b/dockers/docker-gnmi-sidecar/cli-plugin-tests/test_systemd_stub.py
@@ -92,6 +92,8 @@ def ss(tmp_path, monkeypatch):
     commands = []
 
     # ----- Fake run_nsenter for host operations (patch on sidecar_common) -----
+    mktemp_counter = {"n": 0}
+
     def fake_run_nsenter(args, *, text=True, input_bytes=None):
         commands.append(("nsenter", tuple(args)))
 
@@ -104,6 +106,17 @@ def ss(tmp_path, monkeypatch):
                     return 0, out.decode("utf-8", "ignore"), ""
                 return 0, out, b""
             return 1, "" if text else b"", "No such file" if text else b"No such file"
+
+        # /bin/mktemp <template-with-XXXXXX>
+        if args[:1] == ["/bin/mktemp"] and len(args) == 2:
+            template = args[1]
+            mktemp_counter["n"] += 1
+            unique = template.replace("XXXXXX", f"{mktemp_counter['n']:06d}")
+            host_fs[unique] = b""
+            out = unique + "\n"
+            if text:
+                return 0, out, ""
+            return 0, out.encode(), b""
 
         # /bin/sh -c "cat > /tmp/xxx"
         if (

--- a/dockers/docker-restapi-sidecar/cli-plugin-tests/test_systemd_stub.py
+++ b/dockers/docker-restapi-sidecar/cli-plugin-tests/test_systemd_stub.py
@@ -132,6 +132,8 @@ def ss(tmp_path, monkeypatch):
     monkeypatch.setattr(real_sidecar_common, "db_hset", fake_db_hset)
 
     # ----- Patch run_nsenter for host operations -----
+    mktemp_counter = {"n": 0}
+
     def fake_run_nsenter(args, *, text=True, input_bytes=None):
         commands.append(("nsenter", tuple(args)))
 
@@ -144,6 +146,17 @@ def ss(tmp_path, monkeypatch):
                     return 0, out.decode("utf-8", "ignore"), ""
                 return 0, out, b""
             return 1, "" if text else b"", "No such file" if text else b"No such file"
+
+        # /bin/mktemp <template-with-XXXXXX>
+        if args[:1] == ["/bin/mktemp"] and len(args) == 2:
+            template = args[1]
+            mktemp_counter["n"] += 1
+            unique = template.replace("XXXXXX", f"{mktemp_counter['n']:06d}")
+            host_fs[unique] = b""
+            out = unique + "\n"
+            if text:
+                return 0, out, ""
+            return 0, out.encode(), b""
 
         # /bin/sh -c "cat > /tmp/xxx"
         if (

--- a/dockers/docker-telemetry-sidecar/cli-plugin-tests/test_systemd_stub.py
+++ b/dockers/docker-telemetry-sidecar/cli-plugin-tests/test_systemd_stub.py
@@ -125,6 +125,8 @@ def ss(tmp_path, monkeypatch):
     monkeypatch.setattr(real_sidecar_common, "db_del", fake_db_del)
 
     # ----- Fake run_nsenter for host operations (patch on sidecar_common) -----
+    mktemp_counter = {"n": 0}
+
     def fake_run_nsenter(args, *, text=True, input_bytes=None):
         commands.append(("nsenter", tuple(args)))
 
@@ -137,6 +139,17 @@ def ss(tmp_path, monkeypatch):
                     return 0, out.decode("utf-8", "ignore"), ""
                 return 0, out, b""
             return 1, "" if text else b"", "No such file" if text else b"No such file"
+
+        # /bin/mktemp <template-with-XXXXXX>
+        if args[:1] == ["/bin/mktemp"] and len(args) == 2:
+            template = args[1]
+            mktemp_counter["n"] += 1
+            unique = template.replace("XXXXXX", f"{mktemp_counter['n']:06d}")
+            host_fs[unique] = b""
+            out = unique + "\n"
+            if text:
+                return 0, out, ""
+            return 0, out.encode(), b""
 
         # /bin/sh -c "cat > /tmp/xxx"
         if (

--- a/src/sonic-py-common/sonic_py_common/sidecar_common.py
+++ b/src/sonic-py-common/sonic_py_common/sidecar_common.py
@@ -173,33 +173,59 @@ def host_read_bytes(path_on_host: str) -> Optional[bytes]:
 
 
 def host_write_atomic(dst_on_host: str, data: bytes, mode: int) -> bool:
-    """Atomically write file to host filesystem via nsenter."""
-    tmp_path = f"/tmp/{os.path.basename(dst_on_host)}.tmp"
-    rc, _, err = run_nsenter(["/bin/sh", "-c", f"cat > {shlex.quote(tmp_path)}"], text=False, input_bytes=data)
-    if rc != 0:
-        emsg = err.decode(errors="ignore") if isinstance(err, (bytes, bytearray)) else str(err)
-        logger.log_error(f"host write tmp failed: {emsg.strip()}")
-        return False
+    """Atomically write file to host filesystem via nsenter.
 
-    rc, _, err = run_nsenter(["/bin/chmod", f"{mode:o}", tmp_path], text=True)
-    if rc != 0:
-        logger.log_error(f"host chmod failed: {str(err).strip()}")
-        run_nsenter(["/bin/rm", "-f", tmp_path], text=True)
-        return False
-
+    Uses host-side mktemp(1) in the destination directory so that:
+      * concurrent sidecars writing the same dst do not race on a shared
+        /tmp/<basename>.tmp path, and
+      * the final mv is a same-filesystem rename(2) (truly atomic), instead
+        of a cross-filesystem copy when /tmp is on tmpfs.
+    """
     parent = os.path.dirname(dst_on_host) or "/"
+
+    # Ensure destination directory exists before mktemp targets it.
     rc, _, err = run_nsenter(["/bin/mkdir", "-p", parent], text=True)
     if rc != 0:
         logger.log_error(f"host mkdir failed for {parent}: {str(err).strip()}")
-        run_nsenter(["/bin/rm", "-f", tmp_path], text=True)
         return False
 
-    rc, _, err = run_nsenter(["/bin/mv", "-f", tmp_path, dst_on_host], text=True)
+    base = os.path.basename(dst_on_host)
+    tmpl = os.path.join(parent, f".{base}.XXXXXX")
+    rc, out, err = run_nsenter(["/bin/mktemp", tmpl], text=True)
     if rc != 0:
-        logger.log_error(f"host mv failed to {dst_on_host}: {str(err).strip()}")
-        run_nsenter(["/bin/rm", "-f", tmp_path], text=True)
+        logger.log_error(f"host mktemp failed for {tmpl}: {str(err).strip()}")
         return False
-    return True
+    tmp_path = out.strip() if isinstance(out, str) else out.decode(errors="ignore").strip()
+    if not tmp_path:
+        logger.log_error(f"host mktemp returned empty path for {tmpl}")
+        return False
+
+    try:
+        rc, _, err = run_nsenter(
+            ["/bin/sh", "-c", f"cat > {shlex.quote(tmp_path)}"],
+            text=False,
+            input_bytes=data,
+        )
+        if rc != 0:
+            emsg = err.decode(errors="ignore") if isinstance(err, (bytes, bytearray)) else str(err)
+            logger.log_error(f"host write tmp failed: {emsg.strip()}")
+            return False
+
+        rc, _, err = run_nsenter(["/bin/chmod", f"{mode:o}", tmp_path], text=True)
+        if rc != 0:
+            logger.log_error(f"host chmod failed: {str(err).strip()}")
+            return False
+
+        rc, _, err = run_nsenter(["/bin/mv", "-f", tmp_path, dst_on_host], text=True)
+        if rc != 0:
+            logger.log_error(f"host mv failed to {dst_on_host}: {str(err).strip()}")
+            return False
+        # mv succeeded; tmp_path no longer exists, skip cleanup.
+        tmp_path = ""
+        return True
+    finally:
+        if tmp_path:
+            run_nsenter(["/bin/rm", "-f", tmp_path], text=True)
 
 
 # ───────────── SHA256 utilities ─────────────

--- a/src/sonic-py-common/tests/test_sidecar_common.py
+++ b/src/sonic-py-common/tests/test_sidecar_common.py
@@ -44,6 +44,7 @@ def mock_nsenter(monkeypatch):
     """Mock run_nsenter for file operations testing."""
     host_fs = {}
     commands = []
+    mktemp_counter = {"n": 0}
 
     def fake_run_nsenter(args, *, text=True, input_bytes=None):
         commands.append(("nsenter", tuple(args)))
@@ -57,6 +58,18 @@ def mock_nsenter(monkeypatch):
                     return 0, out.decode("utf-8", "ignore"), ""
                 return 0, out, b""
             return 1, "" if text else b"", "No such file" if text else b"No such file"
+
+        # /bin/mktemp <template-with-XXXXXX>
+        if args[:1] == ["/bin/mktemp"] and len(args) == 2:
+            template = args[1]
+            mktemp_counter["n"] += 1
+            # Replace XXXXXX with a deterministic unique suffix.
+            unique = template.replace("XXXXXX", f"{mktemp_counter['n']:06d}")
+            host_fs[unique] = b""
+            out = unique + "\n"
+            if text:
+                return 0, out, ""
+            return 0, out.encode(), b""
 
         # /bin/sh -c "cat > /tmp/xxx"
         if (
@@ -131,6 +144,51 @@ def test_host_write_atomic_and_read(fake_logger, mock_nsenter):
     assert "/bin/chmod" in cmd_names
     assert "/bin/mkdir" in cmd_names
     assert "/bin/mv" in cmd_names
+    # mktemp must be invoked so concurrent writers do not collide.
+    assert "/bin/mktemp" in cmd_names
+
+
+def test_host_write_atomic_uses_unique_tmp_in_dest_dir(fake_logger, mock_nsenter):
+    """Two writes to the same destination must use distinct tmp paths in
+    the destination directory (no shared /tmp/<basename>.tmp)."""
+    host_fs, commands = mock_nsenter
+
+    assert sidecar_common.host_write_atomic("/etc/testfile", b"first", 0o644)
+    assert sidecar_common.host_write_atomic("/etc/testfile", b"second", 0o644)
+
+    # Pull out the mktemp template arguments and verify they target /etc, not /tmp.
+    mktemp_calls = [args for _, args in commands if args and args[0] == "/bin/mktemp"]
+    assert len(mktemp_calls) == 2
+    for args in mktemp_calls:
+        template = args[1]
+        assert template.startswith("/etc/.testfile.")
+        assert template.endswith("XXXXXX")
+
+    # And the resulting mv sources must differ between the two writes.
+    mv_srcs = [args[2] for _, args in commands if args and args[0] == "/bin/mv"]
+    assert len(mv_srcs) == 2
+    assert mv_srcs[0] != mv_srcs[1]
+
+
+def test_host_write_atomic_returns_false_on_mktemp_failure(fake_logger, monkeypatch):
+    """If host mktemp fails, host_write_atomic returns False without writing."""
+    commands = []
+
+    def fake_run_nsenter(args, *, text=True, input_bytes=None):
+        commands.append(tuple(args))
+        if args[:1] == ["/bin/mkdir"]:
+            return 0, "" if text else b"", "" if text else b""
+        if args[:1] == ["/bin/mktemp"]:
+            return 1, "" if text else b"", "mktemp: failed"
+        return 0, "" if text else b"", "" if text else b""
+
+    monkeypatch.setattr(sidecar_common, "run_nsenter", fake_run_nsenter)
+
+    ok = sidecar_common.host_write_atomic("/etc/testfile", b"hello", 0o644)
+    assert ok is False
+    # Must not have attempted to write or move anything.
+    assert not any(c[0] == "/bin/sh" for c in commands)
+    assert not any(c[0] == "/bin/mv" for c in commands)
 
 
 def test_sync_items_success(fake_logger, mock_nsenter, monkeypatch):


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
1. Previous code used a fixed /tmp/<basename>.tmp path. Two sidecar containers writing the same destination concurrently would collide on the same tmp file, producing torn or wrong content.
2. Non-atomic mv: /tmp is typically tmpfs while destinations like /usr/bin or /host/reboot-cause are not, so the final mv was a cross-filesystem copy-then-unlink, not an atomic rename.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Use host-side mktemp with a unique template inside the destination directory itself, so the final mv is a same-filesystem rename and concurrent writers cannot collide. Cleanup of the tmp file on any failure is moved into a finally block.


#### How to verify it
Checked mktemp exist on device and verified on testbed.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

