### PR TITLE
[Mellanox] Make mlnx-fw-manager upgrade timeout configurable via platform.json

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/platform.json
@@ -1,4 +1,5 @@
 {
+    "fw_upgrade_timeout": 600,
     "chassis": {
         "name": "SN6600_LD",
         "components": [

--- a/platform/mellanox/files/mlnx-fw-manager.service
+++ b/platform/mellanox/files/mlnx-fw-manager.service
@@ -24,7 +24,7 @@ Type=oneshot
 RemainAfterExit=yes
 ExecCondition=/bin/grep -qv '\<SONIC_BOOT_TYPE=fastfast\>' /proc/cmdline
 ExecStart=/usr/local/bin/mlnx-fw-manager --clear-semaphore --verbose
-TimeoutSec=300
+TimeoutSec=660
 User=root
 
 [Install]

--- a/platform/mellanox/platform-utils/mellanox_fw_manager/firmware_coordinator.py
+++ b/platform/mellanox/platform-utils/mellanox_fw_manager/firmware_coordinator.py
@@ -22,6 +22,7 @@ Firmware coordinator for managing multiple ASIC firmware operations.
 Handles coordination of firmware upgrades across multiple ASICs,
 including process management, error handling, and SONiC image integration.
 """
+import json
 import os
 import logging
 import subprocess
@@ -62,6 +63,7 @@ class FirmwareCoordinator:
             self.logger.error(f"Failed to detect platform: {e}")
             raise
 
+        self.platform = platform
         self.asic_manager = AsicManager(platform)
 
         from .fw_manager import create_firmware_manager
@@ -169,9 +171,8 @@ class FirmwareCoordinator:
         failure_count = 0
         timeout_failures = set()
 
-        # Wait for all processes with timeout (10 minutes per ASIC)
-        # Firmware upgrades typically take 1-3 minutes, so 10 minutes provides a safe margin
-        timeout_per_asic = 600  # seconds
+        # Wait for all processes with timeout per ASIC (default from _get_fw_upgrade_timeout)
+        timeout_per_asic = self._get_fw_upgrade_timeout()
         for process in processes:
             process.join(timeout=timeout_per_asic)
             if process.is_alive():
@@ -218,6 +219,22 @@ class FirmwareCoordinator:
             raise FirmwareUpgradePartialError(f"Some ASIC upgrades failed ({total_failures}/{total_asics})")
         else:
             self.logger.info("All ASIC upgrades completed successfully")
+
+    def _get_fw_upgrade_timeout(self) -> int:
+        """Read fw_upgrade_timeout from platform.json, fall back to default 600s."""
+        default = 600
+        try:
+            if self.platform:
+                platform_json = f"/usr/share/sonic/device/{self.platform}/platform.json"
+                if os.path.exists(platform_json):
+                    with open(platform_json) as f:
+                        data = json.load(f)
+                    timeout = data.get("fw_upgrade_timeout")
+                    if timeout is not None:
+                        return int(timeout)
+        except Exception:
+            pass
+        return default
 
     def check_upgrade_required(self) -> bool:
         """

--- a/platform/mellanox/platform-utils/tests/test_firmware_coordinator.py
+++ b/platform/mellanox/platform-utils/tests/test_firmware_coordinator.py
@@ -704,5 +704,112 @@ class TestFirmwareCoordinator(unittest.TestCase):
                 manager.join.assert_called_once()
 
 
+    def _make_coordinator(self, mock_detect_platform, mock_asic_manager, mock_create_manager):
+        """Helper to create a FirmwareCoordinator with standard mocks."""
+        mock_detect_platform.return_value = "x86_64-nvidia_sn6600_ld-r0"
+        mock_asic_manager.return_value.get_asic_count.return_value = 1
+        mock_asic_manager.return_value.get_asic_pci_ids.return_value = ["01:00.0"]
+        mock_asic_manager.return_value.get_asic_type.return_value = "spectrum"
+        mock_create_manager.return_value = MagicMock()
+        return FirmwareCoordinator()
+
+    @patch('mellanox_fw_manager.firmware_coordinator._detect_platform')
+    @patch('mellanox_fw_manager.firmware_coordinator.AsicManager')
+    @patch('mellanox_fw_manager.fw_manager.create_firmware_manager')
+    @patch('mellanox_fw_manager.firmware_coordinator.os.path.exists')
+    def test_get_fw_upgrade_timeout_from_platform_json(self, mock_exists, mock_create_manager, mock_asic_manager, mock_detect_platform):
+        """Test _get_fw_upgrade_timeout reads value from platform.json."""
+        coordinator = self._make_coordinator(mock_detect_platform, mock_asic_manager, mock_create_manager)
+        mock_exists.return_value = True
+        platform_json_content = '{"fw_upgrade_timeout": 555}'
+        with patch('builtins.open', mock_open(read_data=platform_json_content)):
+            result = coordinator._get_fw_upgrade_timeout()
+        self.assertEqual(result, 555)
+
+    @patch('mellanox_fw_manager.firmware_coordinator._detect_platform')
+    @patch('mellanox_fw_manager.firmware_coordinator.AsicManager')
+    @patch('mellanox_fw_manager.fw_manager.create_firmware_manager')
+    @patch('mellanox_fw_manager.firmware_coordinator.os.path.exists')
+    def test_get_fw_upgrade_timeout_field_missing(self, mock_exists, mock_create_manager, mock_asic_manager, mock_detect_platform):
+        """Test _get_fw_upgrade_timeout returns default when field absent in platform.json."""
+        coordinator = self._make_coordinator(mock_detect_platform, mock_asic_manager, mock_create_manager)
+        mock_exists.return_value = True
+        with patch('builtins.open', mock_open(read_data='{}')):
+            result = coordinator._get_fw_upgrade_timeout()
+        self.assertEqual(result, 600)
+
+    @patch('mellanox_fw_manager.firmware_coordinator._detect_platform')
+    @patch('mellanox_fw_manager.firmware_coordinator.AsicManager')
+    @patch('mellanox_fw_manager.fw_manager.create_firmware_manager')
+    @patch('mellanox_fw_manager.firmware_coordinator.os.path.exists')
+    def test_get_fw_upgrade_timeout_file_not_exist(self, mock_exists, mock_create_manager, mock_asic_manager, mock_detect_platform):
+        """Test _get_fw_upgrade_timeout returns default when platform.json not found."""
+        coordinator = self._make_coordinator(mock_detect_platform, mock_asic_manager, mock_create_manager)
+        mock_exists.return_value = False
+        result = coordinator._get_fw_upgrade_timeout()
+        self.assertEqual(result, 600)
+
+    @patch('mellanox_fw_manager.firmware_coordinator._detect_platform')
+    @patch('mellanox_fw_manager.firmware_coordinator.AsicManager')
+    @patch('mellanox_fw_manager.fw_manager.create_firmware_manager')
+    @patch('mellanox_fw_manager.firmware_coordinator.os.path.exists')
+    def test_get_fw_upgrade_timeout_json_parse_error(self, mock_exists, mock_create_manager, mock_asic_manager, mock_detect_platform):
+        """Test _get_fw_upgrade_timeout returns default on JSON parse error."""
+        coordinator = self._make_coordinator(mock_detect_platform, mock_asic_manager, mock_create_manager)
+        mock_exists.return_value = True
+        with patch('builtins.open', mock_open(read_data='not valid json')):
+            result = coordinator._get_fw_upgrade_timeout()
+        self.assertEqual(result, 600)
+
+    @patch('mellanox_fw_manager.firmware_coordinator._detect_platform')
+    @patch('mellanox_fw_manager.firmware_coordinator.AsicManager')
+    @patch('mellanox_fw_manager.fw_manager.create_firmware_manager')
+    def test_get_fw_upgrade_timeout_platform_none(self, mock_create_manager, mock_asic_manager, mock_detect_platform):
+        """Test _get_fw_upgrade_timeout returns default when platform is None."""
+        coordinator = self._make_coordinator(mock_detect_platform, mock_asic_manager, mock_create_manager)
+        coordinator.platform = None
+        result = coordinator._get_fw_upgrade_timeout()
+        self.assertEqual(result, 600)
+
+    @patch('mellanox_fw_manager.firmware_coordinator._detect_platform')
+    @patch('mellanox_fw_manager.firmware_coordinator.AsicManager')
+    @patch('mellanox_fw_manager.fw_manager.create_firmware_manager')
+    def test_upgrade_firmware_uses_platform_json_timeout(self, mock_create_manager, mock_asic_manager, mock_detect_platform):
+        """Test upgrade_firmware passes timeout from _get_fw_upgrade_timeout to process.join."""
+        mock_detect_platform.return_value = "x86_64-nvidia_sn6600_ld-r0"
+        mock_asic_manager.return_value.get_asic_count.return_value = 1
+        mock_asic_manager.return_value.get_asic_pci_ids.return_value = ["01:00.0"]
+        mock_asic_manager.return_value.get_asic_type.return_value = "spectrum"
+
+        mock_manager = MagicMock()
+        mock_manager.asic_index = 0
+        mock_manager.is_alive.return_value = False
+        mock_create_manager.return_value = mock_manager
+
+        coordinator = FirmwareCoordinator()
+
+        with patch.object(coordinator, '_start_mst', return_value=True), \
+             patch.object(coordinator, '_stop_mst'), \
+             patch.object(coordinator, '_get_fw_upgrade_timeout', return_value=555) as mock_timeout:
+            with patch('mellanox_fw_manager.firmware_coordinator.Queue') as mock_queue_class:
+                mock_queue_instance = MagicMock()
+                mock_queue_class.return_value = mock_queue_instance
+                status_data = {
+                    'asic_index': 0,
+                    'status': UpgradeStatusType.SUCCESS.value,
+                    'message': 'done',
+                    'current_version': '1.0',
+                    'available_version': '1.1',
+                    'pci_id': '01:00.0'
+                }
+                mock_queue_instance.empty.side_effect = [False, True]
+                mock_queue_instance.get_nowait.return_value = status_data
+
+                coordinator.upgrade_firmware()
+
+                mock_timeout.assert_called_once()
+                mock_manager.join.assert_called_once_with(timeout=555)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The firmware upgrade timeout in mlnx-fw-manager was hardcoded to a fixed value, making it impossible to accommodate platforms with different upgrade time requirements. Some platforms (e.g. SN6600 with a large ASIC) need a longer timeout to complete firmware burning without false-positive failures, while others may need a shorter value. The timeout should be configurable per platform without requiring code changes.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added a fw_upgrade_timeout field to platform.json. FirmwareCoordinator._get_fw_upgrade_timeout() reads this value at runtime from /usr/share/sonic/device/<platform>/platform.json before calling process.join(timeout=...) for each ASIC upgrade process. If the field is absent or the file cannot be read, the existing default of 600 seconds is used unchanged.

#### How to verify it

1. Set fw_upgrade_timeout to a small value (e.g. 5) in platform.json and trigger a firmware upgrade — the process should time out and be killed after 5 seconds.
2. Remove fw_upgrade_timeout from platform.json and verify the upgrade falls back to the default 600-second timeout.
3. Run the unit tests.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

