### PR TITLE
build: remove unused libprotobuf32t64 runtime package from base image

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -372,7 +372,6 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     python3-pip             \
     python-is-python3       \
     cron                    \
-    libprotobuf32t64        \
     haveged                 \
     gpg                     \
     dmidecode               \


### PR DESCRIPTION
#### Why I did it

##### Work item tracking
- Microsoft ADO:

Remove `libgrpc29t64`, `libgrpc++1.51t64`, and `libprotobuf32t64` from the base SONiC image. These packages are installed in the base rootfs but have no consumers — no ELF binary or Python import in the base image links or loads these libraries (confirmed via `ldd`/`readelf` on all binaries in fsroot-vs).

#### How I did it

Remove the three package entries from `build_debian.sh`. If any platform-specific component requires these libraries at runtime, it should declare that dependency in its own debian package control file so apt can manage it explicitly.

#### How to verify it

- Build a VS image and confirm `libgrpc29t64` is not installed in the rootfs
- Verify all existing platform tests continue to pass

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ]

#### Description for the changelog

Remove unused libgrpc and libprotobuf runtime packages from base SONiC image

#### Link to config_db schema for YANG module changes

N/A