### PR TITLE
DNS: Fix DNS_OPTIONS schema to allow ConfigDB/Redis serialization + layout regression test

### DIFF
--- a/files/image_config/resolv-config/resolv.conf.j2
+++ b/files/image_config/resolv-config/resolv.conf.j2
@@ -2,20 +2,19 @@
 nameserver {{ ip }}
 {% endfor -%}
 
-{%- if DNS_OPTIONS is defined %}
-{%   set search = DNS_OPTIONS.get('search') %}
-{%   if search is not none %}
-search {{ search.split(",") | join(" ") }}
+{%- if DNS_OPTIONS is defined and DNS_OPTIONS["GLOBAL"] is defined %}
+{%   if DNS_OPTIONS["GLOBAL"]["search"] is defined %}
+search {{ DNS_OPTIONS["GLOBAL"]["search"] | join(" ") }}
 {%   endif %}
 {%   set options="" %}
-{%   if DNS_OPTIONS["ndots"] is defined %}
-{%     set options = options ~ ' ndots:' ~ DNS_OPTIONS["ndots"] %}
+{%   if DNS_OPTIONS["GLOBAL"]["ndots"] is defined %}
+{%     set options = options ~ ' ndots:' ~ DNS_OPTIONS["GLOBAL"]["ndots"] %}
 {%   endif %}
-{%   if DNS_OPTIONS["timeout"] is defined %}
-{%     set options = options ~ ' timeout:' ~ DNS_OPTIONS["timeout"] %}
+{%   if DNS_OPTIONS["GLOBAL"]["timeout"] is defined %}
+{%     set options = options ~ ' timeout:' ~ DNS_OPTIONS["GLOBAL"]["timeout"] %}
 {%   endif %}
-{%   if DNS_OPTIONS["attempts"] is defined %}
-{%     set options = options ~ ' attempts:' ~ DNS_OPTIONS["attempts"] %}
+{%   if DNS_OPTIONS["GLOBAL"]["attempts"] is defined %}
+{%     set options = options ~ ' attempts:' ~ DNS_OPTIONS["GLOBAL"]["attempts"] %}
 {%   endif %}
 {%   if options|length > 0 %}
 options{{ options }}

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -3268,10 +3268,12 @@ DNS configuration options can also be set when nameservers are defined:
 ```json
 {
     "DNS_OPTIONS": {
-        "search": [ "d1.example.com", "d2.example.com", "d3.example.com" ],
-        "ndots": 0,
-        "timeout": 1,
-        "attempts": 2
+        "GLOBAL": {
+            "search": [ "d1.example.com", "d2.example.com", "d3.example.com" ],
+            "ndots": 0,
+            "timeout": 1,
+            "attempts": 2
+        }
     }
 }
 ```

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -22,10 +22,12 @@
             "fe80:1000:2000:3000::1": {}
         },
         "DNS_OPTIONS": {
-            "search": [ "d1.example.com", "d2.example.com", "d3.example.com" ],
-            "ndots": "0",
-            "timeout": "1",
-            "attempts": "2"
+            "GLOBAL": {
+                "search": [ "d1.example.com", "d2.example.com", "d3.example.com" ],
+                "ndots": "0",
+                "timeout": "1",
+                "attempts": "2"
+            }
         },
         "BUFFER_POOL": {
             "ingress_lossy_pool": {

--- a/src/sonic-yang-models/tests/yang_model_pytests/test_configdb_layout.py
+++ b/src/sonic-yang-models/tests/yang_model_pytests/test_configdb_layout.py
@@ -1,0 +1,46 @@
+"""Every ConfigDB table container must have a row layer - either a `list`
+(keyed rows) or an inner `container` (named singleton row). A table whose
+direct children are only leaf/leaf-list has no row key for ConfigDB to
+serialize against and cannot be persisted to Redis. The DNS_OPTIONS
+schema originally had this shape and was unusable in a live system; this
+test guards against that class of regression for all sonic-* models."""
+import os
+from glob import glob
+
+import libyang as ly
+
+
+def _is_event_schema(snode):
+    """A container that carries an extension from sonic-events-common
+    (ALARM_SEVERITY_*, EVENT_SEVERITY_*, …) is an event/notification payload
+    schema, not a ConfigDB table — it doesn't need a row layer."""
+    for ext in snode.extensions():
+        if ext.module().name() == "sonic-events-common":
+            return True
+    return False
+
+
+def test_every_table_has_row_layer(yang_model):
+    yang_files = glob(os.path.join(yang_model.model_dir, "sonic-*.yang"))
+    violations = []
+    for path in yang_files:
+        module_name = os.path.splitext(os.path.basename(path))[0]
+        module = yang_model.ctx.get_module(module_name)
+        if module is None:
+            continue
+        top = next(iter(module.children(types=(ly.SNode.CONTAINER,))), None)
+        if top is None or top.name() != module.name():
+            continue
+        for table in top.children(types=(ly.SNode.CONTAINER,)):
+            if _is_event_schema(table):
+                continue
+            has_list = any(table.children(types=(ly.SNode.LIST,)))
+            has_inner_container = any(table.children(types=(ly.SNode.CONTAINER,)))
+            if not has_list and not has_inner_container:
+                violations.append(f"{module.name()}:{table.name()}")
+
+    assert not violations, (
+        "ConfigDB table containers without a row layer (list or inner "
+        "container) cannot be serialized to Redis:\n  "
+        + "\n  ".join(violations)
+    )

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/dns.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/dns.json
@@ -12,10 +12,12 @@
                 ]
             },
             "sonic-dns:DNS_OPTIONS": {
-                "search": [ "d1.example.com", "d2.example.com", "d3.example.com" ],
-                "ndots": 0,
-                "timeout": 1,
-                "attempts": 1
+                "GLOBAL": {
+                    "search": [ "d1.example.com", "d2.example.com", "d3.example.com" ],
+                    "ndots": 0,
+                    "timeout": 1,
+                    "attempts": 1
+                }
             }
         }
     },
