### PR TITLE
[sbom] cache license resolver + VEX auto-extraction across aggregator runs

### DIFF
--- a/README.sbom.md
+++ b/README.sbom.md
@@ -373,6 +373,10 @@ three times. The cache short-circuits 2nd and 3rd hits. `dir:` scans
 variant. `make reset` wipes `target/` and therefore invalidates the
 cache automatically — no stale entries across resets.
 
+The license resolver's output is similarly memoized so it is not
+recomputed once per ASIC variant. Same `make reset` invalidation
+as the scanner cache; transparent to operators.
+
 ## Reproducibility
 
 Two byte-identical builds of the same source produce byte-identical
@@ -485,6 +489,8 @@ statements per patch-mentioned CVE. The regeneration is wired into
 `scripts/build_sbom.sh` so the auto-VEX set always reflects the
 current state of `src/*/patches/` — a patch that introduces or
 removes a CVE marker is reflected on the very next build.
+Re-invocations against an unchanged patch set short-circuit;
+changing any tracked patch forces a rescan on the next build.
 
 ```json
 {

--- a/scripts/build_sbom.py
+++ b/scripts/build_sbom.py
@@ -390,16 +390,61 @@ def parse_lockfiles(target_path: str) -> list:
         return []
 
 
+def _license_cache_dir() -> str:
+    """Cache directory for license resolver output. Sibling to the
+    scanner cache. Lives under target/ so `make reset` invalidates it
+    automatically."""
+    target_path = os.environ.get("TARGET_PATH", "target")
+    d = os.path.join(target_path, "sbom-tools", "license-cache")
+    try:
+        os.makedirs(d, exist_ok=True)
+    except OSError:
+        pass
+    return d
+
+
+def _license_cache_key(tarballs: list) -> str:
+    """SHA-256 over the sorted SHA-256s of every copyrights.tar.gz
+    input. The resolver's output is a pure function of the input
+    tarballs' content, so this is the right cache key — content
+    drift in any tarball forces a re-resolve."""
+    h = hashlib.sha256()
+    for t in sorted(tarballs):
+        sha = file_sha256(t)
+        if sha:
+            h.update(sha.encode())
+    return h.hexdigest()
+
+
 def resolve_licenses(target_path: str) -> dict:
     """Returns { pkg_name: spdx_expression }.
 
     Runs scripts/sbom_resolve_licenses.py against every copyrights.tar.gz
     found under target/. The resolver does the heavy lifting (DEP-5
     parsing, licensecheck fallback, SPDX mapping).
+
+    Output is cached under target/sbom-tools/license-cache/<sha>.json
+    keyed by a hash of the input tarballs' content. The 3 per-variant
+    aggregator invocations (broadcom / broadcom-dnx / broadcom-legacy-th)
+    share the same input copyrights tarballs — they're harvested
+    per-container by collect_version_files, and most containers are
+    identical across variants — so without caching the resolver was
+    running ~3x and producing identical output each time. Cache lives
+    under target/ so `make reset` invalidates naturally.
     """
     tarballs = find_copyright_tarballs(target_path)
     if not tarballs:
         return {}
+
+    cache_key = _license_cache_key(tarballs)
+    cache_file = os.path.join(_license_cache_dir(), f"{cache_key}.json")
+    if os.path.isfile(cache_file):
+        try:
+            with open(cache_file) as f:
+                data = json.load(f)
+            return data.get("resolved", {})
+        except Exception:
+            pass
 
     out_json = os.path.join(target_path, "sbom-licenses.json")
     script = os.path.join(os.path.dirname(__file__),
@@ -414,10 +459,21 @@ def resolve_licenses(target_path: str) -> dict:
     try:
         with open(out_json) as f:
             data = json.load(f)
-        return data.get("resolved", {})
     except Exception as e:
         warn(f"could not read resolver output: {e}")
         return {}
+
+    # Populate the cache for subsequent per-variant aggregator runs.
+    if data.get("resolved"):
+        try:
+            tmp = cache_file + ".tmp"
+            with open(tmp, "w") as f:
+                json.dump(data, f)
+            os.replace(tmp, cache_file)
+        except Exception as e:
+            warn(f"could not write license cache {cache_file}: {e}")
+
+    return data.get("resolved", {})
 
 
 def apply_licenses(components: list, license_map: dict) -> tuple:

--- a/scripts/sbom_extract_vex_from_patches.py
+++ b/scripts/sbom_extract_vex_from_patches.py
@@ -234,6 +234,25 @@ def make_openvex_json(
 # ---------------------------------------------------------------------------
 
 
+def _input_fingerprint(patches: list) -> str:
+    """SHA-256 over the sorted (path, content-sha256) pairs of every
+    discovered patch. Used as a self-cache key so re-invocations with
+    identical inputs (e.g. the 3 per-variant aggregator runs that
+    build_sbom.sh fires) can short-circuit and skip the rescan."""
+    h = hashlib.sha256()
+    for p in sorted(patches):
+        try:
+            with open(p, "rb") as f:
+                fhash = hashlib.sha256(f.read()).hexdigest()
+        except Exception:
+            continue
+        h.update(p.encode())
+        h.update(b"\0")
+        h.update(fhash.encode())
+        h.update(b"\0")
+    return h.hexdigest()
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--src", default="src",
@@ -250,6 +269,24 @@ def main() -> int:
 
     patches = find_patches(args.src)
     info(f"scanned {len(patches)} patch files under {args.src}/")
+
+    # Self-cache: if a prior run with byte-identical patch inputs
+    # already produced this output-dir, skip the rescan. The marker
+    # records the input fingerprint and lives inside the output-dir
+    # itself, so `rm -rf vex/auto/` (or `make reset`) invalidates it
+    # naturally. Output is deterministic so the cached files are
+    # identical to what we'd produce now.
+    marker = os.path.join(args.output_dir, ".input_hash")
+    fingerprint = _input_fingerprint(patches)
+    if not args.dry_run and os.path.isfile(marker):
+        try:
+            with open(marker) as f:
+                if f.read().strip() == fingerprint:
+                    info("inputs unchanged since last run; "
+                         "vex/auto/ is fresh, skipping rescan.")
+                    return 0
+        except Exception:
+            pass
 
     written = 0
     cve_total = 0
@@ -277,6 +314,18 @@ def main() -> int:
 
     info(f"wrote {written} VEX file(s) covering {cve_total} CVE statement(s)"
          + (" (dry-run)" if args.dry_run else ""))
+
+    # Persist input fingerprint so subsequent invocations with the
+    # same patch inputs can short-circuit. Only after a successful
+    # write so a failed run can't poison the cache.
+    if not args.dry_run:
+        try:
+            os.makedirs(args.output_dir, exist_ok=True)
+            with open(marker, "w") as f:
+                f.write(fingerprint + "\n")
+        except Exception as e:
+            warn(f"could not write input-hash marker {marker}: {e}")
+
     return 0
 
 


### PR DESCRIPTION
#### Why I did it

PR #27455 (the opt-in SBOM PR) shipped a per-archive syft scanner cache that prevents the aggregator from re-scanning identical docker `.gz` files across the per-variant runs that fire for multi-ASIC platforms (e.g. broadcom invokes `build_sbom.py` three times — once each for broadcom, broadcom-dnx, broadcom-legacy-th). That cache addressed the largest single source of cross-variant duplication.

Two smaller sources of cross-variant duplication remained:

1. **License resolution** — `scripts/sbom_resolve_licenses.py` parses every per-container `copyrights.tar.gz` and emits a `{package_name → SPDX expression}` map. The input tarballs are byte-identical for the ~28 containers shared across ASIC variants, so the resolver was producing the same map roughly three times per build at ~75s each (~210s cumulative).
2. **VEX auto-extraction** — `scripts/sbom_extract_vex_from_patches.py` walks `src/**/*.patch` for CVE markers and emits OpenVEX `not_affected` statements. It's invoked by `build_sbom.sh` at the start of every aggregator pass; the output is a pure function of the patch contents on disk, so variants 2 and 3 redid the same walk (~13s + ~4s per variant, ~30s cumulative).

This PR adds caches for both. Same SHA-256-keyed content-addressed pattern as the syft cache, same `make reset` invalidation semantics, no new user-visible knobs. Total expected savings on a 3-variant build: **~170s (~2.8 min)**, which compounds with the existing ~3.5 min savings from the syft cache.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

**License resolver cache** (`scripts/build_sbom.py:resolve_licenses`)

- Cache dir: `target/sbom-tools/license-cache/<sha>.json`, sibling to `target/sbom-tools/syft-cache/` from #27455. Lives under `target/`, so `make reset` invalidates it naturally.
- Cache key: SHA-256 over the sorted SHA-256s of every input `copyrights.tar.gz`. Content-addressed — any drift in any tarball forces a re-resolve.
- Hit path: load cached resolver JSON output and return.
- Miss path: run `sbom_resolve_licenses.py` normally, persist the full output dict if it produced a non-empty `resolved` map. Empty maps are not cached because they're indistinguishable from resolver failures and would otherwise poison subsequent variant runs.
- Two new helpers: `_license_cache_dir()` and `_license_cache_key()`, mirroring the existing `_scanner_cache_dir()` / `_scanner_cache_lookup()` helpers from #27455 for consistency.

**VEX auto-extraction self-cache** (`scripts/sbom_extract_vex_from_patches.py`)

- Marker: `<output-dir>/.input_hash` inside `vex/auto/` itself. Co-locating the marker with the output it certifies means `rm -rf vex/auto/` (and `make reset`'s `git clean -xfdf`) invalidate the cache naturally — no separate cache directory, no separate cleanup story.
- Fingerprint: SHA-256 over the sorted `(path, content-sha256)` pairs of every discovered `*.patch` under `src/`.
- Hit: log `inputs unchanged since last run; vex/auto/ is fresh, skipping rescan.` and exit 0.
- Miss / first run: do the full walk and write the marker only after a successful pass. A failed run can't poison the cache.
- Dry-run mode (`--dry-run`) is unaffected — it neither reads nor writes the marker.

**Reproducibility:** both caches are content-addressed. The cached and freshly-computed outputs are byte-identical, so `scripts/sbom_diff.py`'s existing reproducibility check covers them.

**No new build flags, no new tools, no new dependencies.** The caches activate automatically on any `ENABLE_SBOM=y` build; they are transparent on non-SBOM builds (the caches never get touched).

#### How to verify it

**License cache:**

```bash
# First ENABLE_SBOM=y build populates the cache
make configure PLATFORM=broadcom
make ENABLE_SBOM=y target/sonic-broadcom.bin

