### PR TITLE
sysctl: set kernel.yama.ptrace_scope=2 to restrict ptrace access

### DIFF
--- a/files/image_config/sysctl/90-sonic.conf
+++ b/files/image_config/sysctl/90-sonic.conf
@@ -56,3 +56,8 @@ kernel.core_pipe_limit=16
 
 vm.panic_on_oom=2
 fs.suid_dumpable=2
+
+# Restrict ptrace to admin-only (CAP_SYS_PTRACE) to mitigate FD-theft attacks
+# via pidfd_getfd(2) during the mm-NULL exit window. Blocks unprivileged
+# exploitation while preserving sudo gdb / sudo strace for operators.
+kernel.yama.ptrace_scope=2


### PR DESCRIPTION
#### Why I did it

SONiC does not set `kernel.yama.ptrace_scope`, so it inherits the kernel boot default of 0 (no restrictions). Setting it to 2 restricts ptrace attachment to processes with `CAP_SYS_PTRACE`, closing same-uid cross-session snooping and FD-theft vectors via `pidfd_getfd(2)`. Operator tooling (`sudo gdb`, `sudo strace`) is unaffected.

##### Work item tracking
- Microsoft ADO:

#### How I did it

Added `kernel.yama.ptrace_scope=2` to `files/image_config/sysctl/90-sonic.conf`.

#### How to verify it

Boot the VS image and run:

```
$ sysctl kernel.yama.ptrace_scope
kernel.yama.ptrace_scope = 2

$ grep ptrace /usr/lib/sysctl.d/90-sonic.conf
kernel.yama.ptrace_scope=2
```

Verified on sonic-vs.img.gz (built 2026-05-28, kernel `6.12.41+deb13-sonic-amd64`) on KVM (`x86_64-kvm_x86_64-r0`).

- SSH login: unaffected
- `sudo gdb --batch -ex "attach <pid>" -ex detach`: attaches and detaches cleanly (operator tooling preserved)
- Unprivileged `ptrace(PTRACE_ATTACH)`: returns `EPERM` (scope=2 enforced)

No unit tests exist for sysctl config files in this repo.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [x] sonic-vs, kernel 6.12.41+deb13-sonic-amd64 (built 2026-05-28)

#### Description for the changelog

sysctl: set kernel.yama.ptrace_scope=2 to restrict ptrace access

#### Link to config_db schema for YANG module changes

N/A