@@ -53,10 +55,12 @@
     "DNS_OPTIONS_NO_NAMESERVER": {
         "sonic-dns:sonic-dns": {
             "sonic-dns:DNS_OPTIONS": {
-                "search": [ "d1.example.com", "d2.example.com", "d3.example.com" ],
-                "ndots": 0,
-                "timeout": 1,
-                "attempts": 1
+                "GLOBAL": {
+                    "search": [ "d1.example.com", "d2.example.com", "d3.example.com" ],
+                    "ndots": 0,
+                    "timeout": 1,
+                    "attempts": 1
+                }
             }
         }
     },
@@ -70,7 +74,9 @@
                 ]
             },
             "sonic-dns:DNS_OPTIONS": {
-                "search": [ "d1*.example.com" ]
+                "GLOBAL": {
+                    "search": [ "d1*.example.com" ]
+                }
             }
         }
     },
@@ -84,7 +90,9 @@
                 ]
             },
             "sonic-dns:DNS_OPTIONS": {
-                "ndots": 100
+                "GLOBAL": {
+                    "ndots": 100
+                }
             }
         }
     },
@@ -98,7 +106,9 @@
                 ]
             },
             "sonic-dns:DNS_OPTIONS": {
-                "timeout": 0
+                "GLOBAL": {
+                    "timeout": 0
+                }
             }
         }
     },
@@ -112,7 +122,9 @@
                 ]
             },
             "sonic-dns:DNS_OPTIONS": {
-                "attempts": 10
+                "GLOBAL": {
+                    "attempts": 10
+                }
             }
         }
     }

