### PR TITLE
[build] fix issues when RFS targets build in parallel

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -421,18 +421,18 @@ sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "mkdir -p /etc/initramfs-tools/
 sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "echo 'MODULES=most' >> /etc/initramfs-tools/conf.d/driver-policy"
 
 # Ensure the relevant directories exist
-sudo mkdir -p /etc/initramfs-tools/scripts/init-premount
-sudo mkdir -p /etc/initramfs-tools/hooks
+sudo mkdir -p $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount
+sudo mkdir -p $FILESYSTEM_ROOT/etc/initramfs-tools/hooks
 
 # Copy the network setup script
-sudo cp files/scripts/network_setup.sh /etc/initramfs-tools/scripts/init-premount/network_setup.sh
+sudo cp files/scripts/network_setup.sh $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/network_setup.sh
 
 # Copy the hook file
-sudo cp files/scripts/network_setup /etc/initramfs-tools/hooks/network_setup
+sudo cp files/scripts/network_setup $FILESYSTEM_ROOT/etc/initramfs-tools/hooks/network_setup
 
 # Make the scripts executable
-sudo chmod +x /etc/initramfs-tools/scripts/init-premount/network_setup.sh
-sudo chmod +x /etc/initramfs-tools/hooks/network_setup
+sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/scripts/init-premount/network_setup.sh
+sudo chmod +x $FILESYSTEM_ROOT/etc/initramfs-tools/hooks/network_setup
 
 # Copy vmcore-sysctl.conf to add more vmcore dump flags to kernel
 sudo cp files/image_config/kdump/vmcore-sysctl.conf $FILESYSTEM_ROOT/etc/sysctl.d/
@@ -863,7 +863,7 @@ sudo LANG=C chroot $FILESYSTEM_ROOT fuser -km /proc || true
 sudo timeout 15s bash -c 'until LANG=C chroot $0 umount /proc; do sleep 1; done' $FILESYSTEM_ROOT || true
 
 ## Prepare empty directory to trigger mount move in initramfs-tools/mount_loop_root, implemented by patching
-sudo mkdir $FILESYSTEM_ROOT/host
+sudo mkdir -p $FILESYSTEM_ROOT/host
 
 
 if [[ "$CHANGE_DEFAULT_PASSWORD" == "y" ]]; then


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When multiple RFS targets are built in parallel (e.g. `target/sonic-aboot-broadcom.swi__broadcom-legacy-th__rfs.squashfs` and `target/sonic-broadcom.bin__broadcom-dnx__rfs.squashfs`), the build fails with errors such as:

- `cp: cannot create regular file '/etc/initramfs-tools/hooks/network_setup': File exists`

Root cause: the initramfs `network_setup` hook and pre-mount script were created and copied into the build **host's** absolute paths (`/etc/initramfs-tools/...`) instead of the per-target root filesystem (`$FILESYSTEM_ROOT/etc/initramfs-tools/...`). Because the host path is shared across concurrent builds, parallel targets race to create the same files, producing the "File exists" failure (and risking cross-contamination between target images).

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Create the `init-premount` and `hooks` directories under `$FILESYSTEM_ROOT` instead of on the host.
- Copy `network_setup.sh` and the `network_setup` hook into `$FILESYSTEM_ROOT/etc/initramfs-tools/...` and `chmod +x` them there, so each target writes only into its own root filesystem.
- Make the `$FILESYSTEM_ROOT/host` directory creation idempotent (`mkdir -p`) to avoid failures when the directory already exists.

#### How to verify it
- Build two or more RFS targets in parallel and confirm the build no longer fails with `cp: cannot create regular file '/etc/initramfs-tools/hooks/network_setup': File exists`.
- Verify the resulting image contains `etc/initramfs-tools/scripts/init-premount/network_setup.sh` and `etc/initramfs-tools/hooks/network_setup` (both executable) inside the target root filesystem.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Fix parallel RFS build failures by writing initramfs `network_setup` hook/script into the per-target root filesystem instead of the build host.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
