### PR TITLE
[build] Fix sources.list permission change issue involved by PR27478

### DIFF
--- a/scripts/build_mirror_config.sh
+++ b/scripts/build_mirror_config.sh
@@ -86,8 +86,8 @@ if [ "$MIRROR_SNAPSHOT" == y ]; then
     # Set the snapshot mirror, and add the SET_REPR_MIRRORS flag
     sed -i -e "/^#*deb.*$ESCAPED_MIRROR_URL/! s/^#*deb/#&/" -e "\$a#SET_REPR_MIRRORS" "$SOURCES_LIST_TMP"
 fi
+chmod 664 "$SOURCES_LIST_TMP"
 mv -f "$SOURCES_LIST_TMP" "$SOURCES_LIST"
-chmod 664 "$SOURCES_LIST"
 
 # Handle apt retry count config. Same race applies — write via temp
 # and atomic rename.
@@ -97,5 +97,5 @@ APT_RETRIES_COUNT_DEST=$CONFIG_PATH/$APT_RETRIES_COUNT_FILENAME
 APT_RETRIES_COUNT_TMP=$(mktemp "${APT_RETRIES_COUNT_DEST}.XXXXXX")
 trap 'rm -f "$SOURCES_LIST_TMP" "$APT_RETRIES_COUNT_TMP"' EXIT
 j2 $TEMPLATE > "$APT_RETRIES_COUNT_TMP"
+chmod 644 "$APT_RETRIES_COUNT_TMP"
 mv -f "$APT_RETRIES_COUNT_TMP" "$APT_RETRIES_COUNT_DEST"
-chmod 664 "$APT_RETRIES_COUNT_DEST"

--- a/scripts/build_mirror_config.sh
+++ b/scripts/build_mirror_config.sh
@@ -87,6 +87,7 @@ if [ "$MIRROR_SNAPSHOT" == y ]; then
     sed -i -e "/^#*deb.*$ESCAPED_MIRROR_URL/! s/^#*deb/#&/" -e "\$a#SET_REPR_MIRRORS" "$SOURCES_LIST_TMP"
 fi
 mv -f "$SOURCES_LIST_TMP" "$SOURCES_LIST"
+chmod 664 "$SOURCES_LIST"
 
 # Handle apt retry count config. Same race applies — write via temp
 # and atomic rename.
@@ -97,3 +98,4 @@ APT_RETRIES_COUNT_TMP=$(mktemp "${APT_RETRIES_COUNT_DEST}.XXXXXX")
 trap 'rm -f "$SOURCES_LIST_TMP" "$APT_RETRIES_COUNT_TMP"' EXIT
 j2 $TEMPLATE > "$APT_RETRIES_COUNT_TMP"
 mv -f "$APT_RETRIES_COUNT_TMP" "$APT_RETRIES_COUNT_DEST"
+chmod 664 "$APT_RETRIES_COUNT_DEST"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
#27478 Fixed race failure when building broadcom image.
But it involved a new issue that sources.list permission changed to 600 from 664
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Fix file permission issue.
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

