### PR TITLE
[Mellanox] Disable thermal updater for liquid cooling system

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_manager.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_manager.py
@@ -16,9 +16,14 @@
 # limitations under the License.
 #
 from sonic_platform_base.sonic_thermal_control.thermal_manager_base import ThermalManagerBase
-from . import thermal_updater 
-from . import smartswitch_thermal_updater 
+from . import thermal_updater
+from . import smartswitch_thermal_updater
 from .device_data import DeviceDataManager
+from .liquid_cooling import LiquidCooling
+from sonic_py_common import logger
+
+SYSLOG_IDENTIFIER = 'thermal_manager'
+log = logger.Logger(SYSLOG_IDENTIFIER)
 
 
 class ThermalManager(ThermalManagerBase):
@@ -35,6 +40,11 @@ class ThermalManager(ThermalManagerBase):
         and any other vendor specific initialization.
         :return:
         """
+        if LiquidCooling().get_num_leak_sensors() > 0:
+            log.log_notice('Liquid cooling platform detected, thermal updater is disabled')
+            cls.thermal_updater_task = None
+            return
+
         dpus_present = DeviceDataManager.get_platform_dpus_data()
         if not dpus_present:
             # Non smart switch behaviour has highest priority

--- a/platform/mellanox/mlnx-platform-api/tests/test_thermal_manager.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_thermal_manager.py
@@ -24,7 +24,8 @@ class TestThermalManager:
 
     @mock.patch('sonic_platform.chassis.Chassis.chassis_instance', new_callable=mock.MagicMock)
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_platform_dpus_data')
-    def test_updater_init(self, mock_dpus_data, mock_chassis_instance):
+    @mock.patch('sonic_platform.thermal_manager.LiquidCooling.get_num_leak_sensors', return_value=0)
+    def test_updater_init(self, _mock_get_num_leak_sensors, mock_dpus_data, mock_chassis_instance):
         mock_dpus_data.return_value = {}
         sfp_mock = mock.MagicMock()
         mod_mock = mock.MagicMock()
@@ -49,3 +50,18 @@ class TestThermalManager:
             mock_sm_thermal.assert_called_once_with(sfp_list=['sfp1', 'sfp2'], dpu_list=['dpu1', 'dpu2'])
             mgr.deinitialize()
             mgr.thermal_updater_task.stop.assert_called_once()
+
+    @mock.patch('sonic_platform.chassis.Chassis.chassis_instance', new_callable=mock.MagicMock)
+    @mock.patch('sonic_platform.device_data.DeviceDataManager.get_platform_dpus_data')
+    @mock.patch('sonic_platform.thermal_manager.LiquidCooling.get_num_leak_sensors', return_value=2)
+    def test_updater_init_liquid_cooling(self, _mock_get_num_leak_sensors, mock_dpus_data, mock_chassis_instance):
+        mock_dpus_data.return_value = {}
+
+        with mock.patch('sonic_platform.thermal_updater.ThermalUpdater') as mock_thermal, \
+          mock.patch('sonic_platform.smartswitch_thermal_updater.SmartswitchThermalUpdater') as mock_sm_thermal:
+            mgr = ThermalManager()
+            mgr.initialize()
+            mock_thermal.assert_not_called()
+            mock_sm_thermal.assert_not_called()
+            assert mgr.thermal_updater_task is None
+            mgr.deinitialize()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Liquid cooling platforms manage thermals through leak sensors rather than fans, and have their own dedicated thermal control logic. The existing ThermalManager.initialize() unconditionally starts a ThermalUpdater task, which is designed for air-cooled systems and is irrelevant — and potentially disruptive — on liquid cooling platforms.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

At the top of ThermalManager.initialize(), check whether the platform is liquid-cooled by calling LiquidCooling().get_num_leak_sensors(). If the count is greater than 0, log a notice, set thermal_updater_task = None, and return early — skipping the ThermalUpdater and SmartswitchThermalUpdater initialization. Non-liquid-cooling platforms are unaffected.                                                        
Modified file: platform/mellanox/mlnx-platform-api/sonic_platform/thermal_manager.py

#### How to verify it

A new unit test test_updater_init_liquid_cooling mocks LiquidCooling.get_num_leak_sensors to return 2 (simulating a liquid cooling platform) and asserts that neither ThermalUpdater nor SmartswitchThermalUpdater is instantiated, and that thermal_updater_task is None.
The existing test_updater_init is also updated to mock get_num_leak_sensors returning 0, confirming the non-liquid-cooling path is unchanged.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

