### PR TITLE
[202511][Mellanox] mellanox-platform-api: back off SFP poll read errors

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -61,6 +61,8 @@ REBOOT_TYPE_KEXEC_PATTERN_WARM = ".*SONIC_BOOT_TYPE=(warm|fastfast).*"
 REBOOT_TYPE_KEXEC_PATTERN_FAST = ".*SONIC_BOOT_TYPE=(fast|fast-reboot).*"
 
 SYS_DISPLAY = "SYS_DISPLAY"
+MALFUNCTION_SYSFS_READ_ERROR_DELAY_SECS = 1
+MALFUNCTION_SYSFS_READ_ERROR_MIN_SLEEP_SECS = 0.5
 
 # Global logger class instance
 logger = Logger()
@@ -487,7 +489,9 @@ class Chassis(ChassisBase):
         begin = time.monotonic()
         wait_ready_task = sfp.SFP.get_wait_ready_task()
         
-        while True:        
+        while True:
+            iteration_begin = time.monotonic()
+            has_read_error = False
             fds_events = self.poll_obj.poll(timeout)
             for fileno, _ in fds_events:
                 if fileno not in self.registered_fds:
@@ -496,8 +500,18 @@ class Chassis(ChassisBase):
                 
                 sfp_index, fd, fd_type = self.registered_fds[fileno]
                 s = self._sfp_list[sfp_index]
-                fd.seek(0)
-                fd_value = int(fd.read().strip())
+                try:
+                    fd.seek(0)
+                except OSError as e:
+                    logger.log_warning(f'Failed to seek file {fd_type} for SFP {sfp_index}: {e}')
+                    has_read_error = True
+                    continue
+                try:
+                    fd_value = int(fd.read().strip())
+                except (OSError, IOError, ValueError) as e:
+                    logger.log_warning(f'Failed to read value from file {fd_type} for SFP {sfp_index}: {e}')
+                    has_read_error = True
+                    continue
 
                 # Detecting dummy event
                 if s.is_dummy_event(fd_type, fd_value):
@@ -560,8 +574,13 @@ class Chassis(ChassisBase):
                     'sfp_error': error_dict
                 }
             else:
+                now = time.monotonic()
+                if has_read_error:
+                    sleep_time = MALFUNCTION_SYSFS_READ_ERROR_DELAY_SECS - (now - iteration_begin)
+                    if sleep_time > MALFUNCTION_SYSFS_READ_ERROR_MIN_SLEEP_SECS:
+                        time.sleep(sleep_time)
                 if not wait_forever:
-                    elapse = time.monotonic() - begin
+                    elapse = now - begin
                     if elapse * 1000 >= timeout:
                         return True, {'sfp': {}}
 
@@ -609,6 +628,8 @@ class Chassis(ChassisBase):
         begin = time.monotonic()
         
         while True:
+            iteration_begin = time.monotonic()
+            has_read_error = False
             fds_events = self.poll_obj.poll(timeout)
             for fileno, _ in fds_events:
                 if fileno not in self.registered_fds:
@@ -616,8 +637,19 @@ class Chassis(ChassisBase):
                     continue
                 
                 sfp_index, fd = self.registered_fds[fileno]
-                fd.seek(0)
-                fd.read()
+                try:
+                    fd.seek(0)
+                except OSError as e:
+                    logger.log_warning(f'Failed to seek module sysfs fd for SFP {sfp_index}: {e}')
+                    has_read_error = True
+                    continue
+                try:
+                    fd.read()
+                except (OSError, IOError) as e:
+                    logger.log_warning(f'Failed to read module sysfs fd for SFP {sfp_index}: {e}')
+                    has_read_error = True
+                    continue
+
                 s = self._sfp_list[sfp_index]
                 sfp_status = s.get_module_status()
 
@@ -655,8 +687,13 @@ class Chassis(ChassisBase):
                     'sfp_error': error_dict
                 }
             else:
+                now = time.monotonic()
+                if has_read_error:
+                    sleep_time = MALFUNCTION_SYSFS_READ_ERROR_DELAY_SECS - (now - iteration_begin)
+                    if sleep_time > MALFUNCTION_SYSFS_READ_ERROR_MIN_SLEEP_SECS:
+                        time.sleep(sleep_time)
                 if not wait_forever:
-                    elapse = time.monotonic() - begin
+                    elapse = now - begin
                     if elapse * 1000 >= timeout:
                         return True, {'sfp': {}}
 

--- a/platform/mellanox/mlnx-platform-api/tests/test_change_event.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_change_event.py
@@ -32,6 +32,179 @@ from sonic_platform import chassis
 from sonic_platform import sfp
 
 
