### PR TITLE
[docker-ptf]: Fix influxdb3 missing libpython3.13 at runtime

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -155,7 +155,8 @@ RUN set -eux \
     && mv "influxdb3-core-${INFLUXDB_VERSION}/influxdb3" /usr/local/bin/influxdb3 \
     && chmod +x /usr/local/bin/influxdb3 \
     && cp -r "influxdb3-core-${INFLUXDB_VERSION}/python" /usr/local/lib/influxdb3-python \
-    && ldconfig /usr/local/lib/influxdb3-python/lib \
+    && echo "/usr/local/lib/influxdb3-python/lib" > /etc/ld.so.conf.d/influxdb3.conf \
+    && ldconfig \
     && ln -sf /usr/local/bin/influxdb3 /usr/local/bin/influxd \
     && rm -f "influxdb3-core-${INFLUXDB_VERSION}_${INFLUXDB_ARCH}.tar.gz" \
     && rm -rf "/tmp/influxdb3-core-${INFLUXDB_VERSION}" \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
PR #26755 introduced InfluxDB 3 Core into the PTF image, but the influxdb3 binary embeds a Python 3.13 interpreter and dynamically links against libpython3.13.so.1.0. The PTF base image is Debian 12 (bookworm), which only ships Python 3.11, so the system does not provide that library. influxdb3 ships its own copy under /usr/local/lib/influxdb3-python/lib/, but the dynamic linker has no knowledge of that directory and the binary fails to start with:

  influxdb3: error while loading shared libraries:
    libpython3.13.so.1.0: cannot open shared object file

This caused tests/high_frequency_telemetry/test_hft_end_to_end.py (from sonic-mgmt PR #21982) to time out waiting for the InfluxDB health endpoint.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Install the bundled python runtime under /usr/local/lib/influxdb3-python and register its lib/ directory with the dynamic linker via /etc/ld.so.conf.d/ + ldconfig. Passing a directory argument to ldconfig alone is a no-op and does not persist the search path, which is why the previous attempt did not work.

#### How to verify it
Verified inside a PTF container built from this branch:
```
  # echo /usr/local/lib/influxdb3-python/lib > /etc/ld.so.conf.d/influxdb3.conf && ldconfig
  # ldd /usr/local/bin/influxdb3 | grep python
    libpython3.13.so.1.0 => /usr/local/lib/influxdb3-python/lib/libpython3.13.so.1.0
  # influxdb3 --version
    influxdb3 InfluxDB 3 Core, 3.9.0, revision 0f1816e...
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

