### PR TITLE
fix: docker-ptf May vulnerability

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -107,15 +107,15 @@ RUN apt-get update          \
 # to ensure they use a patched Go stdlib (GO-2026-4337: crypto/tls)
 {% if CONFIGURED_ARCH == "armhf" %}
 RUN GO_ARCH=armv6l \
-    && GO_SHA256=7d4f0d266d871301e08ef4ac31c56e66048688893b2848392e5c600276351ee8 \
+    && GO_SHA256=39f168f158e693887d3ad006168af1b1a3007b19c5993cae4d9d57f82f52aaf8 \
 {% elif CONFIGURED_ARCH == "arm64" %}
 RUN GO_ARCH=arm64 \
-    && GO_SHA256=ec342e7389b7f489564ed5463c63b16cf8040023dabc7861256677165a8c0e2b \
+    && GO_SHA256=654da1f9b50a5d1c2a85ccf8ed405aa89c06e94d18384628bf186f7712677b08 \
 {% else %}
 RUN GO_ARCH=amd64 \
-    && GO_SHA256=00859d7bd6defe8bf84d9db9e57b9a4467b2887c18cd93ae7460e713db774bc1 \
+    && GO_SHA256=42d4f7a32316aa66591eca7e89867256057a4264451aca10570a715b3637ba70 \
 {% endif %}
-    && GO_VERSION=1.25.9 \
+    && GO_VERSION=1.25.10 \
     && curl -L "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz" -o /tmp/go.tar.gz \
     && echo "${GO_SHA256}  /tmp/go.tar.gz" | sha256sum -c - \
     && tar -C /usr/local -xzf /tmp/go.tar.gz \
@@ -158,7 +158,10 @@ RUN set -eux \
     && ldconfig /usr/local/lib/influxdb3-python/lib \
     && ln -sf /usr/local/bin/influxdb3 /usr/local/bin/influxd \
     && rm -f "influxdb3-core-${INFLUXDB_VERSION}_${INFLUXDB_ARCH}.tar.gz" \
-    && rm -rf "/tmp/influxdb3-core-${INFLUXDB_VERSION}"
+    && rm -rf "/tmp/influxdb3-core-${INFLUXDB_VERSION}" \
+    && pip3 install --target /usr/local/lib/influxdb3-python/lib/python3.13/site-packages "pip>=26.1" \
+    && NEWPIP=$(ls -d /usr/local/lib/influxdb3-python/lib/python3.13/site-packages/pip-*.dist-info | sort -V | tail -1) \
+    && find /usr/local/lib/influxdb3-python/lib/python3.13/site-packages -maxdepth 1 -name 'pip-*.dist-info' ! -path "$NEWPIP" -exec rm -rf {} +
 {% endif %}
 
 {% if PTF_ENV_PY_VER == "py3" %}
@@ -456,8 +459,10 @@ RUN echo "PYTHONPATH=/root/env-python3/lib/python3.11/site-packages" >> /etc/env
 # Final system-level security upgrade: ensure every Debian package is at its
 # latest patched version. This must run AFTER all apt-get install / dpkg -i
 # steps so nothing slips through.
-# Covers OpenSSL, openssh, libpng, gdk-pixbuf, inetutils, tiff CVEs.
-RUN apt-get update \
+# The build system pins package versions via /etc/apt/preferences.d/01-versions-deb.
+# Remove the pin so apt-get upgrade can pull in the latest security patches.
+RUN rm -f /etc/apt/preferences.d/01-versions-deb \
+    && apt-get update \
     && apt-get upgrade -y \
     && apt-get dist-upgrade -y \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

fix the current list of vulneralbity

Python (Pip) Security Update for pip (GHSA-jp4c-xjxw-mgf9)
Debian Security Update for wireshark (CVE-2026-6530)
Debian Security Update for wireshark (CVE-2026-5653)
Debian Security Update for wireshark (CVE-2026-5405)
Debian Security Update for wireshark (CVE-2026-6529)
Go (Go) Security Update for stdlib golang.org/x/net/http2 (GO-2026-4918)
Go (Go) Security Update for stdlib (GO-2026-4982)
Go (Go) Security Update for stdlib (GO-2026-4981)
Go (Go) Security Update for stdlib (GO-2026-4980)
Go (Go) Security Update for stdlib (GO-2026-4986)
Go (Go) Security Update for stdlib (GO-2026-4971)
Go (Go) Security Update for stdlib (GO-2026-4977)
Go (Go) Security Update for stdlib (GO-2026-4976)
Debian Security Update for libpng1.6 (CVE-2026-34757)
Python (Pip) Security Update for pip (GHSA-jp4c-xjxw-mgf9)



##### Work item tracking
- Microsoft ADO **(number only)**: 37938782

#### How I did it
Update the related packages

#### How to verify it
```
Report Summary
┌──────────────────────────────────────────────────────────────────────────────────┬────────────┬─────────────────┐
│                                      Target                                      │    Type    │ Vulnerabilities │
├──────────────────────────────────────────────────────────────────────────────────┼────────────┼─────────────────┤
│ docker-ptf-scan:latest (debian 12.13)                                            │   debian   │        0        │
├──────────────────────────────────────────────────────────────────────────────────┼────────────┼─────────────────┤
│ root/env-python3/lib/python3.11/site-packages/Pyro4-4.82.dist-info/METADATA      │ python-pkg │        0        │
├──────────────────────────────────────────────────────────────────────────────────┼────────────┼─────────────────┤
│ root/env-python3/lib/python3.11/site-packages/asttokens-3.0.1.dist-info/METADATA │ python-pkg │        0        │
├──────────────────────────────────────────────────────────────────────────────────┼────────────┼─────────────────┤
│ root/env-python3/lib/python3.11/site-packages/bcrypt-5.0.0.dist-info/METADATA    │ python-pkg │        0        │
├──────────────────────────────────────────────────────────────────────────────────┼────────────┼─────────────────┤
│ root/env-python3/lib/python3.11/site-packages/blinker-1.9.0.dist-info/METADATA   │ python-pkg │        0        │
├──────────────────────────────────────────────────────────────────────────────────┼────────────┼─────────────────┤
│ root/env-python3/lib/python3.11/site-packages/cffi-2.0.0.dist-info/METADATA      │ python-pkg │        0        │
├──────────────────────────────────────────────────────────────────────────────────┼────────────┼─────────────────┤
│ root/env-python3/lib/python3.11/site-packages/click-8.3.3.dist-info/METADATA     │ python-pkg │        0        │
├──────────────────────────────────────────────────────────────────────────────────┼────────────┼─────────────────┤
│ root/env-python3/lib/python3.11/site-packages/cryptography-48.0.0.dist-info/MET- │ python-pkg │        0        │
│ ADATA                                                                            │            │                 │
├──────────────────────────────────────────────────────────────────────────────────┼────────────┼─────────────────┤
│ root/env-python3/lib/python3.11/site-packages/cython-3.2.4.dist-info/METADATA    │ python-pkg │        0        │
├──────────────────────────────────────────────────────────────────────────────────┼────────────┼─────────────────┤
<exited with exit code 0>
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

