### PR TITLE
Skip generating L1 config on NH-5010 when it is VS platform

### DIFF
--- a/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/hwsku_init_common.py
+++ b/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/hwsku_init_common.py
@@ -343,7 +343,7 @@ class SkuBasePipeline:
             asic_cfg = self.generate_plat_asic_config()
             # Currently we do not support generating gearbox bcm config
             # gb_plat_cfg = self.generate_plat_gearbox_config()
-            asic_type = device_info.get_sonic_version_info(['asic_type'])
+            asic_type = device_info.get_sonic_version_info()['asic_type']
             if asic_type == 'vs':
                 return
             sonic_gb = self.generate_sonic_gearbox_config()

--- a/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/hwsku_init_common.py
+++ b/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/hwsku_init_common.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import logging
 from swsscommon import swsscommon
-from sonic_py_common import syslogger
+from sonic_py_common import syslogger, device_info
 
 SYSLOG_IDENTIFIER = "hwsku-init"
 LOG = syslogger.SysLogger(SYSLOG_IDENTIFIER, enable_runtime_config=False, log_level=logging.DEBUG)
@@ -343,6 +343,9 @@ class SkuBasePipeline:
             asic_cfg = self.generate_plat_asic_config()
             # Currently we do not support generating gearbox bcm config
             # gb_plat_cfg = self.generate_plat_gearbox_config()
+            asic_type = device_info.get_sonic_version_info(['asic_type'])
+            if asic_type == 'vs':
+                return
             sonic_gb = self.generate_sonic_gearbox_config()
             sonic_phy = self.generate_sonic_phy_config()
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Gearbox does not exist on VS platform.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Check asic_type and skip if it is vs

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

