### PR TITLE
[Micas/Platform]: Fix kernel panic caused by packet punt to CPU during warm reboot on 48V/32C devices

### DIFF
--- a/platform/broadcom/sonic-platform-modules-micas/debian/platform-modules-micas-m2-w6510-32c.install
+++ b/platform/broadcom/sonic-platform-modules-micas/debian/platform-modules-micas-m2-w6510-32c.install
@@ -1,1 +1,2 @@
 m2-w6510-32c/modules/sonic_platform-1.0-py3-none-any.whl /usr/share/sonic/device/x86_64-micas_m2-w6510-32c-r0
+m2-w6510-32c/opennsl-modules/10-enable-execstop.conf etc/systemd/system/opennsl-modules.service.d/

--- a/platform/broadcom/sonic-platform-modules-micas/debian/platform-modules-micas-m2-w6510-48v8c.install
+++ b/platform/broadcom/sonic-platform-modules-micas/debian/platform-modules-micas-m2-w6510-48v8c.install
@@ -1,1 +1,2 @@
 m2-w6510-48v8c/modules/sonic_platform-1.0-py3-none-any.whl /usr/share/sonic/device/x86_64-micas_m2-w6510-48v8c-r0
+m2-w6510-48v8c/opennsl-modules/10-enable-execstop.conf etc/systemd/system/opennsl-modules.service.d/

--- a/platform/broadcom/sonic-platform-modules-micas/m2-w6510-32c/opennsl-modules/10-enable-execstop.conf
+++ b/platform/broadcom/sonic-platform-modules-micas/m2-w6510-32c/opennsl-modules/10-enable-execstop.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStop=-/etc/init.d/opennsl-modules stop

--- a/platform/broadcom/sonic-platform-modules-micas/m2-w6510-48v8c/opennsl-modules/10-enable-execstop.conf
+++ b/platform/broadcom/sonic-platform-modules-micas/m2-w6510-48v8c/opennsl-modules/10-enable-execstop.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStop=-/etc/init.d/opennsl-modules stop


### PR DESCRIPTION

#### Why I did it
ASIC Vendor:Broadcom
Switch ASIC:  BCM56873_A0（td3-x7）
Fix kernel panic caused by packet punt to CPU during warm reboot on 48V/32C devices
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
enable ExecStop=-/etc/init.d/opennsl-modules stop
#### How to verify it
After performing warm reboot for 15-20 burn-in cycles under the condition that protocol packets (such as ARP, ICMP) are punted to CPU, no kernel panic occurs.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

