### PR TITLE
[pmon]: Bump grpcio/grpcio-tools to 1.71.0 to fix the ycabled crash on trixie

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -48,8 +48,9 @@ RUN apt-get install -y busybox
 # doesn't ensure all dependencies are installed in the container. So here we
 # install any dependencies required by the Arista sonic_platform package.
 # TODO: eliminate the need to install these explicitly.
-RUN pip3 install grpcio==1.67.1 \
-        grpcio-tools==1.67.1 --no-build-isolation && \
+RUN pip3 install --break-system-packages \
+        grpcio==1.71.0 \
+        grpcio-tools==1.71.0 --no-build-isolation && \
     find /usr/local/lib/python3*/dist-packages/grpc* -name '*.so' -exec strip --strip-unneeded {} +
 
 # Barefoot platform vendors' sonic_platform packages import these Python libraries (and netifaces)


### PR DESCRIPTION



<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix the following issue on internal image:
```
2026 Jun  2 04:07:48.448775 str3-8101c1-07 INFO pmon#supervisord 2026-06-02 04:07:48,448 WARN exited: ycabled (exit status 1; not expected)
2026 Jun  2 04:07:51.512461 str3-8101c1-07 INFO pmon#supervisord 2026-06-02 04:07:51,511 INFO spawned: 'ycabled' with pid 120
2026 Jun  2 04:07:51.519360 str3-8101c1-07 INFO pmon#supervisord: ycabled nice: cannot set niceness: Permission denied
2026 Jun  2 04:07:51.740659 str3-8101c1-07 INFO pmon#supervisord: ycabled Traceback (most recent call last):
2026 Jun  2 04:07:51.741317 str3-8101c1-07 INFO pmon#supervisord: ycabled   File "/usr/local/bin/ycabled", line 5, in <module>
2026 Jun  2 04:07:51.741345 str3-8101c1-07 INFO pmon#supervisord: ycabled     from ycable.ycable import main
2026 Jun  2 04:07:51.741366 str3-8101c1-07 INFO pmon#supervisord: ycabled   File "/usr/local/lib/python3.13/dist-packages/ycable/ycable.py", line 21, in <module>
2026 Jun  2 04:07:51.741381 str3-8101c1-07 INFO pmon#supervisord: ycabled     from .ycable_utilities import y_cable_helper
2026 Jun  2 04:07:51.741398 str3-8101c1-07 INFO pmon#supervisord: ycabled   File "/usr/local/lib/python3.13/dist-packages/ycable/ycable_utilities/y_cable_helper.py", line 21, in <module>
2026 Jun  2 04:07:51.741411 str3-8101c1-07 INFO pmon#supervisord: ycabled     from proto_out import linkmgr_grpc_driver_pb2_grpc
2026 Jun  2 04:07:51.741420 str3-8101c1-07 INFO pmon#supervisord: ycabled   File "/usr/local/lib/python3.13/dist-packages/proto_out/linkmgr_grpc_driver_pb2_grpc.py", line 19, in <module>
2026 Jun  2 04:07:51.741430 str3-8101c1-07 INFO pmon#supervisord: ycabled     raise RuntimeError(
2026 Jun  2 04:07:51.741446 str3-8101c1-07 INFO pmon#supervisord: ycabled     ...<5 lines>...
2026 Jun  2 04:07:51.741460 str3-8101c1-07 INFO pmon#supervisord: ycabled     )
2026 Jun  2 04:07:51.741477 str3-8101c1-07 INFO pmon#supervisord: ycabled RuntimeError: The grpc package installed is at version 1.67.1, but the generated code in proto_out/linkmgr_grpc_driver_pb2_grpc.py depends on grpcio>=1.71.0. Please upgrade your grpc module to grpcio>=1.71.0 or downgrade your generated code using grpcio-tools<=1.67.1
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Bump the pip pin in docker-platform-monitor to grpcio==1.71.0 and
grpcio-tools==1.71.0 so the pmon runtime grpc matches the version used
to generate the ycabled proto stubs in the build slave.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

