### PR TITLE
[platform-modules]: tolerate kernel-headers race during clean

### DIFF
--- a/platform/aspeed/sonic-platform-modules-nexthop/debian/rules
+++ b/platform/aspeed/sonic-platform-modules-nexthop/debian/rules
@@ -122,7 +122,7 @@ override_dh_clean:
 	(for mod in $(MODULE_DIRS); do \
 		set -e; \
 		if [ -d "$(KERNEL_BUILD)" ] && [ -f "$(MOD_SRC_DIR)/$${mod}/modules/Makefile" ]; then \
-			make -C $(KERNEL_BUILD) M=$(MOD_SRC_DIR)/$${mod}/modules clean; \
+			make -C $(KERNEL_BUILD) M=$(MOD_SRC_DIR)/$${mod}/modules clean || true; \
 		fi; \
 	done)
 	rm -f $(MOD_SRC_DIR)/*.whl

--- a/platform/barefoot/sonic-platform-modules-ingrasys/debian/rules
+++ b/platform/barefoot/sonic-platform-modules-ingrasys/debian/rules
@@ -37,6 +37,6 @@ override_dh_auto_install:
 override_dh_clean:
 	dh_clean
 	(for mod in $(MODULE_DIRS); do \
-		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean; \
+		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean || true; \
 	done)
 

--- a/platform/barefoot/sonic-platform-modules-netberg/debian/rules
+++ b/platform/barefoot/sonic-platform-modules-netberg/debian/rules
@@ -45,6 +45,6 @@ override_dh_auto_install:
 override_dh_clean:
 	dh_clean
 	(for mod in $(MODULE_DIRS); do \
-		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean; \
+		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean || true; \
 	done)
 

--- a/platform/broadcom/sonic-platform-modules-dell/debian/rules
+++ b/platform/broadcom/sonic-platform-modules-dell/debian/rules
@@ -145,7 +145,7 @@ override_dh_auto_clean:
                         rm -f $(MOD_SRC_DIR)/$${mod}/modules/dell_z9864f_fpga_ocores.c; \
                         rm -f $(MOD_SRC_DIR)/$${mod}/sonic_platform/ipmihelper.py; \
 		fi; \
-		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean; \
+		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean || true; \
 	done)
 	dh_clean
 

--- a/platform/broadcom/sonic-platform-modules-delta/debian/rules
+++ b/platform/broadcom/sonic-platform-modules-delta/debian/rules
@@ -28,6 +28,6 @@ override_dh_usrlocal:
 override_dh_clean:
 	dh_clean
 	(for mod in $(MODULE_DIRS); do \
-		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean; \
+		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean || true; \
 	done)
 

--- a/platform/broadcom/sonic-platform-modules-ingrasys/debian/rules
+++ b/platform/broadcom/sonic-platform-modules-ingrasys/debian/rules
@@ -37,6 +37,6 @@ override_dh_auto_install:
 override_dh_clean:
 	dh_clean
 	(for mod in $(MODULE_DIRS); do \
-		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean; \
+		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean || true; \
 	done)
 

--- a/platform/broadcom/sonic-platform-modules-inventec/debian/rules
+++ b/platform/broadcom/sonic-platform-modules-inventec/debian/rules
@@ -61,6 +61,6 @@ override_dh_pysupport:
 override_dh_clean:
 	dh_clean
 	(for mod in $(MODULE_DIRS); do \
-		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean; \
+		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean || true; \
 	done)
 

--- a/platform/broadcom/sonic-platform-modules-mitac/debian/rules
+++ b/platform/broadcom/sonic-platform-modules-mitac/debian/rules
@@ -36,6 +36,6 @@ override_dh_usrlocal:
 override_dh_clean:
 	dh_clean
 	(for mod in $(MODULE_DIRS); do \
-			make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean; \
+			make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean || true; \
 	done)
 

--- a/platform/broadcom/sonic-platform-modules-nexthop/debian/rules
+++ b/platform/broadcom/sonic-platform-modules-nexthop/debian/rules
@@ -146,7 +146,7 @@ override_dh_clean:
 	(for mod in $(MODULE_DIRS); do \
 		set -e; \
 		if [ -d "$(KERNEL_BUILD)" ] && [ -f "$(MOD_SRC_DIR)/$${mod}/modules/Makefile" ]; then \
-			make -C $(KERNEL_BUILD) M=$(MOD_SRC_DIR)/$${mod}/modules clean; \
+			make -C $(KERNEL_BUILD) M=$(MOD_SRC_DIR)/$${mod}/modules clean || true; \
 		fi; \
 		echo $(MOD_SRC_DIR); \
 		rm -f $(MOD_SRC_DIR)/*.whl; \

--- a/platform/centec/sonic-platform-modules-e582/debian/rules
+++ b/platform/centec/sonic-platform-modules-e582/debian/rules
@@ -39,7 +39,7 @@ override_dh_usrlocal:
 override_dh_clean:
 	dh_clean
 	(for mod in $(MODULE_DIRS); do \
-		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean; \
+		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean || true; \
 		rm -rf $(MOD_SRC_DIR)/$${mod}/modules/*.ko; \
 		rm -rf debian/platform-modules-e582-$${mod}/$(KERNEL_SRC)/$(INSTALL_MOD_DIR)/*.ko; \
 	done)

--- a/platform/marvell-teralynx/sonic-platform-modules-cel/debian/rules
+++ b/platform/marvell-teralynx/sonic-platform-modules-cel/debian/rules
@@ -28,5 +28,5 @@ override_dh_usrlocal:
 override_dh_clean:
 	dh_clean
 	(for mod in $(MODULE_DIRS); do \
-		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean; \
+		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean || true; \
 	done)

--- a/platform/marvell-teralynx/sonic-platform-modules-delta/debian/rules
+++ b/platform/marvell-teralynx/sonic-platform-modules-delta/debian/rules
@@ -28,6 +28,6 @@ override_dh_usrlocal:
 override_dh_clean:
 	dh_clean
 	(for mod in $(MODULE_DIRS); do \
-		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean; \
+		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean || true; \
 	done)
 

--- a/platform/marvell-teralynx/sonic-platform-modules-netberg/debian/rules
+++ b/platform/marvell-teralynx/sonic-platform-modules-netberg/debian/rules
@@ -37,5 +37,5 @@ override_dh_usrlocal:
 override_dh_clean:
 	dh_clean
 	(for mod in $(MODULE_DIRS); do \
-		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean; \
+		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean || true; \
 	done)

--- a/platform/marvell-teralynx/sonic-platform-modules-supermicro/debian/rules
+++ b/platform/marvell-teralynx/sonic-platform-modules-supermicro/debian/rules
@@ -31,7 +31,7 @@ override_dh_usrlocal:
 override_dh_clean:
 	dh_clean
 	(for mod in $(MODULE_DIRS); do \
-                make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean; \
+                make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean || true; \
                 rm -f $(MOD_SRC_DIR)/$${mod}/modules/*.whl; \
                 rm -rf $(MOD_SRC_DIR)/$${mod}/build; \
                 rm -rf $(MOD_SRC_DIR)/$${mod}/*.egg-info; \

--- a/platform/nephos/sonic-platform-modules-accton/debian/rules
+++ b/platform/nephos/sonic-platform-modules-accton/debian/rules
@@ -36,5 +36,5 @@ override_dh_usrlocal:
 override_dh_clean:
 	dh_clean
 	(for mod in $(MODULE_DIRS); do \
-		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean; \
+		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean || true; \
 	done)

--- a/platform/nephos/sonic-platform-modules-ingrasys/debian/rules
+++ b/platform/nephos/sonic-platform-modules-ingrasys/debian/rules
@@ -37,6 +37,6 @@ override_dh_auto_install:
 override_dh_clean:
 	dh_clean
 	(for mod in $(MODULE_DIRS); do \
-		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean; \
+		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules clean || true; \
 	done)
 


### PR DESCRIPTION
#### Why I did it

Multiple vendor `sonic-platform-modules-*` debian/rules files have an `override_dh_auto_clean` (or `override_dh_clean`) that iterates over a list of per-platform module dirs and runs:

```makefile
make -C \$(KERNEL_SRC)/build M=\$(MOD_SRC_DIR)/\${mod}/modules clean
```

per platform. The iteration takes seconds (Dell has 18 platforms; others fewer). Under parallel builds (e.g. `SONIC_BUILD_JOBS=12`), another concurrent platform-modules-* recipe can declare the `linux-headers-*` debs as prerequisites and trigger SONiC's dep_install / dep_uninstall flow. If `linux-headers-*` is momentarily uninstalled (purge-then-reinstall) while this iteration is mid-flight, the next `make -C /lib/modules/\$KVERSION/build ...` fails fast with `No such file or directory` on the `build` symlink, aborting the entire recipe.

Real-world failure observed during a Broadcom build with `SONIC_BUILD_JOBS=12`:

```
make[3]: *** /lib/modules/6.12.41+deb13-sonic-amd64/build: No such file or directory.  Stop.
make[3]: Leaving directory '/sonic/platform/broadcom/sonic-platform-modules-dell'
make[2]: *** [debian/rules:101: override_dh_auto_clean] Error 2
make[1]: *** [Makefile:22: /sonic/target/debs/trixie/platform-modules-z9100_1.1_amd64.deb] Error 2
make: *** [slave.mk:915: target/debs/trixie/platform-modules-z9100_1.1_amd64.deb] Error 1
```

The clean step's purpose is to remove stale in-tree build artifacts (`Module.symvers`, `*.o`, `*.mod.c`). If a missed clean leaves those behind, the very next `override_dh_auto_build` regenerates them deterministically from kbuild — a missed clean is harmless. An aborted clean, on the other hand, kills the recipe.

##### Work item tracking
- Microsoft ADO **(number only)**: n/a

#### How I did it

Wrapped each racy `make -C \$(KERNEL_SRC)/build M=... clean` (or `\$(KERNEL_BUILD) M=...`) with `|| true` so a transient missing-or-mid-purge kernel-headers package no longer fails the recipe. One-line diff per vendor file, 16 files total.

Two of the affected recipes (aspeed/nexthop, broadcom/nexthop) already have an outer `if [ -d \"\$(KERNEL_BUILD)\" ] ...` guard, but the dir can still disappear between that check and the actual `make` execution — the `|| true` closes that race window for them too.

Affected files:

- platform/aspeed/sonic-platform-modules-nexthop/debian/rules
- platform/barefoot/sonic-platform-modules-ingrasys/debian/rules
- platform/barefoot/sonic-platform-modules-netberg/debian/rules
- platform/broadcom/sonic-platform-modules-dell/debian/rules
- platform/broadcom/sonic-platform-modules-delta/debian/rules
- platform/broadcom/sonic-platform-modules-ingrasys/debian/rules
- platform/broadcom/sonic-platform-modules-inventec/debian/rules
- platform/broadcom/sonic-platform-modules-mitac/debian/rules
- platform/broadcom/sonic-platform-modules-nexthop/debian/rules
- platform/centec/sonic-platform-modules-e582/debian/rules
- platform/marvell-teralynx/sonic-platform-modules-cel/debian/rules
- platform/marvell-teralynx/sonic-platform-modules-delta/debian/rules
- platform/marvell-teralynx/sonic-platform-modules-netberg/debian/rules
- platform/marvell-teralynx/sonic-platform-modules-supermicro/debian/rules
- platform/nephos/sonic-platform-modules-accton/debian/rules
- platform/nephos/sonic-platform-modules-ingrasys/debian/rules

#### How to verify it

1. Trigger a parallel build that includes any of the affected platform-modules recipes (e.g. \`make PLATFORM=broadcom SONIC_BUILD_JOBS=12 target/sonic-broadcom.bin\`).
2. Without the patch, the race surfaces intermittently — most commonly on Dell (largest iteration) or Delta. Frequency increases with build concurrency.
3. With the patch in place, the iteration completes even if the kernel-build symlink momentarily disappears; the in-tree artifacts are regenerated by the subsequent build step.

Alternatively, reproduce more deterministically by injecting an artificial sleep into one platform's clean step while another concurrently runs \`dpkg --remove linux-headers-\$KVERSION-sonic-amd64\` then \`dpkg --install ...\`. Without the patch the clean fails; with the patch it does not.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
-->

n/a (master-only fix; the race exists wherever the parallel-build infra runs).

#### Tested branch (Please provide the tested image version)

- [x] master — observed the race fail builds at SONIC_BUILD_JOBS=12 prior to the patch; subsequent retries succeed once past the affected window. Patch eliminates the failure mode without changing the clean output for builds that don't race.

#### Description for the changelog

\`platform-modules\`: tolerate concurrent-build races against the linux-headers package during the per-platform clean iteration. Prevents intermittent build failures with \`make[3]: *** /lib/modules/\$KVERSION/build: No such file or directory\` under parallel \`SONIC_BUILD_JOBS\`.

#### Link to config_db schema for YANG module changes

n/a

#### A picture of a cute animal (not mandatory but encouraged)

n/a