### PR TITLE
[chassis][voq]Enforce leaf ref for local ports in in the QUEUE config

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/qos.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/qos.json
@@ -88,5 +88,32 @@
     },
     "VOQ_QUEUE_CONFIG": {
         "desc": "Attach scheduler and wred profiles to VOQ."
+    },
+    "QUEUE_VALID_NON_VOQ": {
+        "desc": "Non-VOQ QUEUE entry referencing an existing PORT passes validation."
+    },
+    "VOQ_QUEUE_VALID_LOCAL": {
+        "desc": "VOQ_QUEUE for the local switch (hostname/asic_name match localhost) and matching PORT exists - passes."
+    },
+    "VOQ_QUEUE_LOCAL_MISSING_PORT": {
+        "desc": "VOQ_QUEUE for the local switch but no matching PORT row - must fails.",
+        "eStr": "Local VOQ_QUEUE entry"
+    },
+    "VOQ_QUEUE_LOCAL_BOGUS_PORT": {
+        "desc": "VOQ_QUEUE for the local switch references Ethernet999 while only Ethernet0 exists in PORT - must fails.",
+        "eStr": "Local VOQ_QUEUE entry"
+    },
+    "VOQ_QUEUE_REMOTE_NO_PORT": {
+        "desc": "VOQ_QUEUE owned by a remote hostname/asic_name and no PORT - gate is not satisfied so must passes."
+    },
+    "VOQ_QUEUE_NO_LOCAL_ASIC_NAME": {
+        "desc": "DEVICE_METADATA/localhost has no asic_name; gate degrades to no-op so even local-named VOQ_QUEUE without PORT passes."
+    },
+    "VOQ_QUEUE_MIXED_LOCAL_FAIL_REMOTE_PASS": {
+        "desc": "VOQ_QUEUE has remote entries (lc2/asic0, lc1/asic1) that should pass, plus a local entry (lc1/asic0) whose ifname Ethernet999 is not in PORT - must fails on the local entry.",
+        "eStr": "Local VOQ_QUEUE entry"
+    },
+    "VOQ_QUEUE_MULTIPLE_REMOTE_LCS": {
+        "desc": "VOQ_QUEUE owned by ports across multiple remote linecards/ASICs (lc2/asic0, lc3/asic1, lc4/asic0) and no PORT for them - gate never matches so must passes for all entries."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/qos.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/qos.json
@@ -573,6 +573,292 @@
                 ]
             }
         }
