### PR TITLE
[centec] Replace os.system and Popen shell=True with shell=False

### DIFF
--- a/platform/centec/sonic-platform-modules-v682/48x8c/sonic_platform/sfp.py
+++ b/platform/centec/sonic-platform-modules-v682/48x8c/sonic_platform/sfp.py
@@ -12,7 +12,7 @@ import os
 import time
 import re
 import collections
-#import subprocess
+import subprocess
 #import sonic_device_util
 from ctypes import create_string_buffer
 from subprocess import Popen, PIPE, STDOUT
@@ -358,7 +358,7 @@ class Sfp(SfpBase):
         return ""
 
     def __is_host(self):
-        return os.system(self.HOST_CHK_CMD) == 0
+        return subprocess.call(["docker"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])
@@ -377,8 +377,8 @@ class Sfp(SfpBase):
             return False
 
         sfp_info = self.port_to_i2c_mapping[int(self._port_cfgs[self.port_num].lanes.split(',')[0])]
-        cmd = 'i2cget -y 0 {0} {1}'.format(sfp_info[1], sfp_info[2])
-        presence = int(Popen(cmd, stdout=PIPE, stderr=STDOUT, shell=True).stdout.readline(), 16)
+        cmd = ['i2cget', '-y', '0', str(sfp_info[1]), str(sfp_info[2])]
+        presence = int(Popen(cmd, stdout=PIPE, stderr=STDOUT).stdout.readline(), 16)
         presence &= (1 << sfp_info[3])
 
         try:
@@ -982,8 +982,8 @@ class Sfp(SfpBase):
             return False
 
         sfp_info = self.port_to_i2c_mapping[int(self._port_cfgs[self.port_num].lanes.split(',')[0])]
-        cmd = 'i2cget -y 0 {0} {1}'.format(sfp_info[4], sfp_info[5])
-        reset_status = int(Popen(cmd, stdout=PIPE, stderr=STDOUT, shell=True).stdout.readline(), 16)
+        cmd = ['i2cget', '-y', '0', str(sfp_info[4]), str(sfp_info[5])]
+        reset_status = int(Popen(cmd, stdout=PIPE, stderr=STDOUT).stdout.readline(), 16)
         reset_status &= (1 << sfp_info[6])
 
         return (reset_status == 1)
@@ -1432,16 +1432,16 @@ class Sfp(SfpBase):
             return False
         elif self.sfp_type == QSFP_TYPE:
             sfp_info = self.port_to_i2c_mapping[int(self._port_cfgs[self.port_num].lanes.split(',')[0])]
-            cmd = 'i2cget -y 0 {0} {1}'.format(sfp_info[4], sfp_info[5])
-            reset = int(Popen(cmd, stdout=PIPE, stderr=STDOUT, shell=True).stdout.readline(), 16)
+            cmd = ['i2cget', '-y', '0', str(sfp_info[4]), str(sfp_info[5])]
+            reset = int(Popen(cmd, stdout=PIPE, stderr=STDOUT).stdout.readline(), 16)
 
             reset &= ~(1 << sfp_info[6])
-            cmd = 'i2cset -y 0 {0} {1} {2}'.format(sfp_info[4], sfp_info[5], reset)
-            Popen(cmd, shell=True)
+            cmd = ['i2cset', '-y', '0', str(sfp_info[4]), str(sfp_info[5]), str(reset)]
+            Popen(cmd)
 
             reset |= (1 << sfp_info[6])
-            cmd = 'i2cset -y 0 {0} {1} {2}'.format(sfp_info[4], sfp_info[5], reset)
-            Popen(cmd, shell=True)
+            cmd = ['i2cset', '-y', '0', str(sfp_info[4]), str(sfp_info[5]), str(reset)]
+            Popen(cmd)
 
             return True
 

--- a/platform/centec/sonic-platform-modules-v682/48y8c/sonic_platform/sfp.py
+++ b/platform/centec/sonic-platform-modules-v682/48y8c/sonic_platform/sfp.py
@@ -12,7 +12,7 @@ import os
 import time
 import re
 import collections
