### PR TITLE
switch_cpu_utils require root, otherwise fail with clear error

### DIFF
--- a/platform/aspeed/sonic-platform-modules-nexthop/b27/scripts/switch_cpu_utils.sh
+++ b/platform/aspeed/sonic-platform-modules-nexthop/b27/scripts/switch_cpu_utils.sh
@@ -138,6 +138,12 @@ show_switch_cpu_status() {
 # Main function
 #######################################
 main() {
+    # Check for root.
+    if [ "$(id -u)" -ne 0 ]; then
+        echo "ERROR: ${SCRIPT_NAME} must be run as root (try: sudo ${SCRIPT_NAME} $*)" >&2
+        exit 1
+    fi
+
     # Handle no arguments
     if [ $# -eq 0 ]; then
         echo "ERROR: No command specified" >&2


### PR DESCRIPTION
`switch_cpu_utils.sh` accesses memory-mapped registers via `busybox devmem`, which requires root for `/dev/mem`. Without root, the failure path is misleading. operators see a misleading hardware-error message with no hint that sudo is needed, and any caller checking `$?` thinks the call succeeded.




<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

```
ERROR: switch_cpu_utils.sh must be run as root (try: sudo switch_cpu_utils.sh <args>)
```

#### How I did it
Added an early `id -u` check at the top of `main()` so any non-root invocation exits `1` with a clear message:

#### How to verify it

```
$ ./switch_cpu_utils.sh status
ERROR: switch_cpu_utils.sh must be run as root (try: sudo switch_cpu_utils.sh status)
$ echo $?
1
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

