### PR TITLE
[7050CX3]Revert the media settings for 100G copper media

### DIFF
--- a/device/arista/x86_64-arista_7050cx3_32s/media_settings.json
+++ b/device/arista/x86_64-arista_7050cx3_32s/media_settings.json
@@ -9,14 +9,6 @@
                     "lane3": "0x105004"
                 }
             },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x45808",
-                    "lane1": "0x45808",
-                    "lane2": "0x45808",
-                    "lane3": "0x45808"
-                }
-            },
             "OPTICAL10": {
                 "preemphasis": {
                     "lane0": "0x14410a",
@@ -41,14 +33,6 @@
                     "lane1": "0x105004",
                     "lane2": "0x105004",
                     "lane3": "0x105004"
-                }
-            },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x45808",
-                    "lane1": "0x45808",
-                    "lane2": "0x45808",
-                    "lane3": "0x45808"
                 }
             },
             "OPTICAL10": {
@@ -77,14 +61,6 @@
                     "lane3": "0x105004"
                 }
             },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x45808",
-                    "lane1": "0x45808",
-                    "lane2": "0x45808",
-                    "lane3": "0x45808"
-                }
-            },
             "OPTICAL10": {
                 "preemphasis": {
                     "lane0": "0x14410a",
@@ -109,14 +85,6 @@
                     "lane1": "0x105004",
                     "lane2": "0x105004",
                     "lane3": "0x105004"
-                }
-            },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x45808",
-                    "lane1": "0x45808",
-                    "lane2": "0x45808",
-                    "lane3": "0x45808"
                 }
             },
             "OPTICAL10": {
@@ -145,14 +113,6 @@
                     "lane3": "0x105004"
                 }
             },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x45808",
-                    "lane1": "0x45808",
-                    "lane2": "0x45808",
-                    "lane3": "0x45808"
-                }
-            },
             "OPTICAL10": {
                 "preemphasis": {
                     "lane0": "0x14410a",
@@ -177,14 +137,6 @@
                     "lane1": "0x105004",
                     "lane2": "0x105004",
                     "lane3": "0x105004"
-                }
-            },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x45808",
-                    "lane1": "0x45808",
-                    "lane2": "0x45808",
-                    "lane3": "0x45808"
                 }
             },
             "OPTICAL10": {
@@ -213,14 +165,6 @@
                     "lane3": "0x105004"
                 }
             },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x45808",
-                    "lane1": "0x45808",
-                    "lane2": "0x45808",
-                    "lane3": "0x45808"
-                }
-            },
             "OPTICAL10": {
                 "preemphasis": {
                     "lane0": "0x14410a",
@@ -245,14 +189,6 @@
                     "lane1": "0x105004",
                     "lane2": "0x105004",
                     "lane3": "0x105004"
-                }
-            },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x45808",
-                    "lane1": "0x45808",
-                    "lane2": "0x45808",
-                    "lane3": "0x45808"
                 }
             },
             "OPTICAL10": {
@@ -281,14 +217,6 @@
                     "lane3": "0x105004"
                 }
             },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x45808",
-                    "lane1": "0x45808",
-                    "lane2": "0x45808",
-                    "lane3": "0x45808"
-                }
-            },
             "OPTICAL10": {
                 "preemphasis": {
                     "lane0": "0x14410a",
@@ -313,14 +241,6 @@
                     "lane1": "0x105004",
                     "lane2": "0x105004",
                     "lane3": "0x105004"
-                }
-            },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x45808",
-                    "lane1": "0x45808",
-                    "lane2": "0x45808",
-                    "lane3": "0x45808"
                 }
             },
             "OPTICAL10": {
@@ -349,14 +269,6 @@
                     "lane3": "0x105004"
                 }
             },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x580c",
