### PR TITLE
[platform] Avoid installing Z9864 platform API in postinst

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9864f.postinst
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9864f.postinst
@@ -2,7 +2,6 @@
 
 # Enable Dell-Z9864f-platform-service
 depmod -a
-pip3 install /usr/share/sonic/device/x86_64-dell_z9864f-r0/sonic_platform-1.0-py3-none-any.whl --force-reinstall -q --root-user-action=ignore
 systemctl enable platform-modules-z9864f.service
 systemctl start platform-modules-z9864f.service
 systemctl enable system-health.service


### PR DESCRIPTION
#### Why I did it
Fixes https://github.com/sonic-net/sonic-buildimage/issues/27104.

The Z9864f platform package currently runs `pip3 install .../sonic_platform-1.0-py3-none-any.whl` from its Debian `postinst`. During broadcom image construction, platform packages for many SKUs are installed/removed as build dependencies. That direct pip install writes `sonic_platform` into `/usr/local/lib/python*/dist-packages`, outside dpkg ownership, so removing the Debian package does not clean it up. The leftover Z9864f `sonic_platform` can then be packaged into non-Z9864 broadcom images and shadow the correct platform API at runtime.

The Z9864f platform init script already installs the matching platform API from `DEVICE_METADATA.localhost.platform`, following the existing Dell platform pattern. This change removes the unconditional `postinst` pip install so the API is installed only by the runtime platform path.

#### How I verified it
- `bash -n platform/broadcom/sonic-platform-modules-dell/debian/platform-modules-z9864f.postinst`
- Confirmed `z9864f_platform.sh` still contains the runtime `install_python_api_package()` path and calls it during platform init.
- Confirmed no direct `pip3 install ...sonic_platform` remains in the Z9864f `postinst`.
