### PR TITLE
[bgpcfgd] fix pgrep self-match race causing spurious "bfdd is not running ERR"

### DIFF
--- a/src/sonic-bgpcfgd/bfdmon/bfdmon.py
+++ b/src/sonic-bgpcfgd/bfdmon/bfdmon.py
@@ -36,7 +36,7 @@ class BfdFrrMon:
         """
         try:
             # Use pgrep to check if the process is running
-            rc, output = getstatusoutput_noshell(["pgrep", "-f", "bfdd"])
+            rc, output = getstatusoutput_noshell(["pgrep", "-x", "bfdd"])
             if not rc:
                 self.bfdd_running = True
                 return True

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bfd.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bfd.py
@@ -38,7 +38,7 @@ class BfdMgr(Manager):
         """
         try:
             # Use pgrep to check if the process is running
-            subprocess.check_output(["pgrep", "-f", "bfdd"])
+            subprocess.check_output(["pgrep", "-x", "bfdd"])
             return True
         except subprocess.CalledProcessError:
             # Start bfdd process

--- a/src/sonic-bgpcfgd/tests/test_bfdmgr.py
+++ b/src/sonic-bgpcfgd/tests/test_bfdmgr.py
@@ -45,6 +45,7 @@ def test_check_and_start_bfdd_stopped(mocked_log_warn, mocked_check_output, mock
         '/usr/lib/frr/bfdd', '-A', '127.0.0.1', '-d'
     ]
     assert bfd_mgr.check_and_start_bfdd() == True
+    mocked_check_output.assert_called_with(["pgrep", "-x", "bfdd"])
     mocked_run_command.assert_called_once_with(cmd)
     mocked_log_warn.assert_called_with("bfdd process is not running, starting now...")
 

--- a/src/sonic-bgpcfgd/tests/test_bfdmon.py
+++ b/src/sonic-bgpcfgd/tests/test_bfdmon.py
@@ -23,6 +23,7 @@ def test_constructor(bfd_mon):
 def test_check_bfdd(mocked_getstatusoutput, bfd_mon):
     result = bfd_mon.check_bfdd()
     assert result == True
+    mocked_getstatusoutput.assert_called_once_with(["pgrep", "-x", "bfdd"])
 
 @patch('bfdmon.bfdmon.getstatusoutput_noshell', return_value=(1, ""))
 def test_check_bfdd_failure(mocked_getstatusoutput, bfd_mon):


### PR DESCRIPTION
#### Why I did it
When`software_bfd` enabled, both `bgpcfgd` (via`BfdMgr.check_and_start_bfdd`) and `bfdmon` (via `BfdFrrMon.check_bfdd`) probe for the FRR `bfdd` daemon with `pgrep -f bfdd`. The `-f` flag does a substring match against the full process command line, and the `pgrep -f bfdd` process is itself visible in `/proc` with a cmdline of `pgrep -f bfdd` — which contains the substring `bfdd`. When the two services fire their pgreps concurrently during BGP container startup, each pgrep sees the other and both return success even when no real `bfdd` is running. `bgpcfgd` then skips starting `bfdd`, and both services repeatedly fail `vtysh -c 'show bfd peers json'` with `bfdd is not running`, logging nuisance ERR messages until they retry and start up the service.

```
16:39:08.209  WARNING bgp#bfdmon : *WARNING* bfdd not currently running
16:39:10.208  NOTICE  bgp#bgpcfgd: software_bfd feature is enabled, starting bfd manager
16:39:10.219  DEBUG   bgp#bgpcfgd: execute command '['vtysh', '-c', 'show bfd peers json']'.
16:39:10.241  ERR     bgp#bgpcfgd: command execution returned 1. Command: '['vtysh', '-c', 'show bfd peers json']', stdout: '', stderr: 'bfdd is not running#012'
16:39:10.241  ERR     bgp#bfdmon : *ERROR* Failed with rc:1 when execute: ['vtysh', '-c', 'show bfd peers json']
16:39:10.242  ERR     bgp#bgpcfgd: Can't read bfd peers: bfdd is not running
...
19:46:49.189  NOTICE  bgp#bgpcfgd: software_bfd feature is enabled, starting bfd manager
19:46:49.219  WARNING bgp#bgpcfgd: bfdd process is not running, starting now...
19:46:49.320  DEBUG   bgp#bgpcfgd: execute command '['vtysh', '-c', 'show bfd peers json']'.
19:46:50.952  WARNING bgp#bfdmon : message repeated 3 times: [ *WARNING* bfdd not currently running]
```

##### Work item tracking
- Microsoft ADO **(number only)**: <pending>
#### How I did it
- Replaced `pgrep -f bfdd` with `pgrep -x bfdd` in
  `bgpcfgd/managers_bfd.py::BfdMgr.check_and_start_bfdd`.
- Same one-flag change in `bfdmon/bfdmon.py::BfdFrrMon.check_bfdd`.
- `-x` matches `/proc/<pid>/comm` exactly. The `pgrep` process's `comm`
  is `pgrep` (not `bfdd`), so concurrent pgreps no longer cross-match;
  only a real `bfdd` process (`comm == "bfdd"`) matches.
#### How to verify it
Unit test:
- `cd src/sonic-bgpcfgd && pytest tests/test_bfdmgr.py::test_check_and_start_bfdd_stopped -v`
  (new assertion verifies `pgrep` is invoked with `-x bfdd`).
Manual repro of the race (on any Linux host, no real bfdd needed):
```bash
# Old behavior: two concurrent pgreps can falsely match each other
(pgrep -f bfdd; echo "A rc=$?") & (pgrep -f bfdd; echo "B rc=$?") & wait
# -> both print a pid and rc=0
# New behavior: clean miss
(pgrep -x bfdd; echo "A rc=$?") & (pgrep -x bfdd; echo "B rc=$?") & wait
# -> both rc=1
