### PR TITLE
Add a dependency in sonic-sysmgr makefile

### DIFF
--- a/src/sonic-sysmgr/Makefile.am
+++ b/src/sonic-sysmgr/Makefile.am
@@ -23,4 +23,6 @@ build_gen_librebootgnoi_la_SOURCES = \
         build/gen/github.com/openconfig/gnoi/types/types.pb.cc \
         build/gen/github.com/openconfig/gnoi/common/common.pb.cc
 
+$(build_gen_librebootgnoi_la_SOURCES): rebootbackend_protobuf_compilation
+
 SUBDIRS = rebootbackend


### PR DESCRIPTION

#### Why I did it

While building sonic-buildimage in the sonic-alpine platform, hit a build error in sonic-sysmgr. This started appearing recently, possibly after sysmgr was upgraded from bookworm to trixie. It is not seen in sonic-vs.

```
make[2]: Entering directory '/sonic/src/sonic-sysmgr'
make[2]: warning: -j96 forced in submake: resetting jobserver mode.
mkdir -p build/gen
make[2]: *** No rule to make target 'build/gen/github.com/openconfig/gnoi/system/system.pb.cc', needed by 'build/gen/github.com/openconfig/gnoi/system/system.pb.lo'.  Stop.
make[2]: *** Waiting for unfinished jobs....
/usr/bin/protoc --cpp_out=build/gen \
	--proto_path=github.com/openconfig/gnoi=gnoi \
	gnoi/types/types.proto \
	gnoi/common/common.proto \
	gnoi/system/system.proto
make[2]: Leaving directory '/sonic/src/sonic-sysmgr'
dh_auto_build: error: make -j96 returned exit code 2
make[1]: *** [debian/rules:22: binary] Error 25
make[1]: Leaving directory '/sonic/src/sonic-sysmgr'
dpkg-buildpackage: error: debian/rules binary subprocess returned exit status 2
```

Appears to be because of a timing error triggered by the recent change. The system.pb.cc and two other files are generated from protocol buffers, then used to build librebootgnoi. The build begins before the generation is completed. 

There is a NOTPARALLEL entry that is intended to serialize this. This does not work because rebootbackend_dbus_compilation does not run gcc. It is the lib_LTLIBRARIES that does it. See https://github.com/sonic-net/sonic-buildimage/blob/0bf61008793c21d776a360fa9eaebb6377c6ad5a/src/sonic-sysmgr/Makefile.am

```
.NOTPARALLEL: compile_protobufs
compile_protobufs: rebootbackend_protobuf_compilation rebootbackend_dbus_compilation
```

The suggested fix is to add an explicit dependency for build_gen_librebootgnoi_la_SOURCES on rebootbackend_protobuf_compilation

The build always passes on retry because the source files get generated in the first run, though too late.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added a dependency for build_gen_librebootgnoi_la_SOURCES on rebootbackend_protobuf_compilation

#### How to verify it

Tested and verified both the build failure and the build success after the fix locally and in the pipeline build for alpine in  https://github.com/sonic-net/sonic-buildimage/pull/26836

#### Description for the changelog

Add dependency for librebootgnoi on protocol buffer source file generation