-                    "lane1": "0x580c",
-                    "lane2": "0x580c",
-                    "lane3": "0x580c"
-                }
-            },
             "OPTICAL10": {
                 "preemphasis": {
                     "lane0": "0x14410a",
@@ -381,14 +293,6 @@
                     "lane1": "0x105004",
                     "lane2": "0x105004",
                     "lane3": "0x105004"
-                }
-            },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x580c",
-                    "lane1": "0x580c",
-                    "lane2": "0x580c",
-                    "lane3": "0x580c"
                 }
             },
             "OPTICAL10": {
@@ -417,14 +321,6 @@
                     "lane3": "0x6004"
                 }
             },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x580c",
-                    "lane1": "0x580c",
-                    "lane2": "0x580c",
-                    "lane3": "0x580c"
-                }
-            },
             "OPTICAL10": {
                 "preemphasis": {
                     "lane0": "0x410a",
@@ -449,14 +345,6 @@
                     "lane1": "0x6004",
                     "lane2": "0x6004",
                     "lane3": "0x6004"
-                }
-            },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x580c",
-                    "lane1": "0x580c",
-                    "lane2": "0x580c",
-                    "lane3": "0x580c"
                 }
             },
             "OPTICAL10": {
@@ -485,14 +373,6 @@
                     "lane3": "0x6004"
                 }
             },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x580c",
-                    "lane1": "0x580c",
-                    "lane2": "0x580c",
-                    "lane3": "0x580c"
-                }
-            },
             "OPTICAL10": {
                 "preemphasis": {
                     "lane0": "0x410a",
@@ -517,14 +397,6 @@
                     "lane1": "0x6004",
                     "lane2": "0x6004",
                     "lane3": "0x6004"
-                }
-            },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x580c",
-                    "lane1": "0x580c",
-                    "lane2": "0x580c",
-                    "lane3": "0x580c"
                 }
             },
             "OPTICAL10": {
@@ -553,14 +425,6 @@
                     "lane3": "0x6004"
                 }
             },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x580c",
-                    "lane1": "0x580c",
-                    "lane2": "0x580c",
-                    "lane3": "0x580c"
-                }
-            },
             "OPTICAL10": {
                 "preemphasis": {
                     "lane0": "0x410a",
@@ -585,14 +449,6 @@
                     "lane1": "0x6004",
                     "lane2": "0x6004",
                     "lane3": "0x6004"
-                }
-            },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x580c",
-                    "lane1": "0x580c",
-                    "lane2": "0x580c",
-                    "lane3": "0x580c"
                 }
             },
             "OPTICAL10": {
@@ -621,14 +477,6 @@
                     "lane3": "0x6004"
                 }
             },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x580c",
-                    "lane1": "0x580c",
-                    "lane2": "0x580c",
-                    "lane3": "0x580c"
-                }
-            },
             "OPTICAL10": {
                 "preemphasis": {
                     "lane0": "0x410a",
@@ -653,14 +501,6 @@
                     "lane1": "0x6004",
                     "lane2": "0x6004",
                     "lane3": "0x6004"
-                }
-            },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x580c",
-                    "lane1": "0x580c",
-                    "lane2": "0x580c",
-                    "lane3": "0x580c"
                 }
             },
             "OPTICAL10": {
@@ -689,14 +529,6 @@
                     "lane3": "0x105004"
                 }
             },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x580c",
-                    "lane1": "0x580c",
-                    "lane2": "0x580c",
-                    "lane3": "0x580c"
-                }
-            },
             "OPTICAL10": {
                 "preemphasis": {
                     "lane0": "0x14410a",
@@ -721,14 +553,6 @@
                     "lane1": "0x105004",
                     "lane2": "0x105004",
                     "lane3": "0x105004"
-                }
-            },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x580c",
-                    "lane1": "0x580c",
-                    "lane2": "0x580c",
-                    "lane3": "0x580c"
                 }
             },
             "OPTICAL10": {
@@ -757,14 +581,6 @@
                     "lane3": "0x105004"
                 }
             },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x580c",
