### PR TITLE
gbsyncd: replace --privileged with specific capabilities

### DIFF
--- a/platform/components/docker-gbsyncd-agera2.mk
+++ b/platform/components/docker-gbsyncd-agera2.mk
@@ -31,7 +31,7 @@ SONIC_BOOKWORM_DBG_DOCKERS += $(DOCKER_GBSYNCD_AGERA2_DBG)
 SONIC_INSTALL_DOCKER_DBG_IMAGES += $(DOCKER_GBSYNCD_AGERA2_DBG)
 
 $(DOCKER_GBSYNCD_AGERA2)_CONTAINER_NAME = gbsyncd
-$(DOCKER_GBSYNCD_AGERA2)_RUN_OPT += --privileged -t
+$(DOCKER_GBSYNCD_AGERA2)_RUN_OPT += --cap-add=SYS_RAWIO --cap-add=SYS_ADMIN --cap-add=NET_ADMIN -t --security-opt apparmor=unconfined --security-opt="systempaths=unconfined"
 $(DOCKER_GBSYNCD_AGERA2)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_GBSYNCD_AGERA2)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_GBSYNCD_AGERA2)_RUN_OPT += -v /host/warmboot:/var/warmboot

--- a/platform/components/docker-gbsyncd-agera2.mk
+++ b/platform/components/docker-gbsyncd-agera2.mk
@@ -32,6 +32,8 @@ SONIC_INSTALL_DOCKER_DBG_IMAGES += $(DOCKER_GBSYNCD_AGERA2_DBG)
 
 $(DOCKER_GBSYNCD_AGERA2)_CONTAINER_NAME = gbsyncd
 $(DOCKER_GBSYNCD_AGERA2)_RUN_OPT += --cap-add=SYS_RAWIO --cap-add=SYS_ADMIN --cap-add=NET_ADMIN -t --security-opt apparmor=unconfined --security-opt="systempaths=unconfined"
+$(DOCKER_GBSYNCD_AGERA2)_RUN_OPT += -v /sys/class/mdio_bus:/sys/class/mdio_bus
+$(DOCKER_GBSYNCD_AGERA2)_RUN_OPT += -v /sys/devices:/sys/devices
 $(DOCKER_GBSYNCD_AGERA2)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_GBSYNCD_AGERA2)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_GBSYNCD_AGERA2)_RUN_OPT += -v /host/warmboot:/var/warmboot

--- a/platform/components/docker-gbsyncd-broncos.mk
+++ b/platform/components/docker-gbsyncd-broncos.mk
@@ -27,7 +27,7 @@ SONIC_BOOKWORM_DBG_DOCKERS += $(DOCKER_GBSYNCD_BRONCOS_DBG)
 SONIC_INSTALL_DOCKER_DBG_IMAGES += $(DOCKER_GBSYNCD_BRONCOS_DBG)
 
 $(DOCKER_GBSYNCD_BRONCOS)_CONTAINER_NAME = gbsyncd
-$(DOCKER_GBSYNCD_BRONCOS)_RUN_OPT += --privileged -t
+$(DOCKER_GBSYNCD_BRONCOS)_RUN_OPT += --cap-add=SYS_RAWIO --cap-add=SYS_ADMIN --cap-add=NET_ADMIN -t --security-opt apparmor=unconfined --security-opt="systempaths=unconfined"
 $(DOCKER_GBSYNCD_BRONCOS)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_GBSYNCD_BRONCOS)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 

--- a/platform/components/docker-gbsyncd-milleniob.mk
+++ b/platform/components/docker-gbsyncd-milleniob.mk
@@ -27,7 +27,7 @@ SONIC_BOOKWORM_DBG_DOCKERS += $(DOCKER_GBSYNCD_MILLENIOB_DBG)
 SONIC_INSTALL_DOCKER_DBG_IMAGES += $(DOCKER_GBSYNCD_MILLENIOB_DBG)
 
 $(DOCKER_GBSYNCD_MILLENIOB)_CONTAINER_NAME = gbsyncd
