### PR TITLE
[EVPN-MH] Add EVPN-MH YANG model support

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -35,6 +35,7 @@
   * [DHCP Server IPV4](#dhcp_server_ipv4)
   * [BMP](#bmp)
   * [DSCP_TO_TC_MAP](#dscp_to_tc_map)
+  * [EVPN](#evpn)
   * [FG_NHG](#fg_nhg)
   * [FG_NHG_MEMBER](#fg_nhg_member)
   * [FG_NHG_PREFIX](#fg_nhg_prefix)
@@ -64,6 +65,7 @@
   * [Port](#port)
   * [Port Channel](#port-channel)
   * [Portchannel member](#portchannel-member)
+  * [SAG](#sag)
   * [Scheduler](#scheduler)
   * [Port QoS Map](#port-qos-map)
   * [Queue](#queue)
@@ -83,7 +85,6 @@
   * [Versions](#versions)
   * [VLAN](#vlan)
   * [VLAN_MEMBER](#vlan_member)
-  * [SAG](#sag)
   * [VNET](#vnet)
   * [VNET_ROUTE](#vnet_route)
   * [VNET_ROUTE_TUNNEL](#vnet_route_tunnel)
@@ -1263,6 +1264,33 @@ IPV4 DHPC Server related configuration are defined in **DHCP_SERVER_IPV4**, **DH
 
 ```
 
+### EVPN
+
+The EVPN tables configure Ethernet Segment entries and global EVPN multihoming timers.
+
+The **EVPN_ETHERNET_SEGMENT** table is keyed by a physical port or PortChannel name. Each entry defines the ESI type, the ESI value, and an optional DF preference. Type 0 entries require an operator-configured ESI in canonical ten-octet hexadecimal format, while non-Type 0 entries use `AUTO`.
+
+The **EVPN_MH_GLOBAL** table has a single `default` entry for device-wide EVPN multihoming timers, including `startup_delay`, `mac_holdtime`, and `neigh_holdtime`.
+
+```json
+{
+    "EVPN_ETHERNET_SEGMENT": {
+        "Ethernet120": {
+            "type": "TYPE_0_OPERATOR_CONFIGURED",
+            "esi": "00:01:02:03:04:05:06:07:08:FF",
+            "df_pref": "12012"
+        }
+    },
+    "EVPN_MH_GLOBAL": {
+        "default": {
+            "startup_delay": "1800",
+            "mac_holdtime": "1000",
+            "neigh_holdtime": "600"
+        }
+    }
+}
+```
+
 ### FG_NHG
 
 The FG_NHG table provides information on Next Hop Groups, including a specified Hash Bucket Size (bucket_size), match mode for each group, an optional max-next-hops attribute for prefix_based match_ mode.
@@ -1590,6 +1618,8 @@ These tables have a number of shared attributes as described below:
  * `mac_addr`: Assign administrator-provided MAC address to Interface.  If not specified will use the system MAC (same for all interfaces). Not applicable to `VLAN_SUB_INTERFACE` as it will use the parent interface's mac address.
  * `loopback_action`: Packet action when a packet ingress and gets routed on the same IP interface. `drop` or `forward`.
 
+`VLAN_INTERFACE` entries also support `static_anycast_gateway`, which enables or disables use of the global SAG MAC on the VLAN interface. Valid values are `true` and `false`; the default is `false`.
+
 
 ```json
 
@@ -1606,7 +1636,8 @@ These tables have a number of shared attributes as described below:
     "VLAN_INTERFACE": {
         "Vlan201": {
             "vrf_name": "red",
-            "mac_addr": "AB:CD:EF:12:34:56"
+            "mac_addr": "AB:CD:EF:12:34:56",
+            "static_anycast_gateway": "true"
         }
     },
     "PORTCHANNEL_INTERFACE": {
@@ -2209,11 +2240,14 @@ name as object key and member list as attribute.
         ],
         "mtu": "9100",
         "fallback": "false",
-        "fast_rate": "true"
+        "fast_rate": "true",
+        "system_mac": "aa:bb:cc:dd:ee:ff"
     }
   }
 }
 ```
+
+The optional **system_mac** field overrides the LACP actor system MAC for the PortChannel. When unset, the device system MAC is used. EVPN multihoming deployments can set this field when peer devices must advertise a shared LACP system identifier.
 
 
 ### Portchannel member
@@ -2229,6 +2263,20 @@ name as object key and member list as attribute.
 }
 
 ```
+
+### SAG
+The SAG table defines the global MAC address configuration for static-anycast-gateway.
+```
+{
+
+"SAG": {
+    "GLOBAL": {
+        "gateway_mac": "00:11:22:33:44:55"
+    }
+  }
+}
+```
+
 ### Scheduler
 
 ```
@@ -2779,19 +2827,6 @@ channel name as object key, and tagging mode as attributes.
 	},
 	"Vlan2000|PortChannel47": {
 		"tagging_mode": "tagged"
-	}
-  }
-}
-```
-
-### SAG
-The SAG table defines the global mac address configuration for static-anycast-gateway.
-```
-{
-
-"SAG": {
-	"GLOBAL": {
-		"gateway_mac": "00:11:22:33:44:55"
 	}
   }
 }

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -83,6 +83,7 @@
   * [Versions](#versions)
   * [VLAN](#vlan)
   * [VLAN_MEMBER](#vlan_member)
+  * [SAG](#sag)
   * [VNET](#vnet)
   * [VNET_ROUTE](#vnet_route)
   * [VNET_ROUTE_TUNNEL](#vnet_route_tunnel)
@@ -2778,6 +2779,19 @@ channel name as object key, and tagging mode as attributes.
 	},
 	"Vlan2000|PortChannel47": {
 		"tagging_mode": "tagged"
+	}
+  }
+}
+```
+
+### SAG
+The SAG table defines the global mac address configureation for static-anycast-gateway. 
+```
+{
+
+"SAG": {
+	"GLOBAL": {
+		"gateway_mac": "00:11:22:33:44:55"
 	}
   }
 }

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -2785,7 +2785,7 @@ channel name as object key, and tagging mode as attributes.
 ```
 
 ### SAG
-The SAG table defines the global mac address configureation for static-anycast-gateway.
+The SAG table defines the global mac address configuration for static-anycast-gateway.
 ```
 {
 

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -99,7 +99,7 @@
   * [SYSTEM_DEFAULTS table](#systemdefaults-table)
   * [RADIUS](#radius)
   * [Static DNS](#static-dns)
-  * [ASIC_SENSORS](#asic_sensors)  
+  * [ASIC_SENSORS](#asic_sensors)
   * [SRv6](#srv6)
   * [DPU](#dpu-configuration)
   * [REMOTE_DPU](#remote_dpu-configuration)
@@ -461,7 +461,7 @@ ASIC/SDK health event related configuration is defined in **SUPPRESS_ASIC_SDK_HE
 
 ### BGP Device Global
 
-The **BGP_DEVICE_GLOBAL** table contains device-level BGP global state.  
+The **BGP_DEVICE_GLOBAL** table contains device-level BGP global state.
 It has a STATE object containing device state like **tsa_enabled**, **wcmp_enabled** and **idf_isolation_state**.
 
 When **tsa_enabled** is set to true, the device is isolated using traffic-shift-away (TSA) route-maps in BGP.
@@ -475,7 +475,7 @@ When **tsa_enabled** is set to true, the device is isolated using traffic-shift-
 }
 ```
 
-When **wcmp_enabled** is set to true, the device is configured to use BGP Link Bandwidth Extended Community.  
+When **wcmp_enabled** is set to true, the device is configured to use BGP Link Bandwidth Extended Community.
 Weighted ECMP load balances traffic between the equal cost paths in proportion to the capacity of the local links.
 
 ```json
@@ -498,8 +498,8 @@ The IDF isolation state **idf_isolation_state** could be one of isolated_no_expo
 }
 ```
 
-The **CONFED** object contains BGP confederation configuration for disaggregated T2 devices (LowerSpineRouter, UpperSpineRouter, FabricSpineRouter).  
-**asn** is the confederation identifier (the ASN visible to external peers).  
+The **CONFED** object contains BGP confederation configuration for disaggregated T2 devices (LowerSpineRouter, UpperSpineRouter, FabricSpineRouter).
+**asn** is the confederation identifier (the ASN visible to external peers).
 **peers** is a semicolon-separated list of sub-AS numbers that are members of the confederation.
 
 ```json
@@ -1286,7 +1286,7 @@ The FG_NHG table provides information on Next Hop Groups, including a specified 
         "bucket_size": "120",
         "match_mode": "prefix-based",
         "max_next_hops": "6"
-    }    
+    }
 }
 ```
 
@@ -1326,7 +1326,7 @@ The FG_NHG_PREFIX table provides the FG_NHG_PREFIX for which FG behavior is desi
     },
     "fd:06::/128": {
         "FG_NHG": "dynamic_fgnhg_v6"
-	}    
+	}
 }
 ```
 
@@ -1695,7 +1695,7 @@ lossless traffic for dynamic buffer calculation
 ```
 
 ### Memory Statistics
-The memory statistics configuration is stored in the **MEMORY_STATISTICS** table. This table is used by the memory statistics daemon to manage memory monitoring settings. The configuration allows enabling or disabling memory collection, specifying how frequently memory statistics are sampled, and defining how long the memory data is retained. 
+The memory statistics configuration is stored in the **MEMORY_STATISTICS** table. This table is used by the memory statistics daemon to manage memory monitoring settings. The configuration allows enabling or disabling memory collection, specifying how frequently memory statistics are sampled, and defining how long the memory data is retained.
 
 ```
 {
@@ -2680,11 +2680,11 @@ example mux tunnel configuration for when tunnel_qos_remap is enabled
 
 When the lossy queue exceeds a buffer threshold, it drops packets without any notification to the destination host.
 
-When a packet is lost, it can be recovered through fast retransmission or by using timeouts.  
+When a packet is lost, it can be recovered through fast retransmission or by using timeouts.
 Retransmission triggered by timeouts typically incurs significant latency.
 
-To help the host recover data more quickly and accurately, packet trimming is introduced.  
-This feature upon a failed packet admission to a shared buffer, will trim a packet to a configured size,  
+To help the host recover data more quickly and accurately, packet trimming is introduced.
+This feature upon a failed packet admission to a shared buffer, will trim a packet to a configured size,
 and try sending it on a different queue to deliver a packet drop notification to an end host.
 
 ***TRIMMING***
@@ -2785,7 +2785,7 @@ channel name as object key, and tagging mode as attributes.
 ```
 
 ### SAG
-The SAG table defines the global mac address configureation for static-anycast-gateway. 
+The SAG table defines the global mac address configureation for static-anycast-gateway.
 ```
 {
 
@@ -3531,7 +3531,7 @@ The **VDPU** table introduces the configuration for the VDPUs (Virtual Data Proc
 The **DASH_HA_GLOBAL_CONFIG** table introduces the configuration for the DASH High Availability global settings available on the platform.
 Like NTP global configuration, DASH HA global configuration must have one entry with the key "global".
 
-`vnet_name` will be deprecated with the introduction of `dpu_vnet`. 
+`vnet_name` will be deprecated with the introduction of `dpu_vnet`.
 
 ```json
 {

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -128,6 +128,7 @@ yang_files = [
     'sonic-events-host.yang',
     'sonic-events-swss.yang',
     'sonic-events-syncd.yang',
+    'sonic-evpn.yang',
     'sonic-exp-fc-map.yang',
     'sonic-extension.yang',
     'sonic-fabric-monitor.yang',

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -187,6 +187,7 @@ yang_files = [
     'sonic-spanning-tree.yang',
     'sonic-srv6.yang',
     'sonic-ssh-server.yang',
+    'sonic-static-anycast-gateway.yang',
     'sonic-static-route.yang',
     'sonic-storm-control.yang',
     'sonic-stormond-config.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -108,7 +108,8 @@
                 "tpid": "0x8100",
                 "mtu": "9100",
                 "lacp_key": "auto",
-                "mode":"trunk"
+                "mode":"trunk",
+                "system_mac": "02:26:9b:73:c1:1a"
             },
             "PortChannel0004": {
                 "admin_status": "up",
@@ -133,7 +134,8 @@
                 "tpid": "0x8100",
                 "fast_rate": "false",
                 "fallback" : "true",
-                "mode":"routed"
+                "mode":"routed",
+                "system_mac": "aa:bb:cc:dd:ee:ff"
             }
         },
         "PORTCHANNEL_INTERFACE": {

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -159,7 +159,7 @@
         "VLAN_INTERFACE": {
             "Vlan111": {
                 "nat_zone": "0",
-                "static_anycast_gateway": true,
+                "static_anycast_gateway": "true",
                 "loopback_action": "forward",
                 "ipv6_use_link_local_only": "disable",
                 "mac_addr": "02:ab:cd:ef:12:34"

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -159,6 +159,7 @@
         "VLAN_INTERFACE": {
             "Vlan111": {
                 "nat_zone": "0",
+                "static_anycast_gateway": "true",
                 "loopback_action": "forward",
                 "ipv6_use_link_local_only": "disable",
                 "mac_addr": "02:ab:cd:ef:12:34"
@@ -2270,6 +2271,11 @@
                 "ranges": [
                     "range1"
                 ]
+            }
+        },
+        "SAG": {
+            "GLOBAL": {
+                "gateway_mac": "00:11:22:33:44:55"
             }
         },
         "SCHEDULER": {

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1245,6 +1245,7 @@
             }
         },
         "INTERFACE": {
+            "Ethernet120": {},
             "Ethernet112": {},
             "Ethernet14": {},
             "Ethernet16": {},
@@ -3258,6 +3259,20 @@
                 "polling_time": "10",
                 "guard_time": "2",
                 "ber_threshold": "12"
+            }
+        },
+        "EVPN_ETHERNET_SEGMENT": {
+            "Ethernet120": {
+                "type": "TYPE_0_OPERATOR_CONFIGURED",
+                "esi": "00:01:02:03:04:05:06:07:08:FF",
+                "df_pref": "12012"
+            }
+        },
+        "EVPN_MH_GLOBAL": {
+            "default" : {
+                "startup_delay": "1800",
+                "mac_holdtime": "1000",
+                "neigh_holdtime": "600"
             }
         }
     },

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -159,7 +159,7 @@
         "VLAN_INTERFACE": {
             "Vlan111": {
                 "nat_zone": "0",
-                "static_anycast_gateway": "true",
+                "static_anycast_gateway": true,
                 "loopback_action": "forward",
                 "ipv6_use_link_local_only": "disable",
                 "mac_addr": "02:ab:cd:ef:12:34"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/evpn.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/evpn.json
@@ -2,6 +2,9 @@
     "EVPN_ES_VALID_TEST": {
         "desc": "Valid EVPN Ethernet Segment Configuration"
     },
+    "EVPN_PORTCHANNEL_VALID_TEST": {
+        "desc": "Valid EVPN Ethernet Segment Configuration with PortChannel interfaces"
+    },
     "EVPN_INVALID_AUTO_W_ESI_0": {
         "desc": "Invalid Type 0 ES Configuration w/ AUTO ESI",
         "eStr": "Invalid use of 'AUTO' with Type 0 ESI or a manual ESI w/ AUTO type in not empty"
@@ -40,5 +43,15 @@
     "EVPN_INVALID_NEIGH_HOLDTIME": {
         "desc": "Global Neighbor Holdtime value out of range",
         "eStr": "Neighbor Holdtime value out of range"
+    },
+    "EVPN_INVALID_IFNAME_NOT_EXISTS": {
+        "desc": "Invalid ifname that doesn't exist in PORT table",
+        "eStrKey" : "InvalidValue",
+        "eStr": ["Ethernet99"]
+    },
+    "EVPN_INVALID_PORTCHANNEL_NOT_EXISTS": {
+        "desc": "Invalid ifname that doesn't exist in PORTCHANNEL table",
+        "eStrKey" : "InvalidValue",
+        "eStr": ["PortChannel0099"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/evpn.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/evpn.json
@@ -1,0 +1,44 @@
+{
+    "EVPN_ES_VALID_TEST": {
+        "desc": "Valid EVPN Ethernet Segment Configuration"
+    },
+    "EVPN_INVALID_AUTO_W_ESI_0": {
+        "desc": "Invalid Type 0 ES Configuration w/ AUTO ESI",
+        "eStr": "Invalid use of 'AUTO' with Type 0 ESI or a manual ESI w/ AUTO type in not empty"
+    },
+    "EVPN_INVALID_TYPE_3_W_MANUAL_ESI": {
+        "desc": "Invalid Type 3 ES Configuration w/ Manual ESI",
+        "eStr": "Invalid use of 'AUTO' with Type 0 ESI or a manual ESI w/ AUTO type in not empty"
+    },
+    "EVPN_INVALID_TYPE_0_ESI_LENGTH": {
+        "desc": "Type 0 Manual ESI with invalid length string",
+        "eStr": "Provided ESI is not valid"
+    },
+    "EVPN_INVALID_TYPE_0_ESI_BYTE": {
+        "desc": "Type 0 Manual ESI with an invalid byte",
+        "eStr": "Provided ESI is not valid"
+    },
+    "EVPN_INVALID_TYPE_0_ESI_BYTE_RANGE": {
+        "desc": "Type 0 Manual ESI with a byte out of range 0-0xFF",
+        "eStr": "Provided ESI is not valid"
+    },
+    "EVPN_INVALID_DF_PREF": {
+        "desc": "ES DF Preference value out of range",
+        "eStr": "Invalid value \"12341234\" in \"df_pref\" element"
+    },
+    "EVPN_MH_VALID_TEST": {
+        "desc": "Valid EVPN Ethernet Segment Configuration"
+    },
+    "EVPN_INVALID_STARTUP_DELAY": {
+        "desc": "Global Startup Delay value out of range",
+        "eStr": "Startup Delay value out of range"
+    },
+    "EVPN_INVALID_MAC_HOLDTIME": {
+        "desc": "Global MAC Holdtime value out of range",
+        "eStr": "MAC Holdtime value out of range"
+    },
+    "EVPN_INVALID_NEIGH_HOLDTIME": {
+        "desc": "Global Neighbor Holdtime value out of range",
+        "eStr": "Neighbor Holdtime value out of range"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/evpn.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/evpn.json
@@ -29,6 +29,10 @@
         "desc": "Type 0 Manual ESI with an invalid type prefix",
         "eStr": "Invalid ESI/type combination: Type 0 requires manual '00:' ESI; non-Type 0 requires AUTO ESI"
     },
+    "EVPN_INVALID_RESERVED_ESI_ZERO": {
+        "desc": "Type 0 Manual ESI with reserved all-zero ESI",
+        "eStr": "Reserved all-zero ESI is not allowed"
+    },
     "EVPN_INVALID_DF_PREF": {
         "desc": "ES DF Preference value out of range",
         "eStr": "Invalid value \"12341234\" in \"df_pref\" element"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/evpn.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/evpn.json
@@ -7,11 +7,11 @@
     },
     "EVPN_INVALID_AUTO_W_ESI_0": {
         "desc": "Invalid Type 0 ES Configuration w/ AUTO ESI",
-        "eStr": "Invalid use of 'AUTO' with Type 0 ESI or a manual ESI w/ AUTO type"
+        "eStr": "Invalid ESI/type combination: Type 0 requires manual '00:' ESI; non-Type 0 requires AUTO ESI"
     },
     "EVPN_INVALID_TYPE_3_W_MANUAL_ESI": {
         "desc": "Invalid Type 3 ES Configuration w/ Manual ESI",
-        "eStr": "Invalid use of 'AUTO' with Type 0 ESI or a manual ESI w/ AUTO type"
+        "eStr": "Invalid ESI/type combination: Type 0 requires manual '00:' ESI; non-Type 0 requires AUTO ESI"
     },
     "EVPN_INVALID_TYPE_0_ESI_LENGTH": {
         "desc": "Type 0 Manual ESI with invalid length string",
@@ -24,6 +24,10 @@
     "EVPN_INVALID_TYPE_0_ESI_BYTE_RANGE": {
         "desc": "Type 0 Manual ESI with a byte out of range 0-0xFF",
         "eStr": "Provided ESI is not valid"
+    },
+    "EVPN_INVALID_TYPE_0_ESI_PREFIX": {
+        "desc": "Type 0 Manual ESI with an invalid type prefix",
+        "eStr": "Invalid ESI/type combination: Type 0 requires manual '00:' ESI; non-Type 0 requires AUTO ESI"
     },
     "EVPN_INVALID_DF_PREF": {
         "desc": "ES DF Preference value out of range",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/evpn.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/evpn.json
@@ -7,11 +7,11 @@
     },
     "EVPN_INVALID_AUTO_W_ESI_0": {
         "desc": "Invalid Type 0 ES Configuration w/ AUTO ESI",
-        "eStr": "Invalid use of 'AUTO' with Type 0 ESI or a manual ESI w/ AUTO type in not empty"
+        "eStr": "Invalid use of 'AUTO' with Type 0 ESI or a manual ESI w/ AUTO type"
     },
     "EVPN_INVALID_TYPE_3_W_MANUAL_ESI": {
         "desc": "Invalid Type 3 ES Configuration w/ Manual ESI",
-        "eStr": "Invalid use of 'AUTO' with Type 0 ESI or a manual ESI w/ AUTO type in not empty"
+        "eStr": "Invalid use of 'AUTO' with Type 0 ESI or a manual ESI w/ AUTO type"
     },
     "EVPN_INVALID_TYPE_0_ESI_LENGTH": {
         "desc": "Type 0 Manual ESI with invalid length string",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
@@ -93,5 +93,15 @@
     "PORTCHANNEL_INTERFACE_INVALID_MAC_ADDR": {
         "desc": "Set invalid interface mac address.",
         "eStrKey": "Pattern"
+    },
+    "PORTCHANNEL_SYSTEM_MAC_VALID": {
+        "desc": "Configure valid LACP system MAC address."
+    },
+    "PORTCHANNEL_SYSTEM_MAC_UPPERCASE": {
+        "desc": "Configure LACP system MAC address with uppercase characters."
+    },
+    "PORTCHANNEL_SYSTEM_MAC_INVALID": {
+        "desc": "Configure invalid LACP system MAC address.",
+        "eStrKey": "Pattern"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/static_anycast_gateway.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/static_anycast_gateway.json
@@ -1,0 +1,9 @@
+{
+    "SAG_GLOBAL_MAC_TEST": {
+        "desc": "Configure a entry in SAG table."
+    },
+    "SAG_GLOBAL_WITH_INVALID_MAC_TEST": {
+        "desc": "Configure a invalid MAC address format in SAG table.",
+        "eStrKey" : "Pattern"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/static_anycast_gateway.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/static_anycast_gateway.json
@@ -5,5 +5,9 @@
     "SAG_GLOBAL_WITH_INVALID_MAC_TEST": {
         "desc": "Configure an invalid MAC address format in SAG table.",
         "eStrKey" : "Pattern"
+    },
+    "SAG_INVALID_NAME_TEST": {
+        "desc": "Configure SAG with an invalid singleton name.",
+        "eStr": "SAG entry name must be GLOBAL"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/static_anycast_gateway.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/static_anycast_gateway.json
@@ -1,9 +1,9 @@
 {
     "SAG_GLOBAL_MAC_TEST": {
-        "desc": "Configure a entry in SAG table."
+        "desc": "Configure an entry in SAG table."
     },
     "SAG_GLOBAL_WITH_INVALID_MAC_TEST": {
-        "desc": "Configure a invalid MAC address format in SAG table.",
+        "desc": "Configure an invalid MAC address format in SAG table.",
         "eStrKey" : "Pattern"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
@@ -55,6 +55,13 @@
     "VLAN_INTERFACE_VALID_NAT_ZONE_RANGE": {
         "desc": "Configure valid value for nat zone."
     },
+    "VLAN_INTERFACE_VALID_STATIC_ANYCAST_GATEWAY": {
+        "desc": "Configure valid value for static anycast gateway"
+    },
+    "VLAN_INTERFACE_INVALID_STATIC_ANYCAST_GATEWAY": {
+        "desc": "Configure invalid value for static anycast gateway",
+        "eStrKey": "InvalidValue"
+    },
     "DHCP_SERVER_VALID_FORMAT": {
         "desc": "Add dhcp_server in correct format."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
@@ -60,7 +60,7 @@
     },
     "VLAN_INTERFACE_INVALID_STATIC_ANYCAST_GATEWAY": {
         "desc": "Configure invalid value for static anycast gateway",
-        "eStrKey": "InvalidValue"
+        "eStrKey": "Pattern"
     },
     "DHCP_SERVER_VALID_FORMAT": {
         "desc": "Add dhcp_server in correct format."

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
@@ -58,6 +58,10 @@
     "VLAN_INTERFACE_VALID_STATIC_ANYCAST_GATEWAY": {
         "desc": "Configure valid value for static anycast gateway"
     },
+    "VLAN_INTERFACE_INVALID_STATIC_ANYCAST_GATEWAY_MISSING_SAG": {
+        "desc": "Configure static anycast gateway without SAG GLOBAL gateway_mac",
+        "eStr": ["static_anycast_gateway requires SAG GLOBAL gateway_mac to be configured"]
+    },
     "VLAN_INTERFACE_INVALID_STATIC_ANYCAST_GATEWAY": {
         "desc": "Configure invalid value for static anycast gateway",
         "eStrKey": "Pattern"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/evpn.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/evpn.json
@@ -16,18 +16,6 @@
                 ]
             }
         },
-        "sonic-interface:sonic-interface": {
-            "sonic-interface:INTERFACE": {
-                "INTERFACE_LIST": [
-                    {
-                        "name": "Ethernet10"
-                    },
-                    {
-                        "name": "Ethernet11"
-                    }
-                ]
-            }
-        },
         "sonic-evpn:sonic-evpn": {
             "sonic-evpn:EVPN_ETHERNET_SEGMENT": {
                 "EVPN_ETHERNET_SEGMENT_LIST": [
@@ -40,6 +28,45 @@
                     {
                         "ifname": "Ethernet11",
                         "esi": "00:01:02:03:04:05:06:07:08:FF",
+                        "type": "TYPE_0_OPERATOR_CONFIGURED"
+                    }
+                ]
+            }
+        }
+    },
+    "EVPN_PORTCHANNEL_VALID_TEST": {
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "name": "PortChannel0001",
+                        "admin_status": "up",
+                        "min_links": "1",
+                        "mtu": "9100",
+                        "mode": "routed"
+                    },
+                    {
+                        "name": "PortChannel0002",
+                        "admin_status": "up",
+                        "min_links": "2",
+                        "mtu": "9100",
+                        "mode": "trunk"
+                    }
+                ]
+            }
+        },
+        "sonic-evpn:sonic-evpn": {
+            "sonic-evpn:EVPN_ETHERNET_SEGMENT": {
+                "EVPN_ETHERNET_SEGMENT_LIST": [
+                    {
+                        "ifname": "PortChannel0001",
+                        "esi": "AUTO",
+                        "type": "TYPE_3_MAC_BASED",
+                        "df_pref": 5000
+                    },
+                    {
+                        "ifname": "PortChannel0002",
+                        "esi": "00:01:02:03:04:05:06:07:08:AA",
                         "type": "TYPE_0_OPERATOR_CONFIGURED"
                     }
                 ]
@@ -322,6 +349,56 @@
                         "startup_delay": 1800,
                         "mac_holdtime": 1000,
                         "neigh_holdtime": 86401
+                    }
+                ]
+            }
+        }
+    },
+    "EVPN_INVALID_IFNAME_NOT_EXISTS": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet10",
+                        "lanes": "1,2,3,4",
+                        "speed": 10000
+                    }
+                ]
+            }
+        },
+        "sonic-evpn:sonic-evpn": {
+            "sonic-evpn:EVPN_ETHERNET_SEGMENT": {
+                "EVPN_ETHERNET_SEGMENT_LIST": [
+                    {
+                        "ifname": "Ethernet99",
+                        "esi": "00:01:02:03:04:05:06:07:08:FF",
+                        "type": "TYPE_0_OPERATOR_CONFIGURED"
+                    }
+                ]
+            }
+        }
+    },
+    "EVPN_INVALID_PORTCHANNEL_NOT_EXISTS": {
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "name": "PortChannel0001",
+                        "admin_status": "up",
+                        "min_links": "1",
+                        "mtu": "9100",
+                        "mode": "routed"
+                    }
+                ]
+            }
+        },
+        "sonic-evpn:sonic-evpn": {
+            "sonic-evpn:EVPN_ETHERNET_SEGMENT": {
+                "EVPN_ETHERNET_SEGMENT_LIST": [
+                    {
+                        "ifname": "PortChannel0099",
+                        "esi": "00:01:02:03:04:05:06:07:08:FF",
+                        "type": "TYPE_0_OPERATOR_CONFIGURED"
                     }
                 ]
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/evpn.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/evpn.json
@@ -1,0 +1,330 @@
+{
+    "EVPN_ES_VALID_TEST": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet10",
+                        "lanes": "1,2,3,4",
+                        "speed": 1000
+                    },
+                    {
+                        "name": "Ethernet11",
+                        "lanes": "5,6,7,8",
+                        "speed": 1000
+                    }
+                ]
+            }
+        },
+        "sonic-interface:sonic-interface": {
+            "sonic-interface:INTERFACE": {
+                "INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet10"
+                    },
+                    {
+                        "name": "Ethernet11"
+                    }
+                ]
+            }
+        },
+        "sonic-evpn:sonic-evpn": {
+            "sonic-evpn:EVPN_ETHERNET_SEGMENT": {
+                "EVPN_ETHERNET_SEGMENT_LIST": [
+                    {
+                        "ifname": "Ethernet10",
+                        "esi": "AUTO",
+                        "type": "TYPE_3_MAC_BASED",
+                        "df_pref": 12345
+                    },
+                    {
+                        "ifname": "Ethernet11",
+                        "esi": "00:01:02:03:04:05:06:07:08:FF",
+                        "type": "TYPE_0_OPERATOR_CONFIGURED"
+                    }
+                ]
+            }
+        }
+    },
+    "EVPN_INVALID_AUTO_W_ESI_0": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet10",
+                        "lanes": "1,2,3,4",
+                        "speed": 1000
+                    },
+                    {
+                        "name": "Ethernet11",
+                        "lanes": "5,6,7,8",
+                        "speed": 1000
+                    }
+                ]
+            }
+        },
+        "sonic-interface:sonic-interface": {
+            "sonic-interface:INTERFACE": {
+                "INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet10"
+                    },
+                    {
+                        "name": "Ethernet11"
+                    }
+                ]
+            }
+        },
+        "sonic-evpn:sonic-evpn": {
+            "sonic-evpn:EVPN_ETHERNET_SEGMENT": {
+                "EVPN_ETHERNET_SEGMENT_LIST": [
+                    {
+                        "ifname": "Ethernet10",
+                        "esi": "AUTO",
+                        "type": "TYPE_3_MAC_BASED"
+                    },
+                    {
+                        "ifname": "Ethernet11",
+                        "esi": "AUTO",
+                        "type": "TYPE_0_OPERATOR_CONFIGURED"
+                    }
+                ]
+            }
+        }
+    },
+    "EVPN_INVALID_TYPE_3_W_MANUAL_ESI": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet10",
+                        "lanes": "1,2,3,4",
+                        "speed": 1000
+                    },
+                    {
+                        "name": "Ethernet11",
+                        "lanes": "5,6,7,8",
+                        "speed": 1000
+                    }
+                ]
+            }
+        },
+        "sonic-interface:sonic-interface": {
+            "sonic-interface:INTERFACE": {
+                "INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet10"
+                    },
+                    {
+                        "name": "Ethernet11"
+                    }
+                ]
+            }
+        },
+        "sonic-evpn:sonic-evpn": {
+            "sonic-evpn:EVPN_ETHERNET_SEGMENT": {
+                "EVPN_ETHERNET_SEGMENT_LIST": [
+                    {
+                        "ifname": "Ethernet10",
+                        "esi": "00:01:02:03:04:05:06:07:08:AA",
+                        "type": "TYPE_3_MAC_BASED"
+                    },
+                    {
+                        "ifname": "Ethernet11",
+                        "esi": "00:01:02:03:04:05:06:07:08:FF",
+                        "type": "TYPE_0_OPERATOR_CONFIGURED"
+                    }
+                ]
+            }
+        }
+    },
+    "EVPN_INVALID_TYPE_0_ESI_LENGTH": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet10",
+                        "lanes": "1,2,3,4",
+                        "speed": 1000
+                    }
+                ]
+            }
+        },
+        "sonic-interface:sonic-interface": {
+            "sonic-interface:INTERFACE": {
+                "INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet10"
+                    }
+                ]
+            }
+        },
+        "sonic-evpn:sonic-evpn": {
+            "sonic-evpn:EVPN_ETHERNET_SEGMENT": {
+                "EVPN_ETHERNET_SEGMENT_LIST": [
+                    {
+                        "ifname": "Ethernet10",
+                        "esi": "00:01:02:03:04:05",
+                        "type": "TYPE_0_OPERATOR_CONFIGURED"
+                    }
+                ]
+            }
+        }
+    },
+    "EVPN_INVALID_TYPE_0_ESI_BYTE": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet10",
+                        "lanes": "1,2,3,4",
+                        "speed": 1000
+                    }
+                ]
+            }
+        },
+        "sonic-interface:sonic-interface": {
+            "sonic-interface:INTERFACE": {
+                "INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet10"
+                    }
+                ]
+            }
+        },
+        "sonic-evpn:sonic-evpn": {
+            "sonic-evpn:EVPN_ETHERNET_SEGMENT": {
+                "EVPN_ETHERNET_SEGMENT_LIST": [
+                    {
+                        "ifname": "Ethernet10",
+                        "esi": "00:01:02:03:04:ZZ:06:07:08:FF",
+                        "type": "TYPE_0_OPERATOR_CONFIGURED"
+                    }
+                ]
+            }
+        }
+    },
+    "EVPN_INVALID_TYPE_0_ESI_BYTE_RANGE": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet10",
+                        "lanes": "1,2,3,4",
+                        "speed": 1000
+                    }
+                ]
+            }
+        },
+        "sonic-interface:sonic-interface": {
+            "sonic-interface:INTERFACE": {
+                "INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet10"
+                    }
+                ]
+            }
+        },
+        "sonic-evpn:sonic-evpn": {
+            "sonic-evpn:EVPN_ETHERNET_SEGMENT": {
+                "EVPN_ETHERNET_SEGMENT_LIST": [
+                    {
+                        "ifname": "Ethernet10",
+                        "esi": "00:01:02:03:04:1234:06:07:08:FF",
+                        "type": "TYPE_0_OPERATOR_CONFIGURED"
+                    }
+                ]
+            }
+        }
+    },
+    "EVPN_INVALID_DF_PREF": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet10",
+                        "lanes": "1,2,3,4",
+                        "speed": 1000
+                    }
+                ]
+            }
+        },
+        "sonic-interface:sonic-interface": {
+            "sonic-interface:INTERFACE": {
+                "INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet10"
+                    }
+                ]
+            }
+        },
+        "sonic-evpn:sonic-evpn": {
+            "sonic-evpn:EVPN_ETHERNET_SEGMENT": {
+                "EVPN_ETHERNET_SEGMENT_LIST": [
+                    {
+                        "ifname": "Ethernet10",
+                        "esi": "00:01:02:03:04:12:06:07:08:FF",
+                        "type": "TYPE_0_OPERATOR_CONFIGURED",
+                        "df_pref": 12341234
+                    }
+                ]
+            }
+        }
+    },
+    "EVPN_MH_VALID_TEST": {
+        "sonic-evpn:sonic-evpn": {
+            "sonic-evpn:EVPN_MH_GLOBAL": {
+                "EVPN_MH_GLOBAL_LIST": [
+                    {
+                        "default_key": "default",
+                        "startup_delay": 1800,
+                        "mac_holdtime": 1000,
+                        "neigh_holdtime": 600
+                    }
+                ]
+            }
+        }
+    },
+    "EVPN_INVALID_STARTUP_DELAY": {
+        "sonic-evpn:sonic-evpn": {
+            "sonic-evpn:EVPN_MH_GLOBAL": {
+                "EVPN_MH_GLOBAL_LIST": [
+                    {
+                        "default_key": "default",
+                        "startup_delay": 3601,
+                        "mac_holdtime": 1000,
+                        "neigh_holdtime": 600
+                    }
+                ]
+            }
+        }
+    },
+    "EVPN_INVALID_MAC_HOLDTIME": {
+        "sonic-evpn:sonic-evpn": {
+            "sonic-evpn:EVPN_MH_GLOBAL": {
+                "EVPN_MH_GLOBAL_LIST": [
+                    {
+                        "default_key": "default",
+                        "startup_delay": 1800,
+                        "mac_holdtime": 86401,
+                        "neigh_holdtime": 600
+                    }
+                ]
+            }
+        }
+    },
+    "EVPN_INVALID_NEIGH_HOLDTIME": {
+        "sonic-evpn:sonic-evpn": {
+            "sonic-evpn:EVPN_MH_GLOBAL": {
+                "EVPN_MH_GLOBAL_LIST": [
+                    {
+                        "default_key": "default",
+                        "startup_delay": 1800,
+                        "mac_holdtime": 1000,
+                        "neigh_holdtime": 86401
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/evpn.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/evpn.json
@@ -223,7 +223,7 @@
             "sonic-evpn:EVPN_MH_GLOBAL": {
                 "EVPN_MH_GLOBAL_LIST": [
                     {
-                        "default_key": "default",
+                        "name": "default",
                         "startup_delay": 1800,
                         "mac_holdtime": 1000,
                         "neigh_holdtime": 600
@@ -237,7 +237,7 @@
             "sonic-evpn:EVPN_MH_GLOBAL": {
                 "EVPN_MH_GLOBAL_LIST": [
                     {
-                        "default_key": "default",
+                        "name": "default",
                         "startup_delay": 3601,
                         "mac_holdtime": 1000,
                         "neigh_holdtime": 600
@@ -251,7 +251,7 @@
             "sonic-evpn:EVPN_MH_GLOBAL": {
                 "EVPN_MH_GLOBAL_LIST": [
                     {
-                        "default_key": "default",
+                        "name": "default",
                         "startup_delay": 1800,
                         "mac_holdtime": 86401,
                         "neigh_holdtime": 600
@@ -265,7 +265,7 @@
             "sonic-evpn:EVPN_MH_GLOBAL": {
                 "EVPN_MH_GLOBAL_LIST": [
                     {
-                        "default_key": "default",
+                        "name": "default",
                         "startup_delay": 1800,
                         "mac_holdtime": 1000,
                         "neigh_holdtime": 86401

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/evpn.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/evpn.json
@@ -78,11 +78,6 @@
             "sonic-port:PORT": {
                 "PORT_LIST": [
                     {
-                        "name": "Ethernet10",
-                        "lanes": "1,2,3,4",
-                        "speed": 1000
-                    },
-                    {
                         "name": "Ethernet11",
                         "lanes": "5,6,7,8",
                         "speed": 1000
@@ -93,11 +88,6 @@
         "sonic-evpn:sonic-evpn": {
             "sonic-evpn:EVPN_ETHERNET_SEGMENT": {
                 "EVPN_ETHERNET_SEGMENT_LIST": [
-                    {
-                        "ifname": "Ethernet10",
-                        "esi": "AUTO",
-                        "type": "TYPE_3_MAC_BASED"
-                    },
                     {
                         "ifname": "Ethernet11",
                         "esi": "AUTO",
@@ -115,11 +105,6 @@
                         "name": "Ethernet10",
                         "lanes": "1,2,3,4",
                         "speed": 1000
-                    },
-                    {
-                        "name": "Ethernet11",
-                        "lanes": "5,6,7,8",
-                        "speed": 1000
                     }
                 ]
             }
@@ -131,11 +116,6 @@
                         "ifname": "Ethernet10",
                         "esi": "00:01:02:03:04:05:06:07:08:AA",
                         "type": "TYPE_3_MAC_BASED"
-                    },
-                    {
-                        "ifname": "Ethernet11",
-                        "esi": "00:01:02:03:04:05:06:07:08:FF",
-                        "type": "TYPE_0_OPERATOR_CONFIGURED"
                     }
                 ]
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/evpn.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/evpn.json
@@ -90,18 +90,6 @@
                 ]
             }
         },
-        "sonic-interface:sonic-interface": {
-            "sonic-interface:INTERFACE": {
-                "INTERFACE_LIST": [
-                    {
-                        "name": "Ethernet10"
-                    },
-                    {
-                        "name": "Ethernet11"
-                    }
-                ]
-            }
-        },
         "sonic-evpn:sonic-evpn": {
             "sonic-evpn:EVPN_ETHERNET_SEGMENT": {
                 "EVPN_ETHERNET_SEGMENT_LIST": [
@@ -136,18 +124,6 @@
                 ]
             }
         },
-        "sonic-interface:sonic-interface": {
-            "sonic-interface:INTERFACE": {
-                "INTERFACE_LIST": [
-                    {
-                        "name": "Ethernet10"
-                    },
-                    {
-                        "name": "Ethernet11"
-                    }
-                ]
-            }
-        },
         "sonic-evpn:sonic-evpn": {
             "sonic-evpn:EVPN_ETHERNET_SEGMENT": {
                 "EVPN_ETHERNET_SEGMENT_LIST": [
@@ -177,15 +153,6 @@
                 ]
             }
         },
-        "sonic-interface:sonic-interface": {
-            "sonic-interface:INTERFACE": {
-                "INTERFACE_LIST": [
-                    {
-                        "name": "Ethernet10"
-                    }
-                ]
-            }
-        },
         "sonic-evpn:sonic-evpn": {
             "sonic-evpn:EVPN_ETHERNET_SEGMENT": {
                 "EVPN_ETHERNET_SEGMENT_LIST": [
@@ -206,15 +173,6 @@
                         "name": "Ethernet10",
                         "lanes": "1,2,3,4",
                         "speed": 1000
-                    }
-                ]
-            }
-        },
-        "sonic-interface:sonic-interface": {
-            "sonic-interface:INTERFACE": {
-                "INTERFACE_LIST": [
-                    {
-                        "name": "Ethernet10"
                     }
                 ]
             }
@@ -243,15 +201,6 @@
                 ]
             }
         },
-        "sonic-interface:sonic-interface": {
-            "sonic-interface:INTERFACE": {
-                "INTERFACE_LIST": [
-                    {
-                        "name": "Ethernet10"
-                    }
-                ]
-            }
-        },
         "sonic-evpn:sonic-evpn": {
             "sonic-evpn:EVPN_ETHERNET_SEGMENT": {
                 "EVPN_ETHERNET_SEGMENT_LIST": [
@@ -272,15 +221,6 @@
                         "name": "Ethernet10",
                         "lanes": "1,2,3,4",
                         "speed": 1000
-                    }
-                ]
-            }
-        },
-        "sonic-interface:sonic-interface": {
-            "sonic-interface:INTERFACE": {
-                "INTERFACE_LIST": [
-                    {
-                        "name": "Ethernet10"
                     }
                 ]
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/evpn.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/evpn.json
@@ -217,6 +217,30 @@
             }
         }
     },
+    "EVPN_INVALID_RESERVED_ESI_ZERO": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet10",
+                        "lanes": "1,2,3,4",
+                        "speed": 1000
+                    }
+                ]
+            }
+        },
+        "sonic-evpn:sonic-evpn": {
+            "sonic-evpn:EVPN_ETHERNET_SEGMENT": {
+                "EVPN_ETHERNET_SEGMENT_LIST": [
+                    {
+                        "ifname": "Ethernet10",
+                        "esi": "00:00:00:00:00:00:00:00:00:00",
+                        "type": "TYPE_0_OPERATOR_CONFIGURED"
+                    }
+                ]
+            }
+        }
+    },
     "EVPN_INVALID_DF_PREF": {
         "sonic-port:sonic-port": {
             "sonic-port:PORT": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/evpn.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/evpn.json
@@ -193,6 +193,30 @@
             }
         }
     },
+    "EVPN_INVALID_TYPE_0_ESI_PREFIX": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet10",
+                        "lanes": "1,2,3,4",
+                        "speed": 1000
+                    }
+                ]
+            }
+        },
+        "sonic-evpn:sonic-evpn": {
+            "sonic-evpn:EVPN_ETHERNET_SEGMENT": {
+                "EVPN_ETHERNET_SEGMENT_LIST": [
+                    {
+                        "ifname": "Ethernet10",
+                        "esi": "03:01:02:03:04:05:06:07:08:FF",
+                        "type": "TYPE_0_OPERATOR_CONFIGURED"
+                    }
+                ]
+            }
+        }
+    },
     "EVPN_INVALID_DF_PREF": {
         "sonic-port:sonic-port": {
             "sonic-port:PORT": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
@@ -652,5 +652,101 @@
                 ]
             }
         }
