### PR TITLE
[sonic-yang-models] Extend Generic Hash YANG to support per-packet-type hashing and RoCE hash fields

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/hash.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/hash.json
@@ -2,6 +2,9 @@
     "SWITCH_HASH_VALID": {
         "desc": "Configure SWITCH_HASH."
     },
+    "SWITCH_HASH_PKT_TYPE_VALID": {
+        "desc": "Configure SWITCH_HASH with per-packet-type hash fields including RDMA."
+    },
     "SWITCH_HASH_INVALID_ECMP_HASH": {
         "desc": "Configure invalid ECMP_HASH in SWITCH_HASH.",
         "eStrKey": "InvalidValue"
@@ -16,6 +19,14 @@
     },
     "SWITCH_HASH_INVALID_LAG_HASH_ALGORITHM": {
         "desc": "Configure invalid LAG_HASH_ALGORITHM in SWITCH_HASH.",
+        "eStrKey": "InvalidValue"
+    },
+    "SWITCH_HASH_INVALID_ECMP_HASH_IPV4": {
+        "desc": "Configure invalid ECMP_HASH_IPV4 in SWITCH_HASH.",
+        "eStrKey": "InvalidValue"
+    },
+    "SWITCH_HASH_INVALID_LAG_HASH_IPV4_RDMA": {
+        "desc": "Configure invalid LAG_HASH_IPV4_RDMA in SWITCH_HASH.",
         "eStrKey": "InvalidValue"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/hash.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/hash.json
@@ -29,6 +29,70 @@
             }
         }
     },
+    "SWITCH_HASH_PKT_TYPE_VALID": {
+        "sonic-hash:sonic-hash": {
+            "sonic-hash:SWITCH_HASH": {
+                "sonic-hash:GLOBAL": {
+                    "ecmp_hash_ipv4": [
+                        "DST_IP",
+                        "SRC_IP",
+                        "L4_DST_PORT",
+                        "L4_SRC_PORT"
+                    ],
+                    "ecmp_hash_ipv6": [
+                        "DST_IP",
+                        "SRC_IP",
+                        "IPV6_FLOW_LABEL"
+                    ],
+                    "ecmp_hash_ipnip": [
+                        "INNER_DST_IP",
+                        "INNER_SRC_IP"
+                    ],
+                    "ecmp_hash_ipv4_rdma": [
+                        "DST_IP",
+                        "SRC_IP",
+                        "RDMA_BTH_OPCODE",
+                        "RDMA_BTH_DEST_QP"
+                    ],
+                    "ecmp_hash_ipv6_rdma": [
+                        "DST_IP",
+                        "SRC_IP",
+                        "IPV6_FLOW_LABEL",
+                        "RDMA_BTH_OPCODE",
+                        "RDMA_BTH_DEST_QP"
+                    ],
+                    "lag_hash_ipv4": [
+                        "DST_IP",
+                        "SRC_IP",
+                        "L4_DST_PORT",
+                        "L4_SRC_PORT"
+                    ],
+                    "lag_hash_ipv6": [
+                        "DST_IP",
+                        "SRC_IP",
+                        "IPV6_FLOW_LABEL"
+                    ],
+                    "lag_hash_ipnip": [
+                        "INNER_DST_IP",
+                        "INNER_SRC_IP"
+                    ],
+                    "lag_hash_ipv4_rdma": [
+                        "DST_IP",
+                        "SRC_IP",
+                        "RDMA_BTH_OPCODE",
+                        "RDMA_BTH_DEST_QP"
+                    ],
+                    "lag_hash_ipv6_rdma": [
+                        "DST_IP",
+                        "SRC_IP",
+                        "IPV6_FLOW_LABEL",
+                        "RDMA_BTH_OPCODE",
+                        "RDMA_BTH_DEST_QP"
+                    ]
+                }
+            }
+        }
+    },
     "SWITCH_HASH_INVALID_ECMP_HASH": {
         "sonic-hash:sonic-hash": {
             "sonic-hash:SWITCH_HASH": {
@@ -65,6 +129,28 @@
             "sonic-hash:SWITCH_HASH": {
                 "sonic-hash:GLOBAL": {
                     "lag_hash_algorithm": "INVALID_VALUE"
+                }
+            }
+        }
+    },
+    "SWITCH_HASH_INVALID_ECMP_HASH_IPV4": {
+        "sonic-hash:sonic-hash": {
+            "sonic-hash:SWITCH_HASH": {
+                "sonic-hash:GLOBAL": {
+                    "ecmp_hash_ipv4": [
+                        "INVALID_VALUE"
+                    ]
+                }
+            }
+        }
+    },
+    "SWITCH_HASH_INVALID_LAG_HASH_IPV4_RDMA": {
+        "sonic-hash:sonic-hash": {
+            "sonic-hash:SWITCH_HASH": {
+                "sonic-hash:GLOBAL": {
+                    "lag_hash_ipv4_rdma": [
+                        "INVALID_VALUE"
+                    ]
                 }
             }
         }

--- a/src/sonic-yang-models/yang-models/sonic-hash.yang
+++ b/src/sonic-yang-models/yang-models/sonic-hash.yang
@@ -41,6 +41,8 @@ module sonic-hash {
             enum INNER_L4_DST_PORT;
             enum INNER_L4_SRC_PORT;
             enum IPV6_FLOW_LABEL;
+            enum RDMA_BTH_OPCODE;
+            enum RDMA_BTH_DEST_QP;
         }
     }
 
@@ -59,8 +61,68 @@ module sonic-hash {
                     ordered-by user;
                 }
 
+                leaf-list ecmp_hash_ipv4 {
+                    description "Hash fields for hashing ipv4 packets going through ECMP";
+                    type hash:hash-field;
+                    ordered-by user;
+                }
+
+                leaf-list ecmp_hash_ipv6 {
+                    description "Hash fields for hashing ipv6 packets going through ECMP";
+                    type hash:hash-field;
+                    ordered-by user;
+                }
+
+                leaf-list ecmp_hash_ipnip {
+                    description "Hash fields for hashing ipnip packets going through ECMP";
+                    type hash:hash-field;
+                    ordered-by user;
+                }
+
+                leaf-list ecmp_hash_ipv4_rdma {
+                    description "Hash fields for hashing ipv4_rdma packets going through ECMP";
+                    type hash:hash-field;
+                    ordered-by user;
+                }
+
+                leaf-list ecmp_hash_ipv6_rdma {
+                    description "Hash fields for hashing ipv6_rdma packets going through ECMP";
+                    type hash:hash-field;
+                    ordered-by user;
+                }
+
                 leaf-list lag_hash  {
                     description "Hash fields for hashing packets going through LAG";
+                    type hash:hash-field;
+                    ordered-by user;
+                }
+
+                leaf-list lag_hash_ipv4 {
+                    description "Hash fields for hashing ipv4 packets going through LAG";
+                    type hash:hash-field;
+                    ordered-by user;
+                }
+
+                leaf-list lag_hash_ipv6 {
+                    description "Hash fields for hashing ipv6 packets going through LAG";
+                    type hash:hash-field;
+                    ordered-by user;
+                }
+
+                leaf-list lag_hash_ipnip {
+                    description "Hash fields for hashing ipnip packets going through LAG";
+                    type hash:hash-field;
+                    ordered-by user;
+                }
+
+                leaf-list lag_hash_ipv4_rdma {
+                    description "Hash fields for hashing ipv4_rdma packets going through LAG";
+                    type hash:hash-field;
+                    ordered-by user;
+                }
+
+                leaf-list lag_hash_ipv6_rdma {
+                    description "Hash fields for hashing ipv6_rdma packets going through LAG";
                     type hash:hash-field;
                     ordered-by user;
                 }

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -409,6 +409,8 @@ module sonic-types {
             enum INNER_L4_DST_PORT;
             enum INNER_L4_SRC_PORT;
             enum IPV6_FLOW_LABEL;
+            enum RDMA_BTH_OPCODE;
+            enum RDMA_BTH_DEST_QP;
         }
     }
 
