### PR TITLE
[yang] Add REST_SERVER config model

### DIFF
--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -175,6 +175,7 @@ yang_files = [
     'sonic-portchannel.yang',
     'sonic-queue.yang',
     'sonic-restapi.yang',
+    'sonic-rest-server.yang',
     'sonic-route-common.yang',
     'sonic-route-map.yang',
     'sonic-routing-policy-sets.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1496,6 +1496,16 @@
                 "allow_insecure": "false"
             }
          },
+        "REST_SERVER": {
+            "default": {
+                "port": "443",
+                "client_auth": "user",
+                "log_level": "2",
+                "server_crt": "/etc/sonic/credentials/restserver.crt",
+                "server_key": "/etc/sonic/credentials/restserver.key",
+                "ca_crt": "/etc/sonic/credentials/restca.crt"
+            }
+        },
         "FABRIC_MONITOR": {
             "FABRIC_MONITOR_DATA": {
                 "monErrThreshCrcCells": "1",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/rest_server.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/rest_server.json
@@ -1,0 +1,34 @@
+{
+    "REST_SERVER_TABLE_WITH_VALID_CONFIG": {
+        "sonic-rest-server:sonic-rest-server": {
+            "sonic-rest-server:REST_SERVER": {
+                "default": {
+                    "port": 443,
+                    "client_auth": "user",
+                    "log_level": 2,
+                    "server_crt": "/etc/sonic/credentials/restserver.crt",
+                    "server_key": "/etc/sonic/credentials/restserver.key",
+                    "ca_crt": "/etc/sonic/credentials/restca.crt"
+                }
+            }
+        }
+    },
+    "REST_SERVER_TABLE_WITH_INVALID_CLIENT_AUTH": {
+        "sonic-rest-server:sonic-rest-server": {
+            "sonic-rest-server:REST_SERVER": {
+                "default": {
+                    "client_auth": "invalid"
+                }
+            }
+        }
+    },
+    "REST_SERVER_TABLE_WITH_INVALID_PORT": {
+        "sonic-rest-server:sonic-rest-server": {
+            "sonic-rest-server:REST_SERVER": {
+                "default": {
+                    "port": 70000
+                }
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-rest-server.yang
+++ b/src/sonic-yang-models/yang-models/sonic-rest-server.yang
@@ -1,0 +1,71 @@
+module sonic-rest-server {
+
+    yang-version 1.1;
+
+    namespace "http://github.com/sonic-net/sonic-rest-server";
+    prefix rest-server;
+
+    import ietf-inet-types {
+        prefix inet;
+    }
+
+    organization
+        "SONiC";
+
+    contact
+        "SONiC";
+
+    description "REST server YANG Module for SONiC OS";
+
+    revision 2026-05-15 {
+        description "Add REST_SERVER table model";
+    }
+
+    container sonic-rest-server {
+
+        container REST_SERVER {
+
+            description "REST server configuration.";
+
+            container default {
+                description "Default REST server instance configuration.";
+
+                leaf port {
+                    type inet:port-number;
+                    description "TCP port the REST server listens on.";
+                }
+
+                leaf client_auth {
+                    type enumeration {
+                        enum none;
+                        enum cert;
+                        enum user;
+                    }
+                    description "REST server client authentication mode.";
+                }
+
+                leaf log_level {
+                    type uint8 {
+                        range 0..100;
+                    }
+                    description "REST server log verbosity level.";
+                }
+
+                leaf server_crt {
+                    type string;
+                    description "Local path for the REST server certificate.";
+                }
+
+                leaf server_key {
+                    type string;
+                    description "Local path for the REST server private key.";
+                }
+
+                leaf ca_crt {
+                    type string;
+                    description "Local path for the client CA certificate.";
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Why

ZTP can abort when applying a valid `REST_SERVER|default` entry because the table has no YANG model. This leaves `sonic_yang` reporting:

```text
Below table(s) have no YANG models: REST_SERVER
```

Fixes sonic-net/sonic-buildimage#27062.

## What

- Add a `sonic-rest-server` YANG model for `REST_SERVER|default`
- Model the fields consumed by `dockers/docker-sonic-mgmt-framework/rest-server.sh`: `port`, `client_auth`, `log_level`, `server_crt`, `server_key`, and `ca_crt`
- Include the new model in the `sonic-yang-models` wheel file list

## Validation

- `python3` smoke check confirmed `setup.py` YANG file completeness validation passes: 143 expected / 143 listed, no missing or extra models
- `python3` schema smoke check confirmed the new module includes `REST_SERVER|default` and `client_auth` modes `none`, `cert`, and `user`

`pyang`/`libyang` are not installed in this workspace, so full YANG parser validation could not be run locally.