### PR TITLE
Docker Routing Mode behavior changes for frrcfgd

### DIFF
--- a/dockers/docker-fpm-frr/docker_init.sh
+++ b/dockers/docker-fpm-frr/docker_init.sh
@@ -79,8 +79,8 @@ if [ -z "$CONFIG_TYPE" ] || [ "$CONFIG_TYPE" == "separated" ]; then
               /etc/frr/bfdd.conf /etc/frr/ospfd.conf /etc/frr/pimd.conf \
               /etc/frr/sharpd.conf
     else
-        sonic-cfggen $CFGGEN_PARAMS
         rm -f /etc/frr/bfdd.conf /etc/frr/ospfd.conf
+        sonic-cfggen $CFGGEN_PARAMS
         echo "no service integrated-vtysh-config" > /etc/frr/vtysh.conf
         rm -f /etc/frr/frr.conf
     fi

--- a/dockers/docker-fpm-frr/docker_init.sh
+++ b/dockers/docker-fpm-frr/docker_init.sh
@@ -67,16 +67,23 @@ if [ -z "$CONFIG_TYPE" ] || [ "$CONFIG_TYPE" == "separated" ]; then
     "
     MGMT_FRAMEWORK_CONFIG=$(echo $FRR_VARS | jq -r '.frr_mgmt_framework_config')
     if [ -n "$MGMT_FRAMEWORK_CONFIG" ] && [ "$MGMT_FRAMEWORK_CONFIG" != "false" ]; then
-        CFGGEN_PARAMS="$CFGGEN_PARAMS \
-            -t /usr/local/sonic/frrcfgd/bfdd.conf.j2,/etc/frr/bfdd.conf \
-            -t /usr/local/sonic/frrcfgd/ospfd.conf.j2,/etc/frr/ospfd.conf \
+        CFGGEN_PARAMS=" \
+            -d \
+            -y /etc/sonic/constants.yml \
+            -T /usr/local/sonic/frrcfgd \
+            -t /usr/share/sonic/templates/gen_frr.conf.j2,/etc/frr/frr.conf \
         "
+        sonic-cfggen $CFGGEN_PARAMS
+        echo "service integrated-vtysh-config" > /etc/frr/vtysh.conf
+        rm -f /etc/frr/bgpd.conf /etc/frr/zebra.conf /etc/frr/staticd.conf \
+              /etc/frr/bfdd.conf /etc/frr/ospfd.conf /etc/frr/pimd.conf \
+              /etc/frr/sharpd.conf
     else
+        sonic-cfggen $CFGGEN_PARAMS
         rm -f /etc/frr/bfdd.conf /etc/frr/ospfd.conf
+        echo "no service integrated-vtysh-config" > /etc/frr/vtysh.conf
+        rm -f /etc/frr/frr.conf
     fi
-    sonic-cfggen $CFGGEN_PARAMS
-    echo "no service integrated-vtysh-config" > /etc/frr/vtysh.conf
-    rm -f /etc/frr/frr.conf
 elif [ "$CONFIG_TYPE" == "split" ]; then
     echo "no service integrated-vtysh-config" > /etc/frr/vtysh.conf
     rm -f /etc/frr/frr.conf

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -2168,6 +2168,10 @@ class BGPConfigDaemon:
             self.config_mode = db_entry['docker_routing_config_mode']
         else:
             self.config_mode = "separated"
+        if 'use_template_render_for_restore' in db_entry:
+            self.use_template_render_for_restore = db_entry['use_template_render_for_restore']
+        else:
+            self.use_template_render_for_restore = 'true'
         # VRF ==> local_as
         self.bgp_asn = {}
         # VRF ==> confederation peer list
@@ -2341,7 +2345,7 @@ class BGPConfigDaemon:
         syslog.syslog(syslog.LOG_DEBUG, 'Init Cached DB data')
         for key, entry in self.table_data_cache.items():
             syslog.syslog(syslog.LOG_DEBUG, '  %-20s : %s' % (key, entry))
-        if self.config_mode == "unified":
+        if self.config_mode == "unified" and self.use_template_render_for_restore == 'false':
             for table, _ in self.table_handler_list:
                 table_list = self.config_db.get_table(table)
                 for key, data in table_list.items():

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -1111,7 +1111,8 @@ instance is supported in SONiC.
         "yang_config_validation": "disable",
         "rack_mgmt_map": "dummy_value",
         "timezome": "Europe/Kiev",
-        "bgp_router_id": "8.8.8.8"
+        "bgp_router_id": "8.8.8.8",
+        "use_template_render_for_restore": "true"
     }
   }
 }

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -421,7 +421,8 @@
                 "chassis_hostname": "str-sonic-chassis-1",
                 "slice_type": "AZNG_Production",
                 "nexthop_group": "disabled",
-                "zebra_nexthop": "disabled"
+                "zebra_nexthop": "disabled",
+                "use_template_render_for_restore": "true"
             }
         },
         "VLAN": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -278,5 +278,8 @@
     },
     "DEVICE_METADATA_VALID_ANCHOR_ROUTE_SOURCE": {
         "desc": "Verifying valid anchor_route_source."
+    },
+    "DEVICE_METADATA_USE_TEMPLATE_RENDER_FOR_RESTORE": {
+        "desc": "Verifying use_template_render_for_restore configuration."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
@@ -449,6 +449,15 @@
             }
         }
     },
+    "DEVICE_METADATA_USE_TEMPLATE_RENDER_FOR_RESTORE": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "use_template_render_for_restore": true
+                }
+            }
+        }
+    },
     "DEVICE_METADATA_CORRECT_CLOUDTYPE_REGION_CONFIG": {
         "sonic-device_metadata:sonic-device_metadata": {
             "sonic-device_metadata:DEVICE_METADATA": {

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -18,6 +18,11 @@ module sonic-device_metadata {
     }
 
     description "DEVICE_METADATA YANG Module for SONiC OS";
+    
+    revision 2026-04-11 {
+        description "Adde use_template_render_for_restore to control the method of config restore in FRR.";
+    }
+
 
     revision 2026-04-11 {
         description "Added route_state_async_publish to control async route state publishing.";
@@ -395,6 +400,12 @@ module sonic-device_metadata {
                         enum disabled;
                     }
                     default enabled;
+                }
+
+                leaf use_template_render_for_restore {
+                    type boolean;
+                    description "When set to true, use template rendering to generate FRR configurations during startup in unified mode. When set to false, restore FRR configurations from cached DB tables. This field only takes effect in unified mode.";
+                    default "true";
                 }
             }
             /* end of container localhost */


### PR DESCRIPTION
**Why I did it**
FRR no longer support individual daemon config files in a separated mode.

**How I did it**
**Migration Update:** 

We are migrating backend behavior of docker routing “separated” mode to use single frr.conf file, as FRR no longer supports individual daemon configuration files.

**Behavior Change**
1) Previously, in separated mode, individual configuration files were generated for each FRR daemon.
2) With this change, both separated and unified modes now generate a single consolidated frr.conf file for all FRR daemons.
3) The separated mode is retained only for backward configuration compatibility.
4) Separated mode will be fully removed in release 202611 for frrcfgd, as it is no longer valid for FRR

use_template_render_for_restore option has been added to generate the FRR configs dynamically even during FRR boot-up instead of jinja template based config generation from CONFIG_DB.

Note: migration to unified mode for bgpcfgd is still in progress, as the test suite has not yet been updated to validate the unified mode.
