### PR TITLE
[Arista] boot0: Ignore error from readprefdl

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -465,7 +465,8 @@ EOF
 
 read_eeprom() {
     if [ -x /bin/readprefdl ] && [ -f "$1" ]; then
-        readprefdl -f "$1" -d > $target_path/.system-prefdl
+        readprefdl -f "$1" -d > $target_path/.system-prefdl || err "Failed on readprefdl -f $1 -d"
+
     elif [ -f /etc/prefdl ]; then
         cp /etc/prefdl $target_path/.system-prefdl
         chmod a+r $target_path/.system-prefdl


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Booting may be blocked due to readprefdl errors on prototype platforms or devices with hardware issues. To improve debuggability on these systems, we want to ignore these errors and allow the boot process to continue.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Continue booting even if readprefdl fails.

#### How to verify it
It will not affect the normal systems.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

