### PR TITLE
[ci] Disable CI/CD for 202411 branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,23 +3,9 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
-trigger:
-  branches:
-    include:
-      - master
-      - 202???
-  paths:
-    exclude:
-      - .github
+trigger: none
 
-pr:
-  branches:
-    include:
-      - master
-      - 202???
-  paths:
-    exclude:
-      - .github
+pr: none
 
 name: $(TeamProject)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 


### PR DESCRIPTION
#### Why I did it
The 202411 branch has reached the point where PR testing should be stopped, consistent with the lifecycle of older release branches (202305, 202311).

#### How I did it
Set `trigger` and `pr` to `none` in `azure-pipelines.yml` to disable CI pipeline runs on the 202411 branch.

#### How to verify it
After merging, PRs targeting the 202411 branch should no longer trigger Azure Pipeline builds.

#### Description for the changelog
Stop PR testing for 202411 branch by setting trigger and pr to none in azure-pipelines.yml.