+    },
+
+    "QUEUE_VALID_NON_VOQ": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": "9000",
+                        "name": "Ethernet0",
+                        "tpid": "0x8100",
+                        "speed": "25000"
+                    }
+                ]
+            }
+        },
+        "sonic-scheduler:sonic-scheduler": {
+            "sonic-scheduler:SCHEDULER": {
+                "SCHEDULER_LIST": [
+                    {
+                        "name": "scheduler.0",
+                        "type": "DWRR",
+                        "weight": 25
+                    }
+                ]
+            }
+        },
+        "sonic-queue:sonic-queue": {
+            "sonic-queue:QUEUE": {
+                "QUEUE_LIST": [
+                    {
+                        "ifname": "Ethernet0",
+                        "qindex": "3",
+                        "scheduler": "scheduler.0"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VOQ_QUEUE_VALID_LOCAL": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "hostname": "lc1",
+                    "asic_name": "asic0",
+                    "switch_type": "voq"
+                }
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": "9000",
+                        "name": "Ethernet0",
+                        "tpid": "0x8100",
+                        "speed": "25000"
+                    }
+                ]
+            }
+        },
+        "sonic-queue:sonic-queue": {
+            "sonic-queue:QUEUE": {
+                "VOQ_QUEUE_LIST": [
+                    {
+                        "hostname": "lc1",
+                        "asic_name": "asic0",
+                        "ifname": "Ethernet0",
+                        "qindex": "3"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VOQ_QUEUE_LOCAL_MISSING_PORT": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "hostname": "lc1",
+                    "asic_name": "asic0",
+                    "switch_type": "voq"
+                }
+            }
+        },
+        "sonic-queue:sonic-queue": {
+            "sonic-queue:QUEUE": {
+                "VOQ_QUEUE_LIST": [
+                    {
+                        "hostname": "lc1",
+                        "asic_name": "asic0",
+                        "ifname": "Ethernet0",
+                        "qindex": "3"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VOQ_QUEUE_LOCAL_BOGUS_PORT": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "hostname": "lc1",
+                    "asic_name": "asic0",
+                    "switch_type": "voq"
+                }
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": "9000",
+                        "name": "Ethernet0",
+                        "tpid": "0x8100",
+                        "speed": "25000"
+                    }
+                ]
+            }
+        },
+        "sonic-queue:sonic-queue": {
+            "sonic-queue:QUEUE": {
+                "VOQ_QUEUE_LIST": [
+                    {
+                        "hostname": "lc1",
+                        "asic_name": "asic0",
+                        "ifname": "Ethernet999",
+                        "qindex": "3"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VOQ_QUEUE_REMOTE_NO_PORT": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "hostname": "lc1",
+                    "asic_name": "asic0",
+                    "switch_type": "voq"
+                }
+            }
+        },
+        "sonic-queue:sonic-queue": {
+            "sonic-queue:QUEUE": {
+                "VOQ_QUEUE_LIST": [
+                    {
+                        "hostname": "lc2",
+                        "asic_name": "asic0",
+                        "ifname": "Ethernet0",
+                        "qindex": "3"
+                    },
+                    {
+                        "hostname": "lc1",
+                        "asic_name": "asic1",
+                        "ifname": "Ethernet8",
+                        "qindex": "3"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VOQ_QUEUE_NO_LOCAL_ASIC_NAME": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "hostname": "lc1",
+                    "switch_type": "voq"
+                }
+            }
+        },
+        "sonic-queue:sonic-queue": {
+            "sonic-queue:QUEUE": {
+                "VOQ_QUEUE_LIST": [
+                    {
+                        "hostname": "lc1",
+                        "asic_name": "asic0",
+                        "ifname": "Ethernet0",
+                        "qindex": "3"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VOQ_QUEUE_MIXED_LOCAL_FAIL_REMOTE_PASS": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "hostname": "lc1",
+                    "asic_name": "asic0",
+                    "switch_type": "voq"
+                }
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": "9000",
+                        "name": "Ethernet0",
+                        "tpid": "0x8100",
+                        "speed": "25000"
+                    }
+                ]
+            }
+        },
+        "sonic-queue:sonic-queue": {
+            "sonic-queue:QUEUE": {
+                "VOQ_QUEUE_LIST": [
+                    {
+                        "hostname": "lc2",
+                        "asic_name": "asic0",
+                        "ifname": "Ethernet16",
+                        "qindex": "3"
+                    },
+                    {
+                        "hostname": "lc1",
+                        "asic_name": "asic1",
+                        "ifname": "Ethernet24",
+                        "qindex": "3"
+                    },
+                    {
+                        "hostname": "lc1",
+                        "asic_name": "asic0",
+                        "ifname": "Ethernet999",
+                        "qindex": "3"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VOQ_QUEUE_MULTIPLE_REMOTE_LCS": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "hostname": "lc1",
+                    "asic_name": "asic0",
+                    "switch_type": "voq"
+                }
+            }
+        },
+        "sonic-queue:sonic-queue": {
+            "sonic-queue:QUEUE": {
+                "VOQ_QUEUE_LIST": [
+                    {
+                        "hostname": "lc2",
+                        "asic_name": "asic0",
+                        "ifname": "Ethernet0",
+                        "qindex": "3"
+                    },
+                    {
+                        "hostname": "lc3",
+                        "asic_name": "asic1",
+                        "ifname": "Ethernet32",
+                        "qindex": "0-7"
+                    },
+                    {
+                        "hostname": "lc4",
+                        "asic_name": "asic0",
+                        "ifname": "Ethernet64",
+                        "qindex": "5"
+                    }
+                ]
+            }
+        }
     }
 
 }