+    },
+    "PORTCHANNEL_SYSTEM_MAC_VALID": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "speed": 25000,
+                        "mode": "routed"
+                    }
+                ]
+            }
+        },
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "min_links": "1",
+                        "mtu": "9100",
+                        "name": "PortChannel0001",
+                        "mode": "routed",
+                        "system_mac": "aa:bb:cc:dd:ee:ff"
+                    }
+                ]
+            }
+        }
+    },
+    "PORTCHANNEL_SYSTEM_MAC_UPPERCASE": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "speed": 25000,
+                        "mode": "routed"
+                    }
+                ]
+            }
+        },
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "min_links": "1",
+                        "mtu": "9100",
+                        "name": "PortChannel0001",
+                        "mode": "routed",
+                        "system_mac": "AA:BB:CC:DD:EE:FF"
+                    }
+                ]
+            }
+        }
+    },
+    "PORTCHANNEL_SYSTEM_MAC_INVALID": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "speed": 25000,
+                        "mode": "routed"
+                    }
+                ]
+            }
+        },
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "min_links": "1",
+                        "mtu": "9100",
+                        "name": "PortChannel0001",
+                        "mode": "routed",
+                        "system_mac": "invalid:mac:address"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/static_anycast_gateway.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/static_anycast_gateway.json
@@ -1,0 +1,20 @@
+{
+    "SAG_GLOBAL_MAC_TEST": {
+        "sonic-static-anycast-gateway:sonic-static-anycast-gateway": {
+            "sonic-static-anycast-gateway:SAG": {
+                "sonic-static-anycast-gateway:GLOBAL": {
+                    "gateway_mac": "00:11:22:33:44:55"
+                }
+            }
+        }
+    },
+    "SAG_GLOBAL_WITH_INVALID_MAC_TEST": {
+        "sonic-static-anycast-gateway:sonic-static-anycast-gateway": {
+            "sonic-static-anycast-gateway:SAG": {
+                "sonic-static-anycast-gateway:GLOBAL": {
+                    "gateway_mac": "001122334455"
+                }
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/static_anycast_gateway.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/static_anycast_gateway.json
@@ -22,5 +22,17 @@
                 ]
             }
         }
+    },
+    "SAG_INVALID_NAME_TEST": {
+        "sonic-static-anycast-gateway:sonic-static-anycast-gateway": {
+            "sonic-static-anycast-gateway:SAG": {
+                "SAG_LIST": [
+                    {
+                        "name": "DEFAULT",
+                        "gateway_mac": "00:11:22:33:44:55"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/static_anycast_gateway.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/static_anycast_gateway.json
@@ -2,18 +2,24 @@
     "SAG_GLOBAL_MAC_TEST": {
         "sonic-static-anycast-gateway:sonic-static-anycast-gateway": {
             "sonic-static-anycast-gateway:SAG": {
-                "sonic-static-anycast-gateway:GLOBAL": {
-                    "gateway_mac": "00:11:22:33:44:55"
-                }
+                "SAG_LIST": [
+                    {
+                        "name": "GLOBAL",
+                        "gateway_mac": "00:11:22:33:44:55"
+                    }
+                ]
             }
         }
     },
     "SAG_GLOBAL_WITH_INVALID_MAC_TEST": {
         "sonic-static-anycast-gateway:sonic-static-anycast-gateway": {
             "sonic-static-anycast-gateway:SAG": {
-                "sonic-static-anycast-gateway:GLOBAL": {
-                    "gateway_mac": "001122334455"
-                }
+                "SAG_LIST": [
+                    {
+                        "name": "GLOBAL",
+                        "gateway_mac": "001122334455"
+                    }
+                ]
             }
         }
     }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
@@ -433,6 +433,110 @@
             }
         }
     },
+    "VLAN_INTERFACE_VALID_STATIC_ANYCAST_GATEWAY": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "1",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "description": "vlan_nat",
+                        "name": "Vlan100"
+                    }
+                ]
+            },
+            "sonic-vlan:VLAN_MEMBER": {
+                "VLAN_MEMBER_LIST": [
+                    {
+                        "port": "Ethernet0",
+                        "tagging_mode": "tagged",
+                        "name": "Vlan100"
+                    }
+                ]
+            },
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "family": "IPv4",
+                        "ip-prefix": "10.0.0.1/24",
+                        "scope": "global",
+                        "name": "Vlan100"
+                    }
+                ],
+                "VLAN_INTERFACE_LIST": [
+                    {
+                         "name": "Vlan100",
+                         "static_anycast_gateway": "true"
+                    }
+                ]
+            }
+        }
+    },
+    "VLAN_INTERFACE_INVALID_STATIC_ANYCAST_GATEWAY": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "1",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "description": "vlan_nat",
+                        "name": "Vlan100"
+                    }
+                ]
+            },
+            "sonic-vlan:VLAN_MEMBER": {
+                "VLAN_MEMBER_LIST": [
+                    {
+                        "port": "Ethernet0",
+                        "tagging_mode": "tagged",
+                        "name": "Vlan100"
+                    }
+                ]
+            },
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "family": "IPv4",
+                        "ip-prefix": "10.0.0.1/24",
+                        "scope": "global",
+                        "name": "Vlan100"
+                    }
+                ],
+                "VLAN_INTERFACE_LIST": [
+                    {
+                        "name": "Vlan100",
+                        "static_anycast_gateway": "enabled"
+                    }
+                ]
+            }
+        }
+    },
     "DHCP_SERVER_VALID_FORMAT": {
         "sonic-port:sonic-port": {
             "sonic-port:PORT": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
@@ -479,7 +479,7 @@
                 "VLAN_INTERFACE_LIST": [
                     {
                          "name": "Vlan100",
-                         "static_anycast_gateway": "true"
+                         "static_anycast_gateway": true
                     }
                 ]
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
@@ -483,6 +483,68 @@
                     }
                 ]
             }