--- a/src/sonic-yang-models/yang-models/sonic-dns.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dns.yang
@@ -43,34 +43,36 @@ module sonic-dns {
         container DNS_OPTIONS {
             description "DNS resolver options; requires at least one nameserver to be configured.";
 
-            leaf-list search {
-                description "Configure the DNS search suffix list";
-                type inet:host;
-            }
-
-            leaf ndots {
-                description "Sets a threshold for the number of dots which must appear in a name given before an initial absolute query will be made";
-                type uint8 {
-                    range "0..15";
+            container GLOBAL {
+                leaf-list search {
+                    description "Configure the DNS search suffix list";
+                    type inet:host;
                 }
-                default 1;
-            }
 
-            leaf timeout {
-                description "Sets the amount of time in seconds the resolver will wait for a response from a remote name server before retrying the query via a different name server.";
-                type uint8 {
-                    range "1..30";
+                leaf ndots {
+                    description "Sets a threshold for the number of dots which must appear in a name given before an initial absolute query will be made";
+                    type uint8 {
+                        range "0..15";
+                    }
+                    default 1;
                 }
-                default 5;
-            }
 
-            leaf attempts {
-                description "Sets the number of times the resolver will send a query to its name servers before giving up and returning an error to the calling application.";
-                type uint8 {
-                    range "1..5";
+                leaf timeout {
+                    description "Sets the amount of time in seconds the resolver will wait for a response from a remote name server before retrying the query via a different name server.";
+                    type uint8 {
+                        range "1..30";
+                    }
+                    default 5;
                 }
-                default 2;
-            }
+
+                leaf attempts {
+                    description "Sets the number of times the resolver will send a query to its name servers before giving up and returning an error to the calling application.";
+                    type uint8 {
+                        range "1..5";
+                    }
+                    default 2;
+                }
+            } /* end of container GLOBAL */
 
             when "count(../DNS_NAMESERVER/DNS_NAMESERVER_LIST/ip) > 0";
         } /* end of container DNS_OPTIONS */


### PR DESCRIPTION
#### Why I did it

The DNS_OPTIONS YANG model I originally added cannot actually be persisted to ConfigDB. The schema declared `search`, `ndots`, `timeout`, and `attempts` as direct leafs/leaf-list under the `DNS_OPTIONS` container, but SONiC's Redis-backed config schema requires a two-level container layout (outer container = table, inner container = row key). With DNS_OPTIONS as a single-level container there is no row identifier to serialize against, so any commit to `config_db` is rejected. As a result, DNS_OPTIONS has never actually been usable end-to-end in a live system.

This was a mistake in my initial implementation that went unnoticed because the existing coverage is YANG-only - the `yang_model_tests` and the full-config serialization/deserialization test exercise YANG validation and JSON round-tripping, but neither simulates ConfigDB's table/row constraints, so every test passed even though the feature was broken in practice.

Because DNS_OPTIONS could never be serialized to ConfigDB in the first place, there cannot be any existing consumer reading it out of `config_db`, so this schema change has **no compatibility impact** - there is nothing in the field to break.

DNS_OPTIONS first landed in 202511, so 202511 carries the same broken schema and needs this backported as well.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

**Commit 1 - fix the schema:** Wrap the existing leafs in an inner `GLOBAL` container so `DNS_OPTIONS` becomes the table and `GLOBAL` becomes its single well-known row, matching the pattern used by other singleton tables in SONiC.

- `src/sonic-yang-models/yang-models/sonic-dns.yang` - wrap leafs in a `GLOBAL` container
- `files/image_config/resolv-config/resolv.conf.j2` - read from `DNS_OPTIONS["GLOBAL"]`; also drops the now-unnecessary `.split(",")` on `search` since it's already a list
- `src/sonic-yang-models/doc/Configuration.md` - update example JSON
- `src/sonic-yang-models/tests/files/sample_config_db.json` - update sample
- `src/sonic-yang-models/tests/yang_model_tests/tests_config/dns.json` - update test fixtures

**Commit 2 - regression guard:** Add a structural pytest that walks every `sonic-*` YANG model and asserts every ConfigDB table container has a row layer (a `list` or an inner `container`). A table whose direct children are only leaf/leaf-list cannot be serialized to ConfigDB - this is exactly the gap that let the original DNS_OPTIONS schema ship broken. The test reuses the existing `yang_model` pytest fixture and matches the module-filtering logic in `sonic_yang_ext._build_confDbYangMap` so helper-only modules (typedefs, groupings) are skipped the same way the real ConfigDB xlate path skips them.

- `src/sonic-yang-models/tests/yang_model_pytests/test_configdb_layout.py` (new)

#### How to verify it

1. Run the sonic-yang-models test suite (`yang_model_tests` and `yang_model_pytests`) - all existing DNS test cases pass with the new container layout, and the new structural test passes against every current sonic-* model.
2. Locally re-apply the pre-fix DNS_OPTIONS shape (or any leaf-only table) to confirm the new test catches it.
3. On a live device, commit DNS options via `config reload` / `sonic-cfggen`:
   ```json
   "DNS_OPTIONS": {
       "GLOBAL": {
           "search": [ "example.com" ],
           "ndots": "1",
           "timeout": "5",
           "attempts": "2"
       }
   }
   ```
   The write to `config_db` now succeeds (it previously failed because the schema had no row key to serialize under).
4. Confirm `/etc/resolv.conf` is rendered with the expected `search` line and `options ndots:/timeout:/attempts:` line.

Steps 3-4 are automated end-to-end on a live DUT by the management test in **sonic-net/sonic-mgmt#24997**, which configures `DNS_OPTIONS|GLOBAL`, regenerates `resolv.conf`, and asserts the resulting `search`/`options` lines.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511 - DNS_OPTIONS first shipped in 202511 with the broken schema, so 202511 needs this fix as well.

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

DNS: Fix DNS_OPTIONS schema to allow ConfigDB/Redis serialization (wrap fields in a GLOBAL container); add structural test that guards every ConfigDB table container has a row layer.

#### Link to config_db schema for YANG module changes

https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#dns