--- a/src/sonic-yang-models/yang-models/sonic-queue.yang
+++ b/src/sonic-yang-models/yang-models/sonic-queue.yang
@@ -114,11 +114,35 @@ module sonic-queue {
                 }
 
                 leaf ifname {
-                    type string {
-                        length 1..128;
+                    // Union: try the leafref branch first; if the value resolves to a
+                    // PORT row the leafref is satisfied. If not, the plain string
+                    // branch accepts the value (used for entries that belong to a
+                    // remote linecard/ASIC whose PORT rows live in a different
+                    // namespace and therefore cannot be checked locally).
+                    //
+                    // The must below makes the leafref branch *required* whenever the
+                    // row's (hostname, asic_name) matches DEVICE_METADATA/localhost.
+                    // For non-local rows the must short-circuits and only the string
+                    // branch needs to accept. The gate also degrades to a no-op when
+                    // DEVICE_METADATA/localhost is missing hostname or asic_name.
+                    // Comparison is case-sensitive; SONiC writes asic_name as
+                    // lowercase 'asicN' by convention.
+                    type union {
+                        type leafref {
+                            path "/port:sonic-port/port:PORT/port:PORT_LIST/port:name";
+                            require-instance true;
+                        }
+                        type string {
+                            length 1..128;
+                        }
                     }
-
-                    description "Interface name.";
+                    must "not(../hostname = /sdm:sonic-device_metadata/sdm:DEVICE_METADATA/sdm:localhost/sdm:hostname
+                              and ../asic_name = /sdm:sonic-device_metadata/sdm:DEVICE_METADATA/sdm:localhost/sdm:asic_name)
+                          or /port:sonic-port/port:PORT/port:PORT_LIST[port:name = current()]" {
+                        error-message "Local VOQ_QUEUE entry (matching DEVICE_METADATA/localhost hostname and asic_name) must reference an existing PORT.";
+                        error-app-tag voq-queue-local-port-missing;
+                    }
+                    description "Interface name on the (possibly remote) VOQ chassis ASIC. Leafref to PORT is enforced only for local entries; remote entries fall through to the string branch.";
                 }
                 // qindex format is (X) | (X-Y). X is start and Y is end index.
                 // X and Y value depends on platform, example for physical ports 0-7 and


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In a VOQ chassis, QUEUE configuration is on the system port both for local and remote ports.

When the GCU patch is applied which changes the port speed, the GCU looks for references to remove before removing the port. One voq systems since there was no reference for ports, when port is removed by GCU the queue config was not removed. This causes ref counting issues in the swss and the port speed is not change cleanly.


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
To fix this in this PR, a leaf ref is added for all the local ports in the queue table. 
With this change when the port is changed, the queue configuration is removed as well

With this change not ref count issues are seen when change the speed for 100g to 400g and from 400g to 100g

