### PR TITLE
[platform] Restore Celestica platform API wheels

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.install
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.install
@@ -4,4 +4,5 @@ dx010/systemd/platform-modules-dx010.service lib/systemd/system
 dx010/scripts/fancontrol.sh etc/init.d
 dx010/scripts/fancontrol.service lib/systemd/system
 services/fancontrol/fancontrol  usr/local/bin
+build-dx010/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-cel_seastone-r0
 services/platform_api/platform_api_mgnt.sh usr/local/bin

--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-haliburton.install
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-haliburton.install
@@ -4,6 +4,7 @@ haliburton/systemd/cpu_wdt.service lib/systemd/system
 haliburton/script/fancontrol.sh etc/init.d
 haliburton/script/fancontrol.service lib/systemd/system
 services/fancontrol/fancontrol  usr/local/bin
+build-haliburton/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-cel_e1031-r0
 services/platform_api/platform_api_mgnt.sh usr/local/bin
 haliburton/script/popmsg.sh usr/local/bin
 haliburton/script/udev_prefix.sh usr/local/bin

--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-questone2.install
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-questone2.install
@@ -1,6 +1,7 @@
 questone2/cfg/questone2-modules.conf etc/modules-load.d
 questone2/cfg/questone2-modprobe.conf etc/modprobe.d
 questone2/systemd/platform-modules-questone2.service lib/systemd/system
+build-questone2/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-cel_questone_2-r0
 questone2/cfg/pid_config_questone2.ini usr/local/etc
 questone2/scripts/questone2_platform_shutdown.sh usr/local/bin
 questone2/scripts/sensors usr/bin

--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-seastone2.install
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-seastone2.install
@@ -1,5 +1,6 @@
 seastone2/cfg/seastone2-modules.conf etc/modules-load.d
 seastone2/systemd/platform-modules-seastone2.service lib/systemd/system
+build-seastone2/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-cel_seastone_2-r0
 seastone2/scripts/seastone2_platform_shutdown.sh usr/local/bin
 seastone2/scripts/sensors usr/bin
 seastone2/scripts/platform_sensors.py usr/local/bin

--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-silverstone.install
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-silverstone.install
@@ -3,4 +3,5 @@ silverstone/scripts/platform_sensors.py usr/local/bin
 silverstone/scripts/silverstone_platform_shutdown.sh usr/local/bin
 silverstone/cfg/silverstone-modules.conf etc/modules-load.d
 silverstone/systemd/platform-modules-silverstone.service lib/systemd/system
+build-silverstone/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-cel_silverstone-r0
 services/platform_api/platform_api_mgnt.sh usr/local/bin

--- a/platform/broadcom/sonic-platform-modules-cel/debian/rules
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/rules
@@ -34,6 +34,8 @@ override_dh_auto_build:
 		$(MAKE) $(MAKE_FLAGS) -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules modules; \
 		if [ -f $(MOD_SRC_DIR)/$${mod}/setup.py ]; then \
 			PYBUILD_NAME=$${mod} pybuild --build -d $${mod}; \
+			(cd $(MOD_SRC_DIR)/$${mod} && python3 setup.py bdist_wheel -d $(MOD_SRC_DIR)/build-$${mod}); \
+			echo "Finished making sonic_platform whl package for $$mod"; \
 		fi; \
 		if [ -f $(MOD_SRC_DIR)/$${mod}/pddf/setup.py ]; then \
 			python3 -m build --no-isolation --wheel --outdir $(MOD_SRC_DIR)/build-$${mod} $(MOD_SRC_DIR)/$${mod}/pddf; \


### PR DESCRIPTION
#### Why I did it

Fixes https://github.com/sonic-net/sonic-buildimage/issues/27291.

Celestica DX010 PMON currently reports:

```text
sonic-platform package not installed, attempting to install...
Error: Unable to locate /usr/share/sonic/platform/sonic_platform-1.0-py3-none-any.whl
```

The Celestica Trixie/kernel 6.12 conversion switched non-PDDF modules to `pybuild` and removed the platform API wheel from the device directory. PMON still installs the platform API from `/usr/share/sonic/device/$PLATFORM/sonic_platform-1.0-py3-none-any.whl`, so DX010 loses the platform API and platform sensors/fans/PSUs are not detected.

#### How I did it

- Build the non-PDDF Celestica platform API wheel into `build-<module>/` during `debian/rules`.
- Install the generated wheel back into each affected non-PDDF Celestica platform device directory:
  - DX010
  - Haliburton
  - Silverstone
  - Seastone2
  - Questone2

This preserves the `pybuild` install while restoring the PMON-consumed wheel artifact.

#### How to verify it

Locally verified the wheel command used by the package build creates the expected wheel names for all affected non-PDDF modules:

```text
(cd dx010 && python3 setup.py bdist_wheel -d ../build-dx010)
(cd haliburton && python3 setup.py bdist_wheel -d ../build-haliburton)
(cd silverstone && python3 setup.py bdist_wheel -d ../build-silverstone)
(cd seastone2 && python3 setup.py bdist_wheel -d ../build-seastone2)
(cd questone2 && python3 setup.py bdist_wheel -d ../build-questone2)
```

Result: all produced `sonic_platform-1.0-py3-none-any.whl`.

Also ran:

```text
git diff --check
```
