### PR TITLE
[init_cfg] Enable sflow feature by default

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -86,7 +86,7 @@
 {%- elif include_restapi == "y" %}
     {% do features.append(("restapi", "enabled", false, "enabled")) %}
 {%- endif %}
-{%- if include_sflow == "y" %}{% do features.append(("sflow", "disabled", true, "enabled")) %}{% endif %}
+{%- if include_sflow == "y" %}{% do features.append(("sflow", "enabled", true, "enabled")) %}{% endif %}
 {%- if include_macsec == "y" %}{% do features.append(("macsec", "{% if 'type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] in ['SpineRouter', 'UpperSpineRouter', 'LowerRegionalHub'] and DEVICE_RUNTIME_METADATA['MACSEC_SUPPORTED'] %}enabled{% else %}disabled{% endif %}", false, "enabled")) %}{% endif %}
 {%- if include_system_gnmi == "y" %}{% do features.append(("gnmi", "enabled", true, "enabled")) %}{% endif %}
 {%- if include_system_telemetry == "y" %}{% do features.append(("telemetry", "enabled", true, "enabled")) %}{% endif %}


### PR DESCRIPTION
### Description of PR

Summary:
Enable sflow feature by default in SONiC master builds. Currently `INCLUDE_SFLOW=y` in `rules/config` ensures the sflow docker image is built and included, but the feature state in `init_cfg.json.j2` defaults to `disabled`. This means sflow never starts unless manually enabled post-deployment.

This PR changes the default state from `disabled` to `enabled` so that sflow starts automatically on boot, consistent with other included networking features (lldp, snmp, gnmi).

On current master image:
```
admin@bjw2-can-7260-11:~$ show version | grep Buil
Build commit: c1ad1c0ef
Build date: Thu May 21 14:18:45 UTC 2026
Built by: azureuser@6e67b24fc000000
admin@bjw2-can-7260-11:~$ show feature config
Feature         State            AutoRestart     Owner
--------------  ---------------  --------------  -------
acms            enabled          enabled         local
bgp             enabled          enabled         local
database        always_enabled   always_enabled  local
dhcp_relay      disabled         enabled         local
dhcp_server     disabled         enabled         local
eventd          enabled          enabled         kube
gnmi            enabled          enabled         kube
lldp            enabled          enabled         kube
macsec          disabled         enabled         local
mgmt-framework  enabled          enabled         local
mux             always_disabled  enabled         local
nat             disabled         enabled         local
otel            enabled          enabled         local
pmon            enabled          enabled         kube
radv            enabled          enabled         kube
restapi         enabled          enabled         local
sflow           disabled         enabled         local
snmp            enabled          enabled         kube
swss            enabled          enabled         local
syncd           enabled          enabled         local
teamd           enabled          enabled         local
telemetry       enabled          enabled         kube
```

### Type of change

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Approach
#### What is the motivation for this PR?

The `INCLUDE_SFLOW` build flag is set to `y` on master, meaning the sflow docker image is built into every image. However, the init_cfg.json.j2 template hardcodes the feature state to `disabled`:

```jinja2
{%- if include_sflow == "y" %}{% do features.append(("sflow", "disabled", true, "enabled")) %}{% endif %}
```

This creates an inconsistency — the image ships sflow but never runs it by default. Operators must manually run `config feature state sflow enabled` after every deployment/upgrade.

#### How did you do it?

Changed the default state tuple from `"disabled"` to `"enabled"` in the features list for sflow in `files/build_templates/init_cfg.json.j2`.

#### How did you verify/test it?

- Verified on a live DUT (bjw2-can-7260-11) running master.1119208 that sflow was disabled by default
- Manually enabled sflow via `sudo config feature state sflow enabled` — container started successfully
- Confirmed the sflow docker image (342MB) was already present in the image

#### Any platform specific information?

N/A — applies to all platforms where `INCLUDE_SFLOW=y`.

#### Supported testbed topology if it's a new test case?

N/A

### Documentation

N/A