#### How to verify it
logs
**When changing the speed from 400g to 100g**
```
 dmin@str3-sonic-lc3-1:~$ sudo config apply-patch 100g_config.patch 
Patch Applier: asic0: Patch application starting.
Patch Applier: asic0: Patch: [{"op": "add", "path": "/PORT/Ethernet16", "value": {"admin_status": "up", "alias": "Ethernet3/1", "asic_port_name": "Eth16", "core_id": "1", "core_port_id": "3", "description": "ARISTA03T3:Ethernet1", "index": "3", "lanes": "88,89,90,91", "mtu": "9100", "num_voq": "8", "pfc_asym": "off", "role": "Ext", "speed": "100000", "tpid": "0x8100"}}, {"op": "add", "path": "/PORT/Ethernet24", "value": {"admin_status": "up", "alias": "Ethernet4/1", "asic_port_name": "Eth24", "core_id": "1", "core_port_id": "4", "description": "ARISTA03T3:Ethernet2", "index": "4", "lanes": "96,97,98,99", "mtu": "9100", "num_voq": "8", "pfc_asym": "off", "role": "Ext", "speed": "100000", "tpid": "0x8100"}}, {"op": "add", "path": "/PORT_QOS_MAP/Ethernet16", "value": {"dscp_to_tc_map": "AZURE", "pfc_enable": "3,4", "pfc_to_queue_map": "AZURE", "pfcwd_sw_enable": "3,4", "tc_to_pg_map": "AZURE", "tc_to_queue_map": "AZURE"}}, {"op": "add", "path": "/PFC_WD/Ethernet16", "value": {"action": "drop", "detection_time": "200", "restoration_time": "200"}}, {"op": "add", "path": "/PORT_QOS_MAP/Ethernet24", "value": {"dscp_to_tc_map": "AZURE", "pfc_enable": "3,4", "pfc_to_queue_map": "AZURE", "pfcwd_sw_enable": "3,4", "tc_to_pg_map": "AZURE", "tc_to_queue_map": "AZURE"}}, {"op": "add", "path": "/PFC_WD/Ethernet24", "value": {"action": "drop", "detection_time": "200", "restoration_time": "200"}}, {"op": "add", "path": "/CABLE_LENGTH/AZURE/Ethernet16", "value": "120000m"}, {"op": "add", "path": "/CABLE_LENGTH/AZURE/Ethernet24", "value": "120000m"}, {"op": "add", "path": "/BUFFER_PG/Ethernet16|0", "value": {"profile": "ingress_lossy_profile"}}, {"op": "add", "path": "/BUFFER_PG/Ethernet16|3-4", "value": {"profile": "pg_lossless_400000_120000m_profile"}}, {"op": "add", "path": "/BUFFER_PG/Ethernet24|0", "value": {"profile": "ingress_lossy_profile"}}, {"op": "add", "path": "/BUFFER_PG/Ethernet24|3-4", "value": {"profile": "pg_lossless_400000_120000m_profile"}}, {"op": "add", "path": "/DEVICE_NEIGHBOR/Ethernet16", "value": {"name": "ARISTA03T3", "port": "Ethernet1"}}, {"op": "add", "path": "/DEVICE_NEIGHBOR/Ethernet24", "value": {"name": "ARISTA03T3", "port": "Ethernet2"}}, {"op": "add", "path": "/DEVICE_NEIGHBOR_METADATA/ARISTA03T3", "value": {"hwsku": "Arista-VM", "mgmt_addr": "172.16.32.19", "type": "AZNGHub"}}, {"op": "add", "path": "/PORTCHANNEL/PortChannel104", "value": {"admin_status": "up", "lacp_key": "auto", "min_links": "2", "mtu": "9100", "tpid": "0x8100"}}, {"op": "add", "path": "/PORTCHANNEL_MEMBER/PortChannel104|Ethernet16", "value": {}}, {"op": "add", "path": "/PORTCHANNEL_MEMBER/PortChannel104|Ethernet24", "value": {}}, {"op": "add", "path": "/PORTCHANNEL_INTERFACE/PortChannel104", "value": {}}, {"op": "add", "path": "/PORTCHANNEL_INTERFACE/PortChannel104|10.0.0.4~131", "value": {}}, {"op": "add", "path": "/PORTCHANNEL_INTERFACE/PortChannel104|FC00::9~1126", "value": {}}, {"op": "add", "path": "/BGP_NEIGHBOR/10.0.0.5", "value": {"asn": "65200", "holdtime": "10", "keepalive": "3", "local_addr": "10.0.0.4", "name": "ARISTA03T3", "nhopself": "0", "rrclient": "0"}}, {"op": "add", "path": "/BGP_NEIGHBOR/fc00::a", "value": {"asn": "65200", "holdtime": "10", "keepalive": "3", "local_addr": "fc00::9", "name": "ARISTA03T3", "nhopself": "0", "rrclient": "0"}}]
Patch Applier: asic0 getting current config db.
Patch Applier: asic0: simulating the target full config after applying the patch.
Patch Applier: asic0: validating all JsonPatch operations are permitted on the specified fields
Patch Applier: asic0: validating target config does not have empty tables,
                            since they do not show up in ConfigDb.
Patch Applier: asic0: sorting patch updates.
Patch Applier: The asic0 patch was converted into 78 changes:
Patch Applier: asic0: applying 78 changes in order:
Patch Applier:   * [{"op": "remove", "path": "/CABLE_LENGTH/AZURE/Ethernet16"}]
Patch Applier:   * [{"op": "remove", "path": "/PFC_WD/Ethernet16"}]
Patch Applier:   * [{"op": "remove", "path": "/PORTCHANNEL_MEMBER/PortChannel104|Ethernet16"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|0"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|1"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|2"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|3"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|4"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|5"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|6"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc4-1|asic0|Ethernet16|3"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc4-1|asic0|Ethernet16|4"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc5-1|asic0|Ethernet16|3"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc5-1|asic0|Ethernet16|4"}]
Patch Applier:   * [{"op": "remove", "path": "/CABLE_LENGTH/AZURE/Ethernet24"}]
Patch Applier:   * [{"op": "remove", "path": "/PFC_WD/Ethernet24"}]
Patch Applier:   * [{"op": "remove", "path": "/PORTCHANNEL_MEMBER/PortChannel104|Ethernet24"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|0"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|1"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|2"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|3"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|4"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|5"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|6"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc4-1|asic0|Ethernet24|3"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc4-1|asic0|Ethernet24|4"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc5-1|asic0|Ethernet24|3"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc5-1|asic0|Ethernet24|4"}]
Patch Applier:   * [{"op": "replace", "path": "/PORT/Ethernet16/speed", "value": "100000"}]
Patch Applier:   * [{"op": "replace", "path": "/PORT/Ethernet24/speed", "value": "100000"}]
Patch Applier:   * [{"op": "replace", "path": "/PORT/Ethernet16/admin_status", "value": "down"}]
Patch Applier:   * [{"op": "remove", "path": "/BUFFER_PG/Ethernet16|0"}]
Patch Applier:   * [{"op": "remove", "path": "/BUFFER_PG/Ethernet16|3-4"}]
Patch Applier:   * [{"op": "remove", "path": "/PORT_QOS_MAP/Ethernet16"}]
Patch Applier:   * [{"op": "replace", "path": "/PORT/Ethernet24/admin_status", "value": "down"}]
Patch Applier:   * [{"op": "remove", "path": "/BUFFER_PG/Ethernet24|0"}]
Patch Applier:   * [{"op": "remove", "path": "/BUFFER_PG/Ethernet24|3-4"}]
Patch Applier:   * [{"op": "remove", "path": "/PORT_QOS_MAP/Ethernet24"}]
Patch Applier:   * [{"op": "remove", "path": "/PORT/Ethernet16"}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc4-1|asic0|Ethernet16|3", "value": {"wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc4-1|asic0|Ethernet16|4", "value": {"wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc5-1|asic0|Ethernet16|3", "value": {"wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc5-1|asic0|Ethernet16|4", "value": {"wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "remove", "path": "/PORT/Ethernet24"}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc4-1|asic0|Ethernet24|3", "value": {"wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc4-1|asic0|Ethernet24|4", "value": {"wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc5-1|asic0|Ethernet24|3", "value": {"wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc5-1|asic0|Ethernet24|4", "value": {"wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "add", "path": "/PORT/Ethernet16", "value": {"admin_status": "down", "alias": "Ethernet3/1", "asic_port_name": "Eth16", "core_id": "1", "core_port_id": "3", "description": "ARISTA03T3:Ethernet1", "index": "3", "lanes": "88,89,90,91", "mtu": "9100", "num_voq": "8", "pfc_asym": "off", "role": "Ext", "speed": "100000", "tpid": "0x8100"}}]
Patch Applier:   * [{"op": "add", "path": "/BUFFER_PG/Ethernet16|0", "value": {"profile": "ingress_lossy_profile"}}]
Patch Applier:   * [{"op": "add", "path": "/BUFFER_PG/Ethernet16|3-4", "value": {"profile": "pg_lossless_400000_120000m_profile"}}]
Patch Applier:   * [{"op": "add", "path": "/PFC_WD/Ethernet16", "value": {"action": "drop", "detection_time": "200", "restoration_time": "200"}}]
Patch Applier:   * [{"op": "add", "path": "/PORTCHANNEL_MEMBER/PortChannel104|Ethernet16", "value": {}}]
Patch Applier:   * [{"op": "add", "path": "/PORT_QOS_MAP/Ethernet16", "value": {"dscp_to_tc_map": "AZURE", "pfc_enable": "3,4", "pfc_to_queue_map": "AZURE", "pfcwd_sw_enable": "3,4", "tc_to_pg_map": "AZURE", "tc_to_queue_map": "AZURE"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|0", "value": {"scheduler": "scheduler.0"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|1", "value": {"scheduler": "scheduler.0"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|2", "value": {"scheduler": "scheduler.0"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|3", "value": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|4", "value": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|5", "value": {"scheduler": "scheduler.0"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|6", "value": {"scheduler": "scheduler.0"}}]
Patch Applier:   * [{"op": "add", "path": "/CABLE_LENGTH/AZURE/Ethernet16", "value": "120000m"}]
Patch Applier:   * [{"op": "replace", "path": "/PORT/Ethernet16/admin_status", "value": "up"}]
Patch Applier:   * [{"op": "add", "path": "/PORT/Ethernet24", "value": {"admin_status": "down", "alias": "Ethernet4/1", "asic_port_name": "Eth24", "core_id": "1", "core_port_id": "4", "description": "ARISTA03T3:Ethernet2", "index": "4", "lanes": "96,97,98,99", "mtu": "9100", "num_voq": "8", "pfc_asym": "off", "role": "Ext", "speed": "100000", "tpid": "0x8100"}}]
Patch Applier:   * [{"op": "add", "path": "/BUFFER_PG/Ethernet24|0", "value": {"profile": "ingress_lossy_profile"}}]
Patch Applier:   * [{"op": "add", "path": "/BUFFER_PG/Ethernet24|3-4", "value": {"profile": "pg_lossless_400000_120000m_profile"}}]
Patch Applier:   * [{"op": "add", "path": "/PFC_WD/Ethernet24", "value": {"action": "drop", "detection_time": "200", "restoration_time": "200"}}]
Patch Applier:   * [{"op": "add", "path": "/PORTCHANNEL_MEMBER/PortChannel104|Ethernet24", "value": {}}]
Patch Applier:   * [{"op": "add", "path": "/PORT_QOS_MAP/Ethernet24", "value": {"dscp_to_tc_map": "AZURE", "pfc_enable": "3,4", "pfc_to_queue_map": "AZURE", "pfcwd_sw_enable": "3,4", "tc_to_pg_map": "AZURE", "tc_to_queue_map": "AZURE"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|0", "value": {"scheduler": "scheduler.0"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|1", "value": {"scheduler": "scheduler.0"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|2", "value": {"scheduler": "scheduler.0"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|3", "value": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|4", "value": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|5", "value": {"scheduler": "scheduler.0"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|6", "value": {"scheduler": "scheduler.0"}}]
Patch Applier:   * [{"op": "add", "path": "/CABLE_LENGTH/AZURE/Ethernet24", "value": "120000m"}]
Patch Applier:   * [{"op": "replace", "path": "/PORT/Ethernet24/admin_status", "value": "up"}]
Patch Applier: asic0: verifying patch updates are reflected on ConfigDB.
Patch Applier: asic0 patch application completed.
Patch applied successfully.
```

