### PR TITLE
Update static_th values for TH5-512 hwskus

### DIFF
--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2/buffers_defaults_t0.j2
@@ -20,7 +20,7 @@
         "ingress_lossy_profile": {
             "pool": "ingress_lossless_pool",
             "size": "0",
-            "static_th": "82682080"
+            "static_th": "82434938"
         },
         "egress_lossy_profile": {
             "pool": "egress_lossless_pool",
@@ -30,7 +30,7 @@
         "egress_lossless_profile": {
             "pool": "egress_lossless_pool",
             "size": "0",
-            "static_th": "82682080"
+            "static_th": "82434938"
         }
     },
 {%- endmacro %}

--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2/buffers_defaults_t1.j2
@@ -20,7 +20,7 @@
         "ingress_lossy_profile": {
             "pool": "ingress_lossless_pool",
             "size": "0",
-            "static_th": "82682080"
+            "static_th": "82434938"
         },
         "egress_lossy_profile": {
             "pool": "egress_lossless_pool",
@@ -30,7 +30,7 @@
         "egress_lossless_profile": {
             "pool": "egress_lossless_pool",
             "size": "0",
-            "static_th": "82682080"
+            "static_th": "82434938"
         }
     },
 {%- endmacro %}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/buffers_defaults_lt2.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/buffers_defaults_lt2.j2
@@ -20,7 +20,7 @@
         "ingress_lossy_profile": {
             "pool": "ingress_lossless_pool",
             "size": "0",
-            "static_th": "165364160"
+            "static_th": "82434938"
         },
         "egress_lossy_profile": {
             "pool": "egress_lossless_pool",
@@ -30,7 +30,7 @@
         "egress_lossless_profile": {
             "pool": "egress_lossless_pool",
             "size": "0",
-            "static_th": "165364160"
+            "static_th": "82434938"
         }
     },
 {%- endmacro %}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32O64/buffers_defaults_t1.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32O64/buffers_defaults_t1.j2
@@ -25,12 +25,12 @@
         "egress_lossless_profile": {
             "pool": "egress_lossless_pool",
             "size": "0",
-            "static_th": "165364160"
+            "static_th": "82434938"
         },
         "ingress_lossy_profile": {
             "pool": "ingress_lossless_pool",
             "size": "0",
-            "static_th": "165364160"
+            "static_th": "82434938"
         }
     },
 {%- endmacro %}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32V128/buffers_defaults_t0.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32V128/buffers_defaults_t0.j2
@@ -25,12 +25,12 @@
         "egress_lossless_profile": {
             "pool": "egress_lossless_pool",
             "size": "0",
-            "static_th": "165364160"
+            "static_th": "82434938"
         },
         "ingress_lossy_profile": {
             "pool": "ingress_lossless_pool",
             "size": "0",
-            "static_th": "165364160"
+            "static_th": "82434938"
         }
     },
 {%- endmacro %}

--- a/src/sonic-config-engine/tests/sample_output/py3/buffer-frh-b-o128.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffer-frh-b-o128.json
@@ -150,7 +150,7 @@
         "ingress_lossy_profile": {
             "pool": "ingress_lossless_pool",
             "size": "0",
-            "static_th": "165364160"
+            "static_th": "82434938"
         },
         "egress_lossy_profile": {
             "pool": "egress_lossless_pool",
@@ -160,7 +160,7 @@
         "egress_lossless_profile": {
             "pool": "egress_lossless_pool",
             "size": "0",
-            "static_th": "165364160"
+            "static_th": "82434938"
         }
     },
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Broadcom SAI version 14 changes the way that the static thresholds are used. These values need to be updated for all TH5-512 skus.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Went through all the TH5-512 hwskus and ensured the `static_th` was set to the correct value.

#### How to verify it
Boot device with new threshold, observe no errors related to it in syslog.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
In accordance with the broadcom SAI version 14, these static threshold values need to be changed. All TH5-512 hwskus should have the same value.
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

