### PR TITLE
[build]: Fix race in build_mirror_config.sh shared sources.list write

### DIFF
--- a/scripts/build_mirror_config.sh
+++ b/scripts/build_mirror_config.sh
@@ -66,15 +66,34 @@ TEMPLATE=files/apt/sources.list.j2
 [ -f $CONFIG_PATH/sources.list.j2 ] && TEMPLATE=$CONFIG_PATH/sources.list.j2
 [ -f $CONFIG_PATH/sources.list.$ARCHITECTURE.j2 ] && TEMPLATE=$CONFIG_PATH/sources.list.$ARCHITECTURE.j2
 
-MIRROR_URLS=$MIRROR_URLS MIRROR_SECURITY_URLS=$MIRROR_SECURITY_URLS j2 $TEMPLATE | sed '/^$/N;/^\n$/D' > $CONFIG_PATH/sources.list.$ARCHITECTURE
+# Write the sources.list via a temp file + atomic rename. Several
+# build_debian.sh invocations run in parallel under `make -j`, one
+# per rootfs target (broadcom, broadcom-dnx, broadcom-legacy-th, …),
+# and they all funnel through this same shared CONFIG_PATH/ARCH
+# pair when CONFIG_PATH is files/apt and ARCHITECTURE is amd64. A
+# naive `> file` redirect truncates the destination first, leaving
+# a window in which a sibling build_debian.sh can `cp` the file in
+# its 0-byte state. The chroot then ends up with an empty sources.list,
+# `apt-get update` succeeds trivially (nothing to fetch), and the
+# next `apt-get install` fails with "Unable to locate package".
+SOURCES_LIST=$CONFIG_PATH/sources.list.$ARCHITECTURE
+SOURCES_LIST_TMP=$(mktemp "${SOURCES_LIST}.XXXXXX")
+trap 'rm -f "$SOURCES_LIST_TMP"' EXIT
+MIRROR_URLS=$MIRROR_URLS MIRROR_SECURITY_URLS=$MIRROR_SECURITY_URLS j2 $TEMPLATE | sed '/^$/N;/^\n$/D' > "$SOURCES_LIST_TMP"
 if [ "$MIRROR_SNAPSHOT" == y ]; then
     # Escape special characters in BUILD_SNAPSHOT_URL for use in sed regex
     ESCAPED_MIRROR_URL=$(echo "$BUILD_SNAPSHOT_URL" | sed 's/[\/&.]/\\&/g')
     # Set the snapshot mirror, and add the SET_REPR_MIRRORS flag
-    sed -i -e "/^#*deb.*$ESCAPED_MIRROR_URL/! s/^#*deb/#&/" -e "\$a#SET_REPR_MIRRORS" $CONFIG_PATH/sources.list.$ARCHITECTURE
+    sed -i -e "/^#*deb.*$ESCAPED_MIRROR_URL/! s/^#*deb/#&/" -e "\$a#SET_REPR_MIRRORS" "$SOURCES_LIST_TMP"
 fi
+mv -f "$SOURCES_LIST_TMP" "$SOURCES_LIST"
 
-# Handle apt retry count config
+# Handle apt retry count config. Same race applies — write via temp
+# and atomic rename.
 APT_RETRIES_COUNT_FILENAME=apt-retries-count
 TEMPLATE=files/apt/$APT_RETRIES_COUNT_FILENAME.j2
-j2 $TEMPLATE > $CONFIG_PATH/$APT_RETRIES_COUNT_FILENAME
+APT_RETRIES_COUNT_DEST=$CONFIG_PATH/$APT_RETRIES_COUNT_FILENAME
+APT_RETRIES_COUNT_TMP=$(mktemp "${APT_RETRIES_COUNT_DEST}.XXXXXX")
+trap 'rm -f "$SOURCES_LIST_TMP" "$APT_RETRIES_COUNT_TMP"' EXIT
+j2 $TEMPLATE > "$APT_RETRIES_COUNT_TMP"
+mv -f "$APT_RETRIES_COUNT_TMP" "$APT_RETRIES_COUNT_DEST"


### PR DESCRIPTION
#### Why I did it

`scripts/build_mirror_config.sh` writes `\$CONFIG_PATH/sources.list.<arch>` with a plain bash redirect:

```bash
MIRROR_URLS=$MIRROR_URLS MIRROR_SECURITY_URLS=$MIRROR_SECURITY_URLS \
    j2 $TEMPLATE | sed '/^$/N;/^\n$/D' \
    > $CONFIG_PATH/sources.list.$ARCHITECTURE
```

The `>` redirect truncates the destination first (`O_WRONLY|O_CREAT|O_TRUNC`), so for the duration of the `j2 | sed` pipeline the file is in a 0-byte / partial state.

`build_debian.sh:117` invokes this script with `CONFIG_PATH=files/apt`, a path shared across the whole tree. Multiple `build_debian.sh` invocations run in parallel under `make -j` — one per rootfs target (e.g. `broadcom`, `broadcom-dnx`, `broadcom-legacy-th` — all amd64, all writing `files/apt/sources.list.amd64`). One process can `cp` the shared file into its chroot at the exact instant another's `>` has truncated it, ending up with an empty `sources.list` inside that chroot.

