### PR TITLE
[broadcom][legecy-th] Use libthrift-0.19.0t64 for legacy-th-rpc on trixie

### DIFF
--- a/platform/broadcom/docker-syncd-brcm-legacy-th-rpc/Dockerfile.j2
+++ b/platform/broadcom/docker-syncd-brcm-legacy-th-rpc/Dockerfile.j2
@@ -22,7 +22,7 @@ RUN apt-get update \
     wget                \
     cmake               \
     libnanomsg-dev      \
-    libthrift-0.17.0
+    libthrift-0.19.0t64
 
 {% if docker_syncd_brcm_legacy_th_rpc_debs.strip() -%}
 # Copy locally-built Debian package dependencies


### PR DESCRIPTION
#### Why I did it

`sonic-buildimage` master is trixie-based. Trixie ships libthrift as `libthrift-0.19.0t64` (the `t64` flavor is the 64-bit `time_t` ABI transition package); `libthrift-0.17.0` was the bookworm package name and no longer exists in trixie apt sources.

The `docker-syncd-brcm-legacy-th-rpc` image base step fails on master during `apt-get -y install ... libthrift-0.17.0` with:

```
#11 ERROR: process "/bin/sh -c apt-get update && apt-get -y install ... libthrift-0.17.0" did not complete successfully: exit code: 100
> [base 7/14] RUN apt-get update && apt-get -y install ... libthrift-0.17.0:
E: Unable to locate package libthrift-0.17.0
```

The sibling Dockerfile `platform/broadcom/docker-syncd-brcm-rpc/Dockerfile.j2` was already updated to `libthrift-0.19.0t64` during the bookworm → trixie migration; `docker-syncd-brcm-legacy-th-rpc` was missed.

##### Work item tracking
- Microsoft ADO **(number only)**: 38098188

#### How I did it

Updated `platform/broadcom/docker-syncd-brcm-legacy-th-rpc/Dockerfile.j2` to install `libthrift-0.19.0t64`, bringing it in line with `docker-syncd-brcm-rpc/Dockerfile.j2`.

```diff
-    libthrift-0.17.0
+    libthrift-0.19.0t64
```

#### How to verify it

Build the broadcom platform with `ENABLE_SYNCD_RPC=y` on a trixie-based `master` build; the `docker-syncd-brcm-legacy-th-rpc` base stage `apt-get install` now completes successfully and the image builds end-to-end. Equivalent change has been verified in the corresponding internal build (build id `165366638`), where `docker-syncd-brcm-legacy-th-rpc` builds successfully.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [x] master (internal build `165366638`, commit `403a31b6fe`)

#### Description for the changelog

[broadcom] Update docker-syncd-brcm-legacy-th-rpc to use libthrift-0.19.0t64 to match trixie / sibling docker-syncd-brcm-rpc.

#### Link to config_db schema for YANG module changes

N/A — Dockerfile-only change.