@@ -422,6 +424,17 @@ module sonic-types {
             enum CRC_32HI;
             enum CRC_CCITT;
             enum CRC_XOR;
+        }
+    }
+
+    typedef hash-packet-type {
+        description "Represents the packet type for which hash is configured";
+        type enumeration {
+            enum IPV4;
+            enum IPV6;
+            enum IPNIP;
+            enum IPV4_RDMA;
+            enum IPV6_RDMA;
         }
     }
 


### PR DESCRIPTION
**Why I did it:**
SONiC HLD https://github.com/sonic-net/SONiC/pull/2100 (Enhancements to SONiC Generic Hash) extends the Generic Hash feature in two ways:

1. Adds packet-type based hashing for both ECMP and LAG, so that hash fields can be configured independently per packet type (IPv4, IPv6, IPNIP, IPv4 RDMA, IPv6 RDMA) instead of a single common set of fields for all traffic.
2. Extends the native hash field set to include RoCE/RDMA packet header fields (RDMA BTH opcode and RDMA BTH destination QP) so that RoCE traffic can be hashed using its protocol-specific fields.

The SONiC YANG models must be updated accordingly so that CONFIG_DB SWITCH_HASH|GLOBAL entries carrying the new per-packet-type leaf-lists and the new RDMA hash field enums are accepted and validated; otherwise sonic-cfggen / config validation will reject the new configuration produced by swss/CLI for this feature.

**How I did it:**
Updated the sonic-yang-models package to model the enhanced SWITCH_HASH schema and added test coverage for it.

**How to verify it:**
Run the sonic-yang-models unit tests.

**Which release branch to backport (provide reason below if selected):** 
- [x] 202511

**Tested branch (Please provide the tested image version):** 
- [x] 202511