### PR TITLE
[Mellanox] Support branch input in hw-mgmt integration script

### DIFF
--- a/platform/mellanox/integration-scripts.mk
+++ b/platform/mellanox/integration-scripts.mk
@@ -26,6 +26,7 @@ TEMP_HW_MGMT_DIR = /tmp/hw_mgmt
 PTCH_DIR = $(TEMP_HW_MGMT_DIR)/patch_dir/
 NON_UP_PTCH_DIR = $(TEMP_HW_MGMT_DIR)/non_up_patch_dir/
 PTCH_LIST  = $(TEMP_HW_MGMT_DIR)/series
+HWMGMT_RESOLVED_REF_ENV = $(TEMP_HW_MGMT_DIR)/resolved_hw_mgmt_ref.env
 HWMGMT_NONUP_LIST = $(BUILD_WORKDIR)/$($(MLNX_HW_MANAGEMENT)_SRC_PATH)/hwmgmt_nonup_patches
 HWMGMT_USER_OUTFILE = $(BUILD_WORKDIR)/integrate-mlnx-hw-mgmt_user.out
 SDK_USER_OUTFILE = $(BUILD_WORKDIR)/integrate-mlnx-sdk_user.out
@@ -62,6 +63,15 @@ integrate-mlnx-hw-mgmt:
 	mkdir -p $(PTCH_DIR) $(NON_UP_PTCH_DIR) $(KCFG_BASE_TMPDIR)
 	touch $(PTCH_LIST) $(KCFG_LIST) $(KCFG_DOWN_LIST) $(KCFG_LIST_ARM) $(KCFG_DOWN_LIST_ARM) $(KCFG_LIST_ASPEED)
 
+	# Resolve MLNX_HW_MANAGEMENT_VERSION to a hw-mgmt ref (tag V.<input>
+	# wins over branch <input>), write env vars to $(HWMGMT_RESOLVED_REF_ENV),
+	# then source them.
+	$(BUILD_WORKDIR)/$(MLNX_PLATFORM_PATH)/integration-scripts/hwmgmt_resolve_ref.py \
+		--repo $(BUILD_WORKDIR)/$($(MLNX_HW_MANAGEMENT)_SRC_PATH)/hw-mgmt \
+		--input "$(MLNX_HW_MANAGEMENT_VERSION)" \
+		--env-file $(HWMGMT_RESOLVED_REF_ENV) $(LOG_SIMPLE)
+	. $(HWMGMT_RESOLVED_REF_ENV)
+
 	# Fetch the vanilla .config files
 	pushd $(KCFG_BASE_TMPDIR) $(LOG_SIMPLE)
 	rm -rf linux/; mkdir linux
@@ -78,27 +88,51 @@ integrate-mlnx-hw-mgmt:
 	# clean up existing untracked files
 	pushd $(BUILD_WORKDIR); git clean -f -- $(MLNX_PLATFORM_PATH)/
 ifeq ($(CREATE_BRANCH), y)
-	git checkout -B "$(BRANCH_SONIC)_$(SB_HEAD)_integrate_$(MLNX_HW_MANAGEMENT_VERSION)" HEAD
-	echo $(BRANCH_SONIC)_$(SB_HEAD)_integrate_$(MLNX_HW_MANAGEMENT_VERSION) branch created in sonic-buildimage
+	# Tag path: HWMGMT_PACKAGE_VERSION == input (today's name). Branch path:
+	# "-<sha9>" suffix makes two runs against the same hw-mgmt branch produce
+	# distinct sonic-buildimage branch names.
+	git checkout -B "$(BRANCH_SONIC)_$(SB_HEAD)_integrate_$$HWMGMT_PACKAGE_VERSION" HEAD
+	echo $(BRANCH_SONIC)_$(SB_HEAD)_integrate_$$HWMGMT_PACKAGE_VERSION branch created in sonic-buildimage
 endif
 	popd
 
 	pushd $(BUILD_WORKDIR)/src/sonic-linux-kernel; git clean -f -- patch/
 ifeq ($(CREATE_BRANCH), y)
-	git checkout -B "$(BRANCH_SONIC)_$(SLK_HEAD)_integrate_$(MLNX_HW_MANAGEMENT_VERSION)" HEAD
-	echo $(BRANCH_SONIC)_$(SLK_HEAD)_integrate_$(MLNX_HW_MANAGEMENT_VERSION) branch created in sonic-linux-kernel
+	git checkout -B "$(BRANCH_SONIC)_$(SLK_HEAD)_integrate_$$HWMGMT_PACKAGE_VERSION" HEAD
+	echo $(BRANCH_SONIC)_$(SLK_HEAD)_integrate_$$HWMGMT_PACKAGE_VERSION branch created in sonic-linux-kernel
 endif
 	popd
 
-	echo "#### Integrate HW-MGMT $(MLNX_HW_MANAGEMENT_VERSION) Kernel Patches into SONiC" > ${HWMGMT_USER_OUTFILE}
+	echo "#### Integrate HW-MGMT $$HWMGMT_PACKAGE_VERSION Kernel Patches into SONiC" > ${HWMGMT_USER_OUTFILE}
+	{ \
+		echo ""; \
+		echo "Resolved hw-mgmt source:"; \
+		echo "  input:           $$HWMGMT_INPUT"; \
+		echo "  ref type:        $$HWMGMT_REF_TYPE"; \
+		echo "  checkout ref:    $$HWMGMT_CHECKOUT_REF"; \
+		echo "  commit:          $$HWMGMT_COMMIT"; \
+		echo "  base version:    $$HWMGMT_BASE_VERSION"; \
+		echo "  distinct id:     $$HWMGMT_DISTINCT_ID"; \
+		echo "  package version: $$HWMGMT_PACKAGE_VERSION"; \
+	} >> ${HWMGMT_USER_OUTFILE}
 	pushd $(BUILD_WORKDIR)/$(MLNX_PLATFORM_PATH) $(LOG_SIMPLE)
 
 	# Run tests
 	pushd integration-scripts/tests; pytest-3 -v; popd
 
-	# Checkout to the corresponding hw-mgmt version and update mk file.
-	pushd hw-management/hw-mgmt; git checkout V.${MLNX_HW_MANAGEMENT_VERSION}; popd
-	sed -i "s/\(^MLNX_HW_MANAGEMENT_VERSION = \).*/\1${MLNX_HW_MANAGEMENT_VERSION}/g" hw-management.mk
+	# Detach hw-mgmt at the resolved commit and write HWMGMT_PACKAGE_VERSION
+	# into hw-management.mk. Tag path: byte-identical to today. Branch path:
+	# <changelog-version>-<sha9>, unique per commit so two iterations against
+	# the same branch don't produce identically-named debs in $(DEST).
+	#
+	# HWMGMT_PACKAGE_VERSION is the SONiC-side identity (deb filename,
+	# downstream caching). The Debian package's internal `Version:` still
+	# comes from hw-mgmt/debian/changelog via dpkg-buildpackage and stays
+	# at the unsuffixed base; hw-management/Makefile's wildcard
+	# `mv hw-management_*.deb $(DEST)/$*` reconciles the two. Changing
+	# internal Debian metadata is intentionally out of scope.
+	pushd hw-management/hw-mgmt; git checkout --detach "$$HWMGMT_COMMIT"; popd
+	sed -i "s|\(^MLNX_HW_MANAGEMENT_VERSION = \).*|\1$$HWMGMT_PACKAGE_VERSION|g" hw-management.mk
 
 	# Pre-processing before runing hw_mgmt script
 	integration-scripts/hwmgmt_kernel_patches.py pre \
