### PR TITLE
ci: add Trivy vulnerability scan for broadcom and mellanox platform containers and host rootfs

### DIFF
--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -129,7 +129,7 @@ stages:
         exit $TRIVY_EXIT
       displayName: "Trivy scan docker-sonic-mgmt"
     - publish: $(Build.ArtifactStagingDirectory)/trivy-sonic-mgmt.txt
-      artifact: trivy-scan-results
+      artifact: trivy-scan-sonic-mgmt
       displayName: "Publish Trivy scan results"
       condition: always()
       continueOnError: true

--- a/.azure-pipelines/scripts/trivy-scan-bin.py
+++ b/.azure-pipelines/scripts/trivy-scan-bin.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+Reconstruct docker-save format tarballs from a SONiC .bin installer and
+scan each container image with trivy.
+
+Usage:
+    python3 scan.py <path-to-sonic-PLATFORM.bin> [results-dir]
+
+Example:
+    python3 scan.py ~/sonic-buildimage/target/sonic-broadcom.bin /tmp/broadcom-scan/results
+    python3 scan.py ~/sonic-buildimage/target/sonic-mellanox.bin /tmp/mellanox-scan/results
+"""
+import json, os, tarfile, io, subprocess, sys, shutil, re, zipfile, tempfile
+
+def detect_payload_size(bin_path):
+    """Read payload_image_size from the shell script header."""
+    with open(bin_path, 'rb') as f:
+        header = f.read(4096)
+    m = re.search(rb'payload_image_size=(\d+)', header)
+    if not m:
+        raise RuntimeError("Could not find payload_image_size in .bin header")
+    return int(m.group(1))
+
+def find_exit_marker(bin_path):
+    """Find byte offset just after the exit_marker line."""
+    with open(bin_path, 'rb') as f:
+        header = f.read(8192)
+    marker = b'\nexit_marker\n'
+    pos = header.find(marker)
+    if pos < 0:
+        raise RuntimeError("Could not find exit_marker in .bin header")
+    return pos + len(marker)
+
+def extract_dockerfs(bin_path, workdir):
+    """Extract dockerfs.tar.gz from inside the .bin installer."""
+    payload_size = detect_payload_size(bin_path)
+    payload_start = find_exit_marker(bin_path)
+    print(f"  payload_start={payload_start}, payload_size={payload_size}", flush=True)
+
+    print("  Extracting installer/fs.zip from tar payload...", flush=True)
+    with open(bin_path, 'rb') as f:
+        f.seek(payload_start)
+        payload_data = f.read(payload_size)
+
+    tf = tarfile.open(fileobj=io.BytesIO(payload_data))
+    fs_zip_member = next(m for m in tf.getnames() if m.endswith('fs.zip'))
+    fs_zip_data = tf.extractfile(fs_zip_member).read()
+
+    print("  Extracting dockerfs.tar.gz from fs.zip...", flush=True)
+    zf = zipfile.ZipFile(io.BytesIO(fs_zip_data))
+    dockerfs_data = zf.read('dockerfs.tar.gz')
+    print(f"  dockerfs.tar.gz: {len(dockerfs_data)/1024/1024:.1f} MB", flush=True)
+
+    dockerdata = os.path.join(workdir, 'dockerdata')
+    os.makedirs(dockerdata, exist_ok=True)
+    print("  Extracting overlay2 data...", flush=True)
+    dtf = tarfile.open(fileobj=io.BytesIO(dockerfs_data))
+    # ignore device node errors (volumes/backingFsBlockDev etc)
+    for member in dtf.getmembers():
+        try:
+            dtf.extract(member, path=dockerdata)
+        except Exception:
+            pass
+
+    return dockerdata
+
+def build_diff_to_cache_map(dockerdata):
+    layerdb = os.path.join(dockerdata, 'image/overlay2/layerdb/sha256')
+    diff_to_cache = {}
+    for entry in os.listdir(layerdb):
+        cid_file = os.path.join(layerdb, entry, 'cache-id')
+        diff_file = os.path.join(layerdb, entry, 'diff')
+        if os.path.exists(cid_file) and os.path.exists(diff_file):
+            with open(cid_file) as f: cid = f.read().strip()
+            with open(diff_file) as f: diff = f.read().strip()
+            diff_to_cache[diff] = cid
+    return diff_to_cache
+
+def build_docker_save(image_name, image_sha, dockerdata, diff_to_cache, out_path):
+    img_id = image_sha.replace('sha256:', '')
+    config_path = os.path.join(dockerdata, 'image/overlay2/imagedb/content/sha256', img_id)
+    with open(config_path, 'rb') as f:
+        config_data = f.read()
+    config_obj = json.loads(config_data)
+    diff_ids = config_obj['rootfs']['diff_ids']
+
+    layer_entries = []
+    for i, diff_id in enumerate(diff_ids):
+        cache_id = diff_to_cache.get(diff_id)
+        if not cache_id:
+            print(f"  WARNING: no cache-id for diff {diff_id[:16]} in {image_name}", file=sys.stderr)
+            continue
+        diff_dir = os.path.join(dockerdata, 'overlay2', cache_id, 'diff')
+        layer_entries.append((f'layer_{i:03d}', diff_dir))
+
+    with tarfile.open(out_path, 'w') as out:
+        config_filename = f'{img_id}.json'
+        info = tarfile.TarInfo(name=config_filename)
+        info.size = len(config_data)
+        out.addfile(info, io.BytesIO(config_data))
+
+        layer_paths = []
+        for layer_name, diff_dir in layer_entries:
+            layer_tar_name = f'{layer_name}/layer.tar'
+            layer_paths.append(layer_tar_name)
+
+            layer_buf = io.BytesIO()
+            with tarfile.open(fileobj=layer_buf, mode='w') as lt:
+                if os.path.isdir(diff_dir):
+                    lt.add(diff_dir, arcname='.', recursive=True)
+            layer_data = layer_buf.getvalue()
+
+            dir_info = tarfile.TarInfo(name=layer_name)
+            dir_info.type = tarfile.DIRTYPE
+            dir_info.mode = 0o755
+            out.addfile(dir_info)
+
+            lt_info = tarfile.TarInfo(name=layer_tar_name)
+            lt_info.size = len(layer_data)
+            out.addfile(lt_info, io.BytesIO(layer_data))
+
+        manifest = [{"Config": config_filename,
+                     "RepoTags": [f"{image_name}:latest"],
+                     "Layers": layer_paths}]
+        manifest_data = json.dumps(manifest).encode()
+        minfo = tarfile.TarInfo(name='manifest.json')
+        minfo.size = len(manifest_data)
+        out.addfile(minfo, io.BytesIO(manifest_data))
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    bin_path = sys.argv[1]
+    platform = os.path.basename(bin_path).replace('sonic-', '').replace('.bin', '')
+    workdir = sys.argv[2] if len(sys.argv) > 2 else f'/tmp/{platform}-scan'
+    results_dir = os.path.join(workdir, 'results')
+    archives_dir = os.path.join(workdir, 'archives')
+    os.makedirs(results_dir, exist_ok=True)
+    os.makedirs(archives_dir, exist_ok=True)
+
+    print(f"Platform: {platform}")
+    print(f"BIN:      {bin_path}")
+    print(f"Results:  {results_dir}\n")
+
+    # Check if dockerdata already extracted (allow re-run without re-extraction)
+    dockerdata = os.path.join(workdir, 'dockerdata')
+    repos_path = os.path.join(dockerdata, 'image/overlay2/repositories.json')
+    if os.path.exists(repos_path):
+        print("==> dockerdata already extracted, skipping extraction.", flush=True)
+    else:
+        print("==> Extracting .bin...", flush=True)
+        dockerdata = extract_dockerfs(bin_path, workdir)
+
+    with open(repos_path) as f:
+        repos = json.load(f)['Repositories']
+
+    diff_to_cache = build_diff_to_cache_map(dockerdata)
+
+    overall_exit = 0
+    images = sorted(repos.keys())
+    print(f"==> Scanning {len(images)} images\n")
+
+    for image_name in images:
+        sha = list(repos[image_name].values())[0]
+        archive_path = os.path.join(archives_dir, f'{image_name}.tar')
+        result_path = os.path.join(results_dir, f'{image_name}.txt')
+
+        print(f"[BUILD] {image_name}...", flush=True)
+        try:
+            build_docker_save(image_name, sha, dockerdata, diff_to_cache, archive_path)
+        except Exception as e:
+            print(f"  ERROR: {e}", file=sys.stderr)
+            overall_exit = 1
+            continue
+
+        print(f"[SCAN ] {image_name}...", flush=True)
+        result = subprocess.run([
+            'trivy', 'image',
+            '--input', archive_path,
+            '--skip-db-update',
+            '--severity', 'MEDIUM,HIGH,CRITICAL',
+            '--ignore-unfixed',
+            '--exit-code', '1',
+            '--format', 'table',
+            '--no-progress',
+            '--timeout', '10m',
+            '--output', result_path,
+        ], capture_output=True, text=True)
+
+        status = "CLEAN" if result.returncode == 0 else "FINDINGS"
+        try:
+            with open(result_path) as f:
+                content = f.read()
+            total_lines = [l for l in content.splitlines() if l.startswith('Total:')]
+            summary = total_lines[0] if total_lines else "(no Total line)"
+        except:
+            summary = "(unreadable)"
+
+        print(f"  -> {status}: {summary}", flush=True)
+        if result.returncode not in (0, 1):
+            print(f"  trivy stderr: {result.stderr[:300]}", file=sys.stderr)
+            overall_exit = 1
+
+        os.unlink(archive_path)
+
+    print(f"\n=== DONE. Results in {results_dir} ===")
+    sys.exit(overall_exit)
+
+if __name__ == '__main__':
+    main()

--- a/.azure-pipelines/scripts/trivy-scan-bin.py
+++ b/.azure-pipelines/scripts/trivy-scan-bin.py
@@ -197,9 +197,12 @@ def main():
             total_lines = [l for l in content.splitlines() if l.startswith('Total:')]
             summary = total_lines[0] if total_lines else "(no Total line)"
         except:
+            content = ""
             summary = "(unreadable)"
 
         print(f"  -> {status}: {summary}", flush=True)
+        print(f"\n=== {image_name} ===", flush=True)
+        print(content, flush=True)
         if result.returncode not in (0, 1):
             print(f"  trivy stderr: {result.stderr[:300]}", file=sys.stderr)
             overall_exit = 1

--- a/.azure-pipelines/scripts/trivy-scan-bin.py
+++ b/.azure-pipelines/scripts/trivy-scan-bin.py
@@ -205,7 +205,7 @@ def main():
         print(content, flush=True)
         if result.returncode not in (0, 1):
             print(f"  trivy stderr: {result.stderr[:300]}", file=sys.stderr)
-            overall_exit = 1
+        overall_exit = max(overall_exit, result.returncode)
 
         os.unlink(archive_path)
 

--- a/.azure-pipelines/trivy-scan-platform.yml
+++ b/.azure-pipelines/trivy-scan-platform.yml
@@ -1,29 +1,25 @@
 # .azure-pipelines/trivy-scan-platform.yml
 #
-# Trivy vulnerability scan for a SONiC platform — covers both:
-# 1. All docker-*.gz container images in the platform artifact
-# 2. Host rootfs extracted from the platform .bin installer
+# Trivy vulnerability scan for a SONiC platform.
+# Scans all Docker images extracted from the platform .bin installer (ground truth),
+# plus the host rootfs from the same .bin.
 #
-# Parameterized by platform (e.g. broadcom, mellanox).
-# Runs in a stage that depends on the Build stage.
+# Uses .azure-pipelines/scripts/trivy-scan-bin.py to extract dockerfs.tar.gz
+# from the .bin and scan each container image.
 #
-# Phase 1: exit-code 1, continueOnError: true (does not block merge)
+# continueOnError: true (does not block merge)
 
 parameters:
 - name: platform
   type: string
   # e.g. broadcom, mellanox
-- name: parallelism
-  type: number
-  default: 4
-  # max concurrent Trivy image scans within this job
 
 jobs:
 - job: trivy_scan_${{ parameters.platform }}
   displayName: "[OPTIONAL] Trivy scan (${{ parameters.platform }})"
   pool: sonic-ubuntu-1c
   continueOnError: true
-  timeoutInMinutes: 120
+  timeoutInMinutes: 180
   steps:
   - checkout: self
     clean: true
@@ -32,10 +28,8 @@ jobs:
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: sonic-buildimage.${{ parameters.platform }}
-      itemPattern: |
-        **/target/docker-*.gz
-        **/target/sonic-${{ parameters.platform }}.bin
-    displayName: "Download sonic-buildimage.${{ parameters.platform }} artifact"
+      itemPattern: "**/target/sonic-${{ parameters.platform }}.bin"
+    displayName: "Download sonic-${{ parameters.platform }}.bin"
 
   - script: |
       set -ex
@@ -44,76 +38,37 @@ jobs:
       sudo apt install -y ./trivy_${TRIVY_VERSION}_Linux-64bit.deb
       sudo apt install -y squashfs-tools
       trivy --version
-      unsquashfs -v || true
     displayName: "Install Trivy and squashfs-tools"
 
   - script: |
       set -x
-      # Download DB once; all parallel scans reuse it with --skip-db-update
       trivy image --download-db-only --no-progress
     displayName: "Download Trivy vulnerability DB"
 
   - script: |
-      set -x
-      RESULTS_DIR=$(Build.ArtifactStagingDirectory)/trivy-results
-      mkdir -p "$RESULTS_DIR"
-      OVERALL_EXIT=0
-      MAX_PARALLEL=${{ parameters.parallelism }}
-      pids=()
+      set -ex
+      BIN=$(find $(Pipeline.Workspace) -name "sonic-${{ parameters.platform }}.bin" | head -1)
+      [ -f "$BIN" ] || { echo "ERROR: sonic-${{ parameters.platform }}.bin not found"; exit 1; }
+      echo "Using BIN: $BIN"
 
-      for img in $(Pipeline.Workspace)/target/docker-*.gz; do
-        [ -f "$img" ] || continue
-        name=$(basename "$img" .gz)
-        outfile="$RESULTS_DIR/${name}.txt"
-        echo "--- Queuing scan: $name ---"
-        trivy image \
-          --input "$img" \
-          --skip-db-update \
-          --severity MEDIUM,HIGH,CRITICAL \
-          --ignore-unfixed \
-          --exit-code 1 \
-          --format table \
-          --no-progress \
-          --timeout 15m \
-          --output "$outfile" &
-        pids+=("$!")
-        # Throttle: wait for oldest job when at MAX_PARALLEL
-        while [ ${#pids[@]} -ge $MAX_PARALLEL ]; do
-          wait "${pids[0]}" || OVERALL_EXIT=1
-          pids=("${pids[@]:1}")
-        done
-      done
-
-      # Drain remaining background jobs
-      for pid in "${pids[@]}"; do
-        wait "$pid" || OVERALL_EXIT=1
-      done
-
-      echo ""
-      echo "=== Container Scan Summary (${{ parameters.platform }}) ==="
-      for f in "$RESULTS_DIR"/docker-*.txt; do
-        name=$(basename "$f" .txt)
-        total=$(grep "^Total:" "$f" | head -1 || echo "Clean")
-        echo "  $name: $total"
-      done
-
-      exit $OVERALL_EXIT
-    displayName: "Trivy scan all containers (${{ parameters.platform }}, parallelism=${{ parameters.parallelism }})"
+      python3 $(Build.SourcesDirectory)/.azure-pipelines/scripts/trivy-scan-bin.py \
+        "$BIN" \
+        $(Build.ArtifactStagingDirectory)/trivy-results
+    displayName: "Trivy scan all containers from .bin (${{ parameters.platform }})"
 
   - script: |
       set -x
-      BIN=$(Pipeline.Workspace)/target/sonic-${{ parameters.platform }}.bin
+      BIN=$(find $(Pipeline.Workspace) -name "sonic-${{ parameters.platform }}.bin" | head -1)
       WORKDIR=$(Agent.TempDirectory)/trivy-rootfs-${{ parameters.platform }}
       RESULTS=$(Build.ArtifactStagingDirectory)/trivy-results
+      mkdir -p "$WORKDIR" "$RESULTS"
 
-      mkdir -p "$WORKDIR"
-
-      echo "Extracting installer payload..."
+      echo "Extracting installer/fs.zip from .bin..."
       PAYLOAD_SIZE=$(grep -a 'payload_image_size=' "$BIN" | head -1 | cut -d= -f2)
       sed -e '1,/^exit_marker$/d' "$BIN" | head -c "$PAYLOAD_SIZE" \
         | tar xf - -C "$WORKDIR" installer/fs.zip
 
-      [ -f "$WORKDIR/installer/fs.zip" ] || { echo "ERROR: installer/fs.zip not found — check .bin format for ${{ parameters.platform }}"; exit 1; }
+      [ -f "$WORKDIR/installer/fs.zip" ] || { echo "ERROR: installer/fs.zip not found"; exit 1; }
 
       echo "Extracting fs.squashfs..."
       python3 -c "

--- a/.azure-pipelines/trivy-scan-platform.yml
+++ b/.azure-pipelines/trivy-scan-platform.yml
@@ -1,0 +1,148 @@
+# .azure-pipelines/trivy-scan-platform.yml
+#
+# Trivy vulnerability scan for a SONiC platform — covers both:
+# 1. All docker-*.gz container images in the platform artifact
+# 2. Host rootfs extracted from the platform .bin installer
+#
+# Parameterized by platform (e.g. broadcom, mellanox).
+# Runs in a stage that depends on the Build stage.
+#
+# Phase 1: exit-code 1, continueOnError: true (does not block merge)
+
+parameters:
+- name: platform
+  type: string
+  # e.g. broadcom, mellanox
+- name: parallelism
+  type: number
+  default: 4
+  # max concurrent Trivy image scans within this job
+
+jobs:
+- job: trivy_scan_${{ parameters.platform }}
+  displayName: "Trivy scan (${{ parameters.platform }})"
+  pool: sonic-ubuntu-1c
+  continueOnError: true
+  timeoutInMinutes: 120
+  steps:
+  - checkout: self
+    clean: true
+    fetchDepth: 1
+
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      artifact: sonic-buildimage.${{ parameters.platform }}
+    displayName: "Download sonic-buildimage.${{ parameters.platform }} artifact"
+
+  - script: |
+      set -ex
+      TRIVY_VERSION="0.70.0"
+      curl -fLO https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.deb
+      sudo apt install -y ./trivy_${TRIVY_VERSION}_Linux-64bit.deb
+      sudo apt install -y squashfs-tools
+      trivy --version
+      unsquashfs --version
+    displayName: "Install Trivy and squashfs-tools"
+
+  - script: |
+      set -x
+      # Download DB once; all parallel scans reuse it with --skip-db-update
+      trivy image --download-db-only --no-progress
+    displayName: "Download Trivy vulnerability DB"
+
+  - script: |
+      set -x
+      RESULTS_DIR=$(Build.ArtifactStagingDirectory)/trivy-results
+      mkdir -p "$RESULTS_DIR"
+      OVERALL_EXIT=0
+      MAX_PARALLEL=${{ parameters.parallelism }}
+      pids=()
+
+      for img in $(Pipeline.Workspace)/target/docker-*.gz; do
+        [ -f "$img" ] || continue
+        name=$(basename "$img" .gz)
+        outfile="$RESULTS_DIR/${name}.txt"
+        echo "--- Queuing scan: $name ---"
+        trivy image \
+          --input "$img" \
+          --skip-db-update \
+          --severity HIGH,CRITICAL \
+          --ignore-unfixed \
+          --exit-code 1 \
+          --format table \
+          --no-progress \
+          --timeout 15m \
+          --output "$outfile" &
+        pids+=("$!")
+        # Throttle: wait for oldest job when at MAX_PARALLEL
+        while [ ${#pids[@]} -ge $MAX_PARALLEL ]; do
+          wait "${pids[0]}" || OVERALL_EXIT=1
+          pids=("${pids[@]:1}")
+        done
+      done
+
+      # Drain remaining background jobs
+      for pid in "${pids[@]}"; do
+        wait "$pid" || OVERALL_EXIT=1
+      done
+
+      echo ""
+      echo "=== Container Scan Summary (${{ parameters.platform }}) ==="
+      for f in "$RESULTS_DIR"/docker-*.txt; do
+        name=$(basename "$f" .txt)
+        total=$(grep "^Total:" "$f" | head -1 || echo "Clean")
+        echo "  $name: $total"
+      done
+
+      exit $OVERALL_EXIT
+    displayName: "Trivy scan all containers (${{ parameters.platform }}, parallelism=${{ parameters.parallelism }})"
+
+  - script: |
+      set -x
+      BIN=$(Pipeline.Workspace)/target/sonic-${{ parameters.platform }}.bin
+      WORKDIR=$(Agent.TempDirectory)/trivy-rootfs-${{ parameters.platform }}
+      RESULTS=$(Build.ArtifactStagingDirectory)/trivy-results
+
+      mkdir -p "$WORKDIR"
+
+      echo "Extracting installer payload..."
+      PAYLOAD_SIZE=$(grep -a 'payload_image_size=' "$BIN" | head -1 | cut -d= -f2)
+      sed -e '1,/^exit_marker$/d' "$BIN" | head -c "$PAYLOAD_SIZE" \
+        | tar xf - -C "$WORKDIR" installer/fs.zip
+
+      [ -f "$WORKDIR/installer/fs.zip" ] || { echo "ERROR: installer/fs.zip not found — check .bin format for ${{ parameters.platform }}"; exit 1; }
+
+      echo "Extracting fs.squashfs..."
+      python3 -c "
+      import zipfile
+      z = zipfile.ZipFile('$WORKDIR/installer/fs.zip')
+      z.extract('fs.squashfs', '$WORKDIR/')
+      print('extracted')
+      "
+
+      echo "Unsquashing rootfs..."
+      unsquashfs -d "$WORKDIR/rootfs" "$WORKDIR/fs.squashfs"
+
+      echo "Scanning rootfs..."
+      trivy rootfs \
+        "$WORKDIR/rootfs" \
+        --severity HIGH,CRITICAL \
+        --ignore-unfixed \
+        --exit-code 1 \
+        --format table \
+        --no-progress \
+        --timeout 30m \
+        --output "$RESULTS/rootfs-${{ parameters.platform }}.txt"
+      TRIVY_EXIT=$?
+
+      echo ""
+      echo "=== Rootfs Scan Results (${{ parameters.platform }}) ==="
+      cat "$RESULTS/rootfs-${{ parameters.platform }}.txt"
+      exit $TRIVY_EXIT
+    displayName: "Trivy scan rootfs (${{ parameters.platform }})"
+
+  - publish: $(Build.ArtifactStagingDirectory)/trivy-results
+    artifact: trivy-scan-${{ parameters.platform }}
+    displayName: "Publish Trivy scan results (${{ parameters.platform }})"
+    condition: always()
+    continueOnError: true

--- a/.azure-pipelines/trivy-scan-platform.yml
+++ b/.azure-pipelines/trivy-scan-platform.yml
@@ -32,6 +32,9 @@ jobs:
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: sonic-buildimage.${{ parameters.platform }}
+      itemPattern: |
+        **/target/docker-*.gz
+        **/target/sonic-${{ parameters.platform }}.bin
     displayName: "Download sonic-buildimage.${{ parameters.platform }} artifact"
 
   - script: |
@@ -41,7 +44,7 @@ jobs:
       sudo apt install -y ./trivy_${TRIVY_VERSION}_Linux-64bit.deb
       sudo apt install -y squashfs-tools
       trivy --version
-      unsquashfs --version
+      unsquashfs -v
     displayName: "Install Trivy and squashfs-tools"
 
   - script: |

--- a/.azure-pipelines/trivy-scan-platform.yml
+++ b/.azure-pipelines/trivy-scan-platform.yml
@@ -51,16 +51,17 @@ jobs:
       [ -f "$BIN" ] || { echo "ERROR: sonic-${{ parameters.platform }}.bin not found"; exit 1; }
       echo "Using BIN: $BIN"
 
+      RESULTS=$(Build.ArtifactStagingDirectory)/trivy-results
       python3 $(Build.SourcesDirectory)/.azure-pipelines/scripts/trivy-scan-bin.py \
         "$BIN" \
-        $(Build.ArtifactStagingDirectory)/trivy-results
+        "$RESULTS"
     displayName: "Trivy scan all containers from .bin (${{ parameters.platform }})"
 
   - script: |
       set -x
       BIN=$(find $(Pipeline.Workspace) -name "sonic-${{ parameters.platform }}.bin" | head -1)
       WORKDIR=$(Agent.TempDirectory)/trivy-rootfs-${{ parameters.platform }}
-      RESULTS=$(Build.ArtifactStagingDirectory)/trivy-results
+      RESULTS=$(Build.ArtifactStagingDirectory)/trivy-results/results
       mkdir -p "$WORKDIR" "$RESULTS"
 
       echo "Extracting installer/fs.zip from .bin..."
@@ -99,7 +100,7 @@ jobs:
       exit $TRIVY_EXIT
     displayName: "Trivy scan rootfs (${{ parameters.platform }})"
 
-  - publish: $(Build.ArtifactStagingDirectory)/trivy-results
+  - publish: $(Build.ArtifactStagingDirectory)/trivy-results/results
     artifact: trivy-scan-${{ parameters.platform }}
     displayName: "Publish Trivy scan results (${{ parameters.platform }})"
     condition: always()

--- a/.azure-pipelines/trivy-scan-platform.yml
+++ b/.azure-pipelines/trivy-scan-platform.yml
@@ -20,7 +20,7 @@ parameters:
 
 jobs:
 - job: trivy_scan_${{ parameters.platform }}
-  displayName: "Trivy scan (${{ parameters.platform }})"
+  displayName: "[OPTIONAL] Trivy scan (${{ parameters.platform }})"
   pool: sonic-ubuntu-1c
   continueOnError: true
   timeoutInMinutes: 120
@@ -44,7 +44,7 @@ jobs:
       sudo apt install -y ./trivy_${TRIVY_VERSION}_Linux-64bit.deb
       sudo apt install -y squashfs-tools
       trivy --version
-      unsquashfs -v
+      unsquashfs -v || true
     displayName: "Install Trivy and squashfs-tools"
 
   - script: |
@@ -69,7 +69,7 @@ jobs:
         trivy image \
           --input "$img" \
           --skip-db-update \
-          --severity HIGH,CRITICAL \
+          --severity MEDIUM,HIGH,CRITICAL \
           --ignore-unfixed \
           --exit-code 1 \
           --format table \
@@ -129,7 +129,7 @@ jobs:
       echo "Scanning rootfs..."
       trivy rootfs \
         "$WORKDIR/rootfs" \
-        --severity HIGH,CRITICAL \
+        --severity MEDIUM,HIGH,CRITICAL \
         --ignore-unfixed \
         --exit-code 1 \
         --format table \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -262,3 +262,15 @@ stages:
       displayName: "Publish Trivy scan results"
       condition: always()
       continueOnError: true
+
+- stage: TrivyScan
+  displayName: "Trivy Vulnerability Scan (per platform)"
+  dependsOn: Build
+  condition: in(dependencies.Build.result, 'Succeeded', 'SucceededWithIssues', 'Failed')
+  jobs:
+  - template: .azure-pipelines/trivy-scan-platform.yml
+    parameters:
+      platform: broadcom
+  - template: .azure-pipelines/trivy-scan-platform.yml
+    parameters:
+      platform: mellanox


### PR DESCRIPTION
#### Why I did it

SONiC CI currently has no automated vulnerability scanning for published platform container images or the host rootfs. This PR adds a parameterized Trivy scan template covering both, starting with broadcom and mellanox platforms. Phase 1 is informational only — scans run after the Build stage and never block a PR merge.

##### Work item tracking
- Microsoft ADO:

#### How I did it

Added a reusable pipeline template `.azure-pipelines/trivy-scan-platform.yml` parameterized by `platform` and `parallelism` (default 4). Each invocation:

- Downloads the platform artifact (`sonic-buildimage.<platform>`)
- Installs Trivy v0.70.0 (pinned, avoids GitHub API rate-limit failures on CI agents) and squashfs-tools
- Downloads the Trivy vulnerability DB once; all parallel scans reuse it with `--skip-db-update`
- Scans all `docker-*.gz` container images in parallel (bounded by `parallelism` parameter) — HIGH and CRITICAL severity, `--ignore-unfixed`
- Extracts the host rootfs from the platform `.bin` installer (`fs.squashfs` via `installer/fs.zip`) and scans it with `trivy rootfs`
- Publishes full scan results as a pipeline artifact

Both jobs use `exit-code 1` and `continueOnError: true` — findings are visible but do not block merge.

A new `TrivyScan` stage in `azure-pipelines.yml` depends on `Build` and invokes the template for broadcom and mellanox in parallel.

#### How to verify it

1. Check the `TrivyScan` stage in the CI run for this PR — two jobs (`Trivy scan (broadcom)` and `Trivy scan (mellanox)`) should appear and complete independently.
2. Each job log shows a per-container scan summary and rootfs scan results.
3. Download the `trivy-scan-broadcom` / `trivy-scan-mellanox` artifacts for full table output.
4. Even if findings are present, both jobs exit with `continueOnError` and the overall pipeline passes.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version 1 -->

#### Description for the changelog

Add Trivy vulnerability scanning CI jobs for broadcom and mellanox platform containers and host rootfs (informational, non-blocking)

#### Link to config_db schema for YANG module changes

N/A — no YANG changes