+class TestChangeEventSeekFailure:
+    """Cover OSError from fd.seek(0) in change-event polling loops."""
+
+    @mock.patch('sonic_platform.sfp.SFP.get_fd_for_polling_legacy')
+    @mock.patch('select.poll')
+    @mock.patch('sonic_platform.chassis.time.sleep')
+    @mock.patch('time.monotonic')
+    @mock.patch(
+        'sonic_platform.device_data.DeviceDataManager.is_module_host_management_mode',
+        mock.MagicMock(return_value=False),
+    )
+    @mock.patch('sonic_platform.device_data.DeviceDataManager.get_sfp_count', mock.MagicMock(return_value=1))
+    @mock.patch('sonic_platform.chassis.extract_RJ45_ports_index', mock.MagicMock(return_value=[]))
+    @mock.patch('sonic_platform.chassis.extract_cpo_ports_index', mock.MagicMock(return_value=[]))
+    @mock.patch('sonic_platform.sfp.SFP.get_module_status')
+    def test_get_change_event_legacy_seek_fails(
+        self, mock_status, mock_time, mock_sleep, mock_create_poll, mock_get_fd,
+    ):
+        c = chassis.Chassis()
+        c.get_sfp(1)
+        mock_status.return_value = sfp.SFP_STATUS_INSERTED
+
+        mock_poll = mock.MagicMock()
+        mock_create_poll.return_value = mock_poll
+        mock_poll.poll = mock.MagicMock(side_effect=[[(1, 10)], []])
+
+        mock_file = mock.MagicMock()
+        mock_get_fd.return_value = mock_file
+        mock_file.fileno = mock.MagicMock(return_value=1)
+        mock_file.seek.side_effect = OSError(5, 'seek failed')
+
+        mock_time.side_effect = [0, 0, 0.1, 0.9, 1000]
+
+        _, change_event = c.get_change_event(1000)
+        assert 'sfp' in change_event and not change_event['sfp']
+        mock_file.seek.assert_called_with(0)
+        mock_file.read.assert_not_called()
+        assert abs(mock_sleep.call_args[0][0] - 0.9) < 0.000001
+
+    @mock.patch('sonic_platform.sfp.SFP.get_fd_for_polling_legacy')
+    @mock.patch('select.poll')
+    @mock.patch('sonic_platform.chassis.time.sleep')
+    @mock.patch('time.monotonic')
+    @mock.patch(
+        'sonic_platform.device_data.DeviceDataManager.is_module_host_management_mode',
+        mock.MagicMock(return_value=False),
+    )
+    @mock.patch('sonic_platform.device_data.DeviceDataManager.get_sfp_count', mock.MagicMock(return_value=1))
+    @mock.patch('sonic_platform.chassis.extract_RJ45_ports_index', mock.MagicMock(return_value=[]))
+    @mock.patch('sonic_platform.chassis.extract_cpo_ports_index', mock.MagicMock(return_value=[]))
+    @mock.patch('sonic_platform.sfp.SFP.get_module_status')
+    def test_get_change_event_legacy_seek_fails_without_sleep_after_timeout(
+        self, mock_status, mock_time, mock_sleep, mock_create_poll, mock_get_fd,
+    ):
+        c = chassis.Chassis()
+        c.get_sfp(1)
+        mock_status.return_value = sfp.SFP_STATUS_INSERTED
+
+        mock_poll = mock.MagicMock()
+        mock_create_poll.return_value = mock_poll
+        mock_poll.poll = mock.MagicMock(side_effect=[[(1, 10)], []])
+
+        mock_file = mock.MagicMock()
+        mock_get_fd.return_value = mock_file
+        mock_file.fileno = mock.MagicMock(return_value=1)
+        mock_file.seek.side_effect = OSError(5, 'seek failed')
+
+        mock_time.side_effect = [0, 0, 1000, 1000, 1000]
+
+        _, change_event = c.get_change_event(1000)
+        assert 'sfp' in change_event and not change_event['sfp']
+        mock_sleep.assert_not_called()
+
+    @mock.patch('sonic_platform.wait_sfp_ready_task.WaitSfpReadyTask.get_ready_set')
+    @mock.patch('sonic_platform.sfp.SFP.get_fd')
+    @mock.patch('select.poll')
+    @mock.patch('sonic_platform.chassis.time.sleep')
+    @mock.patch('time.monotonic')
+    @mock.patch(
+        'sonic_platform.device_data.DeviceDataManager.is_module_host_management_mode',
+        mock.MagicMock(return_value=True),
+    )
+    @mock.patch('sonic_platform.device_data.DeviceDataManager.get_sfp_count', mock.MagicMock(return_value=1))
+    @mock.patch('sonic_platform.chassis.extract_RJ45_ports_index', mock.MagicMock(return_value=[]))
+    @mock.patch('sonic_platform.chassis.extract_cpo_ports_index', mock.MagicMock(return_value=[]))
+    @mock.patch('sonic_platform.module_host_mgmt_initializer.ModuleHostMgmtInitializer.initialize', mock.MagicMock())
+    def test_get_change_event_module_host_management_seek_fails(
+        self, mock_time, mock_sleep, mock_create_poll, mock_get_fd, mock_ready,
+    ):
+        c = chassis.Chassis()
+        c.initialize_sfp()
+        s = c._sfp_list[0]
+        s.state = sfp.STATE_SW_CONTROL
+
+        mock_poll = mock.MagicMock()
+        mock_create_poll.return_value = mock_poll
+        mock_poll.poll = mock.MagicMock(side_effect=[[(1, 10)], []])
+
+        mock_hw_present_file = mock.MagicMock()
+        mock_power_good_file = mock.MagicMock()
+        mock_hw_present_file.read = mock.MagicMock(return_value=sfp.SFP_STATUS_INSERTED)
+        mock_hw_present_file.fileno = mock.MagicMock(return_value=1)
+        mock_hw_present_file.seek.side_effect = OSError(5, 'seek failed')
+        mock_power_good_file.read = mock.MagicMock(return_value=1)
+        mock_power_good_file.fileno = mock.MagicMock(return_value=2)
+
+        def get_fd(fd_type):
+            if fd_type == 'hw_present':
+                return mock_hw_present_file
+            if fd_type == 'power_good':
+                return mock_power_good_file
+            return mock.MagicMock()
+
+        mock_get_fd.side_effect = get_fd
+        mock_ready.return_value = set()
+
+        mock_time.side_effect = [0, 0, 0.1, 0.9, 1000]
+
+        _, change_event = c.get_change_event(1000)
+        assert 'sfp' in change_event and not change_event['sfp']
+        mock_hw_present_file.seek.assert_called_with(0)
+        assert abs(mock_sleep.call_args[0][0] - 0.9) < 0.000001
+
+    @mock.patch('sonic_platform.wait_sfp_ready_task.WaitSfpReadyTask.get_ready_set')
+    @mock.patch('sonic_platform.sfp.SFP.get_fd')
+    @mock.patch('select.poll')
+    @mock.patch('sonic_platform.chassis.time.sleep')
+    @mock.patch('time.monotonic')
+    @mock.patch(
+        'sonic_platform.device_data.DeviceDataManager.is_module_host_management_mode',
+        mock.MagicMock(return_value=True),
+    )
+    @mock.patch('sonic_platform.device_data.DeviceDataManager.get_sfp_count', mock.MagicMock(return_value=1))
+    @mock.patch('sonic_platform.chassis.extract_RJ45_ports_index', mock.MagicMock(return_value=[]))
+    @mock.patch('sonic_platform.chassis.extract_cpo_ports_index', mock.MagicMock(return_value=[]))
+    @mock.patch('sonic_platform.module_host_mgmt_initializer.ModuleHostMgmtInitializer.initialize', mock.MagicMock())
+    def test_get_change_event_module_host_management_seek_fails_without_sleep_after_timeout(
+        self, mock_time, mock_sleep, mock_create_poll, mock_get_fd, mock_ready,
+    ):
+        c = chassis.Chassis()
+        c.initialize_sfp()
+        s = c._sfp_list[0]
+        s.state = sfp.STATE_SW_CONTROL
+
+        mock_poll = mock.MagicMock()
+        mock_create_poll.return_value = mock_poll
+        mock_poll.poll = mock.MagicMock(side_effect=[[(1, 10)], []])
+
+        mock_hw_present_file = mock.MagicMock()
+        mock_power_good_file = mock.MagicMock()
+        mock_hw_present_file.read = mock.MagicMock(return_value=sfp.SFP_STATUS_INSERTED)
+        mock_hw_present_file.fileno = mock.MagicMock(return_value=1)
+        mock_hw_present_file.seek.side_effect = OSError(5, 'seek failed')
+        mock_power_good_file.read = mock.MagicMock(return_value=1)
+        mock_power_good_file.fileno = mock.MagicMock(return_value=2)
+
+        def get_fd(fd_type):
+            if fd_type == 'hw_present':
+                return mock_hw_present_file
+            if fd_type == 'power_good':
+                return mock_power_good_file
+            return mock.MagicMock()
+
+        mock_get_fd.side_effect = get_fd
+        mock_ready.return_value = set()
+
+        mock_time.side_effect = [0, 0, 1000, 1000, 1000]
+
+        _, change_event = c.get_change_event(1000)
+        assert 'sfp' in change_event and not change_event['sfp']
+        mock_sleep.assert_not_called()
+
+
 class TestChangeEvent:
     @mock.patch('sonic_platform.sfp.SFP.get_fd_for_polling_legacy')
     @mock.patch('select.poll')
