### PR TITLE
Add daily stale-bot to close long-inactive issues and PRs

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -1,0 +1,80 @@
+name: Close Stale Issues and PRs
+
+on:
+  schedule:
+    - cron: '0 2 * * *'  # Daily at 02:00 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    if: github.repository_owner == 'sonic-net'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          days-before-stale: 365
+          days-before-close: 14
+
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+
+          exempt-issue-labels: 'never-stale'
+          exempt-pr-labels: 'never-stale'
+
+          # Process 200 items per run; at this rate the initial backlog of
+          # ~1,262 stale items will be labelled over roughly 7 daily runs.
+          operations-per-run: 200
+
+          # Remove the stale label when activity resumes.
+          remove-stale-when-updated: true
+
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has
+            not had any activity for 365 days. It will be closed in 14 days
+            if no further activity occurs.
+
+
+            If this issue is still relevant, please leave a comment — this
+            will reset the inactivity timer. If you believe this issue should
+            remain open regardless of activity, add the `never-stale` label.
+
+
+            Thank you for your contribution to SONiC!
+
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because
+            it has not had any activity for 365 days. It will be closed in 14
+            days if no further activity occurs.
+
+
+            If this PR is still relevant, please leave a comment or push a
+            new commit — this will reset the inactivity timer. You may also
+            want to rebase onto the latest `master` to resolve any conflicts.
+            If you believe this PR should remain open regardless of activity,
+            add the `never-stale` label.
+
+
+            Thank you for your contribution to SONiC!
+
+          close-issue-message: >
+            This issue has been closed due to inactivity (no updates in over
+            1 year). If this issue is still relevant, please re-open it or
+            create a new issue with updated context.
+
+
+            Thank you for your contribution to SONiC!
+
+          close-pr-message: >
+            This pull request has been closed due to inactivity (no updates
+            in over 1 year). If you would like to continue this work, please
+            re-open the PR or submit a new one rebased onto the latest
+            `master`.
+
+
+            Thank you for your contribution to SONiC!

--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository_owner == 'sonic-net'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899  # v10.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -27,8 +27,9 @@ jobs:
           exempt-issue-labels: 'never-stale'
           exempt-pr-labels: 'never-stale'
 
-          # Process 200 items per run; at this rate the initial backlog of
-          # ~1,262 stale items will be labelled over roughly 7 daily runs.
+          # Process a bounded number of items per run so the initial backlog
+          # is worked through gradually rather than in a single notification
+          # flood.
           operations-per-run: 200
 
           # Remove the stale label when activity resumes.
@@ -54,8 +55,17 @@ jobs:
 
 
             If this PR is still relevant, please leave a comment or push a
-            new commit — this will reset the inactivity timer. You may also
-            want to rebase onto the latest `master` to resolve any conflicts.
+            new commit — this will reset the inactivity timer.
+
+
+            **Important:** before this PR can be merged it must be rebased onto
+            the latest `master`. After a year of inactivity it is almost
+            certainly out of date and will not build or merge cleanly against
+            the current tree. Please rebase, resolve any conflicts, and force-push
+            so CI can re-run against current `master`; a PR that cannot be rebased
+            cleanly will not be merged.
+
+
             If you believe this PR should remain open regardless of activity,
             add the `never-stale` label.
 


### PR DESCRIPTION
> **Note:** This PR is opened for community discussion following a mention at the
> SONiC Technical Steering Committee meeting. No action will be taken until there
> is consensus. See the *Why I did it* section for the full rationale.
>
> **Pre-merge requirement:** The labels `stale` and `never-stale` must be created
> in the repository before this workflow can be merged and activated.

#### Why I did it

The sonic-buildimage issue tracker has grown to approximately **2,971 open items**
— roughly 1,782 issues and 1,189 pull requests — with no systematic mechanism to
retire items that have been abandoned by their authors.

