### PR TITLE
[Mellanox][multi-asic] Add support for asic ready signal - port to based on an old commit

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -763,6 +763,7 @@ start() {
         -v /var/run/hw-management:/var/run/hw-management:rw \
         -v /etc/hw-management-sensors:/etc/hw-management-sensors:ro \
         -v /tmp/nv-syncd-shared/:/tmp \
+        -v /tmp/asic_ready:/tmp/asic_ready:rw \
         $SMARTSWITCH_MNT \
 {%- else %}
 {%- if mount_default_tmpfs|default("n") == "y" %}

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -27,6 +27,8 @@
 try:
     from sonic_platform_base.chassis_base import ChassisBase
     from sonic_py_common.logger import Logger
+    from .inotify_helper import InotifyEventHelper
+    from collections import defaultdict
     import os
     from sonic_py_common import device_info
     from functools import reduce
@@ -131,6 +133,10 @@ class Chassis(ChassisBase):
         self._cpo_port_list = None
         # Mapping from SFP index to ASIC ID
         self._asic_id_map = None
+        # Mapping asic ID to list of SFP indices
+        # values are set of SFP indices to not have sfp duplications per asic
+        self._asic_modules_dict = defaultdict(set)
+        self._last_asic_ready_states = {}
 
         self._num_npus = device_info.get_num_npus()
 
@@ -342,6 +348,8 @@ class Chassis(ChassisBase):
                                 sfp_object = sfp_module.CpoPort(index, asic_id=asic_id)
                             else:
                                 sfp_object = sfp_module.SFP(index, asic_id=asic_id)
+                            # populate the asic_modules_dict with the sfp object
+                            self._asic_modules_dict[asic_id].add(sfp_object)
                             self._sfp_list.append(sfp_object)
                         self.sfp_initialized_count = sfp_count
                     elif self.sfp_initialized_count != len(self._sfp_list):
@@ -481,6 +489,17 @@ class Chassis(ChassisBase):
             return SfpBase.SFP_PORT_TYPE_BIT_RJ45
         raise NotImplementedError
 
+    def capture_current_asic_states(self, dir_path, filenames):
+        states = {}
+        for name in filenames:
+            path = os.path.join(dir_path, name)
+            try:
+                with open(path) as f:
+                    states[name] = f.read().strip()
+            except FileNotFoundError:
+                states[name] = None
+        return states
+
     def get_change_event(self, timeout=0):
         """
         Returns a nested dictionary containing all devices which have
@@ -505,11 +524,123 @@ class Chassis(ChassisBase):
                       has been inserted and sfp 11 has been removed.
         """
         self.sfp_wait_ready_and_initialize()
+
+        # if asic becomes not available, generate not present events for its modules and add to change_events_dict
+        asic_events_dict = self.get_asic_change_event(timeout=500)
+
         if DeviceDataManager.is_module_host_management_mode():
-            return self.get_change_event_for_module_host_management_mode(timeout)
+            change_events_dict = self.get_change_event_for_module_host_management_mode(timeout)
         else:
-            return self.get_change_event_legacy(timeout)
-            
+            change_events_dict = self.get_change_event_legacy(timeout)
+
+        if asic_events_dict:
+            change_events_dict.setdefault('sfp', {}).update(asic_events_dict)
+        return True, change_events_dict
+    
+    def _disable_polling_for_asic(self, asic_id):
+        """
+        Remove SFP fds of the received asic from self.poll_obj.
+
+        Called when an ASIC transitions to not-ready so we stop polling its
+        sysfs nodes without affecting other ASICs. Works for both module host
+        management mode (3-tuple in registered_fds) and legacy mode (2-tuple).
+        """
+        if not self.poll_obj or not self.registered_fds:
+            return
+
+        sdk_indices = {s.sdk_index for s in self._asic_modules_dict.get(asic_id, ())}
+        if not sdk_indices:
+            return
+        for fileno, item in list(self.registered_fds.items()):
+            # item = (sdk_index, fd) in legacy mode,
+            #        or (sdk_index, fd, fd_type) in module host management mode.
+            sdk_index = item[0]
+            fd = item[1]
+            if sdk_index not in sdk_indices:
+                continue
+            try:
+                self.poll_obj.unregister(fd)
+            except (KeyError, ValueError, OSError):
+                pass
+            try:
+                fd.close()
+            except OSError:
+                pass
+            self.registered_fds.pop(fileno, None)
+
+    def _enable_polling_for_asic(self, asic_id):
+        """Re-register polling fds for SFPs of an ASIC that just became ready.
+
+        Host-mgmt mode: SFP.refresh_poll_obj picks the right fds for the SFP's
+        current state (FW vs SW control). Legacy mode: register the 'present'
+        fd as a 2-tuple, like the initial registration block does.
+        """
+        if not self.poll_obj:
+            return
+        host_mgmt = DeviceDataManager.is_module_host_management_mode()
+        for s in self._asic_modules_dict.get(asic_id, ()):
+            try:
+                if host_mgmt:
+                    s.refresh_poll_obj(self.poll_obj, self.registered_fds)
+                else:
+                    fd = s.get_fd_for_polling_legacy()
+                    if fd is None:
+                        continue
+                    self.poll_obj.register(fd, select.POLLERR | select.POLLPRI)
+                    self.registered_fds[fd.fileno()] = (s.sdk_index, fd)
+                    self.sfp_states_before_first_poll[s.sdk_index] = s.get_module_status()
+            except Exception as e:
+                logger.log_warning(f'Failed to enable polling for SFP {s.sdk_index}: {e}')
+
+    def get_asic_change_event(self, timeout=500):
+        changes = {}
+        asic_count = DeviceDataManager.get_asic_count()
+        asic_ready_dir = "/var/run/hw-management/config"
+        filenames = {f"asic{asic_index}_ready" for asic_index in range(1, asic_count + 1)}
+
+        asic_ready_watcher = InotifyEventHelper(asic_ready_dir, filenames)
+        changed_paths = asic_ready_watcher.wait_for_events(timeout)
+        after_states = self.capture_current_asic_states(asic_ready_dir, filenames)
+        if len(self._last_asic_ready_states) != 0:
+            # capture changes that happened before/after the event watcher started
+            for name in filenames:
+                if self._last_asic_ready_states[name] != after_states[name]:
+                    changed_paths.append(os.path.join(asic_ready_dir, name))
+
+        self._last_asic_ready_states = after_states
+
+        # wait_ready_task only exists in module host management mode
+        if changed_paths and DeviceDataManager.is_module_host_management_mode():
+            from . import sfp as sfp_module
+            wait_ready_task = sfp_module.SFP.get_wait_ready_task()
+        else:
+            wait_ready_task = None
+
+        for path in changed_paths:
+            name = os.path.basename(path)
+            asic_index = int(name.split("asic")[1].split("_")[0]) - 1
+            asic_id = f'asic{asic_index}'
+            sfp_set = self._asic_modules_dict.get(asic_id, set())
+            sfp_indices = [sfp.sdk_index for sfp in sfp_set]
+            if not os.path.exists(path) or utils.read_int_from_file(path) == 0:
+                # asic becomes not available: emit removal events for its modules,
+                # cancel any pending reset waits, and unregister its polling fds
+                value = '0'
+                ready_asic_val = False
+                if wait_ready_task is not None:
+                    for s in sfp_set:
+                        wait_ready_task.cancel_wait(s.sdk_index)
+                self._disable_polling_for_asic(asic_id)
+            else:
+                value = '1'
+                ready_asic_val = True
+                self._enable_polling_for_asic(asic_id)
+            self.module_host_mgmt_initializer.set_asic_ready_value(asic_index, ready_asic_val)
+            for i in sfp_indices:
+                changes[str(i)] = value
+
+        return changes
+
     def get_change_event_for_module_host_management_mode(self, timeout):
         """Get SFP change event when module host management mode is enabled.
 
@@ -518,8 +649,7 @@ class Chassis(ChassisBase):
                 this method will block until a change is detected.
 
         Returns:
-            (bool, dict):
-                - True if call successful, False if not; - Deprecated, will always return True
+            dict:
                 - A nested dictionary where key is a device type,
                   value is a dictionary with key:value pairs in the format of
                   {'device_id':'device_event'},
@@ -534,7 +664,21 @@ class Chassis(ChassisBase):
         if not self.poll_obj:
             self.poll_obj = select.poll()
             self.registered_fds = {}
+
+            # Skip SFPs whose ASIC is currently not ready -
+            # their sysfs nodes may not exist or disappear.
+            not_ready_sdk_indices = set()
+            if self._last_asic_ready_states:
+                for i in range(DeviceDataManager.get_asic_count()):
+                    state = self._last_asic_ready_states.get(f"asic{i + 1}_ready")
+                    if state is None or state == '0':
+                        not_ready_sdk_indices.update(
+                            s.sdk_index for s in self._asic_modules_dict.get(f"asic{i}", ())
+                        )
+
             for s in self._sfp_list:
+                if s.sdk_index in not_ready_sdk_indices:
+                    continue
                 fds = s.get_fds_for_poling()
                 for fd_type, fd in fds.items():
                     if fd is None:
@@ -618,10 +762,20 @@ class Chassis(ChassisBase):
                     s.refresh_poll_obj(self.poll_obj, self.registered_fds)
                 else:
                     logger.log_debug(f'SFP {sfp_index} does not reach stable state, state={s.state}')
-                    
+
             ready_sfp_set = wait_ready_task.get_ready_set()
             for sfp_index in ready_sfp_set:
                 s = self._sfp_list[sfp_index]
+                # Defensive guard: a stale wait_ready_task entry for an SFP
+                # whose ASIC is no longer ready would crash refresh_poll_obj
+                # when get_fd() returns None for missing sysfs nodes.
+                asic_index = int(s.asic_id.replace('asic', ''))
+                ready_path = f"/var/run/hw-management/config/asic{asic_index + 1}_ready"
+                if not os.path.exists(ready_path) or utils.read_int_from_file(ready_path) == 0:
+                    logger.log_info(
+                        f'SFP {sfp_index} ready event ignored: ASIC {asic_index} became not ready'
+                    )
+                    continue
                 s.on_event(sfp.EVENT_RESET_DONE)
                 if s.in_stable_state():
                     self.sfp_module.SFP.wait_sfp_eeprom_ready([s], 2)
@@ -633,7 +787,7 @@ class Chassis(ChassisBase):
             if port_dict:
                 logger.log_notice(f'Sending SFP change event: {port_dict}, error event: {error_dict}')
                 self.reinit_sfps(port_dict)
-                return True, {
+                return {
                     'sfp': port_dict,
                     'sfp_error': error_dict
                 }
@@ -641,7 +795,7 @@ class Chassis(ChassisBase):
                 if not wait_forever:
                     elapse = time.monotonic() - begin
                     if elapse * 1000 >= timeout:
-                        return True, {'sfp': {}}
+                        return {'sfp': {}}
 
     def get_change_event_legacy(self, timeout):
         """Get SFP change event when module host management is disabled.
@@ -650,8 +804,7 @@ class Chassis(ChassisBase):
             timeout (int): polling timeout in ms
 
         Returns:
-            (bool, dict):
-                - True if call successful, False if not; - Deprecated, will always return True
+            dict:
                 - A nested dictionary where key is a device type,
                   value is a dictionary with key:value pairs in the format of
                   {'device_id':'device_event'},
@@ -744,7 +897,7 @@ class Chassis(ChassisBase):
             if port_dict:
                 logger.log_notice(f'Sending SFP change event: {port_dict}, error event: {error_dict}')
                 self.reinit_sfps(port_dict)
-                return True, {
+                return {
                     'sfp': port_dict,
                     'sfp_error': error_dict
                 }
@@ -752,7 +905,7 @@ class Chassis(ChassisBase):
                 if not wait_forever:
                     elapse = time.monotonic() - begin
                     if elapse * 1000 >= timeout:
-                        return True, {'sfp': {}}
+                        return {'sfp': {}}
 
     def reinit_sfps(self, port_dict):
         """

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/inotify_helper.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/inotify_helper.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,3 +63,33 @@ class InotifyHelper():
         if read_value != expected_value:
             return None
         return read_value
+
+
+class InotifyEventHelper():
+    """Helper Code for Inotify Event Implementation -
+    for files which don't exist yet, and not general event for changes"""
+
+    def __init__(self, dir_path, file_names):
+        self.inotify_obj = inotify.adapters.Inotify()
+        self.dir_path = dir_path
+        self.file_names = set(file_names)
+
+        self.inotify_obj.add_watch(self.dir_path, mask=(inotify.constants.IN_CREATE |
+                                                        inotify.constants.IN_DELETE |
+                                                        inotify.constants.IN_MODIFY |
+                                                        inotify.constants.IN_MOVED_TO |
+                                                        inotify.constants.IN_MOVED_FROM |
+                                                        inotify.constants.IN_CLOSE_WRITE
+                                                       )
+        )
+
+    def wait_for_events(self, timeout_ms):
+        changed_files = set()
+
+        for event in self.inotify_obj.event_gen(timeout_s=timeout_ms/1000,
+                                                yield_nones=False):
+            (_, _, path, filename) = event
+            if path == self.dir_path and filename in self.file_names:
+                changed_files.add(os.path.join(path, filename))
+
+        return list(changed_files)

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module_host_mgmt_initializer.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module_host_mgmt_initializer.py
@@ -17,20 +17,32 @@
 #
 
 from . import utils
+from .device_data import DeviceDataManager
 from sonic_py_common.logger import Logger
 
 import atexit
 import os
 import sys
 import threading
+import fcntl
 
 MODULE_READY_MAX_WAIT_TIME = 300
 MODULE_READY_CHECK_INTERVAL = 5
-MODULE_READY_CONTAINER_FILE = '/tmp/module_host_mgmt_ready'
-MODULE_READY_HOST_FILE = '/tmp/nv-syncd-shared/module_host_mgmt_ready'
+ASIC_READY_DIR = '/tmp/asic_ready'
+ASIC_READY_FILE_PREFIX = 'module_host_mgmt_asic_ready'
 DEDICATE_INIT_DAEMON = 'xcvrd'
-initialization_owner = False
 
+
+def get_asic_ready_file_path(asic_id):
+    """Return path to the ready file for one ASIC. asic_id can be int (e.g. 0) or str (e.g. 'asic0')."""
+    if isinstance(asic_id, str) and asic_id.startswith('asic'):
+        suffix = asic_id
+    else:
+        suffix = f'asic{asic_id}'
+    return os.path.join(ASIC_READY_DIR, f'{ASIC_READY_FILE_PREFIX}_{suffix}')
+
+
+initialization_owner = False
 logger = Logger()
 
 
@@ -40,6 +52,10 @@ class ModuleHostMgmtInitializer:
     def __init__(self):
         self.initialized = False
         self.lock = threading.Lock()
+        self.asic_count = DeviceDataManager.get_asic_count()
+        self.initialized_list = [False] * self.asic_count
+        if ASIC_READY_DIR:
+            os.makedirs(ASIC_READY_DIR, exist_ok=True)
 
     def initialize(self, chassis):
         """Initialize all modules. Only applicable for module host management mode.
@@ -50,74 +66,74 @@ class ModuleHostMgmtInitializer:
             chassis (object): chassis object
         """
         global initialization_owner
-        if self.initialized:
+        not_initialized = []
+        for i in range(len(self.initialized_list)):
+            if not self.initialized_list[i]:
+                not_initialized.append(i)
+
+        if not not_initialized:
             return
-        
         if utils.is_host():
-            self.wait_module_ready()
             chassis.initialize_sfp()
         else:
             if self.is_initialization_owner():
-                if not self.initialized:
+                if not_initialized:
                     with self.lock:
-                        if not self.initialized:
-                            from sonic_platform.device_data import DeviceDataManager
-                            logger.log_notice('Waiting for modules to be ready...')
-                            sfp_count = chassis.get_num_sfps()
-                            if not DeviceDataManager.wait_sysfs_ready(sfp_count):
-                                logger.log_error('Modules are not ready')
-                            else:
-                                logger.log_notice('Modules are ready')
+                        logger.log_notice('Waiting for modules to be ready...')
+                        sfp_count = chassis.get_num_sfps()
+                        if not DeviceDataManager.wait_sysfs_ready(sfp_count):
+                            logger.log_error('Modules are not ready')
+                        else:
+                            logger.log_notice('Modules are ready')
 
-                            logger.log_notice('Starting module initialization for module host management...')
-                            initialization_owner = True
-                            self.remove_module_ready_file()
-                            
-                            chassis.initialize_sfp()
-                            
-                            from .sfp import SFP
-                            SFP.initialize_sfp_modules(chassis._sfp_list)
-                            
-                            self.create_module_ready_file()    
-                            self.initialized = True
+                        logger.log_notice('Starting module initialization for module host management...')
+                        initialization_owner = True
+                        self.remove_asics_from_ready_file(not_initialized)
+                        chassis.initialize_sfp()
+                        asic_ready_list = []
+                        sfp_list = []
+                        for asic_id in not_initialized:
+                            asic_id_for_file = asic_id + 1
+                            if utils.read_int_from_file(f'/var/run/hw-management/config/asic{asic_id_for_file}_ready') == 1:
+                                asic_ready_list.append(asic_id)
+                                asic_id = f'asic{asic_id}'
+                                sfp_list.extend(chassis._asic_modules_dict[asic_id])
+                        from .sfp import SFP
+                        if sfp_list:
+                            SFP.initialize_sfp_modules(sfp_list)
+                            self.add_asics_to_ready_file(asic_ready_list)
+                            for asic_index in asic_ready_list:
+                                self.initialized_list[asic_index] = True
                             logger.log_notice('Module initialization for module host management done')
             else:
-                self.wait_module_ready()
                 chassis.initialize_sfp()
-                  
-    @classmethod
-    def create_module_ready_file(cls):
-        """Create module ready file
-        """
-        with open(MODULE_READY_CONTAINER_FILE, 'w'):
-            pass
 
-    @classmethod
-    def remove_module_ready_file(cls):
-        """Remove module ready file
+    def remove_asics_from_ready_file(self, asic_ids):
         """
-        if os.path.exists(MODULE_READY_CONTAINER_FILE):
-            os.remove(MODULE_READY_CONTAINER_FILE)
-                
-    def wait_module_ready(self):
-        """Wait up to MODULE_READY_MAX_WAIT_TIME seconds for all modules to be ready
+        Remove Asic IDs from the asic ready files (one file per ASIC).
+        Deletes the ready file for each given asic_id.
+        Args:
+            asic_ids (list): list of asic ids to remove (numbers)
         """
-        if utils.is_host():
-            module_ready_file = MODULE_READY_HOST_FILE
-        else:
-            module_ready_file = MODULE_READY_CONTAINER_FILE
+        for asic_id in asic_ids:
+            path = get_asic_ready_file_path(asic_id)
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass
 
-        if os.path.exists(module_ready_file):
-            self.initialized = True
-            return
-        else:
-            print('Waiting module to be initialized...')
-        
-        if utils.wait_until(os.path.exists, MODULE_READY_MAX_WAIT_TIME, MODULE_READY_CHECK_INTERVAL, module_ready_file):
-            self.initialized = True
-        else:
-            logger.log_error('Module initialization timeout', True)
-            
+    def add_asics_to_ready_file(self, asic_ids):
+        """
+        Add Asic IDs to the asic ready files (one file per ASIC).
+        Creates or overwrites the ready file for each given asic_id.
+        Args:
+            asic_ids (list): list of asic ids to add (numbers)
+        """
+        for asic_id in asic_ids:
+            path = get_asic_ready_file_path(asic_id)
+            with open(path, 'w') as file:
+                file.write(f"asic{asic_id}\n")
+
     def is_initialization_owner(self):
         """Indicate whether current thread is the owner of doing module initialization
 
@@ -126,12 +142,12 @@ class ModuleHostMgmtInitializer:
         """
         cmd = os.path.basename(sys.argv[0])
         return DEDICATE_INIT_DAEMON in cmd
-
-@atexit.register
-def clean_up():
-    """Remove module ready file when program exits.
-    When module host management is enabled, xcvrd is the dependency for all other
-    daemon/CLI who potentially uses SFP API.
-    """
-    if initialization_owner:
-        ModuleHostMgmtInitializer.remove_module_ready_file()
+    
+    def set_asic_ready_value(self, asic_id, ready_bool):
+        """
+        Update self.initialized_list with ready_bool in case something has changed.
+        """
+        self.initialized_list[asic_id] = ready_bool
+        if not ready_bool:
+            # if the asic becomes not ready, remove it from the ready file
+            self.remove_asics_from_ready_file([asic_id])

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -29,12 +29,14 @@ try:
     import os
     import threading
     import time
+    import fcntl
     from sonic_py_common.logger import Logger
     from sonic_py_common import multi_asic
     from swsscommon.swsscommon import SonicV2Connector, ConfigDBConnector
     from . import utils
     from .db_table_helper import get_db_table_helper
     from .device_data import DeviceDataManager
+    from .module_host_mgmt_initializer import get_asic_ready_file_path
     from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
     from sonic_platform_base.sonic_xcvr.fields import consts
     from sonic_platform_base.sonic_xcvr.api.public import sff8636, sff8436
@@ -476,13 +478,19 @@ class SFP(NvidiaSFPCommon):
         Returns:
             bool: True if device is present, False if not
         """
-
         try:
-            presence_file =  'hw_present' if self.is_sw_control() else 'present'
-            if utils.read_int_from_file(f'/sys/module/sx_core/asic0/module{self.sdk_index}/{presence_file}', log_func=None) != 1:
-                return False
-            eeprom_raw = self._read_eeprom(0, 1, log_on_error=False)
-            return eeprom_raw is not None
+            asic_id = self.asic_id
+            asic_id_for_file = "asic" + str(int(asic_id.replace("asic", "")) + 1)
+            if utils.read_int_from_file(f'/var/run/hw-management/config/{asic_id_for_file}_ready') == 1:
+                if DeviceDataManager.is_module_host_management_mode():
+                    if not os.path.exists(get_asic_ready_file_path(asic_id)):
+                        return False
+
+                presence_file = 'hw_present' if self.is_sw_control() else 'present'
+                presence_sysfs = f'/sys/module/sx_core/asic0/module{self.sdk_index}/{presence_file}'
+                if utils.read_int_from_file(presence_sysfs, log_func=None) == 1:
+                    return True
+            return False
         except Exception as e:
             logger.log_warning(f'Failed to check presence of SFP {self.sdk_index}: {e}')
             return False
@@ -1609,7 +1617,7 @@ class SFP(NvidiaSFPCommon):
             sfp_list (object): all sfps
         """
         wait_ready_task = cls.get_wait_ready_task()
-        wait_ready_task.start()
+        wait_ready_task.start_once()
         
         for s in sfp_list:
             s.on_event(EVENT_START)
@@ -1731,7 +1739,7 @@ class SFP(NvidiaSFPCommon):
     def get_asic_index(self):
         return self.asic_index
 
-
+        
 class RJ45Port(NvidiaSFPCommon):
     """class derived from SFP, representing RJ45 ports"""
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
@@ -149,7 +149,10 @@ class ThermalUpdater:
         logger.log_notice(f'Set hw-management-tc to {"suspend" if suspend else "resume"}')
         utils.write_file('/run/hw-management/config/suspend', 1 if suspend else 0)
 
-    def get_asic_temp(self, asic_name):
+    def get_asic_temp(self, asic_name, asic_index=0):
+        if utils.read_int_from_file(f'/var/run/hw-management/config/asic{asic_index+1}_ready') == 0:
+            logger.log_warning(f'ASIC {asic_index} is not ready, cannot check asic temprature')
+            return None
         try:
             present, temperature = get_db_table_helper().get_temperature_info_table().hget(asic_name, 'temperature')
             return int(float(temperature) * TEMPERATURE_SCALE) if present else 0
@@ -157,10 +160,16 @@ class ThermalUpdater:
             logger.log_error(f'Failed to read ASIC {asic_name} temperature - {temperature} - {e}')
             return None
 
-    def get_asic_temp_warning_threshold(self):
+    def get_asic_temp_warning_threshold(self, asic_index=0):
+        if utils.read_int_from_file(f'/var/run/hw-management/config/asic{asic_index+1}_ready') == 0:
+            logger.log_warning(f'ASIC {asic_index} is not ready, cannot check asic temprature warning threshold')
+            return None
         return ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD
 
-    def get_asic_temp_critical_threshold(self):
+    def get_asic_temp_critical_threshold(self, asic_index=0):
+        if utils.read_int_from_file(f'/var/run/hw-management/config/asic{asic_index+1}_ready') == 0:
+            logger.log_warning(f'ASIC {asic_index} is not ready, cannot check asic temprature critical threshold')
+            return None
         return ASIC_DEFAULT_TEMP_CRITICAL_THRESHOLD
 
     def update_single_module(self, sfp):

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
@@ -432,7 +432,7 @@ def wait_until_conditions(conditions, timeout, interval=1):
         timeout -= interval
     return False
 
-  
+
 class TimerEvent:
     def __init__(self, interval, cb, repeat):
         self.interval = interval

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/wait_sfp_ready_task.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/wait_sfp_ready_task.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,6 +37,10 @@ class WaitSfpReadyTask(threading.Thread):
         super().__init__(daemon=True)
         self.running = False
         
+        # protect this thread from starting more than 1 time
+        self.start_lock = threading.Lock()
+        self.started_once = False
+
         # Lock to protect the wait list 
         self.lock = threading.Lock()
         
@@ -49,6 +53,12 @@ class WaitSfpReadyTask(threading.Thread):
         # The queue to store those SFPs who finish loading firmware.
         self._ready_set = set()
         
+    def start_once(self):
+        with self.start_lock:
+            if not self.started_once:
+                super().start()
+                self.started_once = True
+
     def stop(self):
         """Stop the task, only used in unit test
         """
@@ -81,10 +91,8 @@ class WaitSfpReadyTask(threading.Thread):
         """
         logger.log_debug(f'SFP {sfp_index} is canceled for waiting reset done')
         with self.lock:
-            if sfp_index in self._wait_dict:
-                self._wait_dict.pop(sfp_index)
-            if sfp_index in self._ready_set:
-                self._ready_set.pop(sfp_index)
+            self._wait_dict.pop(sfp_index, None)
+            self._ready_set.discard(sfp_index)
                 
     def get_ready_set(self):
         """Get ready set and clear it

--- a/platform/mellanox/mlnx-platform-api/tests/test_change_event.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_change_event.py
@@ -32,6 +32,18 @@ from sonic_platform import chassis
 from sonic_platform import sfp
 
 
+def _set_monotonic_exit_by_timeout(mock_time, timeout_ms):
+    """Exit an empty poll loop when no SFP events are reported."""
+    timeout_sec = timeout_ms / 1000.0
+    mock_time.side_effect = [0.0, timeout_sec + 1.0]
+
+
+def _set_monotonic_allow_poll_loop(mock_time, timeout_ms=1000, max_poll_iterations=10):
+    """Allow multiple poll-loop iterations, then fall back to timeout exit."""
+    timeout_sec = timeout_ms / 1000.0
+    mock_time.side_effect = [0.0] * (max_poll_iterations + 1) + [timeout_sec + 1.0]
+
+
 class TestChangeEventSeekFailure:
     """Cover OSError from fd.seek(0) in change-event polling loops."""
 
@@ -63,13 +75,14 @@ class TestChangeEventSeekFailure:
         mock_file.fileno = mock.MagicMock(return_value=1)
         mock_file.seek.side_effect = OSError(5, 'seek failed')
 
-        mock_time.side_effect = [0, 1000]
+        _set_monotonic_exit_by_timeout(mock_time, 1000)
 
         _, change_event = c.get_change_event(1000)
         assert 'sfp' in change_event and not change_event['sfp']
         mock_file.seek.assert_called_with(0)
         mock_file.read.assert_not_called()
 
+    @mock.patch('sonic_platform.chassis.Chassis.get_asic_change_event')
     @mock.patch('sonic_platform.wait_sfp_ready_task.WaitSfpReadyTask.get_ready_set')
     @mock.patch('sonic_platform.sfp.SFP.get_fd')
     @mock.patch('select.poll')
@@ -113,7 +126,7 @@ class TestChangeEventSeekFailure:
         mock_get_fd.side_effect = get_fd
         mock_ready.return_value = set()
 
-        mock_time.side_effect = [0, 1000]
+        _set_monotonic_exit_by_timeout(mock_time, 1000)
 
         _, change_event = c.get_change_event(1000)
         assert 'sfp' in change_event and not change_event['sfp']
@@ -148,34 +161,36 @@ class TestChangeEvent:
         mock_file.fileno = mock.MagicMock(return_value = 1)
 
         timeout = 1000
-        # mock time function so that the while loop exit early
-        mock_time.side_effect = [0, timeout]
 
         # no event, expect returning empty change event
+        _set_monotonic_exit_by_timeout(mock_time, timeout)
         _, change_event = c.get_change_event(timeout)
         assert 'sfp' in change_event and not change_event['sfp']
 
         # dummy event, expect returning empty change event
         sfp_index = s.sdk_index + 1
         mock_poll.poll.return_value = [(1, 10)]
-        mock_time.side_effect = [0, timeout]
+        _set_monotonic_exit_by_timeout(mock_time, timeout)
         _, change_event = c.get_change_event(timeout)
         assert 'sfp' in change_event and not change_event['sfp']
 
         # plug out event, expect returning remove event
-        mock_time.side_effect = [0, timeout]
+        _set_monotonic_allow_poll_loop(mock_time)
         mock_status.return_value = sfp.SFP_STATUS_REMOVED
         _, change_event = c.get_change_event(timeout)
         assert 'sfp' in change_event and sfp_index in change_event['sfp'] and change_event['sfp'][sfp_index] == sfp.SFP_STATUS_REMOVED
 
         # error event, expect returning error event
-        mock_time.side_effect = [0, timeout]
+        _set_monotonic_allow_poll_loop(mock_time)
         mock_status.return_value = sfp.SFP_STATUS_ERROR
         s.get_error_info_from_sdk_error_type = mock.MagicMock(return_value=('2', 'some error'))
         _, change_event = c.get_change_event(timeout)
         assert 'sfp' in change_event and sfp_index in change_event['sfp'] and change_event['sfp'][sfp_index] == '2'
         assert 'sfp_error' in change_event and sfp_index in change_event['sfp_error'] and change_event['sfp_error'][sfp_index] == 'some error'
     
+    @mock.patch('sonic_platform.sfp.SFP.wait_sfp_eeprom_ready', mock.MagicMock())
+    @mock.patch('sonic_platform.chassis.utils.read_int_from_file', return_value=1)
+    @mock.patch('os.path.exists', return_value=True)
     @mock.patch('sonic_platform.chassis.Chassis.get_asic_change_event')
     @mock.patch('sonic_platform.wait_sfp_ready_task.WaitSfpReadyTask.get_ready_set')    
     @mock.patch('sonic_platform.sfp.SFP.get_fd')
@@ -186,7 +201,10 @@ class TestChangeEvent:
     @mock.patch('sonic_platform.chassis.extract_RJ45_ports_index', mock.MagicMock(return_value=[]))
     @mock.patch('sonic_platform.chassis.extract_cpo_ports_index', mock.MagicMock(return_value=[]))
     @mock.patch('sonic_platform.module_host_mgmt_initializer.ModuleHostMgmtInitializer.initialize', mock.MagicMock())
-    def test_get_change_event_for_module_host_management_mode(self, mock_time, mock_create_poll, mock_get_fd, mock_ready, mock_get_asic_event):
+    def test_get_change_event_for_module_host_management_mode(
+        self, mock_time, mock_create_poll, mock_get_fd, mock_ready, mock_get_asic_event,
+        mock_exists, mock_read_int,
+    ):
         """Test steps:
             1. Simulate polling with no event
             2. Simulate polling the first dummy event. (SDK always return a event when first polling the fd even if there is no change)
@@ -229,22 +247,21 @@ class TestChangeEvent:
         mock_get_fd.side_effect = get_fd
         
         timeout = 1000
-        # mock time function so that the while loop exit early
-        mock_time.side_effect = [0, timeout]
-        
+
         # no event, expect returning empty change event
+        _set_monotonic_exit_by_timeout(mock_time, timeout)
         _, change_event = c.get_change_event(timeout)
         assert 'sfp' in change_event and not change_event['sfp']
         
         # dummy event, expect returning empty change event
         sfp_index = s.sdk_index + 1
         mock_poll.poll.return_value = [(1, 10)]
-        mock_time.side_effect = [0, timeout]
+        _set_monotonic_exit_by_timeout(mock_time, timeout)
         _, change_event = c.get_change_event(timeout)
         assert 'sfp' in change_event and not change_event['sfp']
         
         # plug out event, expect returning remove event
-        mock_time.side_effect = [0, timeout]
+        _set_monotonic_allow_poll_loop(mock_time)
         mock_hw_present_file.read.return_value = sfp.SFP_STATUS_REMOVED
         _, change_event = c.get_change_event(timeout)
         assert 'sfp' in change_event and sfp_index in change_event['sfp'] and change_event['sfp'][sfp_index] == sfp.SFP_STATUS_REMOVED
@@ -258,7 +275,8 @@ class TestChangeEvent:
         s.get_power_good = mock.MagicMock(return_value=True)
         s.determine_control_type = mock.MagicMock(return_value=sfp.SFP_FW_CONTROL)
         s.set_control_type = mock.MagicMock()
-        mock_time.side_effect = [0, timeout]
+        mock_poll.poll.return_value = [(1, 10)]
+        _set_monotonic_allow_poll_loop(mock_time, timeout)
         mock_ready.return_value = set([0])
         mock_hw_present_file.read.return_value = sfp.SFP_STATUS_INSERTED
         _, change_event = c.get_change_event(timeout)
@@ -267,11 +285,10 @@ class TestChangeEvent:
         assert 1 not in c.registered_fds # stop polling hw_present
         assert 2 not in c.registered_fds # stop polling power_good
         assert 3 in c.registered_fds # start polling present because it is firmware control
-        print(c.registered_fds)
         
         # error event, expect returning error
         mock_ready.return_value = []
-        mock_time.side_effect = [0, timeout]
+        _set_monotonic_allow_poll_loop(mock_time)
         mock_poll.poll.return_value = [(3, 10)]
         mock_present_file.read.return_value = sfp.SFP_STATUS_ERROR
         s.get_error_info_from_sdk_error_type = mock.MagicMock(return_value=('2', 'some error'))
@@ -280,7 +297,7 @@ class TestChangeEvent:
         assert 'sfp_error' in change_event and sfp_index in change_event['sfp_error'] and change_event['sfp_error'][sfp_index] == 'some error'
         
         # plug out the firmware control cable, expect returning remove event
-        mock_time.side_effect = [0, timeout]
+        _set_monotonic_allow_poll_loop(mock_time)
         mock_present_file.read.return_value = sfp.SFP_STATUS_REMOVED
         _, change_event = c.get_change_event(timeout)
         assert 'sfp' in change_event and sfp_index in change_event['sfp'] and change_event['sfp'][sfp_index] == sfp.SFP_STATUS_REMOVED
@@ -290,7 +307,7 @@ class TestChangeEvent:
         assert 3 not in c.registered_fds # stop polling present
         
         # plug in a software control cable, expect returning insert event
-        mock_time.side_effect = [0, timeout]
+        _set_monotonic_allow_poll_loop(mock_time)
         mock_ready.return_value = set([0])
         mock_poll.poll.return_value = [(1, 10)]
         mock_hw_present_file.read.return_value = sfp.SFP_STATUS_INSERTED
@@ -303,7 +320,7 @@ class TestChangeEvent:
         assert s.state == sfp.STATE_SW_CONTROL
         
         # power bad event, expect returning error event
-        mock_time.side_effect = [0, timeout]
+        _set_monotonic_allow_poll_loop(mock_time)
         mock_poll.poll.return_value = [(2, 10)]
         mock_power_good_file.read.return_value = '0'
         _, change_event = c.get_change_event(timeout)
@@ -311,7 +328,7 @@ class TestChangeEvent:
         assert s.state == sfp.STATE_POWER_BAD
         
         # power good event, expect returning insert event
-        mock_time.side_effect = [0, timeout]
+        _set_monotonic_allow_poll_loop(mock_time)
         mock_poll.poll.return_value = [(2, 10)]
         mock_power_good_file.read.return_value = '1'
         _, change_event = c.get_change_event(timeout)

--- a/platform/mellanox/mlnx-platform-api/tests/test_change_event.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_change_event.py
@@ -35,6 +35,7 @@ from sonic_platform import sfp
 class TestChangeEventSeekFailure:
     """Cover OSError from fd.seek(0) in change-event polling loops."""
 
+    @mock.patch('sonic_platform.chassis.Chassis.get_asic_change_event')
     @mock.patch('sonic_platform.sfp.SFP.get_fd_for_polling_legacy')
     @mock.patch('select.poll')
     @mock.patch('time.monotonic')
@@ -47,10 +48,11 @@ class TestChangeEventSeekFailure:
     @mock.patch('sonic_platform.chassis.extract_cpo_ports_index', mock.MagicMock(return_value=[]))
     @mock.patch('sonic_platform.sfp.SFP.get_module_status')
     @mock.patch('sonic_platform.chassis.Chassis.wait_sfp_ready_for_use', mock.MagicMock(return_value=True))
-    def test_get_change_event_legacy_seek_fails(self, mock_status, mock_time, mock_create_poll, mock_get_fd):
+    def test_get_change_event_legacy_seek_fails(self, mock_status, mock_time, mock_create_poll, mock_get_fd, mock_get_asic_event):
         c = chassis.Chassis()
         c.get_sfp(1)
         mock_status.return_value = sfp.SFP_STATUS_INSERTED
+        mock_get_asic_event.return_value = {}
 
         mock_poll = mock.MagicMock()
         mock_create_poll.return_value = mock_poll
@@ -81,7 +83,7 @@ class TestChangeEventSeekFailure:
     @mock.patch('sonic_platform.chassis.extract_cpo_ports_index', mock.MagicMock(return_value=[]))
     @mock.patch('sonic_platform.module_host_mgmt_initializer.ModuleHostMgmtInitializer.initialize', mock.MagicMock())
     def test_get_change_event_module_host_management_seek_fails(
-        self, mock_time, mock_create_poll, mock_get_fd, mock_ready,
+        self, mock_time, mock_create_poll, mock_get_fd, mock_ready, mock_get_asic_event,
     ):
         c = chassis.Chassis()
         c.initialize_sfp()
@@ -91,6 +93,7 @@ class TestChangeEventSeekFailure:
         mock_poll = mock.MagicMock()
         mock_create_poll.return_value = mock_poll
         mock_poll.poll = mock.MagicMock(return_value=[(1, 10)])
+        mock_get_asic_event.return_value = {}
 
         mock_hw_present_file = mock.MagicMock()
         mock_power_good_file = mock.MagicMock()
@@ -118,6 +121,7 @@ class TestChangeEventSeekFailure:
 
 
 class TestChangeEvent:
+    @mock.patch('sonic_platform.chassis.Chassis.get_asic_change_event')
     @mock.patch('sonic_platform.sfp.SFP.get_fd_for_polling_legacy')
     @mock.patch('select.poll')
     @mock.patch('time.monotonic')
@@ -127,12 +131,12 @@ class TestChangeEvent:
     @mock.patch('sonic_platform.chassis.extract_cpo_ports_index', mock.MagicMock(return_value=[]))
     @mock.patch('sonic_platform.sfp.SFP.get_module_status')
     @mock.patch('sonic_platform.chassis.Chassis.wait_sfp_ready_for_use', mock.MagicMock(return_value=True))
-    def test_get_change_event_legacy(self, mock_status, mock_time, mock_create_poll, mock_get_fd):
+    def test_get_change_event_legacy(self, mock_status, mock_time, mock_create_poll, mock_get_fd, mock_get_asic_event):
         c = chassis.Chassis()
         s = c.get_sfp(1)
         
         mock_status.return_value = sfp.SFP_STATUS_INSERTED
-        
+        mock_get_asic_event.return_value = {}
         # mock poll object
         mock_poll = mock.MagicMock()
         mock_create_poll.return_value = mock_poll
@@ -172,6 +176,7 @@ class TestChangeEvent:
         assert 'sfp' in change_event and sfp_index in change_event['sfp'] and change_event['sfp'][sfp_index] == '2'
         assert 'sfp_error' in change_event and sfp_index in change_event['sfp_error'] and change_event['sfp_error'][sfp_index] == 'some error'
     
+    @mock.patch('sonic_platform.chassis.Chassis.get_asic_change_event')
     @mock.patch('sonic_platform.wait_sfp_ready_task.WaitSfpReadyTask.get_ready_set')    
     @mock.patch('sonic_platform.sfp.SFP.get_fd')
     @mock.patch('select.poll')
@@ -181,7 +186,7 @@ class TestChangeEvent:
     @mock.patch('sonic_platform.chassis.extract_RJ45_ports_index', mock.MagicMock(return_value=[]))
     @mock.patch('sonic_platform.chassis.extract_cpo_ports_index', mock.MagicMock(return_value=[]))
     @mock.patch('sonic_platform.module_host_mgmt_initializer.ModuleHostMgmtInitializer.initialize', mock.MagicMock())
-    def test_get_change_event_for_module_host_management_mode(self, mock_time, mock_create_poll, mock_get_fd, mock_ready):
+    def test_get_change_event_for_module_host_management_mode(self, mock_time, mock_create_poll, mock_get_fd, mock_ready, mock_get_asic_event):
         """Test steps:
             1. Simulate polling with no event
             2. Simulate polling the first dummy event. (SDK always return a event when first polling the fd even if there is no change)
@@ -203,6 +208,7 @@ class TestChangeEvent:
         mock_create_poll.return_value = mock_poll
         mock_poll.poll = mock.MagicMock(return_value = [])
         
+        mock_get_asic_event.return_value = {}
         # mock file descriptors for polling
         mock_hw_present_file = mock.MagicMock()
         mock_power_good_file = mock.MagicMock()

--- a/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
@@ -424,3 +424,164 @@ class TestChassis:
              mock.patch('sonic_platform.chassis.Chassis.initialize_bmc') as mock_init_bmc:
             chassis.initialize_components()
             mock_init_bmc.assert_not_called()
+
+    def _make_sfp(self, sdk_index, asic_id='asic0'):
+        sfp = MagicMock()
+        sfp.sdk_index = sdk_index
+        sfp.asic_id = asic_id
+        return sfp
+
+    def test_disable_polling_for_asic_removes_only_target_fds(self):
+        chassis = Chassis()
+        sfp_a0 = self._make_sfp(0, 'asic0')
+        sfp_a1 = self._make_sfp(8, 'asic1')
+        chassis._asic_modules_dict = {'asic0': {sfp_a0}, 'asic1': {sfp_a1}}
+        chassis.poll_obj = mock.MagicMock()
+        fd_a0 = mock.MagicMock()
+        fd_a1 = mock.MagicMock()
+        chassis.registered_fds = {
+            10: (0, fd_a0, 'hw_present'),
+            20: (8, fd_a1, 'hw_present'),
+        }
+
+        chassis._disable_polling_for_asic('asic1')
+
+        chassis.poll_obj.unregister.assert_called_once_with(fd_a1)
+        fd_a1.close.assert_called_once()
+        fd_a0.close.assert_not_called()
+        assert 10 in chassis.registered_fds
+        assert 20 not in chassis.registered_fds
+
+    def test_disable_polling_for_asic_no_poll_obj_is_noop(self):
+        chassis = Chassis()
+        chassis.poll_obj = None
+        chassis.registered_fds = {1: (0, mock.MagicMock(), 'hw_present')}
+        chassis._asic_modules_dict = {'asic0': {self._make_sfp(0)}}
+
+        chassis._disable_polling_for_asic('asic0')
+
+        assert chassis.registered_fds == {1: chassis.registered_fds[1]}
+
+    def test_enable_polling_for_asic_calls_refresh(self):
+        chassis = Chassis()
+        sfp = self._make_sfp(3, 'asic0')
+        chassis._asic_modules_dict = {'asic0': {sfp}}
+        chassis.poll_obj = mock.MagicMock()
+        chassis.registered_fds = {}
+
+        with mock.patch.object(DeviceDataManager, 'is_module_host_management_mode', return_value=True):
+            chassis._enable_polling_for_asic('asic0')
+
+        sfp.refresh_poll_obj.assert_called_once_with(chassis.poll_obj, chassis.registered_fds)
+
+    def test_enable_polling_for_asic_swallows_refresh_errors(self):
+        chassis = Chassis()
+        sfp = self._make_sfp(3, 'asic0')
+        sfp.refresh_poll_obj.side_effect = RuntimeError('boom')
+        chassis._asic_modules_dict = {'asic0': {sfp}}
+        chassis.poll_obj = mock.MagicMock()
+        chassis.registered_fds = {}
+
+        # Should not raise
+        with mock.patch.object(DeviceDataManager, 'is_module_host_management_mode', return_value=True):
+            chassis._enable_polling_for_asic('asic0')
+        sfp.refresh_poll_obj.assert_called_once()
+
+    def _setup_get_asic_change_event(self, chassis, asic_count, ready_value, sfps_by_asic):
+        """Prepare mocks shared by get_asic_change_event tests.
+
+        Forces a delta between previous and current asicN_ready states for
+        asic1 (1-based file naming -> asic_index 0).
+        """
+        DeviceDataManager.get_asic_count = mock.MagicMock(return_value=asic_count)
+        chassis._asic_modules_dict = sfps_by_asic
+        chassis.module_host_mgmt_initializer = mock.MagicMock()
+        chassis._last_asic_ready_states = {f'asic{i}_ready': '1' for i in range(1, asic_count + 1)}
+
+        watcher = mock.MagicMock()
+        watcher.wait_for_events.return_value = []
+        capture = {f'asic{i}_ready': '1' for i in range(1, asic_count + 1)}
+        capture['asic1_ready'] = str(ready_value)
+        return watcher, capture
+
+    @mock.patch('sonic_platform.chassis.os.path.exists', return_value=True)
+    @mock.patch('sonic_platform.chassis.utils.read_int_from_file')
+    @mock.patch('sonic_platform.chassis.InotifyEventHelper')
+    def test_get_asic_change_event_down_disables_and_cancels_waits(
+            self, mock_inotify_cls, mock_read_int, _mock_exists):
+        chassis = Chassis()
+        sfp_a0 = self._make_sfp(0, 'asic0')
+        watcher, capture = self._setup_get_asic_change_event(
+            chassis, asic_count=1, ready_value=0, sfps_by_asic={'asic0': {sfp_a0}})
+        mock_inotify_cls.return_value = watcher
+        chassis.capture_current_asic_states = mock.MagicMock(return_value=capture)
+        mock_read_int.return_value = 0  # asic file content -> not ready
+
+        chassis._disable_polling_for_asic = mock.MagicMock()
+        chassis._enable_polling_for_asic = mock.MagicMock()
+
+        wait_ready_task = mock.MagicMock()
+        with mock.patch('sonic_platform.sfp.SFP.get_wait_ready_task', return_value=wait_ready_task), \
+             mock.patch.object(DeviceDataManager, 'is_module_host_management_mode', return_value=True):
+            changes = chassis.get_asic_change_event(timeout=1)
+
+        assert changes == {'0': '0'}
+        wait_ready_task.cancel_wait.assert_called_once_with(0)
+        chassis._disable_polling_for_asic.assert_called_once_with('asic0')
+        chassis._enable_polling_for_asic.assert_not_called()
+        chassis.module_host_mgmt_initializer.set_asic_ready_value.assert_called_once_with(0, False)
+
+    @mock.patch('sonic_platform.chassis.os.path.exists', return_value=True)
+    @mock.patch('sonic_platform.chassis.utils.read_int_from_file')
+    @mock.patch('sonic_platform.chassis.InotifyEventHelper')
+    def test_get_asic_change_event_up_enables_polling(
+            self, mock_inotify_cls, mock_read_int, _mock_exists):
+        chassis = Chassis()
+        sfp_a0 = self._make_sfp(0, 'asic0')
+        watcher, capture = self._setup_get_asic_change_event(
+            chassis, asic_count=1, ready_value=1, sfps_by_asic={'asic0': {sfp_a0}})
+        # Previous state was not ready -> delta will be detected
+        chassis._last_asic_ready_states = {'asic1_ready': '0'}
+        mock_inotify_cls.return_value = watcher
+        chassis.capture_current_asic_states = mock.MagicMock(return_value=capture)
+        mock_read_int.return_value = 1  # asic file content -> ready
+
+        chassis._disable_polling_for_asic = mock.MagicMock()
+        chassis._enable_polling_for_asic = mock.MagicMock()
+
+        wait_ready_task = mock.MagicMock()
+        with mock.patch('sonic_platform.sfp.SFP.get_wait_ready_task', return_value=wait_ready_task):
+            changes = chassis.get_asic_change_event(timeout=1)
+
+        assert changes == {'0': '1'}
+        chassis._enable_polling_for_asic.assert_called_once_with('asic0')
+        chassis._disable_polling_for_asic.assert_not_called()
+        wait_ready_task.cancel_wait.assert_not_called()
+        chassis.module_host_mgmt_initializer.set_asic_ready_value.assert_called_once_with(0, True)
+
+    @mock.patch('sonic_platform.chassis.os.path.exists', return_value=True)
+    @mock.patch('sonic_platform.chassis.utils.read_int_from_file', return_value=1)
+    @mock.patch('sonic_platform.chassis.InotifyEventHelper')
+    def test_get_asic_change_event_no_change_no_helpers(
+            self, mock_inotify_cls, _mock_read_int, _mock_exists):
+        chassis = Chassis()
+        DeviceDataManager.get_asic_count = mock.MagicMock(return_value=1)
+        chassis._asic_modules_dict = {'asic0': set()}
+        chassis.module_host_mgmt_initializer = mock.MagicMock()
+        chassis._last_asic_ready_states = {'asic1_ready': '1'}
+
+        watcher = mock.MagicMock()
+        watcher.wait_for_events.return_value = []
+        mock_inotify_cls.return_value = watcher
+        chassis.capture_current_asic_states = mock.MagicMock(return_value={'asic1_ready': '1'})
+
+        chassis._disable_polling_for_asic = mock.MagicMock()
+        chassis._enable_polling_for_asic = mock.MagicMock()
+
+        with mock.patch('sonic_platform.sfp.SFP.get_wait_ready_task') as mock_get_task:
+            changes = chassis.get_asic_change_event(timeout=1)
+            mock_get_task.assert_not_called()
+
+        assert changes == {}
+        chassis._disable_polling_for_asic.assert_not_called()
+        chassis._enable_polling_for_asic.assert_not_called()

--- a/platform/mellanox/mlnx-platform-api/tests/test_module_initializer.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_module_initializer.py
@@ -33,67 +33,41 @@ from sonic_platform import module_host_mgmt_initializer
 
 
 class TestModuleInitializer:
-    @mock.patch('os.path.exists')
-    @mock.patch('sonic_platform.utils.wait_until')
-    @mock.patch('sonic_platform.utils.is_host')
-    def test_wait_module_ready(self, mock_is_host, mock_wait, mock_exists):
-        initializer = module_host_mgmt_initializer.ModuleHostMgmtInitializer()
-        mock_is_host.return_value = True
-        mock_exists.return_value = False
-        mock_wait.return_value = True
-        initializer.wait_module_ready()
-        mock_exists.assert_called_with(module_host_mgmt_initializer.MODULE_READY_HOST_FILE)
-        assert initializer.initialized
-        
-        initializer.initialized = False
-        mock_is_host.return_value = False
-        initializer.wait_module_ready()
-        mock_exists.assert_called_with(module_host_mgmt_initializer.MODULE_READY_CONTAINER_FILE)
-        
-        initializer.initialized = False
-        mock_exists.return_value = True
-        initializer.wait_module_ready()
-        assert initializer.initialized
-        
-        initializer.initialized = False
-        mock_wait.return_value = False
-        mock_exists.return_value = False
-        initializer.wait_module_ready()
-        assert not initializer.initialized
 
     @mock.patch('sonic_platform.device_data.DeviceDataManager.wait_sysfs_ready', mock.MagicMock(return_value=True))
+    @mock.patch('sonic_platform.device_data.DeviceDataManager.get_asic_count', mock.MagicMock(return_value=1))
+    @mock.patch('sonic_platform.chassis.Chassis.get_num_sfps', mock.MagicMock(return_value=1))
     @mock.patch('sonic_platform.chassis.extract_RJ45_ports_index', mock.MagicMock(return_value=[]))
     @mock.patch('sonic_platform.chassis.extract_cpo_ports_index', mock.MagicMock(return_value=[]))
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_sfp_count', mock.MagicMock(return_value=1))
-    @mock.patch('sonic_platform.sfp.SFP.initialize_sfp_modules', mock.MagicMock())
+    @mock.patch('sonic_platform.utils.read_int_from_file')
     @mock.patch('sonic_platform.module_host_mgmt_initializer.ModuleHostMgmtInitializer.is_initialization_owner')
-    @mock.patch('sonic_platform.module_host_mgmt_initializer.ModuleHostMgmtInitializer.wait_module_ready')
     @mock.patch('sonic_platform.utils.is_host')
-    def test_initialize(self, mock_is_host, mock_wait_ready, mock_owner):
-        c = chassis.Chassis()
-        initializer = module_host_mgmt_initializer.ModuleHostMgmtInitializer()
-        mock_is_host.return_value = True
-        mock_owner.return_value = False
-        # called from host side, just wait
-        initializer.initialize(c)
-        mock_wait_ready.assert_called_once()
-        mock_wait_ready.reset_mock()
-        
-        mock_is_host.return_value = False
-        # non-initializer-owner called from container side, just wait
-        initializer.initialize(c)
-        mock_wait_ready.assert_called_once()
-        mock_wait_ready.reset_mock()
-        
-        mock_owner.return_value = True
-        initializer.initialize(c)
-        mock_wait_ready.assert_not_called()
-        assert initializer.initialized
-        assert module_host_mgmt_initializer.initialization_owner
-        assert os.path.exists(module_host_mgmt_initializer.MODULE_READY_CONTAINER_FILE)
-        
-        module_host_mgmt_initializer.clean_up()
-        assert not os.path.exists(module_host_mgmt_initializer.MODULE_READY_CONTAINER_FILE)
+    def test_initialize(self, mock_is_host, mock_owner, mock_read_int):
+        # Mock the SFP.initialize_sfp_modules to avoid thread issues
+        mock_init_modules = mock.MagicMock()
+        with mock.patch('sonic_platform.sfp.SFP.initialize_sfp_modules', mock_init_modules):
+            c = chassis.Chassis()
+            initializer = module_host_mgmt_initializer.ModuleHostMgmtInitializer()
+
+            mock_is_host.return_value = True
+            mock_owner.return_value = False
+            # called from host side, just wait (calls chassis.initialize_sfp())
+            initializer.initialize(c)
+
+            mock_is_host.return_value = False
+            # non-initializer-owner called from container side, just wait (calls chassis.initialize_sfp())
+            initializer.initialize(c)
+
+            mock_owner.return_value = True
+            mock_read_int.return_value = 1  # asic1_ready file returns 1
+            initializer.initialize(c)
+            # Verify initialization occurred
+            assert initializer.initialized_list[0] == True  # asic 0 should be initialized
+            assert module_host_mgmt_initializer.initialization_owner
+            assert os.path.exists(module_host_mgmt_initializer.get_asic_ready_file_path(0))
+            # Verify SFP.initialize_sfp_modules was called
+            mock_init_modules.assert_called_once()
 
     def test_is_initialization_owner(self):
         initializer = module_host_mgmt_initializer.ModuleHostMgmtInitializer()

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
@@ -244,21 +244,58 @@ class TestSfp:
         assert page == '/tmp/1/data'
         assert page_offset is 0
 
+    @mock.patch('sonic_platform.sfp.SFP.is_sw_control')
+    @mock.patch('sonic_platform.sfp.os.path.exists')
     @mock.patch('sonic_platform.utils.read_int_from_file')
-    @mock.patch('sonic_platform.sfp.SFP._read_eeprom')
-    def test_sfp_get_presence(self, mock_read, mock_read_int):
-        sfp = SFP(0)
-
-        mock_read_int.return_value = 1
-        mock_read.return_value = None
-        assert not sfp.get_presence()
-        mock_read.return_value = 0
-        assert sfp.get_presence()
-
+    def test_sfp_get_presence(self, mock_read_int, mock_exists, mock_is_sw_control):
+        # Test case 1: asic_ready config file not ready (returns 0)
+        sfp = SFP(0, asic_id='asic0')
         mock_read_int.return_value = 0
-        mock_read.return_value = None
         assert not sfp.get_presence()
-        mock_read.return_value = 0
+        # Verify it checked /var/run/hw-management/config/asic1_ready
+        mock_read_int.assert_called_with('/var/run/hw-management/config/asic1_ready')
+
+        # Test case 2: asic_ready config file ready (returns 1), but asic's ready file does not exist
+        sfp = SFP(0, asic_id='asic2')
+        mock_read_int.reset_mock()
+        mock_read_int.return_value = 1  # asic_ready config file = 1
+        mock_exists.return_value = False  # per-ASIC ready file not present
+        assert not sfp.get_presence()
+        mock_exists.assert_called()
+
+        # Test case 3: asic_ready config file ready, asic's ready file exists, sw_control=True, presence=1
+        sfp = SFP(0, asic_id='asic0')
+        mock_read_int.reset_mock()
+        mock_exists.reset_mock()
+        mock_is_sw_control.return_value = True
+        mock_exists.return_value = True
+        mock_read_int.side_effect = [1, 1]  # config file ready=1, hw_present=1
+        assert sfp.get_presence()
+        # Verify the presence file path was checked with hw_present
+        assert mock_read_int.call_args_list[-1] == mock.call('/sys/module/sx_core/asic0/module0/hw_present', log_func=None)
+
+        # Test case 4: asic_ready config file ready, asic's ready file exists, sw_control=False, presence=1
+        sfp = SFP(0, asic_id='asic0')
+        mock_read_int.reset_mock()
+        mock_is_sw_control.return_value = False
+        mock_read_int.side_effect = [1, 1]  # config file ready=1, present=1
+        assert sfp.get_presence()
+        # Verify the presence file path was checked with present (not hw_present)
+        assert mock_read_int.call_args_list[-1] == mock.call('/sys/module/sx_core/asic0/module0/present', log_func=None)
+
+        # Test case 5: asic's ready file exists, presence=0
+        sfp = SFP(0, asic_id='asic0')
+        mock_read_int.reset_mock()
+        mock_is_sw_control.return_value = False
+        mock_read_int.side_effect = [1, 0]  # config file ready=1, present=0
+        assert not sfp.get_presence()
+
+        # Test case 6: asic's per-ASIC ready file does not exist
+        sfp = SFP(0, asic_id='asic0')
+        mock_read_int.reset_mock()
+        mock_read_int.side_effect = None  # clear exhausted side_effect from previous case
+        mock_read_int.return_value = 1
+        mock_exists.return_value = False
         assert not sfp.get_presence()
 
     @mock.patch('sonic_platform.utils.read_int_from_file')
@@ -501,20 +538,26 @@ class TestSfp:
     @mock.patch('sonic_platform.chassis.extract_cpo_ports_index', mock.MagicMock(return_value=[]))
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_sfp_count', mock.MagicMock(return_value=1))
     def test_initialize_sfp_modules(self):
-        c = Chassis()
-        c.initialize_sfp()
-        s = c._sfp_list[0]
-        s.get_hw_present = mock.MagicMock(return_value=True)
-        s.get_power_on = mock.MagicMock(return_value=False)
-        s.get_reset_state = mock.MagicMock(return_value=True)
-        s.get_power_good = mock.MagicMock(return_value=True)
-        s.determine_control_type = mock.MagicMock(return_value=1) # software control
-        s.set_control_type = mock.MagicMock()
-        SFP.initialize_sfp_modules(c._sfp_list)
-        assert s.in_stable_state()
-        SFP.wait_ready_task.stop()
-        SFP.wait_ready_task.join()
-        SFP.wait_ready_task = None
+        # Create a mock wait_ready_task to avoid starting a real thread
+        mock_wait_task = mock.MagicMock()
+        mock_wait_task.empty.return_value = False
+        mock_wait_task.is_alive.return_value = True
+        mock_wait_task.get_ready_set.return_value = set()
+
+        with mock.patch.object(SFP, 'get_wait_ready_task', return_value=mock_wait_task):
+            c = Chassis()
+            c.initialize_sfp()
+            s = c._sfp_list[0]
+            s.get_hw_present = mock.MagicMock(return_value=True)
+            s.get_power_on = mock.MagicMock(return_value=False)
+            s.get_reset_state = mock.MagicMock(return_value=True)
+            s.get_power_good = mock.MagicMock(return_value=True)
+            s.determine_control_type = mock.MagicMock(return_value=1) # software control
+            s.set_control_type = mock.MagicMock()
+            SFP.initialize_sfp_modules(c._sfp_list)
+            assert s.in_stable_state()
+            # Verify the mock task was used correctly
+            mock_wait_task.start_once.assert_called_once()
 
     @mock.patch('sonic_platform.sfp.SFP.is_sw_control', mock.MagicMock(return_value=False))
     @mock.patch('sonic_platform.utils.read_int_from_file')

--- a/platform/mellanox/mlnx-platform-api/tests/test_thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_thermal_updater.py
@@ -112,8 +112,9 @@ class TestThermalUpdater:
         assert not updater._timer.is_alive()
         mock_write.assert_called_once_with('/run/hw-management/config/suspend', 1)
 
+    @mock.patch('sonic_platform.thermal_updater.utils.read_int_from_file', return_value=1)
     @mock.patch('sonic_platform.thermal_updater.get_db_table_helper')
-    def test_update_asic(self, mock_get_db_table_helper):
+    def test_update_asic(self, mock_get_db_table_helper, mock_read_int):
         hw_management_independent_mode_update.reset_mock()
         mock_temp_table = mock.MagicMock()
         mock_db_table_helper = mock.MagicMock()

--- a/platform/mellanox/mlnx-platform-api/tests/test_wait_sfp_ready_task.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_wait_sfp_ready_task.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,6 +39,20 @@ class TestWaitSfpReadyTask:
         assert not task.empty()
         task.cancel_wait(0)
         assert task.empty()
+
+    def test_cancel_wait_unknown_index(self):
+        task = wait_sfp_ready_task.WaitSfpReadyTask()
+        # cancel_wait must be safe for an index that was never scheduled
+        task.cancel_wait(42)
+        assert task.empty()
+        assert 42 not in task._ready_set
+
+    def test_cancel_wait_removes_from_ready_set(self):
+        task = wait_sfp_ready_task.WaitSfpReadyTask()
+        # Pre-populate ready set to verify discard-style cleanup
+        task._ready_set.add(7)
+        task.cancel_wait(7)
+        assert 7 not in task._ready_set
         
     def test_run(self):
         task = wait_sfp_ready_task.WaitSfpReadyTask()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

Port https://github.com/sonic-net/sonic-buildimage/pull/26678 to be based on commit af8111425c0b2fd0d620d5d3a470559631cbda52

#### Why I did it
For switch to know which asic is ready to use and which is not - we can check asicN_ready and know we can access the asic.

#### How I did it
Update Mellanox platform files to use the new asic ready indication.

#### How to verify it
Run an image with this change and check that asic_ready sysfs is indicating the asic state. 
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