@@ -59,7 +232,7 @@ class TestChangeEvent:
 
         timeout = 1000
         # mock time function so that the while loop exit early
-        mock_time.side_effect = [0, timeout]
+        mock_time.side_effect = [0, 0, timeout]
 
         # no event, expect returning empty change event
         _, change_event = c.get_change_event(timeout)
@@ -68,7 +241,7 @@ class TestChangeEvent:
         # dummy event, expect returning empty change event
         sfp_index = s.sdk_index + 1
         mock_poll.poll.return_value = [(1, 10)]
-        mock_time.side_effect = [0, timeout]
+        mock_time.side_effect = [0, 0, timeout]
         _, change_event = c.get_change_event(timeout)
         assert 'sfp' in change_event and not change_event['sfp']
 
@@ -138,7 +311,7 @@ class TestChangeEvent:
         
         timeout = 1000
         # mock time function so that the while loop exit early
-        mock_time.side_effect = [0, timeout]
+        mock_time.side_effect = [0, 0, timeout]
         
         # no event, expect returning empty change event
         _, change_event = c.get_change_event(timeout)
@@ -147,7 +320,7 @@ class TestChangeEvent:
         # dummy event, expect returning empty change event
         sfp_index = s.sdk_index + 1
         mock_poll.poll.return_value = [(1, 10)]
