### PR TITLE
[aspeed] TFTP installer: verified success signal and default auto-reboot

### DIFF
--- a/platform/aspeed/aspeed-platform-services/scripts/sonic-uboot-env-init.sh
+++ b/platform/aspeed/aspeed-platform-services/scripts/sonic-uboot-env-init.sh
@@ -71,7 +71,7 @@ run_installer_uboot_programming() {
     if ! resolve_program_uboot_sh; then
         umount "$MNT" 2>/dev/null || true
         log "ERROR: sonic-program-uboot-env.sh not found in /usr/bin or /sbin."
-        exit 1
+        return 1
     fi
 
     export UBOOT_ENV_BOOT_DEVICE="$BOOT_PART"
@@ -84,7 +84,8 @@ run_installer_uboot_programming() {
     if "$SONIC_PROGRAM_UBOOT_ENV_SH"; then
         log "U-Boot environment updated."
     else
-        log "Warning: sonic-program-uboot-env.sh failed (see messages above)."
+        log "ERROR: sonic-program-uboot-env.sh failed (see messages above)."
+        return 1
     fi
 }
 
@@ -96,8 +97,8 @@ if [ "$INSTALLER_MODE" = 1 ]; then
     run_fw_env_config
 
     if ! command -v fw_setenv >/dev/null 2>&1 || ! command -v fw_printenv >/dev/null 2>&1; then
-        log "Warning: fw_setenv/fw_printenv not available; skipping U-Boot env update."
-        exit 0
+        log "ERROR: fw_setenv/fw_printenv not available in installer mode."
+        exit 1
     fi
 
     sync
@@ -110,14 +111,14 @@ if [ "$INSTALLER_MODE" = 1 ]; then
         BOOT_PART="${EMMC}p1"
     fi
     if [ -z "$BOOT_PART" ] || [ ! -b "$BOOT_PART" ]; then
-        log "Warning: SONiC-OS partition not found; skipping U-Boot variable programming."
-        exit 0
+        log "ERROR: SONiC-OS partition not found in installer mode."
+        exit 1
     fi
 
     mkdir -p "$MNT"
     if ! mount -t ext4 -o ro "$BOOT_PART" "$MNT" 2>/dev/null; then
-        log "Warning: could not mount $BOOT_PART; skipping U-Boot variable programming."
-        exit 0
+        log "ERROR: could not mount $BOOT_PART in installer mode."
+        exit 1
     fi
 
     IMAGE_DIR=""
@@ -129,11 +130,14 @@ if [ "$INSTALLER_MODE" = 1 ]; then
     done
     if [ -z "$IMAGE_DIR" ]; then
         umount "$MNT" 2>/dev/null || true
-        log "Warning: no image-* directory on $BOOT_PART; skipping U-Boot variable programming."
-        exit 0
+        log "ERROR: no image-* directory on $BOOT_PART in installer mode."
+        exit 1
     fi
 
-    run_installer_uboot_programming
+    if ! run_installer_uboot_programming; then
+        umount "$MNT" 2>/dev/null || true
+        exit 1
+    fi
     umount "$MNT" 2>/dev/null || true
     exit 0
 fi

--- a/platform/aspeed/installer/create_tftp_image.sh
+++ b/platform/aspeed/installer/create_tftp_image.sh
@@ -398,9 +398,11 @@ tftp \$loadaddr sonic_tftp_install.fit
 setenv bootconf <fit-configuration>
 bootm \$loadaddr#conf-\$bootconf
 #
-#    Optional bootargs: sonic_install.reboot=1  (reboot after flash; network is always eth0)
+#    Auto-reboot after a successful install is enabled by default.
+#    To stay in the installer shell after success, add: sonic_install.reboot=n
 #    Static IP instead of DHCP: add e.g. ip=192.168.1.50::192.168.1.1:255.255.255.0::eth0:off
 #    Static IP has no DHCP, so hostname URLs won't resolve — use an IP-literal URL.
+#    (network is always eth0)
 #
 # 3. Manual install (no sonic_install.bmc_image in bootargs): shell then
 #      /sbin/install-to-emmc.sh /tmp/$TFTP_IMAGE_NAME
@@ -433,5 +435,8 @@ echo "  setenv bootargs \"console=... root=/dev/ram0 rw sonic_install.bmc_image=
 echo "  tftp $fit_addr sonic_tftp_install.fit"
 echo "  setenv bootconf <fit-configuration>   # see configurations in platform/aspeed/sonic_fit.its (no conf- prefix)"
 echo "  bootm $fit_addr#conf-\$bootconf"
+echo ""
+echo "Auto-reboot after a successful install is enabled by default."
+echo "Add sonic_install.reboot=n to the bootargs to stay in the installer shell after success."
 echo ""
 echo "Without sonic_install.bmc_image=: shell, then /sbin/install-to-emmc.sh /tmp/$TFTP_IMAGE_NAME"

--- a/platform/aspeed/tftp-installer-init/init
+++ b/platform/aspeed/tftp-installer-init/init
@@ -116,18 +116,21 @@ INSTALL_REBOOT_REASON="enabled by default"
 
 parse_install_reboot_arg() {
     case "$1" in
-    y)
+    y|1|yes|true)
         INSTALL_REBOOT=y
         INSTALL_REBOOT_REASON="enabled by sonic_install.reboot=$1"
         ;;
