### PR TITLE
[docker-sonic-mgmt] regenerate ansible patch for ansible-core 2.20.5

### DIFF
--- a/dockers/docker-sonic-mgmt/0001-Fix-getattr-AttributeError-in-multi-thread-scenario.patch
+++ b/dockers/docker-sonic-mgmt/0001-Fix-getattr-AttributeError-in-multi-thread-scenario.patch
@@ -1,10 +1,8 @@
-From e323263795a0af4c9c61992bd7a3347d8928db39 Mon Sep 17 00:00:00 2001
-From: Xin Wang <xiwang5@microsoft.com>
-Date: Thu, 14 Sep 2023 16:52:54 +0800
-Subject: [PATCH] Fix getattr AttributeError in multi-thread scenario
-
-When multi-thread is used, the plugin loader may raise AttributeError
-while getting "ActionModule" from an action plugin.
+From 94dd505c5e54341414dcb3b02bd50acef302b4eb Mon Sep 17 00:00:00 2001
+From: Sai Kiran <110003254+opcoder0@users.noreply.github.com>
+Date: Fri, 15 May 2026 14:40:48 +1000
+Subject: [PATCH] When multi-thread is used, the plugin loader may raise
+ AttributeError while getting "ActionModule" from an action plugin.
 
 The reason is that cache is used while loading module. Before a module
 is fully loaded, it is already put into the sys.modules cache. When another
@@ -14,33 +12,33 @@ attribute from this module, exception AttributeError could be raised.
 
 Signed-off-by: Xin Wang <xiwang5@microsoft.com>
 ---
- lib/ansible/plugins/loader.py | 11 +++++------
- 1 file changed, 5 insertions(+), 6 deletions(-)
+ lib/ansible/plugins/loader.py | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
 
 diff --git a/lib/ansible/plugins/loader.py b/lib/ansible/plugins/loader.py
-index 74bdeb5719..251531b62e 100644
+index e12ec1b9ea..fe7dc25443 100644
 --- a/lib/ansible/plugins/loader.py
 +++ b/lib/ansible/plugins/loader.py
-@@ -801,15 +801,14 @@ class PluginLoader:
-             warnings.simplefilter("ignore", RuntimeWarning)
-             spec = importlib.util.spec_from_file_location(to_native(full_name), to_native(path))
+@@ -934,14 +934,15 @@ class PluginLoader:
+             spec = importlib.util.spec_from_file_location(to_native(python_module_name), to_native(path))
              module = importlib.util.module_from_spec(spec)
--
+ 
 -            # mimic import machinery; make the module-being-loaded available in sys.modules during import
 -            # and remove if there's a failure...
--            sys.modules[full_name] = module
--
+-            sys.modules[python_module_name] = module
+ 
              try:
                  spec.loader.exec_module(module)
 +                # mimic import machinery; make the module-being-loaded available in sys.modules during import
 +                # and remove if there's a failure...
-+                sys.modules[full_name] = module
++                sys.modules[python_module_name] = module
              except Exception:
--                del sys.modules[full_name]
-+                if full_name in sys.modules:
-+                    del sys.modules[full_name]
+-                del sys.modules[python_module_name]
++                if python_module_name in sys.modules:
++                    del sys.modules[python_module_name]
                  raise
-
+ 
          return module
---
-2.25.1
+-- 
+2.54.0.windows.1
+

--- a/dockers/docker-sonic-mgmt/0001-Fix-getattr-AttributeError-in-multi-thread-scenario.patch
+++ b/dockers/docker-sonic-mgmt/0001-Fix-getattr-AttributeError-in-multi-thread-scenario.patch
@@ -11,6 +11,7 @@ module from the sys.modules cache. Then while getting "ActionModule"
 attribute from this module, exception AttributeError could be raised.
 
 Signed-off-by: Xin Wang <xiwang5@microsoft.com>
+Signed-off-by: Sai Kiran <110003254+opcoder0@users.noreply.github.com>
 ---
  lib/ansible/plugins/loader.py | 9 +++++----
  1 file changed, 5 insertions(+), 4 deletions(-)


### PR DESCRIPTION
#### Why I did it

`ansible` which was pinned to 11.10.0 is now updated to the latest with ansible-core at 2.20.5. The docker-sonic-mgmt patches ansible-core behavior and the patch needs to be regenerated for the current version.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Regenerate patch from ansible v2.20.5

#### How to verify it

NA

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

NA

#### Description for the changelog

[docker-sonic-mgmt] regenerate ansible patch for ansible-core 2.20.5
- ansible which was pinned to 11.10.0 is now updated to the latest with ansible-core at 2.20.5. The docker-sonic-mgmt patches ansible-core behavior and the patch needs to be regenerated for the current version.


#### Link to config_db schema for YANG module changes

NA

#### A picture of a cute animal (not mandatory but encouraged)