### PR TITLE
iccpd: Fix MAC age flag handling

### DIFF
--- a/src/iccpd/src/mlacp_link_handler.c
+++ b/src/iccpd/src/mlacp_link_handler.c
@@ -2840,13 +2840,13 @@ void do_mac_update_from_syncd(uint8_t mac_addr[ETHER_ADDR_LEN], uint16_t vid, ch
                 ICCPD_LOG_DEBUG("ICCP_FDB", "MAC update from mclagsyncd: Update MAC %s, vlan %d ifname %s",
                     mac_addr_to_str(mac_msg->mac_addr), mac_msg->vid, mac_msg->ifname);
                 // MAC is local now Del entry from MCLAG_FDB_TABLE if peer not aged.
-                if (!(mac_msg->age_flag & MAC_AGE_PEER))
+                if (!(mac_info->age_flag & MAC_AGE_PEER))
                 {
                     ICCPD_LOG_DEBUG("ICCP_FDB", " MAC update from mclagsyncd: MAC move Update MAC remote to local %s, vlan %d"
                             " ifname %s, del entry from MCLAG_FDB_TABLE",
                             mac_addr_to_str(mac_msg->mac_addr), mac_msg->vid, mac_msg->ifname);
 		    mac_info->age_flag = MAC_AGE_PEER;
-                    del_mac_from_chip(mac_msg);
+                    del_mac_from_chip(mac_info);
                 }
             }
             else
@@ -2857,12 +2857,12 @@ void do_mac_update_from_syncd(uint8_t mac_addr[ETHER_ADDR_LEN], uint16_t vid, ch
                 ICCPD_LOG_DEBUG("ICCP_FDB", "MAC update from mclagsyncd: Duplicate update MAC %s, vlan %d ifname %s",
                         mac_addr_to_str(mac_msg->mac_addr), mac_msg->vid, mac_msg->ifname);
                 // MAC is local now Del entry from MCLAG_FDB_TABLE if peer not aged.
-                if (!(mac_msg->age_flag & MAC_AGE_PEER))
+                if (!(mac_info->age_flag & MAC_AGE_PEER))
                 {
                     ICCPD_LOG_DEBUG("ICCP_FDB", "MAC update from mclagsyncd: Update MAC remote to local %s, vlan %d"
                             " ifname %s, del entry from MCLAG_FDB_TABLE",
                             mac_addr_to_str(mac_msg->mac_addr), mac_msg->vid, mac_msg->ifname);
-                    del_mac_from_chip(mac_msg);
+                    del_mac_from_chip(mac_info);
                 }
                 return;
             }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fix `do_mac_update_from_syncd()` to check the persistent entry’s `age_flag` instead of the stack-local `mac_msg` copy. The stack copy is initialized with `age_flag = 0` here:

https://github.com/sonic-net/sonic-buildimage/blob/007f4fb911682b466d514d52eb8e0e8c62c92ea3/src/iccpd/src/mlacp_link_handler.c#L2682-L2691

This makes `!(mac_msg->age_flag & MAC_AGE_PEER)` always true, so this could incorrectly delete entries or software state from hardware state during move or duplicate syncd update handling. Before the buggy existing-MAC checks, there's nothing that copies `mac_info->age_flag` into `mac_msg`, and it cannot receive age info from syncd because the syncd message has no such field. (can share a trigger example if it's helpful)

It looks like this could be the root cause of #17606?

(Disclosure: this issue was automatically identified by [Specula](https://github.com/specula-org/Specula))

#### How I did it

Replace `mac_msg` with `mac_info`, and do the same for `del_mac_from_chip()` so `add_to_syncd` is cleared on the persistent entry instead of the stack copy.

#### How to verify it

There's no existing test harness to extend, but the build completes successfully:
```
[ finished ] [ target/debs/trixie/iccpd_0.0.5_amd64.deb
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
<!--
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->
<!--
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] -->

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

Built successfully on master (e31bb18).

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fixes where MAC age flag is read from. 

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### A picture of a cute animal (not mandatory but encouraged)

<img width="300" alt="image" src="https://github.com/user-attachments/assets/0e73bab7-9303-4328-86cc-db9acb0a21ad" />

(courtesy [Unsplash](https://unsplash.com/fr/photos/un-panda-roux-dormant-sur-une-buche-g1KF-KC2ZBg))