-    n)
+    n|0|no|false)
         INSTALL_REBOOT=n
         INSTALL_REBOOT_REASON="disabled by sonic_install.reboot=$1"
         ;;
     *)
-        INSTALL_REBOOT=n
-        INSTALL_REBOOT_REASON="disabled due to invalid sonic_install.reboot=$1"
-        echo "Warning: invalid sonic_install.reboot=$1; auto-reboot disabled."
+        # An unrecognized or empty value is not an explicit disable. The policy is
+        # "reboot on success unless explicitly disabled", so keep the default (reboot)
+        # rather than silently suppressing it; still warn so the typo is visible.
+        INSTALL_REBOOT=y
+        INSTALL_REBOOT_REASON="enabled by default (ignored invalid sonic_install.reboot=$1)"
+        echo "Warning: invalid sonic_install.reboot=$1; using default (auto-reboot enabled)."
         ;;
     esac
 }

--- a/platform/aspeed/tftp-installer-init/init
+++ b/platform/aspeed/tftp-installer-init/init
@@ -2,7 +2,8 @@
 # Net-install initramfs: minimal bring-up, then same driver load path as stock SONiC initramfs
 # (init-top + /conf/modules + init-premount/udev) so MDIO/I2C/GPIO/PHY deps match full initramfs.
 # If cmdline has sonic_install.bmc_image=, DHCP (or existing ip=) + fetch + /sbin/install-to-emmc.sh;
-# else interactive shell. Optional: sonic_install.reboot=1 (network: always eth0)
+# else interactive shell. Optional: sonic_install.reboot=n (network: always eth0)
+# (auto-reboot is the default on successful auto-install; reboot=n keeps the shell open).
 #
 # Transport is selected from the bmc_image value:
 #   http://… or https://…  -> curl
@@ -110,13 +111,32 @@ cd /tmp
 
 INSTALL_BMC_IMAGE=
 INSTALL_TFTP_SERVER=
-INSTALL_REBOOT=
+INSTALL_REBOOT=y
+INSTALL_REBOOT_REASON="enabled by default"
+
+parse_install_reboot_arg() {
+    case "$1" in
+    y)
+        INSTALL_REBOOT=y
+        INSTALL_REBOOT_REASON="enabled by sonic_install.reboot=$1"
+        ;;
+    n)
+        INSTALL_REBOOT=n
+        INSTALL_REBOOT_REASON="disabled by sonic_install.reboot=$1"
+        ;;
+    *)
+        INSTALL_REBOOT=n
+        INSTALL_REBOOT_REASON="disabled due to invalid sonic_install.reboot=$1"
+        echo "Warning: invalid sonic_install.reboot=$1; auto-reboot disabled."
+        ;;
+    esac
+}
+
 for x in $(cat /proc/cmdline); do
     case $x in
