### PR TITLE
[PDDF] Fix pddf_multifpgapci_driver kernel panic by using list_replace_init for safe list migration

### DIFF
--- a/platform/pddf/i2c/modules/multifpgapci/driver/pddf_multifpgapci_driver.c
+++ b/platform/pddf/i2c/modules/multifpgapci/driver/pddf_multifpgapci_driver.c
@@ -274,7 +274,7 @@ void delete_all_fpga_data_nodes(void)
 	struct fpga_data_node *node, *tmp;
 	struct list_head local_list;
 
-	// Clear the global list after copying over the pointer
+	// Clear the global list after moving it to local
 	mutex_lock(&fpga_list_lock);
 	list_replace_init(&fpga_list, &local_list);
 	mutex_unlock(&fpga_list_lock);

--- a/platform/pddf/i2c/modules/multifpgapci/driver/pddf_multifpgapci_driver.c
+++ b/platform/pddf/i2c/modules/multifpgapci/driver/pddf_multifpgapci_driver.c
@@ -276,8 +276,7 @@ void delete_all_fpga_data_nodes(void)
 
 	// Clear the global list after copying over the pointer
 	mutex_lock(&fpga_list_lock);
-	local_list = fpga_list;
-	INIT_LIST_HEAD(&fpga_list);
+	list_replace_init(&fpga_list, &local_list);
 	mutex_unlock(&fpga_list_lock);
 
 	// Work on the local copy without the need for a lock
@@ -709,8 +708,7 @@ static void cleanup_all_protocols(void)
 
 	// Move the list to a local one to be able to process without lock
 	mutex_lock(&protocol_modules_lock);
-	local_list = protocol_modules;
-	INIT_LIST_HEAD(&protocol_modules);
+	list_replace_init(&protocol_modules, &local_list);
 	mutex_unlock(&protocol_modules_lock);
 
 	// Work on local copy without any locks


### PR DESCRIPTION
This PR addresses issue #27423 to fix a critical kernel panic in the PDDF pddf_multifpgapci_driver module during cleanup/unloading.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Directly assigning list_head structures (local_list = global_list) is unsafe in the Linux kernel because it breaks the integrity of the circular doubly linked list, leaving neighboring nodes still pointing to the old head address.

By switching to list_replace_init(), we safely migrate all nodes to the local stack head and properly re-initialize the global head.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

* Replaced incorrect struct list_head direct assignment with list_replace_init().

* Removed redundant INIT_LIST_HEAD() calls, as list_replace_init() automatically handles both head replacement and re-initialization of the source list.

#### How to verify it

```
modprobe pddf_multifpgapci_driver
modprobe -r pddf_multifpgapci_driver
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master <!-- image version 1 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