when change the config from 100g to 400g
```
admin@str3-sonic-lc3-1:~$ sudo config apply-patch 400g_config.patch 
Patch Applier: asic0: Patch application starting.
Patch Applier: asic0: Patch: [{"op": "add", "path": "/PORT/Ethernet16", "value": {"admin_status": "up", "alias": "Ethernet3/1", "asic_port_name": "Eth16", "core_id": "1", "core_port_id": "3", "description": "ARISTA03T3:Ethernet1", "index": "3", "lanes": "88,89,90,91,92,93,94,95", "mtu": "9100", "num_voq": "8", "pfc_asym": "off", "role": "Ext", "speed": "400000", "tpid": "0x8100"}}, {"op": "add", "path": "/PORT/Ethernet24", "value": {"admin_status": "up", "alias": "Ethernet4/1", "asic_port_name": "Eth24", "core_id": "1", "core_port_id": "4", "description": "ARISTA03T3:Ethernet2", "index": "4", "lanes": "96,97,98,99,100,101,102,103", "mtu": "9100", "num_voq": "8", "pfc_asym": "off", "role": "Ext", "speed": "400000", "tpid": "0x8100"}}, {"op": "add", "path": "/PORT_QOS_MAP/Ethernet16", "value": {"dscp_to_tc_map": "AZURE", "pfc_enable": "3,4", "pfc_to_queue_map": "AZURE", "pfcwd_sw_enable": "3,4", "tc_to_pg_map": "AZURE", "tc_to_queue_map": "AZURE"}}, {"op": "add", "path": "/PFC_WD/Ethernet16", "value": {"action": "drop", "detection_time": "200", "restoration_time": "200"}}, {"op": "add", "path": "/PORT_QOS_MAP/Ethernet24", "value": {"dscp_to_tc_map": "AZURE", "pfc_enable": "3,4", "pfc_to_queue_map": "AZURE", "pfcwd_sw_enable": "3,4", "tc_to_pg_map": "AZURE", "tc_to_queue_map": "AZURE"}}, {"op": "add", "path": "/PFC_WD/Ethernet24", "value": {"action": "drop", "detection_time": "200", "restoration_time": "200"}}, {"op": "add", "path": "/CABLE_LENGTH/AZURE/Ethernet16", "value": "120000m"}, {"op": "add", "path": "/CABLE_LENGTH/AZURE/Ethernet24", "value": "120000m"}, {"op": "add", "path": "/BUFFER_PG/Ethernet16|0", "value": {"profile": "ingress_lossy_profile"}}, {"op": "add", "path": "/BUFFER_PG/Ethernet16|3-4", "value": {"profile": "pg_lossless_400000_120000m_profile"}}, {"op": "add", "path": "/BUFFER_PG/Ethernet24|0", "value": {"profile": "ingress_lossy_profile"}}, {"op": "add", "path": "/BUFFER_PG/Ethernet24|3-4", "value": {"profile": "pg_lossless_400000_120000m_profile"}}, {"op": "add", "path": "/DEVICE_NEIGHBOR/Ethernet16", "value": {"name": "ARISTA03T3", "port": "Ethernet1"}}, {"op": "add", "path": "/DEVICE_NEIGHBOR/Ethernet24", "value": {"name": "ARISTA03T3", "port": "Ethernet2"}}, {"op": "add", "path": "/DEVICE_NEIGHBOR_METADATA/ARISTA03T3", "value": {"hwsku": "Arista-VM", "mgmt_addr": "172.16.32.19", "type": "AZNGHub"}}, {"op": "add", "path": "/PORTCHANNEL/PortChannel104", "value": {"admin_status": "up", "lacp_key": "auto", "min_links": "2", "mtu": "9100", "tpid": "0x8100"}}, {"op": "add", "path": "/PORTCHANNEL_MEMBER/PortChannel104|Ethernet16", "value": {}}, {"op": "add", "path": "/PORTCHANNEL_MEMBER/PortChannel104|Ethernet24", "value": {}}, {"op": "add", "path": "/PORTCHANNEL_INTERFACE/PortChannel104", "value": {}}, {"op": "add", "path": "/PORTCHANNEL_INTERFACE/PortChannel104|10.0.0.4~131", "value": {}}, {"op": "add", "path": "/PORTCHANNEL_INTERFACE/PortChannel104|FC00::9~1126", "value": {}}, {"op": "add", "path": "/BGP_NEIGHBOR/10.0.0.5", "value": {"asn": "65200", "holdtime": "10", "keepalive": "3", "local_addr": "10.0.0.4", "name": "ARISTA03T3", "nhopself": "0", "rrclient": "0"}}, {"op": "add", "path": "/BGP_NEIGHBOR/fc00::a", "value": {"asn": "65200", "holdtime": "10", "keepalive": "3", "local_addr": "fc00::9", "name": "ARISTA03T3", "nhopself": "0", "rrclient": "0"}}]
Patch Applier: asic0 getting current config db.
Patch Applier: asic0: simulating the target full config after applying the patch.
Patch Applier: asic0: validating all JsonPatch operations are permitted on the specified fields
Patch Applier: asic0: validating target config does not have empty tables,
                            since they do not show up in ConfigDb.
Patch Applier: asic0: sorting patch updates.
Patch Applier: The asic0 patch was converted into 78 changes:
Patch Applier: asic0: applying 78 changes in order:
Patch Applier:   * [{"op": "remove", "path": "/CABLE_LENGTH/AZURE/Ethernet16"}]
Patch Applier:   * [{"op": "remove", "path": "/PFC_WD/Ethernet16"}]
Patch Applier:   * [{"op": "remove", "path": "/PORTCHANNEL_MEMBER/PortChannel104|Ethernet16"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|0"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|1"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|2"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|3"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|4"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|5"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|6"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc4-1|asic0|Ethernet16|3"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc4-1|asic0|Ethernet16|4"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc5-1|asic0|Ethernet16|3"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc5-1|asic0|Ethernet16|4"}]
Patch Applier:   * [{"op": "remove", "path": "/CABLE_LENGTH/AZURE/Ethernet24"}]
Patch Applier:   * [{"op": "remove", "path": "/PFC_WD/Ethernet24"}]
Patch Applier:   * [{"op": "remove", "path": "/PORTCHANNEL_MEMBER/PortChannel104|Ethernet24"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|0"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|1"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|2"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|3"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|4"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|5"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|6"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc4-1|asic0|Ethernet24|3"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc4-1|asic0|Ethernet24|4"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc5-1|asic0|Ethernet24|3"}]
Patch Applier:   * [{"op": "remove", "path": "/QUEUE/str3-sonic-lc5-1|asic0|Ethernet24|4"}]
Patch Applier:   * [{"op": "replace", "path": "/PORT/Ethernet16/speed", "value": "400000"}]
Patch Applier:   * [{"op": "replace", "path": "/PORT/Ethernet24/speed", "value": "400000"}]
Patch Applier:   * [{"op": "replace", "path": "/PORT/Ethernet16/admin_status", "value": "down"}]
Patch Applier:   * [{"op": "remove", "path": "/BUFFER_PG/Ethernet16|0"}]
Patch Applier:   * [{"op": "remove", "path": "/BUFFER_PG/Ethernet16|3-4"}]
Patch Applier:   * [{"op": "remove", "path": "/PORT_QOS_MAP/Ethernet16"}]
Patch Applier:   * [{"op": "replace", "path": "/PORT/Ethernet24/admin_status", "value": "down"}]
Patch Applier:   * [{"op": "remove", "path": "/BUFFER_PG/Ethernet24|0"}]
Patch Applier:   * [{"op": "remove", "path": "/BUFFER_PG/Ethernet24|3-4"}]
Patch Applier:   * [{"op": "remove", "path": "/PORT_QOS_MAP/Ethernet24"}]
Patch Applier:   * [{"op": "remove", "path": "/PORT/Ethernet16"}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc4-1|asic0|Ethernet16|3", "value": {"wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc4-1|asic0|Ethernet16|4", "value": {"wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc5-1|asic0|Ethernet16|3", "value": {"wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc5-1|asic0|Ethernet16|4", "value": {"wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "remove", "path": "/PORT/Ethernet24"}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc4-1|asic0|Ethernet24|3", "value": {"wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc4-1|asic0|Ethernet24|4", "value": {"wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc5-1|asic0|Ethernet24|3", "value": {"wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc5-1|asic0|Ethernet24|4", "value": {"wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "add", "path": "/PORT/Ethernet16", "value": {"admin_status": "down", "alias": "Ethernet3/1", "asic_port_name": "Eth16", "core_id": "1", "core_port_id": "3", "description": "ARISTA03T3:Ethernet1", "index": "3", "lanes": "88,89,90,91,92,93,94,95", "mtu": "9100", "num_voq": "8", "pfc_asym": "off", "role": "Ext", "speed": "400000", "tpid": "0x8100"}}]
Patch Applier:   * [{"op": "add", "path": "/BUFFER_PG/Ethernet16|0", "value": {"profile": "ingress_lossy_profile"}}]
Patch Applier:   * [{"op": "add", "path": "/BUFFER_PG/Ethernet16|3-4", "value": {"profile": "pg_lossless_400000_120000m_profile"}}]
Patch Applier:   * [{"op": "add", "path": "/PFC_WD/Ethernet16", "value": {"action": "drop", "detection_time": "200", "restoration_time": "200"}}]
Patch Applier:   * [{"op": "add", "path": "/PORTCHANNEL_MEMBER/PortChannel104|Ethernet16", "value": {}}]
Patch Applier:   * [{"op": "add", "path": "/PORT_QOS_MAP/Ethernet16", "value": {"dscp_to_tc_map": "AZURE", "pfc_enable": "3,4", "pfc_to_queue_map": "AZURE", "pfcwd_sw_enable": "3,4", "tc_to_pg_map": "AZURE", "tc_to_queue_map": "AZURE"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|0", "value": {"scheduler": "scheduler.0"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|1", "value": {"scheduler": "scheduler.0"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|2", "value": {"scheduler": "scheduler.0"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|3", "value": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|4", "value": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|5", "value": {"scheduler": "scheduler.0"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet16|6", "value": {"scheduler": "scheduler.0"}}]
Patch Applier:   * [{"op": "add", "path": "/CABLE_LENGTH/AZURE/Ethernet16", "value": "120000m"}]
Patch Applier:   * [{"op": "replace", "path": "/PORT/Ethernet16/admin_status", "value": "up"}]
Patch Applier:   * [{"op": "add", "path": "/PORT/Ethernet24", "value": {"admin_status": "down", "alias": "Ethernet4/1", "asic_port_name": "Eth24", "core_id": "1", "core_port_id": "4", "description": "ARISTA03T3:Ethernet2", "index": "4", "lanes": "96,97,98,99,100,101,102,103", "mtu": "9100", "num_voq": "8", "pfc_asym": "off", "role": "Ext", "speed": "400000", "tpid": "0x8100"}}]
Patch Applier:   * [{"op": "add", "path": "/BUFFER_PG/Ethernet24|0", "value": {"profile": "ingress_lossy_profile"}}]
Patch Applier:   * [{"op": "add", "path": "/BUFFER_PG/Ethernet24|3-4", "value": {"profile": "pg_lossless_400000_120000m_profile"}}]
Patch Applier:   * [{"op": "add", "path": "/PFC_WD/Ethernet24", "value": {"action": "drop", "detection_time": "200", "restoration_time": "200"}}]
Patch Applier:   * [{"op": "add", "path": "/PORTCHANNEL_MEMBER/PortChannel104|Ethernet24", "value": {}}]
Patch Applier:   * [{"op": "add", "path": "/PORT_QOS_MAP/Ethernet24", "value": {"dscp_to_tc_map": "AZURE", "pfc_enable": "3,4", "pfc_to_queue_map": "AZURE", "pfcwd_sw_enable": "3,4", "tc_to_pg_map": "AZURE", "tc_to_queue_map": "AZURE"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|0", "value": {"scheduler": "scheduler.0"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|1", "value": {"scheduler": "scheduler.0"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|2", "value": {"scheduler": "scheduler.0"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|3", "value": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|4", "value": {"scheduler": "scheduler.1", "wred_profile": "AZURE_LOSSLESS"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|5", "value": {"scheduler": "scheduler.0"}}]
Patch Applier:   * [{"op": "add", "path": "/QUEUE/str3-sonic-lc3-1|asic0|Ethernet24|6", "value": {"scheduler": "scheduler.0"}}]
Patch Applier:   * [{"op": "add", "path": "/CABLE_LENGTH/AZURE/Ethernet24", "value": "120000m"}]
Patch Applier:   * [{"op": "replace", "path": "/PORT/Ethernet24/admin_status", "value": "up"}]
Patch Applier: asic0: verifying patch updates are reflected on ConfigDB.
Patch Applier: asic0 patch application completed.
Patch applied successfully.

```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

