### PR TITLE
Enable NBU interrupts for NH5010

### DIFF
--- a/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/sai_postinit_cmd.soc
+++ b/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/sai_postinit_cmd.soc
@@ -222,6 +222,39 @@ INTeRrupt ENAble id=546 p=7
 
 INTeRrupt ENAble id=1529 p=7
 
+# NBU has 32 cores
+INTeRrupt ENAble id=2036 p=0
+INTeRrupt ENAble id=2036 p=1
+INTeRrupt ENAble id=2036 p=2
+INTeRrupt ENAble id=2036 p=3
+INTeRrupt ENAble id=2036 p=4
+INTeRrupt ENAble id=2036 p=5
+INTeRrupt ENAble id=2036 p=6
+INTeRrupt ENAble id=2036 p=7
+INTeRrupt ENAble id=2036 p=8
+INTeRrupt ENAble id=2036 p=9
+INTeRrupt ENAble id=2036 p=10
+INTeRrupt ENAble id=2036 p=11
+INTeRrupt ENAble id=2036 p=12
+INTeRrupt ENAble id=2036 p=13
+INTeRrupt ENAble id=2036 p=14
+INTeRrupt ENAble id=2036 p=15
+INTeRrupt ENAble id=2036 p=16
+INTeRrupt ENAble id=2036 p=17
+INTeRrupt ENAble id=2036 p=18
+INTeRrupt ENAble id=2036 p=19
+INTeRrupt ENAble id=2036 p=20
+INTeRrupt ENAble id=2036 p=21
+INTeRrupt ENAble id=2036 p=22
+INTeRrupt ENAble id=2036 p=23
+INTeRrupt ENAble id=2036 p=24
+INTeRrupt ENAble id=2036 p=25
+INTeRrupt ENAble id=2036 p=26
+INTeRrupt ENAble id=2036 p=27
+INTeRrupt ENAble id=2036 p=28
+INTeRrupt ENAble id=2036 p=29
+INTeRrupt ENAble id=2036 p=30
+INTeRrupt ENAble id=2036 p=31
 
 debug intr error
 


### PR DESCRIPTION
Q3D needs this interrupt enabled to detect packet corruption Enabled the interrupt for all 32 cores

Packet corruption can be triggered for some devices manually and the interrupts will appear in syslog:
 0:dnxc_interrupt_print_info: name=NBU_CrcTxChkErrInt, id=2036, index=0, block=12, unit=0, recurring_action=0 | Check Configuration | None

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Q3D needs this interrupt enabled to detect packet corruption Enabled the interrupt for all 32 cores

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Q3D needs this interrupt enabled to detect packet corruption Enabled the interrupt for all 32 cores

#### How to verify it
Packet corruption can be triggered for some devices manually and the interrupts will appear in syslog:
 ```
 0:dnxc_interrupt_print_info: name=NBU_CrcTxChkErrInt, id=2036, index=0, block=12, unit=0, recurring_action=0 | Check Configuration | None
 ```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