@@ -110,7 +144,7 @@ endif
 							--config_inc_aspeed $(KCFG_LIST_ASPEED) \
 							--build_root $(BUILD_WORKDIR) \
 							--kernel_version $(KERNEL_VERSION) \
-							--hw_mgmt_ver ${MLNX_HW_MANAGEMENT_VERSION} $(LOG_SIMPLE)
+							--hw_mgmt_ver "$$HWMGMT_PACKAGE_VERSION" $(LOG_SIMPLE)
 
 	# Disable Writing KConfigs for arm64 platform
 	# $(BUILD_WORKDIR)/$($(MLNX_HW_MANAGEMENT)_SRC_PATH)/hw-mgmt/recipes-kernel/linux/deploy_kernel_patches.py \
@@ -166,7 +200,7 @@ endif
 							--patches $(PTCH_DIR) \
 							--non_up_patches $(NON_UP_PTCH_DIR) \
 							--kernel_version $(KERNEL_VERSION) \
-							--hw_mgmt_ver ${MLNX_HW_MANAGEMENT_VERSION} \
+							--hw_mgmt_ver "$$HWMGMT_PACKAGE_VERSION" \
 							--config_base_amd $(KCFG_BASE) \
 							--config_base_arm $(KCFG_BASE_ARM) \
 							--config_inc_amd $(KCFG_LIST) \

