### PR TITLE
Revert "[build] Add timeout for apt-get build hook to prevent long hangs"

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -116,7 +116,8 @@ sudo LANG=C chroot $FILESYSTEM_ROOT mount
 ## Pointing apt to public apt mirrors and getting latest packages, needed for latest security updates
 scripts/build_mirror_config.sh files/apt $CONFIGURED_ARCH $IMAGE_DISTRO
 sudo cp files/apt/sources.list.$CONFIGURED_ARCH $FILESYSTEM_ROOT/etc/apt/sources.list
-sudo cp files/apt/apt.conf.d/{81norecommends,apt-{clean,gzip-indexes,no-languages,timeout-n-retries},no-check-valid-until} $FILESYSTEM_ROOT/etc/apt/apt.conf.d/
+sudo cp files/apt/apt-retries-count $FILESYSTEM_ROOT/etc/apt/apt.conf.d/
+sudo cp files/apt/apt.conf.d/{81norecommends,apt-{clean,gzip-indexes,no-languages},no-check-valid-until} $FILESYSTEM_ROOT/etc/apt/apt.conf.d/
 
 ## Note: set lang to prevent locale warnings in your chroot
 sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y update

--- a/dockers/docker-base-bookworm/Dockerfile.j2
+++ b/dockers/docker-base-bookworm/Dockerfile.j2
@@ -16,7 +16,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Configure data sources for apt/dpkg
 COPY ["dpkg_01_drop", "/etc/dpkg/dpkg.cfg.d/01_drop"]
 COPY ["sources.list.{{ CONFIGURED_ARCH }}", "/etc/apt/sources.list"]
-COPY ["files/apt/apt.conf.d/", "/etc/apt/apt.conf.d/"]
+COPY ["no_install_recommend_suggest", "/etc/apt/apt.conf.d"]
+COPY ["no-check-valid-until", "/etc/apt/apt.conf.d"]
 # Install certificates by disabling the peer verification
 RUN apt -o Acquire::https::Verify-Peer=false update && \
     apt -o Acquire::https::Verify-Peer=false install -y ca-certificates

--- a/dockers/docker-base-bookworm/no-check-valid-until
+++ b/dockers/docker-base-bookworm/no-check-valid-until
@@ -1,0 +1,4 @@
+# Instruct apt-get to NOT check the "Valid Until" date in Release files
+# Once the Debian team archives a repo, they stop updating this date
+
+Acquire::Check-Valid-Until "false";

--- a/dockers/docker-base-bookworm/no_install_recommend_suggest
+++ b/dockers/docker-base-bookworm/no_install_recommend_suggest
@@ -1,0 +1,5 @@
+# Instruct apt-get to NOT install "recommended" or "suggested" packages by
+# default when installing a package.
+
+APT::Install-Recommends "false";
+APT::Install-Suggests "false";

--- a/dockers/docker-base-trixie/Dockerfile.j2
+++ b/dockers/docker-base-trixie/Dockerfile.j2
@@ -16,7 +16,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Configure data sources for apt/dpkg
 COPY ["dpkg_01_drop", "/etc/dpkg/dpkg.cfg.d/01_drop"]
 COPY ["sources.list.{{ CONFIGURED_ARCH }}", "/etc/apt/sources.list"]
-COPY ["files/apt/apt.conf.d/", "/etc/apt/apt.conf.d/"]
+COPY ["no_install_recommend_suggest", "/etc/apt/apt.conf.d"]
+COPY ["no-check-valid-until", "/etc/apt/apt.conf.d"]
 # Install certificates by disabling the peer verification
 RUN apt -o Acquire::https::Verify-Peer=false update && \
     apt -o Acquire::https::Verify-Peer=false install -y ca-certificates

--- a/dockers/docker-base-trixie/no-check-valid-until
+++ b/dockers/docker-base-trixie/no-check-valid-until
@@ -1,0 +1,4 @@
+# Instruct apt-get to NOT check the "Valid Until" date in Release files
+# Once the Debian team archives a repo, they stop updating this date
+
+Acquire::Check-Valid-Until "false";

--- a/dockers/docker-base-trixie/no_install_recommend_suggest
+++ b/dockers/docker-base-trixie/no_install_recommend_suggest
@@ -1,0 +1,5 @@
+# Instruct apt-get to NOT install "recommended" or "suggested" packages by
+# default when installing a package.
+
+APT::Install-Recommends "false";
+APT::Install-Suggests "false";

--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -15,8 +15,8 @@ USER root
 WORKDIR /root
 
 COPY ["sources.list.{{ CONFIGURED_ARCH }}", "/etc/apt/sources.list"]
-COPY ["files/apt/apt.conf.d/no-check-valid-until", "/etc/apt/apt.conf.d/"]
-COPY ["files/apt/apt.conf.d/apt-timeout-n-retries", "/etc/apt/apt.conf.d/"]
+COPY ["no-check-valid-until", "/etc/apt/apt.conf.d"]
+COPY ["apt-retries-count", "/etc/apt/apt.conf.d"]
 # Install certificates by disabling the peer verification
 RUN apt -o Acquire::https::Verify-Peer=false update && \
     apt -o Acquire::https::Verify-Peer=false install -y ca-certificates

--- a/dockers/docker-ptf/no-check-valid-until
+++ b/dockers/docker-ptf/no-check-valid-until
@@ -1,0 +1,4 @@
+# Instruct apt-get to NOT check the "Valid Until" date in Release files
+# Once the Debian team archives a repo, they stop updating this date
+
+Acquire::Check-Valid-Until "false";

