### PR TITLE
Add description to vrfs

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -88,6 +88,7 @@
   * [VNET_ROUTE_TUNNEL](#vnet_route_tunnel)
   * [VOQ Inband Interface](#voq-inband-interface)
   * [VXLAN](#vxlan)
+  * [VRF](#vrf)
   * [Virtual router](#virtual-router)
   * [LOGGER](#logger)
   * [WRED_PROFILE](#wred_profile)
@@ -2944,6 +2945,23 @@ Dual tunnel example:
     "VXLAN_EVPN_NVO": {
         "nvo1": {
             "source_vtep": "vtep1"
+        }
+    }
+}
+```
+
+### VRF (Virtual Routing & Forwarding)
+
+The VRF table configured VRF instances for L3 traffic isolation. 
+VRFs have a name and a short description of up to 255 characters,
+as well as its associated VNI.
+
+```
+{
+    "VRF": {
+        "Vrf-red": {
+            "description": "Red VRF",
+            "vni": "1000"
         }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vrf.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vrf.json
@@ -19,5 +19,12 @@
     "VRF_TEST_WITH_VNI_OOR": {
         "desc": "Configure VRF with out of range VNI in VRF table.",
         "eStrKey": "Range"
+    },
+    "VRF_TEST_WITH_DESCRIPTION": {
+        "desc": "Configure VRF with description in VRF table."
+    },
+    "VRF_TEST_WITH_DESCRIPTION_TOO_LONG": {
+        "desc": "Configure VRF with description that exceeds maximum length.",
+        "eStrKey": "Length"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vrf.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vrf.json
@@ -60,5 +60,27 @@
                 }]
             }
         }
+    },
+
+    "VRF_TEST_WITH_DESCRIPTION": {
+        "sonic-vrf:sonic-vrf": {
+            "sonic-vrf:VRF": {
+                "VRF_LIST": [{
+                        "name": "Vrf_blue",
+                        "description": "Customer Blue Network"
+                }]
+            }
+        }
+    },
+
+    "VRF_TEST_WITH_DESCRIPTION_TOO_LONG": {
+        "sonic-vrf:sonic-vrf": {
+            "sonic-vrf:VRF": {
+                "VRF_LIST": [{
+                        "name": "Vrf_blue",
+                        "description": "This is a very long description that exceeds the maximum allowed length of 255 characters. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur."
+                }]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-vrf.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vrf.yang
@@ -54,6 +54,14 @@ module sonic-vrf {
                     description
                         "VNI mapped to VRF";
                 }
+
+                leaf description {
+                    type string {
+                        length "1..255";
+                    }
+                    description
+                        "Description for the VRF";
+                }
             } /* end of list VRF_LISt */
         } /* end of container VRf */
     } /* end of container sonic-vrf */


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Resolves #27481 
The only way to convey the usage/purpose of a VRF was through its naming, but a better approach would be to have a dedicated field to store a concise description.

#### How I did it

Updated `sonic-vrf.yang` to include a field for description. They are 1-255 characters in length (inclusive).

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add description for VRFs in the VRF yang model

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

VRF section didn't exist, so it was added in this PR

#### A picture of a cute animal (not mandatory but encouraged)