--- a/platform/mellanox/integration-scripts/hwmgmt_resolve_ref.py
+++ b/platform/mellanox/integration-scripts/hwmgmt_resolve_ref.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python
+#
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Resolve MLNX_HW_MANAGEMENT_VERSION to a hw-mgmt git ref and write a
+sourceable env file (shlex.quote'd).
+
+Precedence: tag V.<input> wins, else branch <input>. Tag flow is
+byte-identical to today (HWMGMT_PACKAGE_VERSION == input); branch flow
+appends "-<sha9>" so two runs on the same branch at different commits
+produce distinct deb filenames. Branches fetch first and fail if the
+fetch fails — a stale local remote-tracking ref must not silently
+shadow upstream.
+
+The changelog regex mirrors hw-mgmt's own get_hw_mgmt_ver() in
+recipes-kernel/linux/deploy_kernel_patches.py.
+"""
+
+import argparse
+import os
+import re
+import shlex
+import subprocess
+import sys
+
+
+# Permissive: real branch names like "feature/foo", "V.7.0010.1000_BR".
+INPUT_RE = re.compile(r'^[A-Za-z0-9._/+~:-]+$')
+
+# Strict: deb-version-safe AND git-refname-safe. The parsed changelog
+# version lands in `git checkout -B "..._<version>"` under CREATE_BRANCH=y,
+# so '~', '_', ':', '/' (legal in deb versions but not git refnames or deb
+# filenames) are excluded.
+PARSED_VERSION_RE = re.compile(r'^[A-Za-z0-9.+-]+$')
+
+# First line: "hw-management (1.mlnx.7.0060.1430) unstable; urgency=low"
+CHANGELOG_RE = re.compile(r'^hw-management \(1\.mlnx\.([^)]+)\)')
+
+REMOTE = 'origin'
+DISTINCT_ID_LEN = 9  # abbreviated commit SHA suffix on the branch path
+
+ENV_KEYS = (
+    'HWMGMT_INPUT',
+    'HWMGMT_REF_TYPE',
+    'HWMGMT_CHECKOUT_REF',
+    'HWMGMT_COMMIT',
+    'HWMGMT_BASE_VERSION',
+    'HWMGMT_DISTINCT_ID',
+    'HWMGMT_PACKAGE_VERSION',
+)
+
+
+def fail(msg):
+    print('-> FATAL: ' + msg, file=sys.stderr)
+    sys.exit(1)
+
+
+def info(msg, verbose):
+    if verbose:
+        print(msg)
+
+
+def run_git(repo, args):
+    cmd = ['git', '-C', repo] + list(args)
+    return subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def rev_parse(repo, ref):
+    res = run_git(repo, ['rev-parse', '--verify', '--quiet', ref + '^{commit}'])
+    if res.returncode == 0:
+        return res.stdout.strip()
+    return None
+
+
+def have_origin(repo):
+    res = run_git(repo, ['remote', 'get-url', REMOTE])
+    return res.returncode == 0
+
+
+def is_shallow(repo):
+    res = run_git(repo, ['rev-parse', '--is-shallow-repository'])
+    return res.returncode == 0 and res.stdout.strip() == 'true'
+
+
+def parse_changelog_version(repo, commit):
+    res = run_git(repo, ['show', '{}:debian/changelog'.format(commit)])
+    if res.returncode != 0:
+        return None
+    first_line = res.stdout.splitlines()[0] if res.stdout else ''
+    m = CHANGELOG_RE.match(first_line)
+    return m.group(1) if m else None
+
+
+def resolve_tag(repo, value, verbose):
+    """Resolve V.<value> as a tag. Tags are immutable, so a local match is
+    final; only fetch from origin if the tag is missing locally.
+    Returns (checkout_ref, commit, fetch_stderr) or (None, None, stderr).
+    """
+    tag_full_ref = 'refs/tags/V.{}'.format(value)
+    sha = rev_parse(repo, tag_full_ref)
+    if sha:
+        info('-> hw-mgmt: tag {} found locally'.format(tag_full_ref), verbose)
+        return 'V.{}'.format(value), sha, ''
+    if not have_origin(repo):
+        info('-> hw-mgmt: tag {} not local and no origin remote; cannot fetch'.format(tag_full_ref), verbose)
+        return None, None, 'tag missing locally and no origin remote configured'
+    info('-> hw-mgmt: tag {} not local, attempting targeted fetch'.format(tag_full_ref), verbose)
+    res = run_git(repo, ['fetch', REMOTE, 'tag', 'V.{}'.format(value)])
+    info('-> hw-mgmt: fetch tag rc={} stderr={!r}'.format(
+        res.returncode, (res.stderr or '').strip()), verbose)
+    if res.returncode != 0:
+        return None, None, (res.stderr or '').strip()
+    sha = rev_parse(repo, tag_full_ref)
+    if sha:
+        return 'V.{}'.format(value), sha, ''
+    return None, None, ''
+
+
+def resolve_branch(repo, value, verbose):
+    """Resolve <value> as a branch. Branches move, so we force-fetch and
+    fail loudly if the fetch fails — never silently fall back to a
+    possibly-stale local remote-tracking ref. Local refs are only used in
+    offline mode (no `origin` configured).
+    Returns (checkout_ref, commit, fetch_stderr) or (None, None, stderr).
+    """
+    # check-ref-format catches inputs like `..` or `.lock` that pass
+    # INPUT_RE but would produce cryptic git fetch errors.
+    chk = run_git(repo, ['check-ref-format', 'refs/heads/{}'.format(value)])
+    if chk.returncode != 0:
+        info('-> hw-mgmt: branch input {!r} fails git check-ref-format'.format(value), verbose)
+        return None, None, 'invalid git branch refname: {!r}'.format(value)
+
+    remote_ref = 'refs/remotes/{}/{}'.format(REMOTE, value)
+    local_ref = 'refs/heads/{}'.format(value)
+
+    if have_origin(repo):
+        # '+' forces non-fast-forward updates; without it a force-pushed
+        # upstream is rejected and we'd cling to the stale local ref.
+        refspec = '+{}:{}'.format(local_ref, remote_ref)
+        info('-> hw-mgmt: fetching branch {} from origin (forced refresh)'.format(value), verbose)
+        res = run_git(repo, ['fetch', REMOTE, refspec])
+        info('-> hw-mgmt: fetch branch rc={} stderr={!r}'.format(
+            res.returncode, (res.stderr or '').strip()), verbose)
+        if res.returncode == 0:
+            sha = rev_parse(repo, remote_ref)
+            if sha:
+                return remote_ref, sha, ''
+            fail('fetch returned 0 but {} did not resolve'.format(remote_ref))
+        fetch_stderr = (res.stderr or '').strip()
+        if is_shallow(repo):
+            print(
+                '-> NOTICE: hw-mgmt submodule appears to be a shallow clone. '
+                'Run `git -C {} fetch --unshallow` and retry.'.format(repo),
+                file=sys.stderr,
+            )
+        return None, None, fetch_stderr
+
+    # Offline mode: no origin to refresh from, use whatever is local.
+    info('-> hw-mgmt: no origin remote; resolving branch from local refs only', verbose)
+    sha = rev_parse(repo, remote_ref)
+    if sha:
+        return remote_ref, sha, ''
+    sha = rev_parse(repo, local_ref)
+    if sha:
+        return local_ref, sha, ''
+    return None, None, 'no local branch ref and no origin to fetch from'
+
+
+def write_env_atomically(env_file, values):
+    parent = os.path.dirname(env_file)
+    tmp = env_file + '.tmp'
+    try:
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(tmp, 'w') as f:
+            for key in ENV_KEYS:
+                f.write('{}={}\n'.format(key, shlex.quote(values[key])))
+        os.replace(tmp, env_file)
+    except OSError as e:
+        # Best-effort cleanup of the partial tmp; ignore errors so the
+        # original failure surfaces.
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        fail('failed to write env file {!r}: {}'.format(env_file, e))
+
+
+def validate_input(value):
+    if not value:
+        fail('--input is empty')
+    if value.startswith('-'):
+        fail('--input must not start with "-": {!r}'.format(value))
+    if not INPUT_RE.match(value):
+        fail(
+            '--input {!r} contains invalid characters; allowed: '
+            '[A-Za-z0-9._/+~:-]'.format(value)
+        )
+
+
+def validate_repo(repo):
+    """Verify --repo is a git working tree. Origin is checked lazily by the
+    resolvers only when needed, so offline tag flows keep working."""
+    if not os.path.isdir(repo):
+        fail('--repo {!r} does not exist'.format(repo))
+    git_marker = os.path.join(repo, '.git')
+    if not (os.path.isdir(git_marker) or os.path.isfile(git_marker)):
+        fail('--repo {!r} is not a git working tree'.format(repo))
+
+
+def resolve(repo, value, verbose):
+    """Run resolution. Returns dict of env values. Calls fail() on error."""
+    tag_ref, tag_commit, tag_err = resolve_tag(repo, value, verbose)
+    if tag_ref:
+        ref_type = 'tag'
+        ref_name = tag_ref
+        commit = tag_commit
+        base_version = value          # Preserve byte-identical tag flow.
+        distinct_id = ''
+        package_version = base_version
+    else:
+        br_ref, br_commit, br_err = resolve_branch(repo, value, verbose)
+        if not br_ref:
+            details = []
+            if tag_err:
+                details.append('tag fetch error: {}'.format(tag_err))
+            if br_err:
+                details.append('branch fetch error: {}'.format(br_err))
+            suffix = ' ({})'.format('; '.join(details)) if details else ''
+            fail(
+                'hw-mgmt: neither tag {!r} nor branch {!r} could be resolved '
+                'in {}{}'.format('V.' + value, value, repo, suffix)
+            )
+        ref_type = 'branch'
+        ref_name = br_ref
+        commit = br_commit
+        base_version = parse_changelog_version(repo, commit)
+        if not base_version:
+            fail(
+                'hw-mgmt: branch {!r} resolved to {} but debian/changelog '
+                'version could not be parsed (expected first line '
+                '"hw-management (1.mlnx.<version>) ...")'.format(value, commit)
+            )
+        if not PARSED_VERSION_RE.match(base_version):
+            fail(
+                'hw-mgmt: parsed base version {!r} contains characters '
+                'that are not safe for deb filenames or git refnames; '
+                'allowed: [A-Za-z0-9.+-]'.format(base_version)
+            )
+        distinct_id = commit[:DISTINCT_ID_LEN]
+        package_version = '{}-{}'.format(base_version, distinct_id)
+
+    return {
+        'HWMGMT_INPUT': value,
+        'HWMGMT_REF_TYPE': ref_type,
+        'HWMGMT_CHECKOUT_REF': ref_name,
+        'HWMGMT_COMMIT': commit,
+        'HWMGMT_BASE_VERSION': base_version,
+        'HWMGMT_DISTINCT_ID': distinct_id,
+        'HWMGMT_PACKAGE_VERSION': package_version,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--repo', required=True, help='Path to the hw-mgmt submodule working tree')
+    parser.add_argument('--input', required=True, help='User-provided MLNX_HW_MANAGEMENT_VERSION value')
+    parser.add_argument('--env-file', dest='env_file', required=True, help='Output env file path')
+    parser.add_argument('--verbose', action='store_true', help='Print full resolution trace')
+    args = parser.parse_args()
+
+    validate_input(args.input)
+    validate_repo(args.repo)
+
+    env = resolve(args.repo, args.input, args.verbose)
+    write_env_atomically(args.env_file, env)
+
+    short = env['HWMGMT_COMMIT'][:DISTINCT_ID_LEN]
+    if env['HWMGMT_REF_TYPE'] == 'tag':
+        print('-> hw-mgmt: resolved tag {} -> {} (package version {})'.format(
+            env['HWMGMT_CHECKOUT_REF'], short, env['HWMGMT_PACKAGE_VERSION']))
+    else:
+        print('-> hw-mgmt: resolved branch {} -> {} (base {} from changelog, '
+              'package version {})'.format(
+                  env['HWMGMT_CHECKOUT_REF'], short,
+                  env['HWMGMT_BASE_VERSION'], env['HWMGMT_PACKAGE_VERSION']))
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/platform/mellanox/integration-scripts/tests/test_hwmgmt_resolve_ref.py
+++ b/platform/mellanox/integration-scripts/tests/test_hwmgmt_resolve_ref.py
@@ -1,0 +1,655 @@
+#
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Unit tests for hwmgmt_resolve_ref.
+
+Uses real `git` against tmp directories to exercise the resolver end-to-end,
+including the targeted-fetch fallback. No pyfakefs dependency, so these tests
+run in any environment with python3 and git.
+"""
+
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+import hwmgmt_resolve_ref as resolver
+
+
+def run(cmd, cwd=None, check=True, env=None):
+    return subprocess.run(
+        cmd, cwd=cwd, check=check, capture_output=True, text=True, env=env
+    )
+
+
+def init_repo(path):
+    os.makedirs(path, exist_ok=True)
+    run(['git', 'init', '-q', '-b', 'master', path])
+    run(['git', 'config', 'user.email', 'test@example.com'], cwd=path)
+    run(['git', 'config', 'user.name', 'Test'], cwd=path)
+    run(['git', 'config', 'commit.gpgsign', 'false'], cwd=path)
+
+
+def commit_changelog(repo, version, msg='c'):
+    """Write debian/changelog with given version and commit. Return commit SHA."""
+    cl_dir = os.path.join(repo, 'debian')
+    os.makedirs(cl_dir, exist_ok=True)
+    with open(os.path.join(cl_dir, 'changelog'), 'w') as f:
+        f.write('hw-management (1.mlnx.{}) unstable; urgency=low\n'.format(version))
+        f.write('  [ MLNX ]\n\n')
+        f.write(' -- NBU BSP <nbu@example.com>  Thu, 30 Apr 2026 17:04:57 +0300\n')
+    run(['git', 'add', 'debian/changelog'], cwd=repo)
+    run(['git', 'commit', '-q', '-m', msg], cwd=repo)
+    return run(['git', 'rev-parse', 'HEAD'], cwd=repo).stdout.strip()
+
+
+def commit_raw_changelog(repo, content, msg='c'):
+    """Write debian/changelog with raw content (used to test malformed parsing)."""
+    cl_dir = os.path.join(repo, 'debian')
+    os.makedirs(cl_dir, exist_ok=True)
+    with open(os.path.join(cl_dir, 'changelog'), 'w') as f:
+        f.write(content)
+    run(['git', 'add', 'debian/changelog'], cwd=repo)
+    run(['git', 'commit', '-q', '-m', msg], cwd=repo)
+    return run(['git', 'rev-parse', 'HEAD'], cwd=repo).stdout.strip()
+
+
+def commit_blob(repo, name='README.md', text='hello', msg='c'):
+    """Commit an arbitrary file (used when we don't need a changelog)."""
+    with open(os.path.join(repo, name), 'w') as f:
+        f.write(text)
+    run(['git', 'add', name], cwd=repo)
+    run(['git', 'commit', '-q', '-m', msg], cwd=repo)
+    return run(['git', 'rev-parse', 'HEAD'], cwd=repo).stdout.strip()
+
+
+def create_tag(repo, tag, ref='HEAD'):
+    run(['git', 'tag', tag, ref], cwd=repo)
+
+
+def create_branch(repo, branch, ref='HEAD'):
+    run(['git', 'branch', branch, ref], cwd=repo)
+
+
+def add_origin(repo, url):
+    run(['git', 'remote', 'add', 'origin', url], cwd=repo)
+
+
+def read_env(env_file):
+    """Source the env file in bash and dump key=value lines for inspection."""
+    if not os.path.isfile(env_file):
+        return {}
+    keys = ['HWMGMT_INPUT', 'HWMGMT_REF_TYPE', 'HWMGMT_CHECKOUT_REF',
+            'HWMGMT_COMMIT', 'HWMGMT_BASE_VERSION',
+            'HWMGMT_DISTINCT_ID', 'HWMGMT_PACKAGE_VERSION']
+    cmd = '. ' + shlex.quote(env_file) + '; ' + '; '.join(
+        'printf "%s=%s\\n" {} "${}"'.format(k, '{' + k + '}') for k in keys
+    )
+    res = subprocess.run(['bash', '-c', cmd], capture_output=True, text=True)
+    out = {}
+    for line in res.stdout.splitlines():
+        if '=' in line:
+            k, _, v = line.partition('=')
+            out[k] = v
+    return out
+
+
+def call_resolver(repo, input_value, env_file, verbose=False):
+    """Invoke main() in-process and capture exit code + stdout/stderr."""
+    argv = ['hwmgmt_resolve_ref.py',
+            '--repo', repo,
+            '--input', input_value,
+            '--env-file', env_file]
+    if verbose:
+        argv.append('--verbose')
+
+    from io import StringIO
+    stdout, stderr = StringIO(), StringIO()
+    code = 0
+    with mock.patch.object(sys, 'argv', argv):
+        with mock.patch.object(sys, 'stdout', stdout):
+            with mock.patch.object(sys, 'stderr', stderr):
+                try:
+                    resolver.main()
+                except SystemExit as e:
+                    code = e.code if isinstance(e.code, int) else 1
+    return code, stdout.getvalue(), stderr.getvalue()
+
+
+class _GitFixture(unittest.TestCase):
+    """Base class providing tmp dirs and clean teardown."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix='hwmgmt-resolve-test-')
+        self.env_file = os.path.join(self.tmpdir, 'resolved.env')
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+
+class TestTagPath(_GitFixture):
+    """Tag flow regression cases (preserve byte-identical existing behavior)."""
+
+    def test_01_tag_success(self):
+        """Case 1: tag V.7.0001.0026 exists locally; package version == input (byte-identical to today)."""
+        repo = os.path.join(self.tmpdir, 'repo')
+        init_repo(repo)
+        sha = commit_blob(repo)
+        create_tag(repo, 'V.7.0001.0026')
+        bare = os.path.join(self.tmpdir, 'origin.git')
+        run(['git', 'clone', '-q', '--bare', repo, bare])
+        add_origin(repo, bare)
+
+        code, stdout, stderr = call_resolver(repo, '7.0001.0026', self.env_file)
+        self.assertEqual(code, 0, msg='stderr={}'.format(stderr))
+        env = read_env(self.env_file)
+        self.assertEqual(env['HWMGMT_REF_TYPE'], 'tag')
+        self.assertEqual(env['HWMGMT_CHECKOUT_REF'], 'V.7.0001.0026')
+        self.assertEqual(env['HWMGMT_COMMIT'], sha)
+        self.assertEqual(env['HWMGMT_INPUT'], '7.0001.0026')
+        # Tag flow: package version is the user input verbatim, no distinct id.
+        self.assertEqual(env['HWMGMT_BASE_VERSION'], '7.0001.0026')
+        self.assertEqual(env['HWMGMT_DISTINCT_ID'], '')
+        self.assertEqual(env['HWMGMT_PACKAGE_VERSION'], '7.0001.0026')
+
+    def test_02_tag_wins_over_branch(self):
+        """Case 2: tag V.same-name and branch same-name at different commits — tag wins."""
+        repo = os.path.join(self.tmpdir, 'repo')
+        init_repo(repo)
+        sha_a = commit_blob(repo, msg='A')
+        create_tag(repo, 'V.same-name', sha_a)
+        sha_b = commit_blob(repo, name='B.md', msg='B')
+        create_branch(repo, 'same-name', sha_b)
+        bare = os.path.join(self.tmpdir, 'origin.git')
+        run(['git', 'clone', '-q', '--bare', repo, bare])
+        add_origin(repo, bare)
+
+        code, _, stderr = call_resolver(repo, 'same-name', self.env_file)
+        self.assertEqual(code, 0, msg='stderr={}'.format(stderr))
+        env = read_env(self.env_file)
+        self.assertEqual(env['HWMGMT_REF_TYPE'], 'tag')
+        self.assertEqual(env['HWMGMT_COMMIT'], sha_a)
+        # Tag path: BASE = input verbatim, no distinct id, PACKAGE = BASE.
+        self.assertEqual(env['HWMGMT_BASE_VERSION'], 'same-name')
+        self.assertEqual(env['HWMGMT_DISTINCT_ID'], '')
+        self.assertEqual(env['HWMGMT_PACKAGE_VERSION'], 'same-name')
+
+    def test_02b_tag_offline_no_origin(self):
+        """Tag flow must work in a repo with no 'origin' remote when the tag is local
+        (backward compat with offline / pre-prepared trees)."""
+        repo = os.path.join(self.tmpdir, 'repo')
+        init_repo(repo)
+        sha = commit_blob(repo)
+        create_tag(repo, 'V.1.0.0')
+        # Deliberately do NOT add any remote.
+
+        code, stdout, stderr = call_resolver(repo, '1.0.0', self.env_file)
+        self.assertEqual(code, 0,
+                         msg='offline tag resolution must succeed; stderr={}'.format(stderr))
+        env = read_env(self.env_file)
+        self.assertEqual(env['HWMGMT_REF_TYPE'], 'tag')
+        self.assertEqual(env['HWMGMT_PACKAGE_VERSION'], '1.0.0')
+
+    def test_02c_tag_fetched_from_origin(self):
+        """Remote-only tag: not local, present on origin → resolver fetches and resolves."""
+        upstream = os.path.join(self.tmpdir, 'upstream')
+        init_repo(upstream)
+        sha = commit_blob(upstream)
+        create_tag(upstream, 'V.7.0001.0026', sha)
+
+        bare = os.path.join(self.tmpdir, 'origin.git')
+        run(['git', 'clone', '-q', '--bare', upstream, bare])
+
+        # Local repo: init + add origin pointing at bare, do NOT fetch tags.
+        local = os.path.join(self.tmpdir, 'local')
+        init_repo(local)
+        commit_blob(local)
+        add_origin(local, bare)
+
+        # Sanity: tag is not yet local.
+        self.assertIsNone(resolver.rev_parse(local, 'refs/tags/V.7.0001.0026'))
+
+        code, stdout, stderr = call_resolver(local, '7.0001.0026', self.env_file)
+        self.assertEqual(code, 0,
+                         msg='remote-only tag resolution must succeed; stderr={}'.format(stderr))
+        env = read_env(self.env_file)
+        self.assertEqual(env['HWMGMT_REF_TYPE'], 'tag')
+        self.assertEqual(env['HWMGMT_COMMIT'], sha)
+        self.assertEqual(env['HWMGMT_PACKAGE_VERSION'], '7.0001.0026')
+        # Tag is now local after the fetch.
+        self.assertEqual(resolver.rev_parse(local, 'refs/tags/V.7.0001.0026'), sha)
+
+
+class TestBranchPath(_GitFixture):
+    """Branch fallback flow with debian/changelog version parsing."""
+
+    def test_03_branch_fallback_changelog_version(self):
+        """Case 3: branch resolves; BASE from changelog, PACKAGE = BASE-<sha9>."""
+        repo = os.path.join(self.tmpdir, 'repo')
+        init_repo(repo)
+        commit_changelog(repo, '7.0050.0000', msg='base')
+        sha_branch = commit_changelog(repo, '7.0060.1430', msg='bump')
+        # Reset master to the base commit so 'bmc-draft' diverges.
+        run(['git', 'reset', '-q', '--hard', 'HEAD~1'], cwd=repo)
+        create_branch(repo, 'bmc-draft', sha_branch)
+        bare = os.path.join(self.tmpdir, 'origin.git')
+        run(['git', 'clone', '-q', '--bare', repo, bare])
+        add_origin(repo, bare)
+
+        code, _, stderr = call_resolver(repo, 'bmc-draft', self.env_file)
+        self.assertEqual(code, 0, msg='stderr={}'.format(stderr))
+        env = read_env(self.env_file)
+        self.assertEqual(env['HWMGMT_REF_TYPE'], 'branch')
+        self.assertEqual(env['HWMGMT_COMMIT'], sha_branch)
+        self.assertEqual(env['HWMGMT_BASE_VERSION'], '7.0060.1430')
+        self.assertEqual(env['HWMGMT_DISTINCT_ID'], sha_branch[:9])
+        self.assertEqual(env['HWMGMT_PACKAGE_VERSION'],
+                         '7.0060.1430-{}'.format(sha_branch[:9]))
+
+    def test_04_branch_with_slash(self):
+        """Case 4: branch name 'feature/foo' resolves and produces a sane suffixed package version."""
+        repo = os.path.join(self.tmpdir, 'repo')
+        init_repo(repo)
+        sha = commit_changelog(repo, '7.0060.1430')
+        create_branch(repo, 'feature/foo', sha)
+        bare = os.path.join(self.tmpdir, 'origin.git')
+        run(['git', 'clone', '-q', '--bare', repo, bare])
+        add_origin(repo, bare)
+
+        code, _, stderr = call_resolver(repo, 'feature/foo', self.env_file)
+        self.assertEqual(code, 0, msg='stderr={}'.format(stderr))
+        env = read_env(self.env_file)
+        self.assertEqual(env['HWMGMT_REF_TYPE'], 'branch')
+        self.assertEqual(env['HWMGMT_BASE_VERSION'], '7.0060.1430')
+        self.assertEqual(env['HWMGMT_PACKAGE_VERSION'],
+                         '7.0060.1430-{}'.format(sha[:9]))
+        # The unsafe '/' in the input must NOT propagate into the package version.
+        self.assertNotIn('/', env['HWMGMT_PACKAGE_VERSION'])
+
+    def test_05_remote_branch_needs_fetch(self):
+        """Case 5: local has no remote-tracking branch; resolver fetches from origin first."""
+        upstream = os.path.join(self.tmpdir, 'upstream')
+        init_repo(upstream)
+        sha = commit_changelog(upstream, '7.0060.1430')
+        create_branch(upstream, 'bmc-draft', sha)
+
+        bare = os.path.join(self.tmpdir, 'origin.git')
+        run(['git', 'clone', '-q', '--bare', upstream, bare])
+
+        # Local repo: init + add origin pointing at bare, do NOT fetch.
+        local = os.path.join(self.tmpdir, 'local')
+        init_repo(local)
+        commit_blob(local)
+        add_origin(local, bare)
+
+        self.assertIsNone(resolver.rev_parse(local, 'refs/remotes/origin/bmc-draft'))
+
+        code, _, stderr = call_resolver(local, 'bmc-draft', self.env_file)
+        self.assertEqual(code, 0, msg='stderr={}'.format(stderr))
+        env = read_env(self.env_file)
+        self.assertEqual(env['HWMGMT_REF_TYPE'], 'branch')
+        self.assertEqual(env['HWMGMT_COMMIT'], sha)
+        self.assertEqual(env['HWMGMT_PACKAGE_VERSION'],
+                         '7.0060.1430-{}'.format(sha[:9]))
+
+    def test_05b_branch_fetch_first_picks_up_upstream_advance(self):
+        """Resolver must fetch before resolving, so an upstream advance is picked up
+        even when refs/remotes/origin/<branch> already exists locally pointing at
+        the old commit (regression test for fast-forward stale-ref bug)."""
+        upstream = os.path.join(self.tmpdir, 'upstream')
+        init_repo(upstream)
+        sha_old = commit_changelog(upstream, '7.0050.0000', msg='old')
+        create_branch(upstream, 'moving', sha_old)
+
+        bare = os.path.join(self.tmpdir, 'origin.git')
+        run(['git', 'clone', '-q', '--bare', upstream, bare])
+
+        local = os.path.join(self.tmpdir, 'local')
+        run(['git', 'clone', '-q', bare, local])
+        run(['git', 'config', 'user.email', 'test@example.com'], cwd=local)
+        run(['git', 'config', 'user.name', 'Test'], cwd=local)
+
+        # Sanity: local already has the old commit as origin/moving.
+        before = resolver.rev_parse(local, 'refs/remotes/origin/moving')
+        self.assertEqual(before, sha_old)
+
+        # Upstream advances past the local ref (fast-forward).
+        sha_new = commit_changelog(upstream, '7.0060.1430', msg='new')
+        run(['git', 'branch', '-f', 'moving', sha_new], cwd=upstream)
+        # Push the new commit to the bare so 'origin' has it.
+        run(['git', 'push', '-q', '-f', bare, 'moving:moving'], cwd=upstream)
+
+        code, _, stderr = call_resolver(local, 'moving', self.env_file)
+        self.assertEqual(code, 0, msg='stderr={}'.format(stderr))
+        env = read_env(self.env_file)
+        # The fetch must have run and picked up sha_new, NOT sha_old.
+        self.assertEqual(env['HWMGMT_COMMIT'], sha_new,
+                         msg='resolver used stale local ref instead of fetching')
+        self.assertEqual(env['HWMGMT_BASE_VERSION'], '7.0060.1430')
+
+    def test_05c_branch_force_rewind_picks_up_unrelated_tip(self):
+        """Force-pushed/rebased upstream branch (non-fast-forward update) must NOT
+        leave the resolver pegged on the stale local remote-tracking ref. Regression
+        test for the missing '+' on the fetch refspec.
+        """
+        upstream = os.path.join(self.tmpdir, 'upstream')
+        init_repo(upstream)
+        # Initial 'moving' tip: a chain of two commits, branch points at HEAD.
+        commit_changelog(upstream, '7.0050.0000', msg='base')
+        sha_old = commit_changelog(upstream, '7.0060.0000', msg='old-tip')
+        run(['git', 'branch', '-f', 'moving', sha_old], cwd=upstream)
+
+        bare = os.path.join(self.tmpdir, 'origin.git')
+        run(['git', 'clone', '-q', '--bare', upstream, bare])
+
+        local = os.path.join(self.tmpdir, 'local')
+        run(['git', 'clone', '-q', bare, local])
+        run(['git', 'config', 'user.email', 'test@example.com'], cwd=local)
+        run(['git', 'config', 'user.name', 'Test'], cwd=local)
+
+        # Local has origin/moving pointing at sha_old.
+        self.assertEqual(
+            resolver.rev_parse(local, 'refs/remotes/origin/moving'), sha_old)
+
+        # Upstream rewinds 'moving' to an EARLIER commit (non-fast-forward
+        # from the local view). Without '+' in the fetch refspec, git fetch
+        # rejects this update.
+        run(['git', 'reset', '-q', '--hard', 'HEAD~1'], cwd=upstream)
+        sha_new = run(['git', 'rev-parse', 'HEAD'], cwd=upstream).stdout.strip()
+        run(['git', 'branch', '-f', 'moving', sha_new], cwd=upstream)
+        run(['git', 'push', '-q', '-f', bare, 'moving:moving'], cwd=upstream)
+        self.assertNotEqual(sha_new, sha_old)
+
+        code, _, stderr = call_resolver(local, 'moving', self.env_file)
+        self.assertEqual(code, 0, msg='stderr={}'.format(stderr))
+        env = read_env(self.env_file)
+        # If the resolver fetches with '+', it will pick up sha_new. Without
+        # '+' it falls back to the stale local ref pointing at sha_old.
+        self.assertEqual(
+            env['HWMGMT_COMMIT'], sha_new,
+            msg='resolver clung to stale local ref after force-update')
+
+
+class TestFailureCases(_GitFixture):
+    """Failure modes — all must exit non-zero with a useful message."""
+
+    def _make_repo_with_branch(self, branch_name, changelog_content=None, version=None):
+        repo = os.path.join(self.tmpdir, 'repo')
+        init_repo(repo)
+        if changelog_content is not None:
+            sha = commit_raw_changelog(repo, changelog_content)
+        elif version is not None:
+            sha = commit_changelog(repo, version)
+        else:
+            sha = commit_blob(repo)
+        create_branch(repo, branch_name, sha)
+        bare = os.path.join(self.tmpdir, 'origin.git')
+        run(['git', 'clone', '-q', '--bare', repo, bare])
+        add_origin(repo, bare)
+        return repo
+
+    def test_06_branch_changelog_malformed(self):
+        """Case 6: branch resolves, changelog first line doesn't match the regex."""
+        repo = self._make_repo_with_branch(
+            'bar',
+            changelog_content='garbage (oops) unstable; urgency=low\n',
+        )
+        code, _, stderr = call_resolver(repo, 'bar', self.env_file)
+        self.assertNotEqual(code, 0)
+        self.assertIn('debian/changelog', stderr)
+        self.assertFalse(os.path.isfile(self.env_file),
+                         'env file must not exist on failure')
+
+    def test_07_branch_parsed_version_unsafe(self):
+        """Case 7: changelog version contains '/' — must be rejected."""
+        repo = self._make_repo_with_branch(
+            'baz',
+            changelog_content='hw-management (1.mlnx.7.0060.1430_dev/foo) unstable;\n',
+        )
+        code, _, stderr = call_resolver(repo, 'baz', self.env_file)
+        self.assertNotEqual(code, 0)
+        self.assertIn('not safe for deb filenames', stderr)
+
+    def test_08_neither_tag_nor_branch(self):
+        """Case 8: input matches no tag and no branch — error mentions both."""
+        repo = os.path.join(self.tmpdir, 'repo')
+        init_repo(repo)
+        commit_blob(repo)
+        bare = os.path.join(self.tmpdir, 'origin.git')
+        run(['git', 'clone', '-q', '--bare', repo, bare])
+        add_origin(repo, bare)
+
+        code, _, stderr = call_resolver(repo, 'does-not-exist', self.env_file)
+        self.assertNotEqual(code, 0)
+        self.assertIn('V.does-not-exist', stderr)
+        self.assertIn("'does-not-exist'", stderr)
+        self.assertIn('neither', stderr)
+
+    def test_09_empty_input(self):
+        """Case 9: --input '' fails before any git op."""
+        repo = os.path.join(self.tmpdir, 'repo')
+        init_repo(repo)
+        commit_blob(repo)
+        bare = os.path.join(self.tmpdir, 'origin.git')
+        run(['git', 'clone', '-q', '--bare', repo, bare])
+        add_origin(repo, bare)
+
+        code, _, stderr = call_resolver(repo, '', self.env_file)
+        self.assertNotEqual(code, 0)
+        self.assertIn('empty', stderr)
+
+    def test_10_no_origin_remote_and_no_local_match(self):
+        """Repo has no 'origin' remote AND no local tag/branch matches the input.
+
+        The resolver must still fail (since there's nothing to resolve), but
+        the offline-tag-with-local-match case is covered separately by
+        test_02b_tag_offline_no_origin to confirm absence of `origin` is
+        no longer a blocking precondition.
+        """
+        repo = os.path.join(self.tmpdir, 'repo')
+        init_repo(repo)
+        commit_blob(repo)
+        # No tags or matching branches.
+
+        code, _, stderr = call_resolver(repo, '7.0001.0026', self.env_file)
+        self.assertNotEqual(code, 0)
+        # The error should mention both attempts, and may mention origin in
+        # the diagnostic detail since the fetch could not run.
+        self.assertIn('neither', stderr)
+
+    def test_11_branch_fetch_fails_when_origin_invalid(self):
+        """Case 11: origin URL is bogus, fetch fails, error surfaces."""
+        repo = os.path.join(self.tmpdir, 'repo')
+        init_repo(repo)
+        commit_blob(repo)
+        # Point origin at a path that doesn't exist; fetches will fail.
+        add_origin(repo, os.path.join(self.tmpdir, 'nonexistent.git'))
+
+        code, _, stderr = call_resolver(repo, 'never-existed', self.env_file)
+        self.assertNotEqual(code, 0)
+        self.assertIn('neither', stderr)
+
+    def test_11b_no_silent_fallback_to_stale_remote_tracking_ref(self):
+        """When origin exists but fetch fails AND a stale local
+        refs/remotes/origin/<branch> exists, the resolver must NOT silently
+        use the stale ref. Regression test for the 'fetch failed → use
+        whatever's local' anti-pattern.
+        """
+        # Set up a real remote with the branch, clone locally so the stale
+        # remote-tracking ref exists, then break the origin URL so any future
+        # fetch fails.
+        upstream = os.path.join(self.tmpdir, 'upstream')
+        init_repo(upstream)
+        sha = commit_changelog(upstream, '7.0050.0000')
+        create_branch(upstream, 'mybranch', sha)
+
+        bare = os.path.join(self.tmpdir, 'origin.git')
+        run(['git', 'clone', '-q', '--bare', upstream, bare])
+
+        local = os.path.join(self.tmpdir, 'local')
+        run(['git', 'clone', '-q', bare, local])
+        # Sanity: the stale remote-tracking ref is now local.
+        self.assertEqual(
+            resolver.rev_parse(local, 'refs/remotes/origin/mybranch'), sha)
+
+        # Break the origin URL so subsequent fetches fail.
+        run(['git', 'remote', 'set-url', 'origin',
+             os.path.join(self.tmpdir, 'gone.git')], cwd=local)
+
+        code, _, stderr = call_resolver(local, 'mybranch', self.env_file)
+        self.assertNotEqual(code, 0,
+                            msg='resolver must fail rather than use stale ref')
+        # No env file should be written on failure.
+        self.assertFalse(os.path.isfile(self.env_file))
+
+    def test_12a_invalid_input_chars(self):
+        """Whitespace and shell metacharacters are rejected at the input layer."""
+        repo = os.path.join(self.tmpdir, 'repo')
+        init_repo(repo)
+        commit_blob(repo)
+        bare = os.path.join(self.tmpdir, 'origin.git')
+        run(['git', 'clone', '-q', '--bare', repo, bare])
+        add_origin(repo, bare)
+
+        for bad in ['has space', 'has;semicolon', 'has`tick`', 'has$dollar']:
+            code, _, stderr = call_resolver(repo, bad, self.env_file)
+            self.assertNotEqual(code, 0,
+                                msg='input {!r} should have been rejected'.format(bad))
+            self.assertIn('invalid characters', stderr)
+
+    def test_12c_invalid_git_refname_branch(self):
+        """Inputs that pass INPUT_RE but fail Git's refname rules (e.g. contain
+        '..' or end with '.lock') must be rejected on the branch path by
+        git check-ref-format, with a clean diagnostic rather than a cryptic
+        git fetch failure."""
+        repo = os.path.join(self.tmpdir, 'repo')
+        init_repo(repo)
+        commit_blob(repo)
+        bare = os.path.join(self.tmpdir, 'origin.git')
+        run(['git', 'clone', '-q', '--bare', repo, bare])
+        add_origin(repo, bare)
+
+        # These inputs all pass INPUT_RE (only contain chars from the
+        # permissive set) but fail Git's stricter refname rules, so the
+        # check-ref-format guard is the layer that rejects them.
+        for bad in ['has..dotdot', 'ends.lock']:
+            code, _, stderr = call_resolver(repo, bad, self.env_file)
+            self.assertNotEqual(code, 0,
+                                msg='input {!r} should have been rejected'.format(bad))
+            self.assertIn('invalid git branch refname', stderr,
+                          msg='input {!r} should be flagged by check-ref-format'.format(bad))
+
+    def test_12b_input_starts_with_dash(self):
+        """Inputs starting with '-' must be rejected by our own validation.
+
+        Pass via --input=<val> form so argparse doesn't treat the value as a flag;
+        this exercises the resolver's own dash-prefix check.
+        """
+        repo = os.path.join(self.tmpdir, 'repo')
+        init_repo(repo)
+        commit_blob(repo)
+        bare = os.path.join(self.tmpdir, 'origin.git')
+        run(['git', 'clone', '-q', '--bare', repo, bare])
+        add_origin(repo, bare)
+
+        argv = ['hwmgmt_resolve_ref.py',
+                '--repo', repo,
+                '--input=-rf',
+                '--env-file', self.env_file]
+        from io import StringIO
+        stdout, stderr = StringIO(), StringIO()
+        code = 0
+        with mock.patch.object(sys, 'argv', argv):
+            with mock.patch.object(sys, 'stdout', stdout):
+                with mock.patch.object(sys, 'stderr', stderr):
+                    try:
+                        resolver.main()
+                    except SystemExit as e:
+                        code = e.code if isinstance(e.code, int) else 1
+        self.assertNotEqual(code, 0)
+        self.assertIn('must not start with', stderr.getvalue())
+
+
+class TestEnvFileFormat(_GitFixture):
+    """Verify the env file format and atomicity invariants."""
+
+    def test_14_atomic_write_no_tmp_left_behind(self):
+        """After a successful run, no .tmp file should remain alongside the env file."""
+        repo = os.path.join(self.tmpdir, 'repo')
+        init_repo(repo)
+        commit_blob(repo)
+        create_tag(repo, 'V.1.0.0')
+        bare = os.path.join(self.tmpdir, 'origin.git')
+        run(['git', 'clone', '-q', '--bare', repo, bare])
+        add_origin(repo, bare)
+
+        for _ in range(3):
+            code, _, _ = call_resolver(repo, '1.0.0', self.env_file)
+            self.assertEqual(code, 0)
+            self.assertFalse(os.path.isfile(self.env_file + '.tmp'),
+                             'temp file leaked after successful run')
+            self.assertTrue(os.path.isfile(self.env_file))
+
+    def test_16_env_file_write_failure_clean_diagnostic(self):
+        """Env-file write failures must emit -> FATAL:, not a Python traceback."""
+        repo = os.path.join(self.tmpdir, 'repo')
+        init_repo(repo)
+        commit_blob(repo)
+        create_tag(repo, 'V.1.0.0')
+
+        # Path-is-a-directory case
+        bad_dir = os.path.join(self.tmpdir, 'is_a_dir')
+        os.makedirs(bad_dir, exist_ok=True)
+        code, _, stderr = call_resolver(repo, '1.0.0', bad_dir)
+        self.assertNotEqual(code, 0)
+        self.assertIn('FATAL', stderr)
+        self.assertIn('failed to write env file', stderr)
+        self.assertNotIn('Traceback', stderr)
+        # No leftover .tmp file alongside the directory.
+        self.assertFalse(os.path.isfile(bad_dir + '.tmp'))
+
+    def test_15_values_with_special_chars_quoted_safely(self):
+        """Branch names with '/' must round-trip through the env file unchanged.
+        With fetch-first behavior in effect (origin present), the resolver must
+        select the remote-tracking ref."""
+        repo = os.path.join(self.tmpdir, 'repo')
+        init_repo(repo)
+        sha = commit_changelog(repo, '7.0060.1430')
+        create_branch(repo, 'feature/foo', sha)
+        bare = os.path.join(self.tmpdir, 'origin.git')
+        run(['git', 'clone', '-q', '--bare', repo, bare])
+        add_origin(repo, bare)
+
+        code, _, stderr = call_resolver(repo, 'feature/foo', self.env_file)
+        self.assertEqual(code, 0, msg='stderr={}'.format(stderr))
+        env = read_env(self.env_file)
+        self.assertEqual(env['HWMGMT_INPUT'], 'feature/foo')
+        # Origin is present and the fetch succeeds, so the checkout ref must
+        # be the remote-tracking form.
+        self.assertEqual(env['HWMGMT_CHECKOUT_REF'],
+                         'refs/remotes/origin/feature/foo')
+        self.assertEqual(env['HWMGMT_COMMIT'], sha)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The `integrate-mlnx-hw-mgmt` make target previously only accepted a released tag (`V.<version>`) for `MLNX_HW_MANAGEMENT_VERSION`. Now we need to integrate hw-mgmt work-in-progress before a tag is cut, so the script must also accept a branch name. The existing tag flow must remain same so today's users see no behavior change.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added a resolver helper `platform/mellanox/integration-scripts/hwmgmt_resolve_ref.py` that takes the user input and tries tag `V.<input>` first, then branch `<input>`. The resolver writes a sourceable shell env file (atomically, via `os.replace`, with `shlex.quote`'d values) containing:

