### PR TITLE
[Arista] Disable orphan_file in arista-convertfs

### DIFF
--- a/files/initramfs-tools/arista-convertfs.j2
+++ b/files/initramfs-tools/arista-convertfs.j2
@@ -234,7 +234,7 @@ cmd="wait_for_root_dev"
 run_cmd "$cmd" "$err_msg"
 
 err_msg="Error: formatting to ext4 failed"
-cmd="/usr/local/sbin/mke2fs -t ext4 -F -O '^huge_file,^metadata_csum' $root_dev"
+cmd="/usr/local/sbin/mke2fs -t ext4 -F -O '^huge_file,^metadata_csum,^orphan_file' $root_dev"
 run_cmd "$cmd" "$err_msg"
 
 err_msg="Error: mounting $root_dev to $root_mnt failed"


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The vfat-to-ext4 conversion could occur on Upperlake devices when booting SONiC for the first time from the factory-default vfat state. That ext4 feature disabled is not compatible with Aboot on Upperlake.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Disable orphan_file feature in arista-convertfs

#### How to verify it
Format the flash to the factory-default vfat state.
Boot SONiC in Aboot for the first time
Reboot and check SONiC can still be booted

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

