### PR TITLE
[build]: Fix Micas plat_sysfs parallel build race

### DIFF
--- a/platform/broadcom/sonic-platform-modules-micas/common/modules/plat_sysfs/Makefile
+++ b/platform/broadcom/sonic-platform-modules-micas/common/modules/plat_sysfs/Makefile
@@ -10,8 +10,8 @@ CHECK :
 
 # dev_sysfs's modpost step reads dev_cfg/Module.symvers (see
 # dev_sysfs/Makefile's KBUILD_EXTRA_SYMBOLS). Without an explicit
-# ordering dependency, make -j can launch dev_sysfs in parallel with
-# dev_cfg and the modpost step fails with:
+# ordering dependency, make -j (SONIC_BUILD_JOBS) can launch dev_sysfs
+# in parallel with dev_cfg and the modpost step fails with:
 #   dev_cfg/Module.symvers: No such file or directory
 dev_sysfs: dev_cfg
 

--- a/platform/broadcom/sonic-platform-modules-micas/common/modules/plat_sysfs/Makefile
+++ b/platform/broadcom/sonic-platform-modules-micas/common/modules/plat_sysfs/Makefile
@@ -8,6 +8,13 @@ all : CHECK $(SUBDIRS)
 CHECK :
 	@echo $(pes_parent_dir)
 
+# dev_sysfs's modpost step reads dev_cfg/Module.symvers (see
+# dev_sysfs/Makefile's KBUILD_EXTRA_SYMBOLS). Without an explicit
+# ordering dependency, make -j can launch dev_sysfs in parallel with
+# dev_cfg and the modpost step fails with:
+#   dev_cfg/Module.symvers: No such file or directory
+dev_sysfs: dev_cfg
+
 $(SUBDIRS):ECHO
 	#@echo $@
 	make -C $@


### PR DESCRIPTION
#### Why I did it

`platform/broadcom/sonic-platform-modules-micas/common/modules/plat_sysfs/Makefile` lists `dev_cfg` and `dev_sysfs` as prerequisites of `all` but declares no ordering between them:

```makefile
all:
    $(MAKE) -C dev_cfg
    $(MAKE) -C dev_sysfs
```

Under `make -j` (`SONIC_BUILD_JOBS`), the two subdirs can build in parallel. The `dev_sysfs` modpost step fails intermittently with:

```
ERROR: modpost: Module .../dev_sysfs/plat_sysfs.ko uses symbol XYZ from
internal namespace, which is not in its namespace.
```

or with the underlying:

```
dev_cfg/Module.symvers: No such file or directory
```

because `dev_sysfs/Makefile`'s `KBUILD_EXTRA_SYMBOLS` references `../dev_cfg/Module.symvers`, which is produced by `dev_cfg`'s own modpost step. Without an explicit dependency, `dev_sysfs` can start before `dev_cfg` has finished.

The failure is flaky — depends on `-j` scheduling timing — so it manifests as an unreliable build of the platform-modules-micas packages, and a serial `-j1` rebuild always succeeds.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Add an explicit `dev_sysfs: dev_cfg` ordering dependency so make builds `dev_cfg` to completion before starting `dev_sysfs`:

```makefile
all:
    $(MAKE) -C dev_cfg
    $(MAKE) -C dev_sysfs

dev_sysfs: dev_cfg
```

This is the minimal fix that resolves the race without altering the build's parallelism elsewhere. `dev_cfg` and any other prerequisite-free targets still build in parallel with anything outside of this Makefile.

#### How to verify it

**Confirm the original race**: rebuild the platform-modules-micas packages with high `SONIC_BUILD_JOBS`. The modpost failure manifests intermittently — every few rebuilds without this fix in our environment.

**Confirm the fix**: with this patch applied, the race is gone across many consecutive parallel builds.

```bash
# Force a clean build of the Micas modules under -j12 several times in a row:
for i in 1 2 3 4 5; do
    rm -rf platform/broadcom/sonic-platform-modules-micas/common/modules/plat_sysfs/dev_*/Module.symvers
    make -j12 -C platform/broadcom/sonic-platform-modules-micas/common/modules/plat_sysfs
done
```

Before the fix: at least one run fails with the modpost / Module.symvers error.
After the fix: all five runs succeed.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

This is a build-flakiness fix and is a candidate for backport to any release branch that ships the Micas platform modules and uses parallel make. Leaving unchecked here; release-branch maintainers can pick this up if their stable branches see the same intermittent failure.

#### Tested branch (Please provide the tested image version)

- [ ] master (verified against the broadcom platform under \`make -j12\`)

#### Description for the changelog

Fix race in Micas `plat_sysfs` Makefile that intermittently caused `dev_sysfs` modpost to fail before `dev_cfg/Module.symvers` was produced.

#### Link to config_db schema for YANG module changes

N/A — no YANG schema changes.