-        mock_time.side_effect = [0, timeout]
+        mock_time.side_effect = [0, 0, timeout]
         _, change_event = c.get_change_event(timeout)
         assert 'sfp' in change_event and not change_event['sfp']
         
@@ -166,7 +339,7 @@ class TestChangeEvent:
         s.get_power_good = mock.MagicMock(return_value=True)
         s.determine_control_type = mock.MagicMock(return_value=sfp.SFP_FW_CONTROL)
         s.set_control_type = mock.MagicMock()
-        mock_time.side_effect = [0, timeout]
+        mock_time.side_effect = [0, 0, timeout]
         mock_ready.return_value = set([0])
         mock_hw_present_file.read.return_value = sfp.SFP_STATUS_INSERTED
         _, change_event = c.get_change_event(timeout)
@@ -198,7 +371,7 @@ class TestChangeEvent:
         assert 3 not in c.registered_fds # stop polling present
         
         # plug in a software control cable, expect returning insert event
-        mock_time.side_effect = [0, timeout]
+        mock_time.side_effect = [0, 0, timeout]
         mock_ready.return_value = set([0])
         mock_poll.poll.return_value = [(1, 10)]
         mock_hw_present_file.read.return_value = sfp.SFP_STATUS_INSERTED


### PR DESCRIPTION
It's a backport PR of https://github.com/sonic-net/sonic-buildimage/pull/27497

#### Why I did it
xcvrd can repeatedly process SFP change-event sysfs fds when a transient fd operation fails, for example `OSError(16, 'Device or resource busy')` from `fd.seek(0)` or `fd.read()`. Without throttling, the platform API can return immediately and xcvrd may re-enter the same failing poll path, producing frequent error logs while the module sysfs path is temporarily unavailable.

#### How I did it
Added a short backoff for SFP change-event poll read errors in the Mellanox platform API.
When `get_change_event()` or the module host-management change-event path hits `OSError`, `IOError`, or invalid data while seeking or reading an SFP poll fd, the code records that a read error happened, continues processing the remaining
ready fds in the same poll result, and returns an empty SFP event after waiting up to the 1-second backoff interval.
This keeps isolation between SFPs: if one SFP fd fails, other SFPs from the same poll batch can still be read and reported normally. If all SFP fds fail, xcvrd backs off before retrying, avoiding a tight error loop.
Added UT coverage for legacy and module host-management change-event paths, including seek/read failures, timeout behavior, and retry after the backoff window.
The tradeoff is that recovery from a transient sysfs read failure may be delayed by up to 1 second.

#### How to verify it
Ran targeted UTs for test_sfp.py covering the new backoff behavior.
Also validated on switch with temporary debug instrumentation:
1. One failing SFP: SFP0 entered the error path, while other SFPs continued to
  generate change events.
2. All failing SFPs: returned empty events with about 1 second between retries.

#### Which release branch to backport (provide reason below if selected)
- [ ] 202511

#### Tested branch (Please provide the tested image version)
202511
