### PR TITLE
[alpinevs] Add Alpine to the build pipeline

### DIFF
--- a/.azure-pipelines/azure-pipelines-build.yml
+++ b/.azure-pipelines/azure-pipelines-build.yml
@@ -58,6 +58,10 @@ jobs:
             dbg_image: yes
             asan_image: yes
 
+        - name: alpinevs
+          variables:
+            dbg_image: yes
+
         - name: barefoot
           variables:
             docker_syncd_rpc_image: yes
@@ -165,6 +169,8 @@ jobs:
               mv target/sonic-vpp.img.gz target/sonic-vpp-dbg.img.gz
             fi
             make $BUILD_OPTIONS target/sonic-vpp.img.gz
+          elif [ $(GROUP_NAME) == alpinevs ]; then
+            make $BUILD_OPTIONS target/sonic-alpinevs.img.gz
           else
             if [ $(dbg_image) == yes ]; then
               make  $BUILD_OPTIONS INSTALL_DEBUG_TOOLS=y target/sonic-$(GROUP_NAME).bin

--- a/.azure-pipelines/azure-pipelines-image-template.yml
+++ b/.azure-pipelines/azure-pipelines-image-template.yml
@@ -36,7 +36,7 @@ jobs:
       - script: |
           [ -n "$OVERRIDE_BUILD_OPTIONS" ] && OVERRIDE_BUILD_OPTIONS=$(OVERRIDE_BUILD_OPTIONS)
           BUILD_OPTIONS="$(BUILD_OPTIONS) $OVERRIDE_BUILD_OPTIONS"
-          if [ -n "$(CACHE_MODE)" ] && echo $(PLATFORM_AZP) | grep -E -q "^(vs|broadcom|mellanox|marvell-prestera-armhf|marvell-prestera-arm64|vpp|nvidia-bluefield)$"; then
+          if [ -n "$(CACHE_MODE)" ] && echo $(PLATFORM_AZP) | grep -E -q "^(vs|broadcom|mellanox|marvell-prestera-armhf|marvell-prestera-arm64|vpp|nvidia-bluefield|alpinevs)$"; then
             CACHE_OPTIONS="SONIC_DPKG_CACHE_METHOD=$(CACHE_MODE) SONIC_DPKG_CACHE_SOURCE=/nfs/dpkg_cache/$(PLATFORM_AZP)"
             BUILD_OPTIONS="$BUILD_OPTIONS $CACHE_OPTIONS"
           fi

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -94,6 +94,8 @@ jobs:
 
         make USERNAME=admin $CACHE_OPTIONS SONIC_BUILD_JOBS=$(nproc) target/docker-sonic-vs.gz target/sonic-vs.img.gz target/docker-ptf.gz
         make USERNAME=admin $CACHE_OPTIONS SONIC_BUILD_JOBS=$(nproc) target/docker-ptf-sai.gz
+      elif [ ${{ parameters.platform }} == alpinevs ]; then
+        make USERNAME=admin SONIC_BUILD_JOB=2 $CACHE_OPTIONS target/sonic-alpinevs.img.gz
       else
         if [ ${{ parameters.dbg_image }} == true ]; then
           make USERNAME=admin $CACHE_OPTIONS SONIC_BUILD_JOBS=$(nproc) INSTALL_DEBUG_TOOLS=y target/sonic-${{ parameters.platform }}.bin && \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,6 +73,12 @@ stages:
       jobGroups:
       - name: vpp
         continueOnError: true
+  - template: .azure-pipelines/azure-pipelines-build.yml
+    parameters:
+      buildOptions: 'USERNAME=admin SONIC_BUILD_JOBS=2 ${{ variables.VERSION_CONTROL_OPTIONS }}'
+      jobGroups:
+      - name: alpinevs
+        continueOnError: true
 
 - stage: Build
   pool: sonicso1ES-amd64


### PR DESCRIPTION
#### Why I did it

Added sonic-alpine platform to the azure build pipeline.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added Alpinevs to the pipeline files under BuildVS. 
Enabled rcache and cache path for alpinevs. The number of jobs is set to 2 for optimal use of memory while building lucius package. 

#### How to verify it

Pipeline tested several times and issues fixed using this PR and https://github.com/sonic-net/sonic-buildimage/pull/26836

Pipeline build time without cache for alpinevs
```
vs - 1:59:40
vpp - 1:11:11
alpinevs - 5:54:25
```

Pipeline build time with rwcache enabled for alpinevs
```
vs - 1:29:56
vpp - 1:44:15
alpine - 1:32:39
```
The build times can vary based on the server load, the above times are numbers from a recent run. When the cache is enabled, all three usually take between 1 and 2 hours. Refer https://github.com/sonic-net/sonic-buildimage/pull/27369/checks for the last run.

Logs from the alpine image in the artifacts : 

```

root@sonic:/home/admin# show vers

SONiC Software Version: SONiC.master-27369.1120548-625c9b23b
SONiC OS Version: 13
Distribution: Debian 13.5
Kernel: 6.12.41+deb13-sonic-amd64
Build commit: 625c9b23b
Build date: Sat May 23 02:00:54 UTC 2026
Built by: azureuser@6e67b24fc000000

Platform: x86_64-kvm_x86_64-r0
HwSKU: alpine_vs
ASIC: alpinevs
ASIC Count: 1
Serial Number: N/A
Model Number: N/A
Hardware Revision: N/A
Uptime: 04:30:53 up 0 min,  1 user,  load average: 1.00, 0.24, 0.08
Date: Mon 25 May 2026 04:30:53


root@sonic:/home/admin# docker ps
CONTAINER ID   IMAGE                                COMMAND                  CREATED          STATUS          PORTS     NAMES
07e0478bdcc4   docker-platform-monitor:latest       "/usr/bin/docker_ini…"   27 seconds ago   Up 26 seconds             pmon
94ba8efc887c   docker-sonic-mgmt-framework:latest   "/usr/local/bin/supe…"   29 seconds ago   Up 28 seconds             mgmt-framework
9f1f83170ac8   docker-sonic-gnmi:latest             "/usr/local/bin/supe…"   32 seconds ago   Up 30 seconds             gnmi
7a1c61fbf05c   docker-syncd-vs:latest               "/usr/local/bin/supe…"   2 minutes ago    Up 2 minutes              syncd
0451095fdedc   docker-sysmgr:latest                 "/usr/local/bin/supe…"   2 minutes ago    Up 2 minutes              sysmgr
0af2faad675a   docker-orchagent:latest              "/usr/bin/docker-ini…"   2 minutes ago    Up 2 minutes              swss
c3ac60d6d8d4   docker-database:latest               "/usr/local/bin/dock…"   2 minutes ago    Up 2 minutes              database
root@sonic:/home/admin# 

```

#### Description for the changelog

Added sonic-alpine platform to to the sonic-buldimage azure pipeline