The downstream symptom is bizarre and easy to misattribute to a network/proxy issue:

```
+ sudo LANG=C chroot ./fsroot-broadcom-dnx apt-get -y update
Reading package lists...                       ← no Get:/Hit:/Err: lines at all
+ sudo LANG=C chroot ./fsroot-broadcom-dnx apt-get -y upgrade
Reading package lists...
Building dependency tree...
Calculating upgrade...
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
+ sudo LANG=C chroot ./fsroot-broadcom-dnx apt-get -y install eatmydata
Reading package lists...
Building dependency tree...
E: Unable to locate package eatmydata
```

With an empty `sources.list`:
- `apt-get update` succeeds trivially (nothing to fetch, exit 0)
- `apt-get upgrade` reports "0 upgraded" (packages installed via debootstrap are in dpkg/status; no Packages.gz to compare against, so apt sees nothing to upgrade)
- `apt-get install eatmydata` fails with "Unable to locate package" because the local index is empty

The failure is flaky — only one of the three rootfs builds hits the truncation window per affected run. `Acquire::Retries "20"` in `files/apt/apt-retries-count` doesn't help because the apt fetch wasn't attempted at all; there's nothing for it to retry. Container builds are immune: `prepare_docker_buildinfo.sh:47` calls `build_mirror_config.sh` with a per-container `DOCKERFILE_PATH` rather than `files/apt`, so each container has its own non-shared `sources.list.<arch>` and there's no inter-process race.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Replace the truncating `>` redirect with **write-to-temp-then-atomic-rename**:

```bash
SOURCES_LIST=$CONFIG_PATH/sources.list.$ARCHITECTURE
SOURCES_LIST_TMP=$(mktemp "${SOURCES_LIST}.XXXXXX")
trap 'rm -f "$SOURCES_LIST_TMP"' EXIT
MIRROR_URLS=$MIRROR_URLS MIRROR_SECURITY_URLS=$MIRROR_SECURITY_URLS \
    j2 $TEMPLATE | sed '/^$/N;/^\n$/D' > "\$SOURCES_LIST_TMP"
# ...optional MIRROR_SNAPSHOT sed -i runs against the temp file...
mv -f "\$SOURCES_LIST_TMP" "\$SOURCES_LIST"
```

`mv` within the same filesystem is atomic at the directory-entry level — concurrent readers either see the old contents or the new contents, never a partial / 0-byte state. The same pattern is applied to the `apt-retries-count` file write a few lines below, which has the same race shape (single shared destination, called from parallel `build_debian.sh` invocations).

Trap on EXIT cleans up the temp file if the script aborts before the `mv` lands.

#### How to verify it

**Confirm the original race**: run `make` with multiple `*.bin` targets that share an architecture (e.g. broadcom + broadcom-dnx + broadcom-legacy-th, all amd64) and a high `SONIC_BUILD_JOBS`. The "Unable to locate package eatmydata" failure during one of the three rootfs assemblies appears on roughly one in every 4–6 builds in our environment.

**Confirm the fix**: with this patch applied, the failure is gone across many consecutive builds. Direct verification of the atomic-write property:

```bash
mkdir -p /tmp/test/apt
cp -r files/apt/* /tmp/test/apt/
MIRROR_SNAPSHOT=n bash scripts/build_mirror_config.sh /tmp/test/apt amd64 bookworm
wc -l /tmp/test/apt/sources.list.amd64    # > 0, contents complete
```

For the race window itself, this trace shows it (run two `build_mirror_config.sh` invocations against the same shared dir while a third process `cp`s the output repeatedly):

```bash
( for i in 1 2 3 4 5 6 7 8 9 10; do bash scripts/build_mirror_config.sh /tmp/test/apt amd64 bookworm; done ) &
( for i in 1 2 3 4 5 6 7 8 9 10; do bash scripts/build_mirror_config.sh /tmp/test/apt amd64 bookworm; done ) &
while true; do
    cp /tmp/test/apt/sources.list.amd64 /tmp/test/captured
    [ ! -s /tmp/test/captured ] && echo "TORN WRITE OBSERVED" && break
done
```

Before the fix: "TORN WRITE OBSERVED" within seconds. After the fix: loops indefinitely without ever capturing an empty file.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

This is a build-flakiness fix and is a candidate for backport to any release branch that ships build infrastructure with the same race. Leaving unchecked here; release-branch maintainers can pick this up if their stable branches see the same intermittent build failure.

#### Tested branch (Please provide the tested image version)

- [ ] master (verified end-to-end against the broadcom platform with all three rootfs variants under \`make -j12\`)

#### Description for the changelog

Fix race in `scripts/build_mirror_config.sh` that occasionally produced an empty `sources.list` in one of the parallel rootfs chroots, causing `apt-get install` to fail with "Unable to locate package".

#### Link to config_db schema for YANG module changes

N/A — no YANG schema changes.