### PR TITLE
[docker-sonic-mgmt] bypass NFS build cache on scheduled runs to absorb upstream USNs

### DIFF
--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -35,6 +35,10 @@ parameters:
 - name: registry_conn
   type: string
   default: sonicdev
+- name: bypass_cache
+  type: boolean
+  default: false
+  displayName: "Bypass NFS build cache (force full rebuild to pick up upstream USNs)"
 
 stages:
 - stage: Build
@@ -55,8 +59,22 @@ stages:
         set -xe
         git submodule update --init --recursive -- src/sonic-platform-daemons src/sonic-genl-packet src/sonic-sairedis src/ptf src/sonic-device-data src/sonic-dash-api
 
+        # Bypass the NFS build cache on scheduled runs (or when manually
+        # requested via the bypass_cache parameter) so that the docker
+        # image is actually rebuilt and `apt-get upgrade -y` inside
+        # Dockerfile.j2 picks up newly-released Ubuntu security updates
+        # (USNs). Without this, GIT_CONTENT_SHA cache hits cause daily
+        # scheduled runs to re-publish an unchanged docker-sonic-mgmt.gz
+        # for weeks at a time, leaving freshly-disclosed CVEs unpatched
+        # (e.g. USN-8292-1 for libarchive13t64).
+        EXTRA_BUILD_VARS=""
+        if [ "$(Build.Reason)" = "Schedule" ] || [ "${{ parameters.bypass_cache }}" = "True" ]; then
+          EXTRA_BUILD_VARS="SONIC_OVERRIDE_BUILD_VARS+=DOCKER_SONIC_MGMT_CACHE_MODE=none"
+          echo "##[notice]Bypassing NFS build cache for docker-sonic-mgmt (reason=$(Build.Reason), bypass_cache=${{ parameters.bypass_cache }})"
+        fi
+
         make NOBUSTER=1 NOBULLSEYE=1 SONIC_BUILD_JOBS=$(nproc) DEFAULT_CONTAINER_REGISTRY=publicmirror.azurecr.io ENABLE_DOCKER_BASE_PULL=y ENABLE_SBOM=y configure PLATFORM=generic DOCKER_BUILDKIT=0
-        make -f Makefile.work BLDENV=bookworm SONIC_BUILD_JOBS=$(nproc) DEFAULT_CONTAINER_REGISTRY=publicmirror.azurecr.io ENABLE_DOCKER_BASE_PULL=y ENABLE_SBOM=y target/docker-sonic-mgmt.gz
+        make -f Makefile.work BLDENV=bookworm SONIC_BUILD_JOBS=$(nproc) DEFAULT_CONTAINER_REGISTRY=publicmirror.azurecr.io ENABLE_DOCKER_BASE_PULL=y ENABLE_SBOM=y $EXTRA_BUILD_VARS target/docker-sonic-mgmt.gz
         cp -r target $(Build.ArtifactStagingDirectory)/target
       env:
         REGISTRY_SERVER: ${{ parameters.registry_url }}


### PR DESCRIPTION
### Why I did it
The `docker-sonic-mgmt` rule uses `_CACHE_MODE := GIT_CONTENT_SHA` (see `rules/docker-sonic-mgmt.dep`). The daily scheduled pipeline `Azure.docker-sonic-mgmt` ([definitionId=194](https://dev.azure.com/mssonic/build/_build?definitionId=194)) succeeds every night, but whenever nothing under `dockers/docker-sonic-mgmt/` has changed, the build restores the cached `target/docker-sonic-mgmt.gz` from NFS (`/nfs/dpkg_cache/...`) and `docker build` is skipped entirely. As a result, `apt-get update && apt-get upgrade -y` inside `Dockerfile.j2` never re-runs, and freshly-released Ubuntu USNs are not picked up.

Concrete miss: USN-8292-1 (`libarchive13t64` 3.7.2-2ubuntu0.6 → 0.7) was published on 2026-05-21, but the last real rebuild was 2026-05-20 (commit 14c70e69, ansible patch regen). Every daily run since then re-published the same `sha256:ea549ff…` digest as `:latest`, and Defender kept flagging the same finding.

This is a structural issue, not a one-off — Ubuntu publishes a libarchive USN roughly every 3–4 months, and the same gap will apply to any other Ubuntu package that gets a USN.

### How I did it
Override the cache mode at the `make` invocation in `.azure-pipelines/docker-sonic-mgmt.yml` when:
- the run was triggered by the daily schedule (`Build.Reason == 'Schedule'`), or
- the new `bypass_cache` pipeline parameter is checked at queue time.

In those cases the build is invoked with:
```
SONIC_OVERRIDE_BUILD_VARS+=DOCKER_SONIC_MGMT_CACHE_MODE=none
```
which causes `slave.mk` to skip the NFS cache for the `docker-sonic-mgmt` target only, forcing a real `docker build` and re-running `apt-get upgrade -y`. PR and CI runs continue to use the cache, so PR turnaround is unchanged.

### How to verify it
- Queue the pipeline manually with `bypass_cache` checked — confirm the build log shows `[CACHE] DOCKER_SONIC_MGMT cache mode: none`, that `docker build` actually runs, and that the resulting `docker-sonic-mgmt:latest` digest differs from the previous one.
- After the next daily scheduled run, confirm `Build.Reason` is `Schedule`, the bypass message is printed, and the new image has `libarchive13t64=3.7.2-2ubuntu0.7` (or newer).
- A PR build on this branch should still hit the cache and complete in normal time.
