### PR TITLE
[docker-ptf] re-add gnmic, built from openconfig/gnmic main

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -107,15 +107,15 @@ RUN apt-get update          \
 # to ensure they use a patched Go stdlib (GO-2026-4337: crypto/tls)
 {% if CONFIGURED_ARCH == "armhf" %}
 RUN GO_ARCH=armv6l \
-    && GO_SHA256=7d4f0d266d871301e08ef4ac31c56e66048688893b2848392e5c600276351ee8 \
+    && GO_SHA256=39f168f158e693887d3ad006168af1b1a3007b19c5993cae4d9d57f82f52aaf8 \
 {% elif CONFIGURED_ARCH == "arm64" %}
 RUN GO_ARCH=arm64 \
-    && GO_SHA256=ec342e7389b7f489564ed5463c63b16cf8040023dabc7861256677165a8c0e2b \
+    && GO_SHA256=654da1f9b50a5d1c2a85ccf8ed405aa89c06e94d18384628bf186f7712677b08 \
 {% else %}
 RUN GO_ARCH=amd64 \
-    && GO_SHA256=00859d7bd6defe8bf84d9db9e57b9a4467b2887c18cd93ae7460e713db774bc1 \
+    && GO_SHA256=42d4f7a32316aa66591eca7e89867256057a4264451aca10570a715b3637ba70 \
 {% endif %}
-    && GO_VERSION=1.25.9 \
+    && GO_VERSION=1.25.10 \
     && curl -L "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz" -o /tmp/go.tar.gz \
     && echo "${GO_SHA256}  /tmp/go.tar.gz" | sha256sum -c - \
     && tar -C /usr/local -xzf /tmp/go.tar.gz \

--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -413,16 +413,13 @@ RUN cd gnxi \
 
 # Build gnmic from source at a pinned upstream main commit. Picks up the
 # dependency fixes merged after v0.45.0 (grpc 1.79.3, otel-sdk 1.43.0,
-# go-git 5.19.0, etc.) that address the CVEs which forced removal in
-# #27059. Temporary until the next tagged gnmic release ships.
-# prometheus is pinned forward to v0.311.3 to close CVE-2026-42151
-# (Azure AD OAuth client secret exposed via config API); upstream gnmic
-# still pins v0.311.2 at the SHA above.
-RUN GNMIC_REV=71878d1936327b96883488d5f7a7584b1dda9bf1 \
+# go-git 5.19.0, prometheus 0.311.3, etc.) that address the CVEs which
+# forced removal in #27059. Temporary until the next tagged gnmic
+# release ships.
+RUN GNMIC_REV=653dc5dd4ddcd3bd4197317875a10c1ce8b06653 \
     && git clone https://github.com/openconfig/gnmic.git /tmp/gnmic \
     && cd /tmp/gnmic \
     && git checkout "${GNMIC_REV}" \
-    && go get github.com/prometheus/prometheus@v0.311.3 \
     && go build -o /usr/local/bin/gnmic . \
     && chmod +x /usr/local/bin/gnmic \
     && rm -rf /tmp/gnmic /root/go/pkg/mod /root/.cache/go-build

--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -415,10 +415,14 @@ RUN cd gnxi \
 # dependency fixes merged after v0.45.0 (grpc 1.79.3, otel-sdk 1.43.0,
 # go-git 5.19.0, etc.) that address the CVEs which forced removal in
 # #27059. Temporary until the next tagged gnmic release ships.
+# prometheus is pinned forward to v0.311.3 to close CVE-2026-42151
+# (Azure AD OAuth client secret exposed via config API); upstream gnmic
+# still pins v0.311.2 at the SHA above.
 RUN GNMIC_REV=71878d1936327b96883488d5f7a7584b1dda9bf1 \
     && git clone https://github.com/openconfig/gnmic.git /tmp/gnmic \
     && cd /tmp/gnmic \
     && git checkout "${GNMIC_REV}" \
+    && go get github.com/prometheus/prometheus@v0.311.3 \
     && go build -o /usr/local/bin/gnmic . \
     && chmod +x /usr/local/bin/gnmic \
     && rm -rf /tmp/gnmic /root/go/pkg/mod /root/.cache/go-build

--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -411,6 +411,17 @@ RUN cd gnxi \
 # Deactivating a virtualenv.
 # ENV PATH="$BACKUP_OF_PATH"
 