- `HWMGMT_PACKAGE_VERSION` — the SONiC-side identity used for the deb filename and downstream caching.
  - Tag path: equals the user input, byte-identical to today.
  - Branch path: `<changelog-version>-<sha9>`, where `<changelog-version>` is parsed from `hw-mgmt/debian/changelog` (same regex hw-mgmt uses internally) and `<sha9>` is the first 9 hex chars of the resolved commit. Two integration runs against the same branch at different commits produce distinct deb filenames.
- `HWMGMT_COMMIT`, `HWMGMT_CHECKOUT_REF`, `HWMGMT_REF_TYPE`, `HWMGMT_BASE_VERSION`, `HWMGMT_DISTINCT_ID`, `HWMGMT_INPUT` — for traceability and downstream consumers.

Branch resolution always force-fetches from origin (`+refs/heads/<x>:refs/remotes/origin/<x>`) so force-pushed or rebased branches are picked up; if the fetch fails the resolver fails loudly. Local refs are only consulted when no `origin` is configured. Inputs are validated against a shell-safe charset and `git check-ref-format` so malformed names produce clean diagnostics instead of cryptic git errors. Env-file write failures emit `-> FATAL: ...` rather than a Python traceback.

Updated `platform/mellanox/integration-scripts.mk` to invoke the resolver, source the env file once, and replace every `$(MLNX_HW_MANAGEMENT_VERSION)` reference with the shell variable `$$HWMGMT_PACKAGE_VERSION` (relies on slave.mk's existing `.ONESHELL:` + `SHELLFLAGS=-e` so the vars persist across recipe lines and any failure aborts the run). Added a "Resolved hw-mgmt source:" block to `integrate-mlnx-hw-mgmt_user.out` so reviewers can see exactly which commit was integrated.

The Aspeed BMC integration in `platform/aspeed/nvidia-hw-mgmt.mk` continues to work unchanged via the existing `MLNX_PLATFORM_PATH` indirection.

Note: `HWMGMT_PACKAGE_VERSION` is the SONiC-side filename identity. The Debian package's internal `Version:` field still comes from `hw-mgmt/debian/changelog` via `dpkg-buildpackage` and stays at the unsuffixed base; `hw-management/Makefile`'s wildcard `mv hw-management_*.deb $(DEST)/$*` reconciles the two names. Changing internal Debian metadata is intentionally out of scope.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

`NOBOOKWORM=1 BLDENV=trixie SONIC_OVERRIDE_BUILD_VARS=" MLNX_HW_MANAGEMENT_VERSION=1.2345.6789 " make -f Makefile.work integrate-mlnx-hw-mgmt`
`NOBOOKWORM=1 BLDENV=trixie SONIC_OVERRIDE_BUILD_VARS=" MLNX_HW_MANAGEMENT_VERSION=hw-mgmt-sonic-bmc " make -f Makefile.work integrate-mlnx-hw-mgmt`

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