As of today, **1,122 open issues (63%) and 140 open PRs (12%)** have not received
any activity in over a year. The oldest open issue (#378) has not been touched
since March 2017; the oldest open PR (#1848) since December 2018.

This backlog imposes a real cost on maintainers: genuine bug reports, security
issues, and actively developed pull requests are buried in noise, making triage
slower and less reliable. New contributors filing issues or opening PRs are also
less likely to receive timely attention when the tracker is this congested.

This was raised during the **SONiC Technical Steering Committee meeting** as a
housekeeping concern, and this PR is opened for broader community discussion and
review before any action is taken. The proposed policy is:

- Any issue or PR with **no activity for 365 days** is marked `stale` and its
  author is notified via an automated comment, with instructions to simply reply
  to reset the timer.
- If no activity occurs within **14 days** of the stale warning, the item is
  automatically closed.
- The `stale` label is **automatically removed** if the author or anyone else
  comments or pushes new commits, restarting the clock cleanly.
- Items labelled `never-stale` are **permanently exempt** from this process —
  maintainers or authors can apply this label to any issue or PR that should
  never be closed due to inactivity (e.g., long-running tracking issues, known
  defects without a clear fix timeline, ongoing design discussions).

##### Work item tracking
- Microsoft ADO: N/A

#### How I did it

Added `.github/workflows/close-stale.yml` using the official
[`actions/stale`](https://github.com/actions/stale) action. The action is
**pinned to a full commit SHA** (`eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899`,
v10.1.0) rather than a floating `@v10` tag, so a future re-tag of that version
cannot silently change the code we run — standard supply-chain hardening for
third-party actions. The workflow:

- Runs on a daily cron schedule (02:00 UTC) and can also be triggered manually
  via `workflow_dispatch`.
- Is guarded with `if: github.repository_owner == 'sonic-net'` so it does not
  fire on forks.
- Is rate-limited to **200 operations per run** so the existing backlog is
  worked through gradually rather than in a single notification flood.

**Automated stale comment posted to issues:**
> This issue has been automatically marked as stale because it has not had any
> activity for 365 days. It will be closed in 14 days if no further activity
> occurs.
>
> If this issue is still relevant, please leave a comment — this will reset the
> inactivity timer. If you believe this issue should remain open regardless of
> activity, add the `never-stale` label.
>
> Thank you for your contribution to SONiC!

**Automated stale comment posted to PRs:**
> This pull request has been automatically marked as stale because it has not had
> any activity for 365 days. It will be closed in 14 days if no further activity
> occurs.
>
> If this PR is still relevant, please leave a comment or push a new commit —
> this will reset the inactivity timer.
>
> **Important:** before this PR can be merged it must be rebased onto the latest
> `master`. After a year of inactivity it is almost certainly out of date and
> will not build or merge cleanly against the current tree. Please rebase,
> resolve any conflicts, and force-push so CI can re-run against current
> `master`; a PR that cannot be rebased cleanly will not be merged.
>
> If you believe this PR should remain open regardless of activity, add the
> `never-stale` label.
>
> Thank you for your contribution to SONiC!

#### How to verify it

This workflow does not affect build artifacts, test results, or runtime behaviour.
Verification steps:

- [ ] Confirm the workflow file parses correctly: `gh workflow list` after merging
      should show *Close Stale Issues and PRs*.
- [ ] Trigger manually via `gh workflow run close-stale.yml` and confirm that items
      inactive for >365 days receive the `stale` label and the expected comment.
- [ ] Confirm that replying to a stale-labelled item removes the label and resets
      the timer.
- [ ] Confirm that items carrying `never-stale` are not touched.

**Pre-merge checklist:**
- [ ] Label `stale` has been created in the repository.
- [ ] Label `never-stale` has been created in the repository.

#### Which release branch to backport (provide reason below if selected)

Not applicable — this is a repository-management workflow, not a SONiC platform
change.

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

Not applicable — no build artifacts are produced.

#### Description for the changelog

Add a daily GitHub Actions workflow that marks issues and pull requests as stale
after 365 days of inactivity and closes them after a further 14 days, with an
opt-out via the `never-stale` label.

#### Link to config_db schema for YANG module changes

Not applicable.

#### A picture of a cute animal (not mandatory but encouraged)