+# Build gnmic from source at a pinned upstream main commit. Picks up the
+# dependency fixes merged after v0.45.0 (grpc 1.79.3, otel-sdk 1.43.0,
+# go-git 5.19.0, etc.) that address the CVEs which forced removal in
+# #27059. Temporary until the next tagged gnmic release ships.
+RUN GNMIC_REV=71878d1936327b96883488d5f7a7584b1dda9bf1 \
+    && git clone https://github.com/openconfig/gnmic.git /tmp/gnmic \
+    && cd /tmp/gnmic \
+    && git checkout "${GNMIC_REV}" \
+    && go build -o /usr/local/bin/gnmic . \
+    && chmod +x /usr/local/bin/gnmic \
+    && rm -rf /tmp/gnmic /root/go/pkg/mod /root/.cache/go-build
 
 # Remove Go toolchain to reduce image size
 RUN rm -rf /usr/local/go "$(go env GOPATH 2>/dev/null || echo $HOME/go)"


### PR DESCRIPTION
#### Why I did it

Two related changes to `docker-ptf/Dockerfile.j2`:

**1. Re-add gnmic, built from a pinned upstream main commit.**
`docker-ptf` previously shipped gnmic (added in #25537, switched to from-source build with dep overrides shortly after). In #27059 it was removed because three CVEs in v0.45.0's dependency chain could not be patched cleanly via `go get @latest` overrides:

- GHSA-x744-4wpc-v9h2 / GHSA-pxq6-2prw-chj9 — `github.com/docker/docker` needed a version that didn't exist as a Go module tag (Docker moved to `moby/moby/v2`, gnmic still imported the old path).
- GHSA-vffh-x6r8-xx99 — `github.com/prometheus/prometheus` upgrade pulled in `k8s.io/kube-openapi` with a broken transitive dep, breaking `go mod tidy`.

Those fixes have all since landed on `openconfig/gnmic` main (grpc 1.79.3, otel-sdk 1.43.0, go-git 5.19.0, docker→moby/moby/v2 migration, prometheus v0.311.3). The pinned commit `653dc5dd4ddcd3bd4197317875a10c1ce8b06653` is the merge of [openconfig/gnmic#872](https://github.com/openconfig/gnmic/pull/872) into main and additionally closes [CVE-2026-42151](https://github.com/advisories/GHSA-wg65-39gg-5wfj) (prometheus → v0.311.3). To unblock gNMI testing in docker-ptf before the next tagged gnmic release, re-add gnmic by building from that pinned main commit.

**2. Bump Go toolchain to 1.25.10.**
Go 1.25.10 is the 2026-05-07 stdlib security release ([golang-announce qcCIEXso47M](https://groups.google.com/g/golang-announce/c/qcCIEXso47M)). It closes five DoS/crash CVEs present in 1.25.9, all of which currently end up in the from-source binaries this Dockerfile builds (grpcurl, gnoic, gnmic):

- CVE-2026-33811 — `net.LookupCNAME` double-free (cgo resolver)
- CVE-2026-33814 — `net/http` HTTP/2 `SETTINGS_MAX_FRAME_SIZE=0` DoS (most relevant for gRPC tools)
- CVE-2026-39820 — `net/mail.ParseAddress`/`ParseDate` DoS
- CVE-2026-39836 — `net.Dial`/`LookupPort` panic on Windows with NUL byte
- CVE-2026-42499 — `net/mail.consumePhrase` DoS

#### How I did it

`dockers/docker-ptf/Dockerfile.j2`:

- New `RUN` block that clones `openconfig/gnmic`, checks out commit `653dc5dd`, and runs `go build -o /usr/local/bin/gnmic .` — no `go get @latest` chains, no gocloud patch; trust upstream's vendored deps. Cleans up `/tmp/gnmic`, `\$GOPATH/pkg/mod`, and the Go build cache after the build to keep layer size in check. Placed right before "Remove Go toolchain to reduce image size" so the Go toolchain is still available.
- Bumped `GO_VERSION=1.25.9 → 1.25.10` and the matching armv6l/arm64/amd64 SHA256s (taken from `https://go.dev/dl/?mode=json` on 2026-05-14).

The gnmic pin is temporary — the intent is to swap back to a tagged release once `openconfig/gnmic` cuts one that contains the dep fixes from #864 and #872.

#### How to verify it

Build the docker-ptf image and confirm gnmic is on PATH and links against the patched toolchain and prometheus:

\`\`\`
$ docker run -it --rm --entrypoint bash docker-ptf:latest
root@...:~# gnmic version
\`\`\`

Expected: `gnmic` reports a version string referencing commit `653dc5dd` (or whatever the pinned SHA is). The compiled binaries (grpcurl, gnoic, gnmic) embed Go 1.25.10 stdlib, and gnmic links against `prometheus/prometheus v0.311.3`.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

re-add gnmic to docker-ptf (built from openconfig/gnmic main, pinned); bump Go toolchain to 1.25.10

#### Link to config_db schema for YANG module changes

N/A