-    sonic_install.bmc_image=*) INSTALL_BMC_IMAGE="${x#sonic_install.bmc_image=}" ;;
+    sonic_install.bmc_image=*)   INSTALL_BMC_IMAGE="${x#sonic_install.bmc_image=}" ;;
     sonic_install.tftp_server=*) INSTALL_TFTP_SERVER="${x#sonic_install.tftp_server=}" ;;
-    sonic_install.reboot=1|sonic_install.reboot=yes|sonic_install.reboot=true)
-        INSTALL_REBOOT=y ;;
+    sonic_install.reboot=*)      parse_install_reboot_arg "${x#sonic_install.reboot=}" ;;
     esac
 done
 
@@ -125,6 +145,8 @@ drop_shell() {
     echo "  Manual install: /sbin/install-to-emmc.sh /tmp/<image.img.gz>"
     echo "  Auto install (HTTP/HTTPS): sonic_install.bmc_image=http(s)://<host>/<path>/<image.img.gz>"
     echo "  Auto install (TFTP):       sonic_install.bmc_image=<path-or-filename> sonic_install.tftp_server=<ip>"
+    echo "                             (auto-reboot is the default; pass sonic_install.reboot=n to stay here on success)"
+    echo ""
     if [ -x /bin/bash ]; then
         exec /bin/bash
     fi
@@ -259,14 +281,56 @@ if ! /sbin/install-to-emmc.sh "$FETCHED_IMAGE"; then
     drop_shell
 fi
 
-if [ -x /sbin/sonic-uboot-env-init.sh ]; then
-    SONIC_UBOOT_ENV_INSTALLER=1 /sbin/sonic-uboot-env-init.sh || echo "Warning: U-Boot env update failed or incomplete."
+if [ ! -x /sbin/sonic-uboot-env-init.sh ]; then
+    echo "Error: /sbin/sonic-uboot-env-init.sh missing from initramfs; not safe to reboot."
+    drop_shell
+fi
+if ! SONIC_UBOOT_ENV_INSTALLER=1 /sbin/sonic-uboot-env-init.sh; then
+    echo "Error: U-Boot env update failed; not safe to reboot."
+    drop_shell
 fi
 
+print_install_success_banner() {
+    target_device=
+    image_dir=
+    # Parse as data rather than sourcing — the file is generated, but a glob-derived basename
+    # shouldn't be eval'd into the running shell.
+    if [ -r /tmp/sonic-bmc-install-status ]; then
+        while IFS='=' read -r _k _v; do
+            case "$_k" in
+                target_device) target_device="$_v" ;;
+                image_dir)     image_dir="$_v" ;;
+            esac
+        done < /tmp/sonic-bmc-install-status
+    fi
+    if [ "$INSTALL_REBOOT" = y ]; then
+        _result="rebooting to boot SONiC from eMMC."
+    else
+        _result="reboot manually to boot SONiC from eMMC."
+    fi
+    cat <<EOF
+
+==========================================================
+SONiC-BMC installation complete.
+==========================================================
+Target device   : ${target_device:-unknown}
+Image directory : ${image_dir:-unknown}
+U-Boot env      : programmed
+Auto reboot     : ${INSTALL_REBOOT_REASON}
+Result          : ${_result}
+==========================================================
+
+EOF
+}
+
+print_install_success_banner
+
 if [ "$INSTALL_REBOOT" = y ]; then
-    echo "Rebooting..."
+    echo "Rebooting in 1 second (pass sonic_install.reboot=n to disable)..."
+    sleep 1
     sync
     reboot -f 2>/dev/null || busybox reboot -f 2>/dev/null || /sbin/reboot -f
+    echo "Error: reboot command failed; dropping to shell."
 fi
 
 drop_shell

--- a/platform/aspeed/tftp-installer-init/install-to-emmc.sh
+++ b/platform/aspeed/tftp-installer-init/install-to-emmc.sh
@@ -90,3 +90,57 @@ if [ -f "$MACHINE_CONF_SRC" ] && [ -s "$MACHINE_CONF_SRC" ]; then
         echo "Warning: SONiC-OS partition not found; could not write machine.conf to eMMC."
     fi
 fi