+        },
+        "sonic-static-anycast-gateway:sonic-static-anycast-gateway": {
+            "sonic-static-anycast-gateway:SAG": {
+                "SAG_LIST": [
+                    {
+                        "name": "GLOBAL",
+                        "gateway_mac": "00:11:22:33:44:55"
+                    }
+                ]
+            }
+        }
+    },
+    "VLAN_INTERFACE_INVALID_STATIC_ANYCAST_GATEWAY_MISSING_SAG": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "lanes": "1",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "description": "vlan_nat",
+                        "name": "Vlan100"
+                    }
+                ]
+            },
+            "sonic-vlan:VLAN_MEMBER": {
+                "VLAN_MEMBER_LIST": [
+                    {
+                        "port": "Ethernet0",
+                        "tagging_mode": "tagged",
+                        "name": "Vlan100"
+                    }
+                ]
+            },
+            "sonic-vlan:VLAN_INTERFACE": {
+                "VLAN_INTERFACE_IPPREFIX_LIST": [
+                    {
+                        "family": "IPv4",
+                        "ip-prefix": "10.0.0.1/24",
+                        "scope": "global",
+                        "name": "Vlan100"
+                    }
+                ],
+                "VLAN_INTERFACE_LIST": [
+                    {
+                         "name": "Vlan100",
+                         "static_anycast_gateway": "true"
+                    }
+                ]
+            }
         }
     },
     "VLAN_INTERFACE_INVALID_STATIC_ANYCAST_GATEWAY": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
