### PR TITLE
[master][sonic-mgmt] Refresh ansible loader multi-thread fix for new ansible

### DIFF
--- a/dockers/docker-sonic-mgmt/0001-Fix-getattr-AttributeError-in-multi-thread-scenario.patch
+++ b/dockers/docker-sonic-mgmt/0001-Fix-getattr-AttributeError-in-multi-thread-scenario.patch
@@ -23,22 +23,22 @@ index 74bdeb5719..251531b62e 100644
 +++ b/lib/ansible/plugins/loader.py
 @@ -801,15 +801,14 @@ class PluginLoader:
              warnings.simplefilter("ignore", RuntimeWarning)
-             spec = importlib.util.spec_from_file_location(to_native(full_name), to_native(path))
+             spec = importlib.util.spec_from_file_location(to_native(python_module_name), to_native(path))
              module = importlib.util.module_from_spec(spec)
 -
 -            # mimic import machinery; make the module-being-loaded available in sys.modules during import
 -            # and remove if there's a failure...
--            sys.modules[full_name] = module
+-            sys.modules[python_module_name] = module
 -
              try:
                  spec.loader.exec_module(module)
 +                # mimic import machinery; make the module-being-loaded available in sys.modules during import
 +                # and remove if there's a failure...
-+                sys.modules[full_name] = module
++                sys.modules[python_module_name] = module
              except Exception:
--                del sys.modules[full_name]
-+                if full_name in sys.modules:
-+                    del sys.modules[full_name]
+-                del sys.modules[python_module_name]
++                if python_module_name in sys.modules:
++                    del sys.modules[python_module_name]
                  raise
 
          return module


### PR DESCRIPTION
The 0001-Fix-getattr-AttributeError-in-multi-thread-scenario
patch (carried in docker-sonic-mgmt and applied to ansible's
lib/ansible/plugins/loader.py) was written against an older
ansible where the local variable was `full_name`. Ansible has
since been unpinned upstream and the variable is now
`python_module_name`, so the original hunk no longer applies.

PR that unpinned ansible: https://github.com/sonic-net/sonic-buildimage/pull/27301

#### How to verify it

Checked that there are no patch conflicts while building sonic-mgmt container.