### PR TITLE
ci: add medium vulnerability scan for trivy

### DIFF
--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -93,7 +93,7 @@ stages:
     value: $(Build.SourceBranchName)
   jobs:
   - job: trivy_scan
-    displayName: "Trivy vulnerability scan (docker-sonic-mgmt)"
+    displayName: "[OPTIONAL] Trivy vulnerability scan (docker-sonic-mgmt)"
     pool: sonic-ubuntu-1c
     continueOnError: true
     timeoutInMinutes: 30
@@ -115,7 +115,7 @@ stages:
         set -x
         trivy image \
           --input $(Pipeline.Workspace)/docker-sonic-mgmt/target/docker-sonic-mgmt.gz \
-          --severity HIGH,CRITICAL \
+          --severity MEDIUM,HIGH,CRITICAL \
           --ignore-unfixed \
           --exit-code 1 \
           --format table \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -219,7 +219,7 @@ stages:
 
   # Trivy scan for docker-ptf — informational, runs in parallel with KVM tests
   - job: trivy_scan
-    displayName: "Trivy vulnerability scan (docker-ptf)"
+    displayName: "[OPTIONAL] Trivy vulnerability scan (docker-ptf)"
     pool: sonic-ubuntu-1c
     continueOnError: true
     timeoutInMinutes: 60
@@ -244,7 +244,7 @@ stages:
         # docker-ptf.gz is ~1.3GB; scan takes 15-20 min on CI agents
         trivy image \
           --input $(Pipeline.Workspace)/target/docker-ptf.gz \
-          --severity HIGH,CRITICAL \
+          --severity MEDIUM,HIGH,CRITICAL \
           --ignore-unfixed \
           --exit-code 1 \
           --format table \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Current CI Trivy scan only detect HIGH, CRITICAL, whereas internally we're also flagging for MEDIUM. We should check for MEDIUM as well

##### Work item tracking
- Microsoft ADO **(number only)**: 37938782

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add MEDIUM to trivy scan

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

