### PR TITLE
[docker] Avoid slow docker restarts from netfilter readiness check

### DIFF
--- a/files/docker/docker-netfilter-ready.sh
+++ b/files/docker/docker-netfilter-ready.sh
@@ -3,17 +3,28 @@
 # Docker may be socket-activated very early during first boot. On some systems,
 # the IPv6 iptables/nf_tables path may not be ready yet, which can cause dockerd
 # initialization to fail and cascade dependency failures to database/config
-# services. Wait until the ip6tables paths used by dockerd are usable.
+# services.
+#
+# This check is only needed during early boot. Skip it for normal docker restarts
+# to avoid expensive or blocking ip6tables probes.
 
-for i in $(seq 1 30); do
-    if ip6tables -w 5 -t filter -L >/dev/null 2>&1 && \
-       ip6tables -w 5 -t nat -L >/dev/null 2>&1; then
+uptime_seconds=$(awk '{printf "%d", $1}' /proc/uptime)
+if [ "$uptime_seconds" -gt 120 ] 2>/dev/null; then
+    exit 0
+fi
+
+MAX_ATTEMPTS=30
+CALL_TIMEOUT=5
+
+for i in $(seq 1 $MAX_ATTEMPTS); do
+    if timeout $CALL_TIMEOUT ip6tables -w 1 -n -t filter -L >/dev/null 2>&1 && \
+       timeout $CALL_TIMEOUT ip6tables -w 1 -n -t nat -L >/dev/null 2>&1; then
         logger "docker-netfilter-ready: ip6tables ready after ${i} attempt(s)"
         exit 0
     fi
     sleep 1
 done
 
-logger "docker-netfilter-ready: ip6tables not ready after 30 attempts"
+logger "docker-netfilter-ready: ip6tables not ready after $MAX_ATTEMPTS attempts"
 echo "Docker netfilter/ip6tables path is not ready" >&2
 exit 1

--- a/files/docker/docker-netfilter-ready.sh
+++ b/files/docker/docker-netfilter-ready.sh
@@ -27,4 +27,4 @@ done
 
 logger "docker-netfilter-ready: ip6tables not ready after $MAX_ATTEMPTS attempts"
 echo "Docker netfilter/ip6tables path is not ready" >&2
-exit 1
+exit 0


### PR DESCRIPTION
#### Why I did it
The initial docker netfilter readiness gate fixed a SmartSwitch first-boot
race where docker.service could start before the IPv6 netfilter/ip6tables
path was fully ready, causing cascading dependency failures in database,
config-setup, interfaces-config, and related services.

However, the original implementation introduced long delays during normal
docker restarts on some platforms because ip6tables -L could block for
extended periods in the kernel.

Improve the readiness helper by:

Skipping the readiness check after early boot (>120s uptime)
Adding timeout protection around ip6tables invocations
Reducing iptables lock wait time from 5s to 1s
Using -n to avoid unnecessary name resolution during table listing

This preserves the SmartSwitch first-boot protection while avoiding
minutes-long hangs during routine docker restarts on other platforms.

Fixes: #27647


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Updated docker-netfilter-ready.sh to avoid expensive or potentially blocking
ip6tables probes during normal docker restarts while still preserving the
early first-boot SmartSwitch protection.

Changes made:

Skip the readiness check once system uptime exceeds 120 seconds
Wrap each ip6tables invocation with timeout to prevent indefinite kernel-level blocking
Reduce xtables lock wait time from -w 5 to -w 1
Add -n to avoid DNS/service name resolution overhead during table listing

This keeps the original first-boot race protection intact while eliminating
minutes-long delays seen during routine systemctl restart docker operations
on some platforms.

#### How to verify it
Verify SmartSwitch first-boot protection still works:
Install a fresh SONiC image using sonic-installer install
Reboot into the new image
Confirm docker/database/config services start successfully during first boot

Verify management interface is configured automatically:

show ip int | grep eth0

Verify no long docker restart delays remain:

time sudo systemctl restart docker

Expected:

Docker restart completes normally without multi-minute delay
Restart time is comparable to pre-fix behavior

Verify readiness helper logging:

journalctl -u docker.service | grep docker-netfilter-ready
Verify normal platforms are unaffected:
Reboot non-SmartSwitch platforms
Confirm docker.service and dependent services start successfully
Confirm no prolonged startup delays are introduced
#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)
202511

