### PR TITLE
[docker-ptf] Push PR built dock-ptf image to registry

### DIFF
--- a/.azure-pipelines/azure-pipelines-image-template.yml
+++ b/.azure-pipelines/azure-pipelines-image-template.yml
@@ -78,6 +78,7 @@ jobs:
     postSteps:
       - script: |
           BUILD_REASON=$(Build.Reason)
+          PTF_MODIFIED_IN_PR="False"
           echo "Build.Reason = $BUILD_REASON"
           echo "Build.DefinitionName = $BUILD_DEFINITIONNAME"
           if [[ "$BUILD_REASON" == "PullRequest" ]]; then
@@ -88,28 +89,44 @@ jobs:
             if [ ! -f "target/docker-ptf.gz.log" ]; then
               echo "docker-ptf was not built in this PR, setting PTF_MODIFIED to False"
               echo "##vso[task.setvariable variable=PTF_MODIFIED;isOutput=true]False"
+              PTF_MODIFIED_IN_PR="False"
             else
               if grep -q "CACHE::LOADED" target/docker-ptf.gz.log; then
                 echo "docker-ptf was built from cache in this PR, setting PTF_MODIFIED to False"
                 echo "##vso[task.setvariable variable=PTF_MODIFIED;isOutput=true]False"
+                PTF_MODIFIED_IN_PR="False"
               else
                 echo "docker-ptf was not built from cache in this PR, setting PTF_MODIFIED to True"
                 echo "##vso[task.setvariable variable=PTF_MODIFIED;isOutput=true]True"
+                PTF_MODIFIED_IN_PR="True"
               fi
             fi
           else
             echo "Not a PR build, setting PTF_MODIFIED to false"
             echo "##vso[task.setvariable variable=PTF_MODIFIED;isOutput=true]False"
+            PTF_MODIFIED_IN_PR="False"
           fi
 
+          echo "PTF_MODIFIED_IN_PR = $PTF_MODIFIED_IN_PR"
+          # Prepare publish settings
+          PORT=443
+          DOCKERS=$(ls target/docker-ptf.gz)
+          BRANCH=$(Build.SourceBranchName)
+          echo "Branch = $BRANCH"
+          PUSH_DOCKER="False"
           if [[ "$BUILD_REASON" != "PullRequest" && "$BUILD_DEFINITIONNAME" == "Azure.sonic-buildimage.official.vs" ]]
           then
-            PORT=443
-            DOCKERS=$(ls target/docker-ptf.gz)
-            BRANCH=$(Build.SourceBranchName)
-            echo "Branch = $BRANCH"
             LABELS="$BRANCH"
             [[ "$BRANCH" == "master" ]] && LABELS="$LABELS latest"
+            PUSH_DOCKER="True"
+          elif [[ "$PTF_MODIFIED_IN_PR" == "True" ]]
+          then
+            LABELS="ptf-$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER"
+            PUSH_DOCKER="True"
+          else
+            echo "Not publishing docker images since docker-ptf was not modified in this PR or build definition name is not Azure.sonic-buildimage.official.vs"
+          fi
+          if [[ "$PUSH_DOCKER" == "True" ]]; then
             for f in $DOCKERS; do
               echo $f
               echo "Labels = $LABELS"

--- a/.azure-pipelines/azure-pipelines-image-template.yml
+++ b/.azure-pipelines/azure-pipelines-image-template.yml
@@ -110,7 +110,6 @@ jobs:
           echo "PTF_MODIFIED_IN_PR = $PTF_MODIFIED_IN_PR"
           # Prepare publish settings
           PORT=443
-          DOCKERS=$(ls target/docker-ptf.gz)
           BRANCH=$(Build.SourceBranchName)
           echo "Branch = $BRANCH"
           PUSH_DOCKER="False"
@@ -118,10 +117,12 @@ jobs:
           then
             LABELS="$BRANCH"
             [[ "$BRANCH" == "master" ]] && LABELS="$LABELS latest"
+            DOCKERS=$(ls target/docker-ptf.gz)
             PUSH_DOCKER="True"
           elif [[ "$PTF_MODIFIED_IN_PR" == "True" ]]
           then
             LABELS="ptf-$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER"
+            DOCKERS=$(ls target/docker-ptf.gz)
             PUSH_DOCKER="True"
           else
             echo "Not publishing docker images since docker-ptf was not modified in this PR or build definition name is not Azure.sonic-buildimage.official.vs"


### PR DESCRIPTION
#### Why I did it

If a PR changes the `docker-ptf` image, then publish the PR built `docker-ptf` image to the registry. This image will then be used for testing the change in the PR CI.

##### Work item tracking
- Microsoft ADO **(number only)**: 38021121

#### How I did it

Enable docker push for PR built image

#### How to verify it

Will be verified via CI run.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

NA

#### Description for the changelog

[docker-ptf] Push PR built dock-ptf image to registry

- If a PR changes the `docker-ptf` image, then publish the PR built `docker-ptf` image to the registry. This image will then be used for testing the change in the PR CI.

#### Link to config_db schema for YANG module changes

NA

#### A picture of a cute animal (not mandatory but encouraged)