-$(DOCKER_GBSYNCD_MILLENIOB)_RUN_OPT += --privileged -t
+$(DOCKER_GBSYNCD_MILLENIOB)_RUN_OPT += --cap-add=SYS_RAWIO --cap-add=SYS_ADMIN --cap-add=NET_ADMIN -t --security-opt apparmor=unconfined --security-opt="systempaths=unconfined"
 $(DOCKER_GBSYNCD_MILLENIOB)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_GBSYNCD_MILLENIOB)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 

--- a/platform/template/docker-gbsyncd-base.mk
+++ b/platform/template/docker-gbsyncd-base.mk
@@ -23,6 +23,6 @@ SONIC_BULLSEYE_DBG_DOCKERS += $(DOCKER_GBSYNCD_BASE_DBG)
 SONIC_INSTALL_DOCKER_DBG_IMAGES += $(DOCKER_GBSYNCD_BASE_DBG)
 
 $(DOCKER_GBSYNCD_BASE)_CONTAINER_NAME = gbsyncd
-$(DOCKER_GBSYNCD_BASE)_RUN_OPT += --privileged -t
+$(DOCKER_GBSYNCD_BASE)_RUN_OPT += --cap-add=SYS_RAWIO --cap-add=SYS_ADMIN --cap-add=NET_ADMIN -t --security-opt apparmor=unconfined --security-opt="systempaths=unconfined"
 $(DOCKER_GBSYNCD_BASE)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_GBSYNCD_BASE)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro

--- a/platform/template/docker-gbsyncd-bookworm.mk
+++ b/platform/template/docker-gbsyncd-bookworm.mk
@@ -23,6 +23,6 @@ SONIC_BOOKWORM_DBG_DOCKERS += $(DOCKER_GBSYNCD_BASE_DBG)
 SONIC_INSTALL_DOCKER_DBG_IMAGES += $(DOCKER_GBSYNCD_BASE_DBG)
 
 $(DOCKER_GBSYNCD_BASE)_CONTAINER_NAME = gbsyncd
-$(DOCKER_GBSYNCD_BASE)_RUN_OPT += --privileged -t
+$(DOCKER_GBSYNCD_BASE)_RUN_OPT += --cap-add=SYS_RAWIO --cap-add=SYS_ADMIN --cap-add=NET_ADMIN -t --security-opt apparmor=unconfined --security-opt="systempaths=unconfined"
 $(DOCKER_GBSYNCD_BASE)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_GBSYNCD_BASE)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro


### PR DESCRIPTION
#### Why I did it

All processes in the gbsyncd container run with `--privileged`, granting full host capabilities. Replace with the minimum required capabilities for gearbox syncd operation, following the same pattern used by the pmon container.

##### Work item tracking
- Microsoft ADO:

#### How I did it

Replace `--privileged -t` with specific capabilities in all gbsyncd mk files (templates and standalone components):
- `--cap-add=SYS_RAWIO` — hardware device I/O
- `--cap-add=SYS_ADMIN` — system administration operations
- `--cap-add=NET_ADMIN` — network interface configuration
- `--security-opt apparmor=unconfined`
- `--security-opt systempaths=unconfined`

Applies to: `docker-gbsyncd-base.mk`, `docker-gbsyncd-bookworm.mk`, `docker-gbsyncd-agera2.mk`, `docker-gbsyncd-broncos.mk`, `docker-gbsyncd-milleniob.mk`. The credo, vpp, and vs variants inherit from the templates.

#### How to verify it

Verified on VS (KVM):
1. Loaded `docker-gbsyncd-vs` image and started container with the new capability flags
2. `docker inspect gbsyncd` shows `Privileged: false`, `CapAdd: [CAP_NET_ADMIN, CAP_SYS_ADMIN, CAP_SYS_RAWIO]`
3. Container starts successfully (supervisord + rsyslogd up, no crash)

Gearbox hardware verification: TBD — engaging with platform owners to verify gearbox syncd operates normally on a real gearbox platform.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch

Verified on VS (KVM) image with `docker-gbsyncd-vs`. Gearbox hardware verification TBD — engaging with platform owners.

#### Description for the changelog

gbsyncd: replace --privileged with minimum required Linux capabilities

#### Link to config_db schema for YANG module changes

N/A