### PR TITLE
[cache] Include RFS account config in cache key

### DIFF
--- a/Makefile.cache
+++ b/Makefile.cache
@@ -450,10 +450,16 @@ $(foreach pkg, $(SONIC_INSTALL_PKGS), \
         $(eval $(pkg)_DST_PATH := $(if $($(pkg)_DST_PATH), $($(pkg)_DST_PATH), $(FSROOT_PATH))) \
 		$(eval $(FSROOT_PATH)/$(pkg)_TARGET := $(pkg)) )
 
+# RFS squashfs contents include the configured login/BMC accounts. Keep these
+# values in the RFS cache key so a cache hit cannot reuse an image built with a
+# different account configuration.
+SONIC_RFS_CONFIG_FLAGS_LIST := $(USERNAME) $(PASSWORD) $(CHANGE_DEFAULT_PASSWORD) \
+                               $(BMC_NOS_ACCOUNT_USERNAME) $(BMC_ROOT_ACCOUNT_DEFAULT_PASSWORD)
+
 $(foreach pkg, $(SONIC_RFS_TARGETS), \
         $(eval $(pkg)_DST_PATH := $(if $($(pkg)_DST_PATH), $($(pkg)_DST_PATH), $(TARGET_PATH))) \
         $(eval $(pkg)_CACHE_MODE := GIT_CONTENT_SHA) \
-        $(eval $(pkg)_DEP_FLAGS := $(SONIC_COMMON_FLAGS_LIST)) \
+        $(eval $(pkg)_DEP_FLAGS := $(SONIC_COMMON_FLAGS_LIST) $(SONIC_RFS_CONFIG_FLAGS_LIST)) \
         $(eval $(pkg)_DEP_FILES := $(SONIC_COMMON_BASE_FILES_LIST) $(RFS_DEP_FILES)) \
         $(eval $(TARGET_PATH)/$(pkg)_TARGET := $(pkg)) )
 


### PR DESCRIPTION
#### Why I did it
Fixes https://github.com/sonic-net/sonic-buildimage/issues/27064.

The RFS squashfs target embeds the configured login/BMC account settings through `build_debian.sh`, but the cache key only used the common build flags. Rebuilding the same source with a different `USERNAME`/`PASSWORD` could therefore reuse a stale cached RFS image and fail later during installer generation.

#### How I did it
Added the RFS account configuration values to the RFS target dependency flags so the cached squashfs is invalidated when any embedded account setting changes:

- `USERNAME`
- `PASSWORD`
- `CHANGE_DEFAULT_PASSWORD`
- `BMC_NOS_ACCOUNT_USERNAME`
- `BMC_ROOT_ACCOUNT_DEFAULT_PASSWORD`

#### How I verified it
- `git diff --check -- Makefile.cache`
- Generated the RFS flags target with cache enabled and custom account values:
  `make -f Makefile.work BLDENV=bookworm target/sonic-vs.img.gz__vs__rfs.squashfs.flags SONIC_DPKG_CACHE_METHOD=cache PLATFORM=vs USERNAME=cacheuser PASSWORD=cachepass CHANGE_DEFAULT_PASSWORD=y`
