### PR TITLE
[FC] Move DPU counter defaults to init_cfg.json (#20492)

### DIFF
--- a/dockers/docker-orchagent/enable_counters.py
+++ b/dockers/docker-orchagent/enable_counters.py
@@ -2,7 +2,6 @@
 
 import time
 from swsscommon import swsscommon
-from sonic_py_common import device_info
 
 # ALPHA defines the size of the window over which we calculate the average value. ALPHA is 2/(N+1) where N is the interval(window size)
 # In this case we configure the window to be 10s. This way if we have a huge 1s spike in traffic,
@@ -10,14 +9,6 @@ from sonic_py_common import device_info
 DEFAULT_SMOOTH_INTERVAL = '10'
 DEFAULT_ALPHA = '0.18'
 
-
-def enable_counter_group(db, name):
-    entry_info = db.get_entry("FLEX_COUNTER_TABLE", name)
-
-    if not entry_info:
-        info = {}
-        info['FLEX_COUNTER_STATUS'] = 'enable'
-        db.mod_entry("FLEX_COUNTER_TABLE", name, info)
 
 def enable_rates():
     # set the default interval for rates
@@ -34,16 +25,8 @@ def enable_rates():
     counters_db.set('COUNTERS_DB', 'RATES:QUEUE', 'QUEUE_SMOOTH_INTERVAL', DEFAULT_SMOOTH_INTERVAL)
     counters_db.set('COUNTERS_DB', 'RATES:QUEUE', 'QUEUE_ALPHA', DEFAULT_ALPHA)
 
+
 def enable_counters():
-    db = swsscommon.ConfigDBConnector()
-    db.connect()
-    dpu_counters = ["ENI","DASH_METER"]
-
-    platform_info = device_info.get_platform_info(db)
-    if platform_info.get('switch_type') == 'dpu':
-        for key in dpu_counters:
-            enable_counter_group(db, key)
-
     enable_rates()
 
 

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -56,6 +56,20 @@
         "PORT_BUFFER_DROP": {
             "FLEX_COUNTER_STATUS": "enable"
         }
+{%- if sonic_asic_platform in ["nvidia-bluefield", "pensando"] %},
+        "ENI": {
+            "FLEX_COUNTER_STATUS": "enable",
+            "POLL_INTERVAL": "10000"
+        },
+        "DASH_METER": {
+            "FLEX_COUNTER_STATUS": "enable",
+            "POLL_INTERVAL": "10000"
+        },
+        "HA_SET": {
+            "FLEX_COUNTER_STATUS": "enable",
+            "POLL_INTERVAL": "10000"
+        }
+{%- endif %}
     },
     "BGP_DEVICE_GLOBAL": {
         "STATE": {


### PR DESCRIPTION
#### Why I did it

Eliminate the runtime CONFIG_DB write in `enable_counters.py` that adds
`FLEX_COUNTER_TABLE|ENI` / `|DASH_METER` 60-180 s after swss starts on a DPU.
This caused running CONFIG_DB to drift from `init_cfg.json`, breaking
config-as-source-of-truth.

Follows the same pattern as sonic-net/sonic-buildimage#20506 for issue
sonic-net/sonic-buildimage#20302.

##### Work item tracking
- GitHub issue: sonic-net/sonic-buildimage#20492
- Microsoft ADO **(number only)**: N/A (downstream port of the upstream GitHub issue above)

#### How I did it

- Add `ENI`, `DASH_METER`, `HA_SET` rows to `FLEX_COUNTER_TABLE` in
  `files/build_templates/init_cfg.json.j2`, gated on
  `sonic_asic_platform in ("nvidia-bluefield", "pensando")`.
- Each new row sets `POLL_INTERVAL=10000` explicitly; the removed runtime path
  in `enable_counter_group()` only wrote `FLEX_COUNTER_STATUS=enable` and let
  FlexCounter pick its default poll interval. `10000` matches the value already
  used by the `ACL` row in the same table.
- Drop the DPU branch (and the now-unused `enable_counter_group()` helper and
  the `sonic_py_common.device_info` import) from
  `dockers/docker-orchagent/enable_counters.py`.

Note on the gate: the predicate moved from runtime
`platform_info.get('switch_type') == 'dpu'` (CONFIG_DB derived) to build-time
`sonic_asic_platform in ("nvidia-bluefield", "pensando")`. Equivalent for
today's DPU images; any future DPU ASIC platform must be added to this list.

#### How to verify it

- On an `nvidia-bluefield` DPU image built from this branch:
  `redis-cli -n 4 KEYS 'FLEX_COUNTER_TABLE|*'` captures the same set of rows
  (including `ENI`, `DASH_METER`, `HA_SET`) immediately after
  `config reload -y` and 240 s later, confirming the runtime drift is gone.
- The Jinja `{%- if sonic_asic_platform in ("nvidia-bluefield", "pensando") %}`
  gate is the only change on the non-DPU code path, so other platforms
  (mellanox, broadcom, cisco-8000, vs, pensando) get no template delta and
  were not re-rendered for this PR.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

No backport requested — `master_RC` only. The ENI/DASH_METER/HA_SET FLEX
counters are DPU-specific and not in scope for any of the listed release
branches.

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

Verified manually on an internal DPU image built from this branch; no public
release-image version applies.

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

Move DPU FLEX_COUNTER defaults (ENI/DASH_METER/HA_SET) from runtime CONFIG_DB write to init_cfg.json.j2.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes

N/A — no YANG schema change. `FLEX_COUNTER_TABLE` shape is unchanged; only
default rows are added on DPU platforms.

#### A picture of a cute animal (not mandatory but encouraged)

#### External PR

- Upstream tracking issue: sonic-net/sonic-buildimage#20492
- Pattern reference (sibling fix): sonic-net/sonic-buildimage#20506
- Underlying upstream issue: sonic-net/sonic-buildimage#20302
