### PR TITLE
[sonic-frr] Enable FRR tcmalloc build by default

### DIFF
--- a/rules/config
+++ b/rules/config
@@ -142,7 +142,7 @@ FRR_USER_UID = 300
 FRR_USER_GID = 300
 
 # ENABLE_FRR_TCMALLOC - build FRR with gperftools tcmalloc support.
-ENABLE_FRR_TCMALLOC ?= n
+ENABLE_FRR_TCMALLOC ?= y
 
 # DPKG cache allows the .deb files to be stored in the cache path. This allows the submodules
 # package to be cached and restored back if its commit hash is not modified and its dependencies are not modified.


### PR DESCRIPTION
#### What I did
Enable `ENABLE_FRR_TCMALLOC` by default (change from `n` to `y`).

This builds FRR with gperftools tcmalloc support, which provides two key benefits over glibc malloc for FRR daemons:

1. **No memory stranding across threads** — glibc's ptmalloc2 assigns per-thread arenas where freed memory cannot be reused by other threads. In FRR, I/O threads allocate peer/update data that the main thread later frees — this memory gets stranded in the wrong arena and RSS grows over time. tcmalloc's shared central cache eliminates this problem.

2. **Active memory release to OS** — tcmalloc provides a background timer that periodically returns free pages back to the host OS (when pageheap_free_bytes exceeds threshold). This helps avoid OOM situations on long-running FRR daemons. glibc does not do this automatically.

#### How I did it
Single config knob change in `rules/config`. All build infrastructure was added in #26794.

#### How to verify it
- Build an image and verify FRR is linked against tcmalloc:
  `vtysh -c "show tcmalloc stats"` (should show tcmalloc memory info)
- `memory release rate` CLI available in vtysh to tune the release interval

#### Test
Scale route download tests (single-path and multi-path) were run using Snappi (open traffic generator), comparing glibc (default allocator) vs tcmalloc. Results were presented at the SONiC Routing WG meeting.

Profiling data to be attached.

#### Reference
- Build support: #26794
- Upstream FRR: FRRouting/frr#19377
