### PR TITLE
[NH-5010] Ensure ASIC come out of reset before bcm drivers

### DIFF
--- a/platform/broadcom/sonic-platform-modules-nexthop/nh-5010/utils/asic_init.sh
+++ b/platform/broadcom/sonic-platform-modules-nexthop/nh-5010/utils/asic_init.sh
@@ -5,6 +5,10 @@ LOCKFILE="/var/run/nexthop-asic-init.lock"
 FPGA_BDF=$(setpci -s 00:02.2 0x19.b | xargs printf '0000:%s:00.0')
 KOMODO_FPGA_BDF=$(setpci -s 00:02.1 0x19.b | xargs printf '0000:%s:00.0')
 LOG_TAG="asic_init"
+LOG_PRIO="user.info"
+
+lsmod | grep -q 'linux_ngbde'
+IS_OPENNSL_INITIALLY_LOADED=$?
 
 fpga_read() {
   local offset="$1"
@@ -175,6 +179,11 @@ check_fan_status
 
 acquire_lock
 
+if [ "$IS_OPENNSL_INITIALLY_LOADED" -eq 0 ]; then
+  logger -t $LOG_TAG -p $LOG_PRIO "Removing ASIC modules"
+  /etc/init.d/opennsl-modules stop
+fi
+
 # Per HW, do this right before taking the ASIC out of reset.
 clear_sticky_bits
 
@@ -197,6 +206,12 @@ sleep 0.2
 fpga write32 "$FPGA_BDF" 0x8 0x1 --bits "10:10"
 
 enable_phy
+
+if [ "$IS_OPENNSL_INITIALLY_LOADED" -eq 0 ]; then
+  logger -t $LOG_TAG -p $LOG_PRIO "Inserting ASIC modules: $(lsmod | grep linux_ngbde)"
+  /etc/init.d/opennsl-modules start
+  logger -t $LOG_TAG -p $LOG_PRIO "Inserting ASIC modules done: $(lsmod | grep linux_ngbde)"
+fi
 
 release_lock
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
On the first boot of the system before the platform debian packages are fully installed, it is possible that opennsl-modules.service runs before platform specific initialization. 

For subsequent reboots, platform specific initialization always runs before `opennsl-modules.service` due to service files having being installed from the first boot of the image.
https://github.com/sonic-net/sonic-buildimage/blob/0080442412473c525e1df145bb15de9f022ca4d2/platform/broadcom/sonic-platform-modules-nexthop/common/service/pddf-platform-init.service#L3 

Recently we started seeing this more often in 202511, and we able to reproduce in a recent community build.

This fix also matches the existing behavior of NH-4010.
https://github.com/sonic-net/sonic-buildimage/blob/0080442412473c525e1df145bb15de9f022ca4d2/platform/broadcom/sonic-platform-modules-nexthop/nh-4010/utils/asic_init.sh#L104-L107

On NH-4010 the stopping/starting of opennsl was to allow the system to power cycle the ASIC when sycnd restarts, to provide a recover from unhealthy ASIC state. Without stopping opennsl, the system would kernel panic if we were to power cycle the ASIC.


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

