### PR TITLE
[202511] Update DPU HWSKU context config to use DPU_COUNTERS_DB

### DIFF
--- a/device/nvidia-bluefield/arm64-nvda_bf-bf3comdpu/Nvidia-bf3-com-dpu/context_config.json
+++ b/device/nvidia-bluefield/arm64-nvda_bf-bf3comdpu/Nvidia-bf3-com-dpu/context_config.json
@@ -4,7 +4,7 @@
             "guid" : 0,
             "name" : "syncd0",
             "dbAsic" : "ASIC_DB",
-            "dbCounters" : "COUNTERS_DB",
+            "dbCounters" : "DPU_COUNTERS_DB",
             "dbFlex": "FLEX_COUNTER_DB",
             "dbState" : "STATE_DB",
             "zmq_enable": true,

--- a/device/pensando/arm64-elba-asic-flash128-r0/Pensando-elba/context_config.json
+++ b/device/pensando/arm64-elba-asic-flash128-r0/Pensando-elba/context_config.json
@@ -4,7 +4,7 @@
             "guid" : 0,
             "name" : "syncd0",
             "dbAsic" : "ASIC_DB",
-            "dbCounters" : "COUNTERS_DB",
+            "dbCounters" : "DPU_COUNTERS_DB",
             "dbFlex": "FLEX_COUNTER_DB",
             "dbState" : "STATE_DB",
             "zmq_enable": true,


### PR DESCRIPTION
#### Why I did it
Backport of https://github.com/sonic-net/sonic-buildimage/pull/27498 to 202511.

Update the DPU HWSKU context_config.json to use DPU_COUNTERS_DB instead of COUNTERS_DB for the dbCounters field.

#### How I did it
Cherry-picked commit 0ae52137a94f68d91f507200d379fb5fb6ad7ea4 from master.

Changed the `dbCounters` value from `COUNTERS_DB` to `DPU_COUNTERS_DB` in the context_config.json for:
- `device/nvidia-bluefield/arm64-nvda_bf-bf3comdpu/Nvidia-bf3-com-dpu/context_config.json`
- `device/pensando/arm64-elba-asic-flash128-r0/Pensando-elba/context_config.json`

#### How to verify it
Verify that the context_config.json files reference DPU_COUNTERS_DB.