+
+# Post-write sanity check: mount the SONiC-OS partition and confirm an image-* directory
+# is present. This catches the rare case where dd reported success but the eMMC didn't
+# actually persist a valid SONiC payload. Also captures the image dir for /init's banner.
+sync
+blockdev --rereadpt "$EMMC" 2>/dev/null || true
+partprobe "$EMMC" 2>/dev/null || true
+INSTALL_PART=$(blkid -L SONiC-OS 2>/dev/null || true)
+# blkid -L searches every visible block device; reject any match that isn't on our target eMMC
+# (e.g. a USB stick with the same label) so we don't verify the wrong disk.
+case "$INSTALL_PART" in
+    "${EMMC}"*) ;;
+    *) INSTALL_PART="" ;;
+esac
+if [ -z "$INSTALL_PART" ] && [ -b "${EMMC}p1" ]; then
+    INSTALL_PART="${EMMC}p1"
+fi
+INSTALL_IMAGE_DIR=""
+INSTALL_VERIFY_ERR=""
+if [ -n "$INSTALL_PART" ] && [ -b "$INSTALL_PART" ]; then
+    MNT_STATUS=$(mktemp -d)
+    if mount -t ext4 -o ro "$INSTALL_PART" "$MNT_STATUS" 2>/dev/null; then
+        for d in "$MNT_STATUS"/image-*; do
+            [ -d "$d" ] || continue
+            if [ ! -s "$d/boot/sonic_arm64.fit" ]; then
+                INSTALL_VERIFY_ERR="$(basename "$d")/boot/sonic_arm64.fit missing or empty"
+                continue
+            fi
+            if [ ! -s "$d/fs.squashfs" ]; then
+                INSTALL_VERIFY_ERR="$(basename "$d")/fs.squashfs missing or empty"
+                continue
+            fi
+            INSTALL_IMAGE_DIR=$(basename "$d")
+            break
+        done
+        umount "$MNT_STATUS" 2>/dev/null || true
+        [ -z "$INSTALL_IMAGE_DIR" ] && [ -z "$INSTALL_VERIFY_ERR" ] && \
+            INSTALL_VERIFY_ERR="no image-* directory on $INSTALL_PART"
+    else
+        INSTALL_VERIFY_ERR="could not mount $INSTALL_PART read-only"
+    fi
+    rmdir "$MNT_STATUS" 2>/dev/null || true
+else
+    INSTALL_VERIFY_ERR="SONiC-OS partition not found on $EMMC"
+fi
+if [ -z "$INSTALL_IMAGE_DIR" ]; then
+    echo "Error: post-write verification failed: $INSTALL_VERIFY_ERR"
+    exit 1
+fi
+{
+    echo "target_device=$EMMC"
+    echo "image_dir=$INSTALL_IMAGE_DIR"
+} > /tmp/sonic-bmc-install-status
+echo "Image write complete: image_dir=$INSTALL_IMAGE_DIR on $EMMC"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Two related problems in the SONiC-BMC TFTP installer (AST2700):

1. **No verified success signal.** The previous flow trusted only `gunzip` / `dd` exit codes and printed a generic "Installation Complete" message. Several silent-failure paths existed: post-write payload could be incomplete, `sonic-uboot-env-init.sh` (installer mode) would warn-and-continue on missing partition / mount failure / missing image-*, and `/init` would silently skip U-Boot programming if the helper script was missing from the initramfs. Any of these could let the installer print success and reach a non-bootable state.

2. **Auto-reboot was opt-in.** Operators had to add `sonic_install.reboot=y` to bootargs to avoid a manual reboot after a successful install. Unattended lab and manufacturing flows benefit from the inverse default (reboot on success unless explicitly disabled).

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

