### PR TITLE
[yang] MUX_CABLE: add server_ipv6_subnet leaf for mux subnet slicing

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/mux_cable.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/mux_cable.json
@@ -18,6 +18,7 @@
     },
     "MUX_CABLE_INVALID_SERVER_IPV6_SUBNET": {
         "desc": "Load MUX_CABLE with IPv4 prefix in server_ipv6_subnet (must reject).",
-        "eStrKey": "Pattern"
+        "eStrKey": "Pattern",
+        "eStr": ["server_ipv6_subnet"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/mux_cable.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/mux_cable.json
@@ -12,5 +12,12 @@
     "MUX_CABLE_INVALID_IP": {
         "desc": "Load MUX_CABLE with invalid server ip address.",
         "eStrKey": "Pattern"
+    },
+    "MUX_CABLE_WITH_SERVER_IPV6_SUBNET": {
+        "desc": "Load MUX_CABLE with valid server_ipv6_subnet for slicing."
+    },
+    "MUX_CABLE_INVALID_SERVER_IPV6_SUBNET": {
+        "desc": "Load MUX_CABLE with IPv4 prefix in server_ipv6_subnet (must reject).",
+        "eStrKey": "Pattern"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/mux_cable.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/mux_cable.json
@@ -91,5 +91,50 @@
 
             }
         }
+    },
+
+    "MUX_CABLE_WITH_SERVER_IPV6_SUBNET": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                {
+                    "admin_status": "up",
+                    "alias": "eth0",
+                    "description": "Ethernet0",
+                    "lanes": "65",
+                    "mtu": "9000",
+                    "name": "Ethernet0",
+                    "tpid": "0x8100",
+                    "speed": "25000"
+                }
+                ]
+            }
+        },
+        "sonic-mux-cable:sonic-mux-cable": {
+            "sonic-mux-cable:MUX_CABLE": {
+                "MUX_CABLE_LIST": [
+                    {
+                        "ifname": "Ethernet0",
+                        "server_ipv4": "192.168.0.2/32",
+                        "server_ipv6": "fc02:1000::30/128",
+                        "server_ipv6_subnet": "fc02:1000::/64",
+                        "state": "auto"
+                    }
+                ]
+            }
+        }
+    },
+
+    "MUX_CABLE_INVALID_SERVER_IPV6_SUBNET": {
+        "sonic-mux-cable:sonic-mux-cable": {
+            "sonic-mux-cable:MUX_CABLE": {
+                "MUX_CABLE_LIST": [
+                    {
+                        "server_ipv6_subnet": "192.168.0.0/24"
+                    }
+                ]
+
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/mux_cable.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/mux_cable.json
@@ -126,10 +126,27 @@
     },
 
     "MUX_CABLE_INVALID_SERVER_IPV6_SUBNET": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                {
+                    "admin_status": "up",
+                    "alias": "eth0",
+                    "description": "Ethernet0",
+                    "lanes": "65",
+                    "mtu": "9000",
+                    "name": "Ethernet0",
+                    "tpid": "0x8100",
+                    "speed": "25000"
+                }
+                ]
+            }
+        },
         "sonic-mux-cable:sonic-mux-cable": {
             "sonic-mux-cable:MUX_CABLE": {
                 "MUX_CABLE_LIST": [
                     {
+                        "ifname": "Ethernet0",
                         "server_ipv6_subnet": "192.168.0.0/24"
                     }
                 ]

--- a/src/sonic-yang-models/yang-models/sonic-mux-cable.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mux-cable.yang
@@ -20,6 +20,11 @@ module sonic-mux-cable {
     description
         "Dual-ToR mux cable state and configuration per port";
 
+    revision 2026-06-01 {
+        description
+            "Add server_ipv6_subnet leaf for mux subnet slicing.";
+    }
+
     revision 2022-08-19 {
         description
             "Initial revision";
@@ -90,6 +95,12 @@ module sonic-mux-cable {
                     type inet:ipv6-prefix;
 
                     description "SoC IPv6 address. Optional and for active-active ports only. ";
+                }
+
+                leaf server_ipv6_subnet {
+                    type inet:ipv6-prefix;
+                    description
+                        "Optional IPv6 subnet of server-facing neighbors that participate in mux subnet slicing. When set, neighbors whose IPv6 address falls within this prefix are eligible for slice-based suppression by orchagent. Immutable once set (enforced at runtime).";
                 }
 
                 leaf state {


### PR DESCRIPTION
#### Why I did it
Companion YANG schema change for mux subnet slicing. Adds an optional `server_ipv6_subnet` leaf to `MUX_CABLE` so orchagent can identify the IPv6 subnet of server-facing neighbors that participate in slicing.

Part of the mux subnet slicing feature:
- HLD: sonic-net/SONiC#2318
- orchagent implementation: sonic-net/sonic-swss#4616

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Added the `server_ipv6_subnet` leaf (`inet:ipv6-prefix`) to `sonic-mux-cable.yang`.
- Validation expressible in YANG: must be an IPv6 prefix (IPv4 prefix rejected by pattern).
- Validation enforced at runtime in orchagent (not in YANG): non-zero prefix, and immutable once set on an existing entry.

#### How to verify it
Run the YANG model unit tests:
- `MUX_CABLE_WITH_SERVER_IPV6_SUBNET` (positive)
- `MUX_CABLE_INVALID_SERVER_IPV6_SUBNET` (negative — pattern reject)

#### Which release branch to backport (provide reason below if selected)
- [ ] 202405
- [ ] 202411

#### Description for the changelog
[yang] MUX_CABLE: add server_ipv6_subnet leaf for mux subnet slicing