### PR TITLE
Prevent false-FATAL on telemetry:dependent-startup during SIGTERM race

### DIFF
--- a/dockers/docker-sonic-telemetry/supervisord.conf
+++ b/dockers/docker-sonic-telemetry/supervisord.conf
@@ -7,6 +7,7 @@ nodaemon=true
 command=python3 -m supervisord_dependent_startup
 autostart=true
 autorestart=unexpected
+startsecs=0
 startretries=0
 exitcodes=0,3
 events=PROCESS_STATE


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Add `startsecs=0` to the `[eventlistener:dependent-startup]` block in
docker-sonic-telemetry's supervisord.conf.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

When supervisord receives SIGTERM within ~1 second of spawning the
`dependent-startup` eventlistener (e.g., during rapid container restart),
the eventlistener exits with code 3 while still in STARTING state.

Even though telemetry itself was unaffected, the FATAL log line is
misleading for on-call and pollutes monitoring.

With `startsecs=0`, the eventlistener enters RUNNING immediately, so the
same exit is evaluated against the existing `exitcodes=0,3` and logged
correctly as `INFO exited: ... ; expected`.

#### How to verify it

Repro by replacing command in dependent-startup with immediate exit. Without startsecs=0, observe EXITED not expected status 3. With startsecs=0, observe the absence.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

