### PR TITLE
[build-hooks] Avoid apt invalid filename extension warning for debian.sources.back

### DIFF
--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -123,10 +123,10 @@ set_reproducible_mirrors()
         expression3="/#SET_REPR_MIRRORS/d"
     fi
     if [[ "$1" != "-d" ]] && [ -f /etc/apt/sources.list.d/debian.sources ]; then
-        $SUDO mv /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list.d/debian.sources.back
+        $SUDO mv /etc/apt/sources.list.d/debian.sources /etc/apt/debian.sources.back
     fi
-    if [[ "$1" == "-d" ]] && [ -f /etc/apt/sources.list.d/debian.sources.back ]; then
-        $SUDO mv /etc/apt/sources.list.d/debian.sources.back /etc/apt/sources.list.d/debian.sources
+    if [[ "$1" == "-d" ]] && [ -f /etc/apt/debian.sources.back ]; then
+        $SUDO mv /etc/apt/debian.sources.back /etc/apt/sources.list.d/debian.sources
     fi
 
     local mirrors="/etc/apt/sources.list $(find /etc/apt/sources.list.d/ -type f)"


### PR DESCRIPTION
The backup file debian.sources.back from /etc/apt/sources.list.d/ to /etc/apt/. The previous location caused APT to scan the backup file during package operations because it was placed inside a directory reserved for active repository source configurations. As a result, APT generated unnecessary warnings while processing repository metadata. By moving the backup file outside the scanned source-list directory, the backup is preserved safely without being interpreted as an active repository configuration, thereby preventing misleading warnings and ensuring cleaner package management operations.