-                    "lane1": "0x580c",
-                    "lane2": "0x580c",
-                    "lane3": "0x580c"
-                }
-            },
             "OPTICAL10": {
                 "preemphasis": {
                     "lane0": "0x14410a",
@@ -789,14 +605,6 @@
                     "lane1": "0x105004",
                     "lane2": "0x105004",
                     "lane3": "0x105004"
-                }
-            },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x580c",
-                    "lane1": "0x580c",
-                    "lane2": "0x580c",
-                    "lane3": "0x580c"
                 }
             },
             "OPTICAL10": {
@@ -825,14 +633,6 @@
                     "lane3": "0x105004"
                 }
             },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x580c",
-                    "lane1": "0x580c",
-                    "lane2": "0x580c",
-                    "lane3": "0x580c"
-                }
-            },
             "OPTICAL10": {
                 "preemphasis": {
                     "lane0": "0x14410a",
@@ -857,14 +657,6 @@
                     "lane1": "0x105004",
                     "lane2": "0x105004",
                     "lane3": "0x105004"
-                }
-            },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x580c",
-                    "lane1": "0x580c",
-                    "lane2": "0x580c",
-                    "lane3": "0x580c"
                 }
             },
             "OPTICAL10": {
@@ -893,14 +685,6 @@
                     "lane3": "0x105004"
                 }
             },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x85804",
-                    "lane1": "0x85804",
-                    "lane2": "0x85804",
-                    "lane3": "0x85804"
-                }
-            },
             "OPTICAL10": {
                 "preemphasis": {
                     "lane0": "0x14410a",
@@ -925,14 +709,6 @@
                     "lane1": "0x105004",
                     "lane2": "0x105004",
                     "lane3": "0x105004"
-                }
-            },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x85804",
-                    "lane1": "0x85804",
-                    "lane2": "0x85804",
-                    "lane3": "0x85804"
                 }
             },
             "OPTICAL10": {
@@ -961,14 +737,6 @@
                     "lane3": "0x105004"
                 }
             },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x85804",
-                    "lane1": "0x85804",
-                    "lane2": "0x85804",
-                    "lane3": "0x85804"
-                }
-            },
             "OPTICAL10": {
                 "preemphasis": {
                     "lane0": "0x14410a",
@@ -993,14 +761,6 @@
                     "lane1": "0x105004",
                     "lane2": "0x105004",
                     "lane3": "0x105004"
-                }
-            },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x85804",
-                    "lane1": "0x85804",
-                    "lane2": "0x85804",
-                    "lane3": "0x85804"
                 }
             },
             "OPTICAL10": {
@@ -1029,14 +789,6 @@
                     "lane3": "0x105004"
                 }
             },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x85804",
-                    "lane1": "0x85804",
-                    "lane2": "0x85804",
-                    "lane3": "0x85804"
-                }
-            },
             "OPTICAL10": {
                 "preemphasis": {
                     "lane0": "0x14410a",
@@ -1061,14 +813,6 @@
                     "lane1": "0x105004",
                     "lane2": "0x105004",
                     "lane3": "0x105004"
-                }
-            },
-            "COPPER25": {
-                "preemphasis": {
-                    "lane0": "0x85804",
-                    "lane1": "0x85804",
-                    "lane2": "0x85804",
-                    "lane3": "0x85804"
                 }
             },
             "OPTICAL10": {


### PR DESCRIPTION
#### Why I did it
This [PR22428](https://github.com/sonic-net/sonic-buildimage/pull/22428) has potentially introduced CRC error on the peer NIC connected to this TOR 7050CX3-32S during cold reboot upgrade to 202505

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Removed the SI settings for `COPPER25` media i.e 100G DAC cables

#### How to verify it
1. Verified with brcm diag shell the 100G DAC cables are now using the old TX FIR settings
2. Tested this with multiple RX signal adaptation on the NIC side

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