@@ -479,7 +479,7 @@
                 "VLAN_INTERFACE_LIST": [
                     {
                          "name": "Vlan100",
-                         "static_anycast_gateway": true
+                         "static_anycast_gateway": "true"
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-evpn.yang
+++ b/src/sonic-yang-models/yang-models/sonic-evpn.yang
@@ -4,8 +4,12 @@ module sonic-evpn {
     namespace "http://github.com/sonic-net/sonic-evpn";
     prefix sevpn;
 
-    import sonic-interface {
-        prefix sinterface;
+    import sonic-port {
+        prefix port;
+    }
+
+    import sonic-portchannel {
+        prefix lag;
     }
 
     organization
@@ -49,13 +53,14 @@ module sonic-evpn {
 
                 key "ifname";
 
-                /*
-                 * It's not possible to have a leafref pointing to two separate models
-                 * (INTERFACE and PORTCHANNEL), so a raw interface name is used instead.
-                 */
                 leaf ifname {
-                    type string {
-                        length 1..128;
+                    type union {
+                        type leafref {
+                            path "/port:sonic-port/port:PORT/port:PORT_LIST/port:name";
+                        }
+                        type leafref {
+                            path "/lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:name";
+                        }
                     }
                 }
 

--- a/src/sonic-yang-models/yang-models/sonic-evpn.yang
+++ b/src/sonic-yang-models/yang-models/sonic-evpn.yang
@@ -1,0 +1,146 @@
+module sonic-evpn {
+    yang-version 1.1;
+
+    namespace "http://github.com/sonic-net/sonic-evpn";
+    prefix sevpn;
+
+    import sonic-interface {
+        prefix sinterface;
+    }
+
+    organization
+        "SONiC";
+
+    contact
+        "SONiC";
+
+    description
+        "SONIC EVPN";
+
+    revision 2024-05-08 {
+        description
+            "First revision.";
+    }
+
+    revision 2024-06-14 {
+        description
+            "Add global EVPN Multihoming configuration.";
+    }
+
+    typedef esi-type {
+        type enumeration {
+            enum TYPE_0_OPERATOR_CONFIGURED {
+                value 0;
+                description "Type 0 ESI - Operator Configured";
+            }
+            enum TYPE_3_MAC_BASED {
+                value 3;
+                description "Type 3 ESI - MAC-Based ESI";
+            }
+        }
+    }
+
+    container sonic-evpn {
+
+        container EVPN_ETHERNET_SEGMENT {
+            description "CONFIG_DB EVPN_ETHERNET_SEGMENT Table";
+
+            list EVPN_ETHERNET_SEGMENT_LIST {
+
+                key "ifname";
+
+                /*
+                 * It's not possible to have a leafref pointing to two separate models
+                 * (INTERFACE and PORTCHANNEL), so a raw interface name is used instead.
+                 */
+                leaf ifname {
+                    type string {
+                        length 1..128;
+                    }
+                }
+
+                leaf esi {
+                    type string {
+                        /*
+                         * Valid ESIs include:
+                         * AUTO (Anything but Type 0)
+                         * 00:01:02:03:04:05:06:07:08:09 (Only Type 0)
+                         */
+                        pattern "AUTO|([a-fA-F0-9]{1,2}:){9}[a-fA-F0-9]{1,2}" {
+                            error-message "Provided ESI is not valid";
+                            error-app-tag esi-invalid;
+                        }
+                    }
+                }
+
+                leaf type {
+                    type esi-type;
+                }
+
+                leaf df_pref {
+                    type uint16 {
+                        range "1..65535" {
+                            error-message "DF Preference value out of range";
+                            error-app-tag df-pref-invalid;
+                        }
+                    }
+                    default 32767;
+                }
+
+                /*
+                 * 'AUTO' ESI is not allowed for Type 0 ESIs.
+                 * 'AUTO' ESI is mandatory for all other ESI types.
+                 */
+                must "(type = 'TYPE_0_OPERATOR_CONFIGURED' and esi != 'AUTO') or
+                      (type != 'TYPE_0_OPERATOR_CONFIGURED' and esi = 'AUTO')" {
+                    error-message "Invalid use of 'AUTO' with Type 0 ESI or a manual ESI w/ AUTO type";
+                    error-app-tag auto-esi-type-invalid;
+                }
+            }
+        }
+        container EVPN_MH_GLOBAL {
+            description "CONFIG_DB EVPN_MH_GLOBAL Table";
+
+            list EVPN_MH_GLOBAL_LIST {
+                key "default_key";
+
+                leaf default_key {
+                    type string {
+                        length 1..128;
+                    }
+                }
+
+                leaf startup_delay {
+                    type uint16 {
+                        range "0..3600" {
+                            error-message "Startup Delay value out of range";
+                            error-app-tag startup-delay-invalid;
+                        }
+                    }
+                    default 300;
+                }
+
+                leaf mac_holdtime {
+                    type uint32 {
+                        range "0..86400" {
+                            error-message "MAC Holdtime value out of range";
+                            error-app-tag mac-holdtime-invalid;
+                        }
+                    }
+                    default 1080;
+                }
+
+
+                leaf neigh_holdtime {
+                    type uint32 {
+                        range "0..86400" {
+                            error-message "Neighbor Holdtime value out of range";
+                            error-app-tag neigh-holdtime-invalid;
+                        }
+                    }
+                    default 1080;
+                }
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-evpn.yang
+++ b/src/sonic-yang-models/yang-models/sonic-evpn.yang
@@ -23,12 +23,7 @@ module sonic-evpn {
 
     revision 2026-05-27 {
         description
-            "Add global EVPN Multihoming configuration.";
-    }
-
-    revision 2026-05-26 {
-        description
-            "First revision.";
+            "Initial EVPN multihoming model.";
     }
 
     typedef esi-type {
@@ -72,7 +67,7 @@ module sonic-evpn {
                          * AUTO (Anything but Type 0)
                          * 00:01:02:03:04:05:06:07:08:09 (Only Type 0)
                          */
-                        pattern "AUTO|([a-fA-F0-9]{1,2}:){9}[a-fA-F0-9]{1,2}" {
+                        pattern "AUTO|([a-fA-F0-9]{2}:){9}[a-fA-F0-9]{2}" {
                             error-message "Provided ESI is not valid";
                             error-app-tag esi-invalid;
                         }

--- a/src/sonic-yang-models/yang-models/sonic-evpn.yang
+++ b/src/sonic-yang-models/yang-models/sonic-evpn.yang
@@ -21,14 +21,14 @@ module sonic-evpn {
     description
         "SONIC EVPN";
 
-    revision 2024-05-08 {
-        description
-            "First revision.";
-    }
-
     revision 2024-06-14 {
         description
             "Add global EVPN Multihoming configuration.";
+    }
+
+    revision 2024-05-08 {
+        description
+            "First revision.";
     }
 
     typedef esi-type {
@@ -65,6 +65,7 @@ module sonic-evpn {
                 }
 
                 leaf esi {
+                    mandatory true;
                     type string {
                         /*
                          * Valid ESIs include:
@@ -79,6 +80,7 @@ module sonic-evpn {
                 }
 
                 leaf type {
+                    mandatory true;
                     type esi-type;
                 }
 

--- a/src/sonic-yang-models/yang-models/sonic-evpn.yang
+++ b/src/sonic-yang-models/yang-models/sonic-evpn.yang
@@ -104,9 +104,10 @@ module sonic-evpn {
             description "CONFIG_DB EVPN_MH_GLOBAL Table";
 
             list EVPN_MH_GLOBAL_LIST {
-                key "default_key";
+                key "name";
 
-                leaf default_key {
+                leaf name {
+                    description "EVPN_MH_GLOBAL singleton entry name. Only default is valid.";
                     type string {
                         pattern "default";
                     }

--- a/src/sonic-yang-models/yang-models/sonic-evpn.yang
+++ b/src/sonic-yang-models/yang-models/sonic-evpn.yang
@@ -21,12 +21,12 @@ module sonic-evpn {
     description
         "SONIC EVPN";
 
-    revision 2024-06-14 {
+    revision 2026-05-27 {
         description
             "Add global EVPN Multihoming configuration.";
     }
 
-    revision 2024-05-08 {
+    revision 2026-05-26 {
         description
             "First revision.";
     }
@@ -113,7 +113,7 @@ module sonic-evpn {
 
                 leaf default_key {
                     type string {
-                        length 1..128;
+                        pattern "default";
                     }
                 }
 

--- a/src/sonic-yang-models/yang-models/sonic-evpn.yang
+++ b/src/sonic-yang-models/yang-models/sonic-evpn.yang
@@ -100,6 +100,12 @@ module sonic-evpn {
                     error-message "Invalid ESI/type combination: Type 0 requires manual '00:' ESI; non-Type 0 requires AUTO ESI";
                     error-app-tag auto-esi-type-invalid;
                 }
+
+                /* The all-zero ESI is reserved and must not be configured. */
+                must "esi != '00:00:00:00:00:00:00:00:00:00'" {
+                    error-message "Reserved all-zero ESI is not allowed";
+                    error-app-tag reserved-esi-invalid;
+                }
             }
         }
         container EVPN_MH_GLOBAL {
@@ -111,7 +117,10 @@ module sonic-evpn {
                 leaf name {
                     description "EVPN_MH_GLOBAL singleton entry name. Only default is valid.";
                     type string {
-                        pattern "default";
+                        pattern "default" {
+                            error-message "EVPN_MH_GLOBAL entry name must be default";
+                            error-app-tag evpn-mh-global-name-invalid;
+                        }
                     }
                 }
 

--- a/src/sonic-yang-models/yang-models/sonic-evpn.yang
+++ b/src/sonic-yang-models/yang-models/sonic-evpn.yang
@@ -90,12 +90,14 @@ module sonic-evpn {
                 }
 
                 /*
-                 * 'AUTO' ESI is not allowed for Type 0 ESIs.
+                 * Type 0 ESIs must be operator configured and must use the
+                 * canonical Type 0 format with a leading 00 octet.
                  * 'AUTO' ESI is mandatory for all other ESI types.
                  */
-                must "(type = 'TYPE_0_OPERATOR_CONFIGURED' and esi != 'AUTO') or
-                      (type != 'TYPE_0_OPERATOR_CONFIGURED' and esi = 'AUTO')" {
-                    error-message "Invalid use of 'AUTO' with Type 0 ESI or a manual ESI w/ AUTO type";
+                must "(type = 'TYPE_0_OPERATOR_CONFIGURED' and esi != 'AUTO' and " +
+                     "substring(esi, 1, 3) = '00:') or " +
+                     "(type != 'TYPE_0_OPERATOR_CONFIGURED' and esi = 'AUTO')" {
+                    error-message "Invalid ESI/type combination: Type 0 requires manual '00:' ESI; non-Type 0 requires AUTO ESI";
                     error-app-tag auto-esi-type-invalid;
                 }
             }

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -128,7 +128,12 @@ module sonic-portchannel {
                 }
 
                 leaf system_mac {
-                    description "LACP System MAC";
+                    description
+                        "Optional override for the LACP system MAC address used by this PortChannel.
+                         When set, this MAC is used as the LACP actor system identifier instead of the
+                         device's default system MAC, which is useful for MC-LAG / EVPN multihoming
+                         deployments that require peer devices to advertise a shared LACP system ID.
+                         When unset, the device's default system MAC is used.";
                     type yang:mac-address;
                 }
 

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -24,6 +24,10 @@ module sonic-portchannel {
 
     description "Link Aggregation Group (LAG/PortChannel) configuration using LACP";
 
+    revision 2025-06-24 {
+        description "Add LACP System MAC address";
+    }
+
     revision 2021-06-13 {
         description "Change min-links valid range from 1-128 to 1-1024";
     }
@@ -121,6 +125,11 @@ module sonic-portchannel {
                 leaf fast_rate {
                     description "Enable LACP fast rate";
                     type stypes:boolean_type;
+                }
+
+                leaf system_mac {
+                    description "LACP System MAC";
+                    type yang:mac-address;
                 }
 
             } /* end of list PORTCHANNEL_LIST */

--- a/src/sonic-yang-models/yang-models/sonic-static-anycast-gateway.yang
+++ b/src/sonic-yang-models/yang-models/sonic-static-anycast-gateway.yang
@@ -2,7 +2,7 @@ module sonic-static-anycast-gateway {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-static-anycast-gateway";
+    namespace "http://github.com/sonic-net/sonic-static-anycast-gateway";
     prefix sag;
 
     import ietf-yang-types {

--- a/src/sonic-yang-models/yang-models/sonic-static-anycast-gateway.yang
+++ b/src/sonic-yang-models/yang-models/sonic-static-anycast-gateway.yang
@@ -1,0 +1,30 @@
+module sonic-static-anycast-gateway {
+
+    yang-version 1.1;
+
+    namespace "http://github.com/Azure/sonic-static-anycast-gateway";
+    prefix sag;
+
+    import ietf-yang-types {
+        prefix yang;
+    }
+
+    description "SAG yang Module for SONiC OS";
+
+    revision 2025-04-22 {
+        description
+            "Initial version";
+    }
+
+    container sonic-static-anycast-gateway {
+        container SAG {
+            container GLOBAL {
+                description "Global static anycast gateway configuration";
+
+                leaf gateway_mac {
+                    type yang:mac-address;
+                }
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-static-anycast-gateway.yang
+++ b/src/sonic-yang-models/yang-models/sonic-static-anycast-gateway.yang
@@ -30,7 +30,10 @@ module sonic-static-anycast-gateway {
                 leaf name {
                     description "SAG singleton entry name. Only GLOBAL is valid.";
                     type string {
-                        pattern "GLOBAL";
+                        pattern "GLOBAL" {
+                            error-message "SAG entry name must be GLOBAL";
+                            error-app-tag sag-name-invalid;
+                        }
                     }
                 }
 

--- a/src/sonic-yang-models/yang-models/sonic-static-anycast-gateway.yang
+++ b/src/sonic-yang-models/yang-models/sonic-static-anycast-gateway.yang
@@ -22,6 +22,8 @@ module sonic-static-anycast-gateway {
                 description "Global static anycast gateway configuration";
 
                 leaf gateway_mac {
+                    description
+                        "Globally shared anycast gateway MAC address used by VLAN interfaces with static anycast gateway enabled.";
                     type yang:mac-address;
                 }
             }

--- a/src/sonic-yang-models/yang-models/sonic-static-anycast-gateway.yang
+++ b/src/sonic-yang-models/yang-models/sonic-static-anycast-gateway.yang
@@ -18,10 +18,18 @@ module sonic-static-anycast-gateway {
 
     container sonic-static-anycast-gateway {
         container SAG {
-            container GLOBAL {
-                description "Global static anycast gateway configuration";
+            list SAG_LIST {
+                key "name";
+
+                leaf name {
+                    description "SAG singleton entry name. Only GLOBAL is valid.";
+                    type string {
+                        pattern "GLOBAL";
+                    }
+                }
 
                 leaf gateway_mac {
+                    mandatory true;
                     description
                         "Globally shared anycast gateway MAC address used by VLAN interfaces with static anycast gateway enabled.";
                     type yang:mac-address;

--- a/src/sonic-yang-models/yang-models/sonic-static-anycast-gateway.yang
+++ b/src/sonic-yang-models/yang-models/sonic-static-anycast-gateway.yang
@@ -9,6 +9,12 @@ module sonic-static-anycast-gateway {
         prefix yang;
     }
 
+    organization
+        "SONiC";
+
+    contact
+        "SONiC";
+
     description "SAG yang Module for SONiC OS";
 
     revision 2025-04-22 {

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -151,8 +151,10 @@ module sonic-vlan {
 						 Requires SAG GLOBAL gateway_mac to be configured when enabled.";
 					type stypes:boolean_type;
 					default "false";
+					/* SAG GLOBAL gateway_mac must exist before enabling static anycast gateway on a VLAN interface. */
 					must "current() = 'false' or /sag:sonic-static-anycast-gateway/sag:SAG/sag:SAG_LIST[sag:name='GLOBAL']/sag:gateway_mac" {
 						error-message "static_anycast_gateway requires SAG GLOBAL gateway_mac to be configured";
+						error-app-tag static-anycast-gateway-requires-global-mac;
 					}
 				}
 

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -43,6 +43,10 @@ module sonic-vlan {
 
 	description "VLAN yang Module for SONiC OS";
 
+	revision 2025-04-22 {
+		description "Add SAG support";
+	}
+
 	revision 2025-03-06 {
 		description "Add leaf vnet_name";
 	}
@@ -135,6 +139,12 @@ module sonic-vlan {
 					description "Enable/Disable IPv6 link local address on vlan interface";
 					type stypes:mode-status;
 					default disable;
+				}
+
+				leaf static_anycast_gateway {
+					description "Enable/disable static anycast gateway for the vlan interface";
+					type boolean;
+					default false;
 				}
 
 				leaf mac_addr {

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -143,8 +143,8 @@ module sonic-vlan {
 
 				leaf static_anycast_gateway {
 					description "Enable/disable static anycast gateway for the vlan interface";
-					type boolean;
-					default false;
+					type stypes:boolean_type;
+					default "false";
 				}
 
 				leaf mac_addr {

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -41,6 +41,10 @@ module sonic-vlan {
 		prefix svnet;
 	}
 
+	import sonic-static-anycast-gateway {
+		prefix sag;
+	}
+
 	description "VLAN yang Module for SONiC OS";
 
 	revision 2025-04-22 {
@@ -147,6 +151,9 @@ module sonic-vlan {
 						 Requires SAG GLOBAL gateway_mac to be configured when enabled.";
 					type stypes:boolean_type;
 					default "false";
+					must "current() = 'false' or /sag:sonic-static-anycast-gateway/sag:SAG/sag:SAG_LIST[sag:name='GLOBAL']/sag:gateway_mac" {
+						error-message "static_anycast_gateway requires SAG GLOBAL gateway_mac to be configured";
+					}
 				}
 
 				leaf mac_addr {

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -142,7 +142,9 @@ module sonic-vlan {
 				}
 
 				leaf static_anycast_gateway {
-					description "Enable/disable static anycast gateway for the vlan interface";
+					description
+						"Enable/disable static anycast gateway for the vlan interface.
+						 Requires SAG GLOBAL gateway_mac to be configured when enabled.";
 					type stypes:boolean_type;
 					default "false";
 				}


### PR DESCRIPTION
#### Why I did it

Split the EVPN-MH YANG model updates from Barry Friedman's EVPN-MH sonic-buildimage PR into a focused PR that can be reviewed independently from FRR patches and other build/package updates.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Cherry-picked the YANG/model-related changes from Barry's PR onto current sonic-buildimage master and kept the scope limited to `src/sonic-yang-models`.

This PR includes:
- EVPN-MH YANG model definitions
- EVPN-related PortChannel model updates
- Static anycast gateway YANG model support
- CVL/YANG test data updates for EVPN-MH, PortChannel, VLAN, and static anycast gateway
- Configuration documentation updates
- A follow-up whitespace cleanup for the touched documentation section

#### How to verify it

- Verified the branch is clean.
- Verified all commits include `Signed-off-by` lines.
- Ran strict whitespace validation against current master:
  - `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check github/master...HEAD`
- Verified touched JSON test/config samples parse successfully with Python `json.load()`.
- Verified `src/sonic-yang-models/setup.py` compiles with `python3 -m py_compile`.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [x] master — local validation only; no full image built

#### Description for the changelog

Add EVPN-MH and static anycast gateway YANG model support.

#### Link to config_db schema for YANG module changes

https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#vxlan_evpn_nvo

#### A picture of a cute animal (not mandatory but encouraged)