**1. Post-write verification (`install-to-emmc.sh`)**
- After `dd` + `sync`, mount the `SONiC-OS` partition read-only and confirm `image-*/boot/sonic_arm64.fit` and `image-*/fs.squashfs` exist and are non-empty.
- Distinguish failure causes: partition not found, mount failed, payload incomplete (each with a specific error message).
- Write `/tmp/sonic-bmc-install-status` (target_device, image_dir) for the banner.

**2. Fail-closed U-Boot env programming (`sonic-uboot-env-init.sh`, installer mode only)**
- Missing `fw_setenv` / `fw_printenv`, missing `SONiC-OS` partition, mount failure, missing `image-*` directory, or non-zero return from `sonic-program-uboot-env.sh` are now fatal (was: warn-and-continue).
- Host first-boot mode is unchanged.

**3. Success gates and banner in `/init`**
- Missing `/sbin/sonic-uboot-env-init.sh` → `drop_shell` (was: silently skip U-Boot programming and print success).
- Non-zero from `sonic-uboot-env-init.sh` → `drop_shell` (was: warning).
- New `print_install_success_banner` reads `/tmp/sonic-bmc-install-status` with `while IFS='=' read` (parsed as data, not sourced), reports target device / image directory / U-Boot env state.

**4. Default auto-reboot with opt-out (`/init`)**
- `INSTALL_REBOOT=y` by default; new `parse_install_reboot_arg` handles the policy:
  - Enable: `y|1|yes|true` (preserves back-compat with the previously documented `1|yes|true` tokens; `y` is the new alias for the default).
  - Disable: `n|0|no|false`.
  - Unrecognized or empty value: warn + keep the default (reboot). A typo or empty value is not an explicit disable, so it must not silently suppress the new default.
- 1-second delay before `reboot -f` so the success banner is visible on serial console without slowing automation.
- State-aware banner lines: `Auto reboot: <reason>` and `Result: rebooting to boot SONiC from eMMC.` / `reboot manually to boot SONiC from eMMC.`
- `drop_shell` help text mentions the new default and the opt-out bootarg.

**5. Documentation (`create_tftp_image.sh`)**
- `uboot-tftp-commands.txt` cheat sheet rewritten: new default documented, `sonic_install.reboot=n` listed as the opt-out.
- Terminal summary line corrected (`boot from TFTP → auto installer initramfs`, not `initramfs shell`) and an explicit two-line note about the auto-reboot default added.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

1. **Default reboot** — bootargs: `sonic_install.tftp_server=<ip>` (no reboot arg). Expect: TFTP fetch → install → post-write verify → U-Boot env programmed → banner shows "Auto reboot: enabled by default" + "Result: rebooting..." → 1-second delay → reboot → SONiC-BMC boots from eMMC.

2. **Opt-out** — add `sonic_install.reboot=n`. Expect: success path runs → banner shows "Auto reboot: disabled by sonic_install.reboot=n" + "Result: reboot manually..." → drops to shell → operator runs `reboot -f` → SONiC-BMC boots.

3. **Back-compat** — `sonic_install.reboot=1`. Expect: same as default reboot, banner shows "enabled by sonic_install.reboot=1".

4. **Invalid value** — `sonic_install.reboot=maybe`. Expect: warning printed at parse time → install completes → banner shows "enabled by default (ignored invalid sonic_install.reboot=maybe)" → reboots (an invalid or empty value is not an explicit disable, so the default reboot is preserved).

5. **TFTP failure** — bad server / missing file / corrupt `.img.gz`. Expect: no reboot, drop_shell.

6. **Install failure** — break `image-*/fs.squashfs` before TFTP. Expect: post-write verification fails with specific error message → no reboot, drop_shell.

7. **Malformed initramfs** — rebuild without `/sbin/sonic-uboot-env-init.sh`. Expect: `/init` reports "missing from initramfs" → drop_shell, NOT auto-reboot.

8. **Post-reboot activation** (after test 1): `/proc/cmdline` references the expected `loop=image-*/fs.squashfs`, `/host` is mounted from `SONiC-OS`, `fw_printenv -n image_dir` matches the installed `image-*`, `fw_printenv -n boot_next` is `run sonic_image_1`.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