-#import subprocess
+import subprocess
 #import sonic_device_util
 from ctypes import create_string_buffer
 from subprocess import Popen, PIPE, STDOUT
@@ -358,7 +358,7 @@ class Sfp(SfpBase):
         return ""
 
     def __is_host(self):
-        return os.system(self.HOST_CHK_CMD) == 0
+        return subprocess.call(["docker"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) == 0
 
     def __get_path_to_port_config_file(self):
         platform_path = "/".join([self.PLATFORM_ROOT_PATH, self.PLATFORM])
@@ -377,8 +377,8 @@ class Sfp(SfpBase):
             return False
 
         sfp_info = self.port_to_i2c_mapping[int(self._port_cfgs[self.port_num].lanes.split(',')[0])]
-        cmd = 'i2cget -y 0 {0} {1}'.format(sfp_info[1], sfp_info[2])
-        presence = int(Popen(cmd, stdout=PIPE, stderr=STDOUT, shell=True).stdout.readline(), 16)
+        cmd = ['i2cget', '-y', '0', str(sfp_info[1]), str(sfp_info[2])]
+        presence = int(Popen(cmd, stdout=PIPE, stderr=STDOUT).stdout.readline(), 16)
         presence &= (1 << sfp_info[3])
 
         try:
@@ -982,8 +982,8 @@ class Sfp(SfpBase):
             return False
 
         sfp_info = self.port_to_i2c_mapping[int(self._port_cfgs[self.port_num].lanes.split(',')[0])]
-        cmd = 'i2cget -y 0 {0} {1}'.format(sfp_info[4], sfp_info[5])
-        reset_status = int(Popen(cmd, stdout=PIPE, stderr=STDOUT, shell=True).stdout.readline(), 16)
+        cmd = ['i2cget', '-y', '0', str(sfp_info[4]), str(sfp_info[5])]
+        reset_status = int(Popen(cmd, stdout=PIPE, stderr=STDOUT).stdout.readline(), 16)
         reset_status &= (1 << sfp_info[6])
 
         return (reset_status == 1)
@@ -1432,16 +1432,16 @@ class Sfp(SfpBase):
             return False
         elif self.sfp_type == QSFP_TYPE:
             sfp_info = self.port_to_i2c_mapping[int(self._port_cfgs[self.port_num].lanes.split(',')[0])]
-            cmd = 'i2cget -y 0 {0} {1}'.format(sfp_info[4], sfp_info[5])
-            reset = int(Popen(cmd, stdout=PIPE, stderr=STDOUT, shell=True).stdout.readline(), 16)
+            cmd = ['i2cget', '-y', '0', str(sfp_info[4]), str(sfp_info[5])]
+            reset = int(Popen(cmd, stdout=PIPE, stderr=STDOUT).stdout.readline(), 16)
 
             reset &= ~(1 << sfp_info[6])
-            cmd = 'i2cset -y 0 {0} {1} {2}'.format(sfp_info[4], sfp_info[5], reset)
-            Popen(cmd, shell=True)
+            cmd = ['i2cset', '-y', '0', str(sfp_info[4]), str(sfp_info[5]), str(reset)]
+            Popen(cmd)
 
             reset |= (1 << sfp_info[6])
-            cmd = 'i2cset -y 0 {0} {1} {2}'.format(sfp_info[4], sfp_info[5], reset)
-            Popen(cmd, shell=True)
+            cmd = ['i2cset', '-y', '0', str(sfp_info[4]), str(sfp_info[5]), str(reset)]
+            Popen(cmd)
 
             return True
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR addresses Semgrep findings by replacing os.system() with subprocess.call(..., shell=False) and Popen(..., shell=True) with Popen([...]) in Centec V682 platform SFP modules.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Changes:

- Replace os.system(self.HOST_CHK_CMD) with subprocess.call(["docker"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) in __is_host().
- Replace all Popen(cmd_string, ..., shell=True) with Popen(cmd_list, ...) in get_presence(), get_reset_status(), and reset().
- Uncomment import subprocess to support subprocess.call.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