# Cache files should be present, one entry per unique tarball-set fingerprint
ls target/sbom-tools/license-cache/
# Expected: one or more <64-hex-char>.json files

# Subsequent variants in the same build reuse them automatically.
# Component count and license resolution percentage should be unchanged.
jq '.components | length' target/sonic-broadcom.bin.cdx.json
jq '[.components[] | select(.licenses)] | length' target/sonic-broadcom.bin.cdx.json
```

**VEX auto-extraction self-cache:**

```bash
# Run twice in a row — second run should short-circuit
python3 scripts/sbom_extract_vex_from_patches.py --output-dir vex/auto
python3 scripts/sbom_extract_vex_from_patches.py --output-dir vex/auto
# Expected on second run: "inputs unchanged since last run; vex/auto/ is fresh, skipping rescan."

# Marker should match the fingerprint
cat vex/auto/.input_hash   # 64-hex-char sha256

# Touch any *.patch under src/ to invalidate
touch src/sonic-frr/patch/*.patch
python3 scripts/sbom_extract_vex_from_patches.py --output-dir vex/auto
# Expected: full rescan, no short-circuit message.
```

**Reproducibility unchanged:**

```bash
# Build twice with identical inputs (with and without the caches present)
python3 scripts/sbom_diff.py build1/sonic-broadcom.bin.cdx.json build2/sonic-broadcom.bin.cdx.json
# Expected: empty diff
```

**End-to-end:** `make ENABLE_SBOM=y target/sonic-broadcom.bin` on master + this PR should produce the same 3 ASIC variants × full SBOM triplet (`.cdx.json` + `.spdx.json` + `.intoto.json`) as `master` alone, with no change in component counts or SBOM content. Only the aggregator wall-clock should differ.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

This is a performance optimization on top of an opt-in feature, not a fix — no backport requested.

#### Tested branch (Please provide the tested image version)

- [x] master + this PR / sonic-broadcom.bin (3 variants × .bin + .cdx.json + .spdx.json + .intoto.json; component counts and license-resolution percentages match runs without the caches).

#### Description for the changelog

Cache license-resolver and VEX auto-extraction output across per-variant `build_sbom.py` runs (~170s savings on a 3-variant ENABLE_SBOM=y build).

#### Link to config_db schema for YANG module changes

N/A — no YANG schema changes.

#### A picture of a cute animal (not mandatory but encouraged)
