### PR TITLE
sysctl: enable ignore_routes_with_linkdown for IPv4 and IPv6

### DIFF
--- a/files/image_config/sysctl/90-sonic.conf
+++ b/files/image_config/sysctl/90-sonic.conf
@@ -61,3 +61,6 @@ fs.suid_dumpable=2
 # via pidfd_getfd(2) during the mm-NULL exit window. Blocks unprivileged
 # exploitation while preserving sudo gdb / sudo strace for operators.
 kernel.yama.ptrace_scope=2
+
+net.ipv4.conf.all.ignore_routes_with_linkdown=1
+net.ipv6.conf.all.ignore_routes_with_linkdown=1


### PR DESCRIPTION
Fixes #24462 

Today in Sonic, control path continues to use connected routes even when the link is down, despite alternative routes being available, causing traffic failure. This behavior differs from data path, which removes the downed connected route and switches to alternatives.

Enabling ignore_routes_with_linkdown sysctl aligns control and data path behavior by allowing control path to fallback to BGP-learned routes with lower metrics. 

Once the link is restored, the connected route is reused. 

This behavior follows FRR documentation and standard Linux network manager practices.

#### Why I did it
To avoid control path traffic failure and have common behavior across control and data path

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Enabled ignore_routes_with_linkdown sysctl parameter
#### How to verify it
```bash
root@sonic:/home/admin# ip route
default via 10.28.60.1 dev eth0
1.1.1.0/30 dev Ethernet0 proto kernel scope link src 1.1.1.1
**10.10.10.0/30 dev PortChannel02 scope link linkdown**                               <-- Connected route
**10.10.10.0/30 via 1.1.1.2 dev Ethernet0 proto bgp src 100.100.100.1 metric 20**     <-- BGP learnt route
10.28.60.0/24 dev eth0 proto kernel scope link src 10.28.60.43
100.100.100.2 via 1.1.1.2 dev Ethernet0 proto bgp src 100.100.100.1 metric 20
240.127.1.0/24 dev docker0 proto kernel scope link src 240.127.1.1 linkdown
```

```bash
#show ip route
Codes: K - kernel route, C - connected, S - static, R - RIP,
       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
       F - PBR, f - OpenFabric,
       > - selected route, * - FIB route, q - queued route, r - rejected route
K>*0.0.0.0/0 [0/0] via 10.28.60.1, eth0, 02:47:55
C>*1.1.1.0/30 is directly connected, Ethernet0, 02:47:28
B>*10.10.10.0/30 [200/0] via 1.1.1.2, Ethernet0, 02:20:56                    <-- BGP learnt route
C>*10.28.60.0/24 is directly connected, eth0, 02:47:55
K 10.28.60.0/24 [0/0] is directly connected, eth0, 02:47:55
C>*100.100.100.1/32 is directly connected, Loopback0, 02:47:51
B>*100.100.100.2/32 [200/0] via 1.1.1.2, Ethernet0, 02:43:44
K 240.127.1.0/24 [0/0] is directly connected, docker0, inactive 02:47:55
```

```bash
root@sonic:/home/admin# ping 10.10.10.2
PING 10.10.10.2 (10.10.10.2) 56(84) bytes of data.
64 bytes from 10.10.10.2: icmp_seq=1 ttl=63 time=0.229 ms
```

#### Which release branch to backport (provide reason below if selected)
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202511

#### Tested branch (Please provide the tested image version)
- [202511] <!-- image version 1 -->


#### Description for the changelog
[sysctl]: Enable ignore_routes_with_linkdown to avoid using routes of linkdown interface

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