--- a/files/apt/apt.conf.d/81norecommends
+++ b/files/apt/apt.conf.d/81norecommends
@@ -1,4 +1,3 @@
 APT::Install-Recommends "false";
-APT::Install-Suggests "false";
 APT::AutoRemove::RecommendsImportant "false";
 APT::AutoRemove::SuggestsImportant "false";

--- a/files/apt/apt.conf.d/apt-multiple-retries
+++ b/files/apt/apt.conf.d/apt-multiple-retries
@@ -1,0 +1,4 @@
+# Instruct apt to retry downloads on failures
+# This is required only for bullseye.
+
+Acquire::Retries "3";

--- a/files/apt/apt.conf.d/apt-timeout-n-retries
+++ b/files/apt/apt.conf.d/apt-timeout-n-retries
@@ -1,7 +1,0 @@
-# Instruct apt-get to timeout after 20 seconds and retry 3 times before giving up. 
-# This can help mitigate issues with slow or unreliable network connections when using apt-get in Docker builds.
-
-Acquire::http::Timeout "20";
-Acquire::https::Timeout "20";
-Acquire::ftp::Timeout "20";
-Acquire::Retries "3";

--- a/scripts/prepare_docker_buildinfo.sh
+++ b/scripts/prepare_docker_buildinfo.sh
@@ -45,8 +45,6 @@ fi
 
 if [[ "$IMAGENAME" == sonic-slave-* ]] || [[ "$IMAGENAME" == docker-base-* ]] || [[ "$IMAGENAME" == docker-ptf ]]; then
     scripts/build_mirror_config.sh ${DOCKERFILE_PATH} $ARCH $DISTRO
-	mkdir -p "${DOCKERFILE_PATH}/files/apt/apt.conf.d"
-	cp -f files/apt/apt.conf.d/* "${DOCKERFILE_PATH}/files/apt/apt.conf.d/"
 fi
 
 # add script for reproducible build. using sha256 instead of tag for docker base image.

--- a/sonic-slave-bookworm/Dockerfile.j2
+++ b/sonic-slave-bookworm/Dockerfile.j2
@@ -21,8 +21,7 @@ FROM {{ prefix }}debian:bookworm
 
 MAINTAINER gulv@microsoft.com
 
-COPY ["files/apt/apt.conf.d/no-check-valid-until", "/etc/apt/apt.conf.d/"]
-COPY ["files/apt/apt.conf.d/apt-timeout-n-retries", "/etc/apt/apt.conf.d/"]
+COPY ["no-check-valid-until", "/etc/apt/apt.conf.d/"]
 
 {%- if CROSS_BUILD_ENVIRON != "y" %}
 COPY ["sources.list.{{ CONFIGURED_ARCH }}", "/etc/apt/sources.list"]

--- a/sonic-slave-bookworm/no-check-valid-until
+++ b/sonic-slave-bookworm/no-check-valid-until
@@ -1,0 +1,4 @@
+# Instruct apt-get to NOT check the "Valid Until" date in Release files
+# Once the Debian team archives a repo, they stop updating this date
+
+Acquire::Check-Valid-Until "false";

--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -21,8 +21,8 @@ FROM {{ prefix }}debian:bullseye
 
 MAINTAINER gulv@microsoft.com
 
-COPY ["files/apt/apt.conf.d/no-check-valid-until", "/etc/apt/apt.conf.d/"]
-COPY ["files/apt/apt.conf.d/apt-timeout-n-retries", "/etc/apt/apt.conf.d/"]
+COPY ["no-check-valid-until", "/etc/apt/apt.conf.d/"]
+COPY ["apt-retries-count", "/etc/apt/apt.conf.d"]
 
 {%- if CROSS_BUILD_ENVIRON != "y" %}
 COPY ["sources.list.{{ CONFIGURED_ARCH }}", "/etc/apt/sources.list"]

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -20,8 +20,8 @@ FROM {{ prefix }}debian:buster
 
 MAINTAINER gulv@microsoft.com
 
-COPY ["files/apt/apt.conf.d/no-check-valid-until", "/etc/apt/apt.conf.d/"]
-COPY ["files/apt/apt.conf.d/apt-timeout-n-retries", "/etc/apt/apt.conf.d/"]
+COPY ["no-check-valid-until", "/etc/apt/apt.conf.d/"]
+COPY ["apt-retries-count", "/etc/apt/apt.conf.d"]
 
 {%- if CROSS_BUILD_ENVIRON != "y" %}
 COPY ["sources.list.{{ CONFIGURED_ARCH }}", "/etc/apt/sources.list"]

--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -21,8 +21,7 @@ FROM {{ prefix }}debian:trixie
 
 MAINTAINER gulv@microsoft.com
 
-COPY ["files/apt/apt.conf.d/no-check-valid-until", "/etc/apt/apt.conf.d/"]
-COPY ["files/apt/apt.conf.d/apt-timeout-n-retries", "/etc/apt/apt.conf.d/"]
+COPY ["no-check-valid-until", "/etc/apt/apt.conf.d/"]
 
 {%- if CROSS_BUILD_ENVIRON != "y" %}
 COPY ["sources.list.{{ CONFIGURED_ARCH }}", "/etc/apt/sources.list"]

--- a/sonic-slave-trixie/no-check-valid-until
+++ b/sonic-slave-trixie/no-check-valid-until
@@ -1,0 +1,4 @@
+# Instruct apt-get to NOT check the "Valid Until" date in Release files
+# Once the Debian team archives a repo, they stop updating this date
+
+Acquire::Check-Valid-Until "false";


### PR DESCRIPTION
Reverts sonic-net/sonic-buildimage#26865
It caused sonic-slave-* image permission change on /etc/apt/sources.list