### PR TITLE
[sflow] Batch port discovery to fix 10-minute init regression (#27330)

### DIFF
--- a/src/sflow/hsflowd/patch/0008-mod_sonic-batch-port-discovery.patch
+++ b/src/sflow/hsflowd/patch/0008-mod_sonic-batch-port-discovery.patch
@@ -1,0 +1,51 @@
+--- a/src/Linux/mod_sonic.c
++++ b/src/Linux/mod_sonic.c
+@@ -1035,13 +1035,19 @@
+ 
+   static bool mapPorts(EVMod *mod) {
+     HSP_mod_SONIC *mdata = (HSP_mod_SONIC *)mod->data;
+-    // kick off just one - starts a chain reaction if there are more.
+-    // Gets the ifIndex and Linux (OS) ifIndex
+-    HSPSonicPort *prt = UTArrayPop(mdata->unmappedPorts);
+-    if(prt) {
++    // Dispatch all unmapped ports at once using Redis async pipelining.
++    // The callbacks no longer chain (hiredis 1.2.0 forbids redisAsyncCommand
++    // from within callbacks), so we fire all queries here and let the
++    // replies arrive asynchronously.
++    bool dispatched = NO;
++    HSPSonicPort *prt;
++    while((prt = UTArrayPop(mdata->unmappedPorts)) != NULL) {
+       prt->unmappedPort = NO;
+       db_getIfIndexMap(mod, prt);
+-      return YES;  // still mapping points
++      dispatched = YES;
++    }
++    if(dispatched) {
++      return YES;  // still waiting for replies
+     }
+ 
+     // something changed - for example we may have just learned the alias for the
+@@ -1223,15 +1229,17 @@
+ 
+   static bool discoverNewPorts(EVMod *mod) {
+     HSP_mod_SONIC *mdata = (HSP_mod_SONIC *)mod->data;
+-    // kick off just one - starts a chain reaction if there are more.
+-    // Gets the state (index, speed etc.) so we can add it as an adaptor.
+-    HSPSonicPort *prt = UTArrayPop(mdata->newPorts);
+-    if(prt) {
++    // Dispatch all new ports at once using Redis async pipelining.
++    // The callbacks no longer chain (hiredis 1.2.0 forbids redisAsyncCommand
++    // from within callbacks), so we fire all queries here.
++    bool dispatched = NO;
++    HSPSonicPort *prt;
++    while((prt = UTArrayPop(mdata->newPorts)) != NULL) {
+       prt->newPort = NO;
+       db_getPortState(mod, prt);
+-      return YES; // still discovering new ports
++      dispatched = YES;
+     }
+-    return NO; // done discoveriny new ports
++    return dispatched; // YES if we dispatched queries, NO if nothing to do
+   }
+ 
+ 

--- a/src/sflow/hsflowd/patch/series
+++ b/src/sflow/hsflowd/patch/series
@@ -5,3 +5,4 @@
 0005-Use-close-range-syscall-over-blindly-looping-over-al.patch
 0006-mod_sonic-defer-redis-commands.patch
 0007-hsflowd-stop-overriding-sigabrt.patch
+0008-mod_sonic-batch-port-discovery.patch


### PR DESCRIPTION
#### What I did

After the hiredis 1.2.0 deferral patch (0006), `mapPorts()` and `discoverNewPorts()` only process one port per `evt_tick` (1-second interval). On systems with 500+ ports this causes sFlow to take 500+ seconds to initialize instead of ~10 seconds.

The root cause is that the original code relied on callbacks calling `redisAsyncCommand()` to chain to the next port (a "chain reaction" pattern). After hiredis 1.2.0, `redisAsyncCommand()` from within callbacks is deferred, breaking the chain — only one port gets dispatched per event loop tick.

Fix by changing `mapPorts()` and `discoverNewPorts()` to dispatch **all** pending ports at once using a `while` loop, leveraging Redis async pipelining. Since callbacks no longer chain, firing all queries in a single call is both correct and efficient.

Fixes: #27330

#### How I did it

Changed `mapPorts()` from popping one port and returning to a `while` loop that pops and dispatches all unmapped ports. Same change for `discoverNewPorts()`.

**Before (one port per tick):**
```c
HSPSonicPort *prt = UTArrayPop(mdata->unmappedPorts);
if(prt) {
    prt->unmappedPort = NO;
    db_getIfIndexMap(mod, prt);
    return YES;
}
```

**After (all ports in one burst):**
```c
bool dispatched = NO;
HSPSonicPort *prt;
while((prt = UTArrayPop(mdata->unmappedPorts)) != NULL) {
    prt->unmappedPort = NO;
    db_getIfIndexMap(mod, prt);
    dispatched = YES;
}
if(dispatched) return YES;
```

#### How to verify it

**VS KVM testbed (32 ports) — all sflow tests pass:**
```
$ pytest sflow/ --inventory veos_vtb --testbed_file vtestbed.yaml --testbed vms-kvm-t0 --device_type=vs
15 passed
```

**Console evidence (`hsflowd -dd`) — AFTER fix:**
All 32 `db_getIfIndexMap()` calls fire in a single burst with no `evt_poll_tick` between them:
```
dbg1:sonic system_ready 0 -> 1
...
dbg1:sonic db_portNamesCB: new port Ethernet96 -> oid:0x100000000001a
dbg1:sonic db_getIfIndexMap()
dbg1:sonic db_getIfIndexMap() returned 0
dbg1:sonic db_getIfIndexMap()
dbg1:sonic db_getIfIndexMap() returned 0
[... 32 consecutive calls, no evt_poll_tick between them ...]
dbg1:sonic db_getIfIndexMap()
dbg1:sonic db_getIfIndexMap() returned 0
dbg1:hsflowd: evt_poll_tick() waitConfig   <-- first tick AFTER all 32 dispatched
```

Compare with **BEFORE fix** (from issue #27330 — one port per tick):
```
dbg1:sonic db_getIfIndexMap()
dbg1:sonic db_getIfIndexMap() returned 0
dbg1:hsflowd: evt_poll_tick() waitConfig   <-- tick between EACH port
dbg1:sonic db_ifIndexMapCB: reply=array(4)
dbg1:sonic db_ifIndexMapCB: index=string(3)="394"
dbg1:sonic db_ifIndexMapCB: ifindex=string(3)="401"
dbg1:sonic db_getIfIndexMap()
dbg1:sonic db_getIfIndexMap() returned 0
dbg1:hsflowd: evt_poll_tick() waitConfig   <-- another tick, another port
```

**Performance improvement:**
- Before: N ports × 1s/tick = **N seconds** (32 ports = ~32s, 500 ports = ~500s)
- After: All N ports dispatched in **<1 second** regardless of port count

#### Previous command output (if the output of a command-Loss/redirect)

N/A
