### PR TITLE
[202511] Add 'sai_instru_stat_accum_enable=1' to Arista DNX SKUs

### DIFF
--- a/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/0/jr2p-a7280dra3-36-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/0/jr2p-a7280dra3-36-36x400G.config.bcm
@@ -986,3 +986,4 @@ sai_pfc_dlr_init_capability=0
 sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
 sai_lag_default_crc_hash=1
+sai_instru_stat_accum_enable=1

--- a/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/1/jr2p-a7280dra3-36-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/1/jr2p-a7280dra3-36-36x400G.config.bcm
@@ -985,3 +985,4 @@ sai_pfc_dlr_init_capability=0
 sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
 sai_lag_default_crc_hash=1
+sai_instru_stat_accum_enable=1

--- a/device/arista/x86_64-arista_7280r4_32qf_32df/Arista-7280R4-32QF-32DF-64O/q3d-a7280R4-32QFx400G-32DFx400G.config.bcm
+++ b/device/arista/x86_64-arista_7280r4_32qf_32df/Arista-7280R4-32QF-32DF-64O/q3d-a7280R4-32QFx400G-32DFx400G.config.bcm
@@ -1272,3 +1272,4 @@ sai_default_cpu_tx_tc=7
 sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
+sai_instru_stat_accum_enable=1

--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
@@ -866,3 +866,4 @@ sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=58
 appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
+sai_instru_stat_accum_enable=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1020,3 +1020,4 @@ sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
+sai_instru_stat_accum_enable=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1020,3 +1020,4 @@ sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
+sai_instru_stat_accum_enable=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1037,3 +1037,4 @@ sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
+sai_instru_stat_accum_enable=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1037,3 +1037,4 @@ sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
+sai_instru_stat_accum_enable=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1057,3 +1057,4 @@ sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
+sai_instru_stat_accum_enable=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1057,3 +1057,4 @@ sai_disable_srcmacqedstmac_ctrl=1
 appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
+sai_instru_stat_accum_enable=1

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -366,3 +366,4 @@ appl_param_rcy_mirror_ports_range
 rcy_mirror_to_forward_port_map
 port_priorities_sch
 sai_lag_default_crc_hash
+sai_instru_stat_accum_enable


### PR DESCRIPTION
Manual cherry-pick of https://github.com/sonic-net/sonic-buildimage/pull/27009

This will likely conflict with https://github.com/sonic-net/sonic-buildimage/pull/26462 when it merges to 202511 as well.