### PR TITLE
[gnmi] mount /host rw into gnmi container

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -797,6 +797,9 @@ start() {
 {%- if docker_container_name == "dash-ha" %}
         -v /var/log/dash-ha:/var/log/dash-ha:rw \
 {%- endif %}
+{%- if docker_container_name == "gnmi" %}
+        -v /host:/mnt/host/host:rw \
+{%- endif %}
 {%- if docker_container_name == "database" %}
         $DB_OPT \
 {%- else %}


### PR DESCRIPTION
The SONiC `device-ops-agent` uses gNOI `File.Put` against the local gnmi sock to stage files into the next-image overlay at `/host/image-{next}/rw/etc/sonic/`. Today the `gnmi` container mounts the root filesystem only via the implicit container root, which is read-only for `/host`, so every such write is rejected by the kernel with `EROFS` — independent of whether sonic-gnmi's `validatePath` whitelists `/host/` (companion PR: sonic-net/sonic-gnmi `[gnoi] expand File.Put whitelist to /host/`).

This PR adds a **gnmi-only** bind mount inside the `docker create` invocation in `files/build_templates/docker_image_ctl.j2`:

```
-v /host:/mnt/host/host:rw \
```

It is scoped to the gnmi container via a `{%- if docker_container_name == "gnmi" %}` guard, so other containers (`swss`, `syncd`, `bgp`, `pmon`, ...) are unaffected.

The mount target `/mnt/host/host` matches the `translatePathForContainer` prefix convention used by sonic-gnmi (which prepends `/mnt/host` when running inside a container), so `File.Put` for `/host/image-{next}/rw/...` resolves to `/mnt/host/host/image-{next}/rw/...` inside the container and writes through to the host `/host/`.

## Discrepancy note

The in-tree upgrade-PoC design doc (D6-G1b) names `files/scripts/gnmi.sh` as the patch target, but `gnmi.sh` is generated from `docker_image_ctl.j2`. The rendered `/usr/bin/gnmi.sh` on a device contains only systemd wrappers, not `docker create`. The actual `docker create` lives in this Jinja template, so PR-B is filed against the template instead.

## Companion PR

sonic-net/sonic-gnmi: `[gnoi] expand File.Put whitelist to /host/ + mkdir-p parent dirs` — without it, even with this mount in place, `File.Put` to `/host/...` is rejected by `validatePath` before reaching the filesystem.
