### PR TITLE
[yang][orchagent]: Consolidate route performance knobs to SYSTEM_DEFAULTS

### DIFF
--- a/dockers/docker-orchagent/orch_zmq_tables.conf.j2
+++ b/dockers/docker-orchagent/orch_zmq_tables.conf.j2
@@ -24,7 +24,7 @@ DASH_ROUTING_APPLIANCE_TABLE
 DASH_FLOW_SYNC_SESSION_TABLE
 DASH_FLOW_DUMP_FILTER_TABLE
 {% endif %}
-{% if DEVICE_METADATA.localhost.orch_northbond_route_zmq_enabled == "true"  %}
+{% if SYSTEM_DEFAULTS is defined and SYSTEM_DEFAULTS.route_performance is defined and SYSTEM_DEFAULTS.route_performance.zmq == "enabled"  %}
 ROUTE_TABLE
 LABEL_ROUTE_TABLE
 {% endif %}

--- a/dockers/docker-orchagent/orch_zmq_tables.conf.j2
+++ b/dockers/docker-orchagent/orch_zmq_tables.conf.j2
@@ -24,7 +24,7 @@ DASH_ROUTING_APPLIANCE_TABLE
 DASH_FLOW_SYNC_SESSION_TABLE
 DASH_FLOW_DUMP_FILTER_TABLE
 {% endif %}
-{% if SYSTEM_DEFAULTS is defined and SYSTEM_DEFAULTS.route_performance is defined and SYSTEM_DEFAULTS.route_performance.zmq == "enabled"  %}
+{% if SYSTEM_DEFAULTS is defined and SYSTEM_DEFAULTS.swss_zmq is defined and SYSTEM_DEFAULTS.swss_zmq.status == "enabled"  %}
 ROUTE_TABLE
 LABEL_ROUTE_TABLE
 {% endif %}

--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -36,7 +36,7 @@ fi
 # Set zmq mode by default for smartswitch DPU and increase the max bulk limit
 # Otherwise, set synchronous mode if it is enabled in CONFIG_DB
 SYNC_MODE=$(echo $SWSS_VARS | jq -r '.synchronous_mode')
-SOUTHBOUND_ZMQ=$(echo $SWSS_VARS | jq -r '.orch_southbound_zmq_enabled')
+SOUTHBOUND_ZMQ=$(echo $SWSS_VARS | jq -r '.route_perf_zmq')
 if [ "$LOCALHOST_SWITCHTYPE" == "dpu" ]; then
     ORCHAGENT_ARGS+="-z zmq_sync -k $DPU_BATCH_SIZE "
 elif [ "$SOUTHBOUND_ZMQ" == "true" ]; then
@@ -67,7 +67,7 @@ if [[ "$NAMESPACE_ID" ]]; then
 fi
 
 # Enable async swss recorder when explicitly configured
-ASYNC_SWSS_REC=$(sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "async_swss_rec")
+ASYNC_SWSS_REC=$(sonic-db-cli CONFIG_DB hget "SYSTEM_DEFAULTS|route_performance" "async_rec")
 if [ "$ASYNC_SWSS_REC" == "enabled" ]; then
     ORCHAGENT_ARGS+="-A "
 fi

--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -36,7 +36,7 @@ fi
 # Set zmq mode by default for smartswitch DPU and increase the max bulk limit
 # Otherwise, set synchronous mode if it is enabled in CONFIG_DB
 SYNC_MODE=$(echo $SWSS_VARS | jq -r '.synchronous_mode')
-SOUTHBOUND_ZMQ=$(echo $SWSS_VARS | jq -r '.route_perf_zmq')
+SOUTHBOUND_ZMQ=$(echo $SWSS_VARS | jq -r '.swss_zmq')
 if [ "$LOCALHOST_SWITCHTYPE" == "dpu" ]; then
     ORCHAGENT_ARGS+="-z zmq_sync -k $DPU_BATCH_SIZE "
 elif [ "$SOUTHBOUND_ZMQ" == "true" ]; then
@@ -67,7 +67,7 @@ if [[ "$NAMESPACE_ID" ]]; then
 fi
 
 # Enable async swss recorder when explicitly configured
-ASYNC_SWSS_REC=$(sonic-db-cli CONFIG_DB hget "SYSTEM_DEFAULTS|route_performance" "async_rec")
+ASYNC_SWSS_REC=$(sonic-db-cli CONFIG_DB hget "SYSTEM_DEFAULTS|async_rec" "status")
 if [ "$ASYNC_SWSS_REC" == "enabled" ]; then
     ORCHAGENT_ARGS+="-A "
 fi

--- a/files/build_templates/swss_vars.j2
+++ b/files/build_templates/swss_vars.j2
@@ -12,6 +12,6 @@
     {% endif -%}
     "dual_tor": {% if DEVICE_METADATA.localhost.type == "ToRRouter" and DEVICE_METADATA.localhost.subtype == "DualToR" %}"enable"{% else %}"disable"{% endif %},
     "dscp_remapping": {% if SYSTEM_DEFAULTS is defined and SYSTEM_DEFAULTS.tunnel_qos_remap is defined and SYSTEM_DEFAULTS.tunnel_qos_remap.status == "enabled" %}"enable"{% else %}"disable"{% endif %},
-    "route_perf_zmq": {% if SYSTEM_DEFAULTS is defined and SYSTEM_DEFAULTS.route_performance is defined and SYSTEM_DEFAULTS.route_performance.zmq == "enabled" %}"true"{% else %}"false"{% endif %},
+    "swss_zmq": {% if SYSTEM_DEFAULTS is defined and SYSTEM_DEFAULTS.swss_zmq is defined and SYSTEM_DEFAULTS.swss_zmq.status == "enabled" %}"true"{% else %}"false"{% endif %},
     "switch_type": "{{ DEVICE_METADATA.localhost.switch_type }}"
 }

--- a/files/build_templates/swss_vars.j2
+++ b/files/build_templates/swss_vars.j2
@@ -12,6 +12,6 @@
     {% endif -%}
     "dual_tor": {% if DEVICE_METADATA.localhost.type == "ToRRouter" and DEVICE_METADATA.localhost.subtype == "DualToR" %}"enable"{% else %}"disable"{% endif %},
     "dscp_remapping": {% if SYSTEM_DEFAULTS is defined and SYSTEM_DEFAULTS.tunnel_qos_remap is defined and SYSTEM_DEFAULTS.tunnel_qos_remap.status == "enabled" %}"enable"{% else %}"disable"{% endif %},
-    "orch_southbound_zmq_enabled": {% if DEVICE_METADATA.localhost.orch_southbound_zmq_enabled is defined and DEVICE_METADATA.localhost.orch_southbound_zmq_enabled == "true" %}"true"{% else %}"false"{% endif %},
+    "route_perf_zmq": {% if SYSTEM_DEFAULTS is defined and SYSTEM_DEFAULTS.route_performance is defined and SYSTEM_DEFAULTS.route_performance.zmq == "enabled" %}"true"{% else %}"false"{% endif %},
     "switch_type": "{{ DEVICE_METADATA.localhost.switch_type }}"
 }

--- a/platform/vs/docker-sonic-vs/orchagent.sh
+++ b/platform/vs/docker-sonic-vs/orchagent.sh
@@ -49,7 +49,7 @@ fi
 # Set zmq mode by default for DPU vs
 # Otherwise, set synchronous mode if it is enabled in CONFIG_DB
 SYNC_MODE=$(echo $SWSS_VARS | jq -r '.synchronous_mode')
-SOUTHBOUND_ZMQ=$(echo $SWSS_VARS | jq -r '.route_perf_zmq')
+SOUTHBOUND_ZMQ=$(echo $SWSS_VARS | jq -r '.swss_zmq')
 
 if [ "$SWITCH_TYPE" == "dpu" ]; then
     ORCHAGENT_ARGS+="-z zmq_sync -k 65536 "
@@ -60,7 +60,7 @@ elif [ "$SYNC_MODE" == "enable" ]; then
 fi
 
 # Enable async swss recorder when explicitly configured
-ASYNC_SWSS_REC=$(sonic-db-cli CONFIG_DB hget "SYSTEM_DEFAULTS|route_performance" "async_rec")
+ASYNC_SWSS_REC=$(sonic-db-cli CONFIG_DB hget "SYSTEM_DEFAULTS|async_rec" "status")
 if [ "$ASYNC_SWSS_REC" == "enabled" ]; then
     ORCHAGENT_ARGS+="-A "
 fi

--- a/platform/vs/docker-sonic-vs/orchagent.sh
+++ b/platform/vs/docker-sonic-vs/orchagent.sh
@@ -49,7 +49,7 @@ fi
 # Set zmq mode by default for DPU vs
 # Otherwise, set synchronous mode if it is enabled in CONFIG_DB
 SYNC_MODE=$(echo $SWSS_VARS | jq -r '.synchronous_mode')
-SOUTHBOUND_ZMQ=$(echo $SWSS_VARS | jq -r '.orch_southbound_zmq_enabled')
+SOUTHBOUND_ZMQ=$(echo $SWSS_VARS | jq -r '.route_perf_zmq')
 
 if [ "$SWITCH_TYPE" == "dpu" ]; then
     ORCHAGENT_ARGS+="-z zmq_sync -k 65536 "
@@ -57,6 +57,12 @@ elif [ "$SOUTHBOUND_ZMQ" == "true" ]; then
     ORCHAGENT_ARGS+="-z zmq_sync "
 elif [ "$SYNC_MODE" == "enable" ]; then
     ORCHAGENT_ARGS+="-s "
+fi
+
+# Enable async swss recorder when explicitly configured
+ASYNC_SWSS_REC=$(sonic-db-cli CONFIG_DB hget "SYSTEM_DEFAULTS|route_performance" "async_rec")
+if [ "$ASYNC_SWSS_REC" == "enabled" ]; then
+    ORCHAGENT_ARGS+="-A "
 fi
 
 # Enable ring buffer

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -3209,22 +3209,33 @@ The **SUBNET_DECAP** table is used for subnet decap configuration.
 ### SYSTEM_DEFAULTS table
 To have a better management of the features in SONiC, a new table `SYSTEM_DEFAULTS` is introduced.
 
-```
+```json
 "SYSTEM_DEFAULTS": {
         "tunnel_qos_remap": {
             "status": "enabled"
-        }
+        },
         "default_bgp_status": {
             "status": "down"
-        }
+        },
         "synchronous_mode": {
             "status": "enable"
-        }
+        },
         "dhcp_server": {
-            "status": "enable"
+            "status": "enabled"
+        },
+        "route_performance": {
+            "zmq": "enabled",
+            "async_rec": "enabled"
         }
     }
 ```
+
+The `route_performance` entry controls route-performance optimizations:
+- `zmq`: When set to `"enabled"`, enables ZMQ-based communication between orchagent, syncd, and fpmsyncd (both southbound SAI operations and northbound route programming).
+- `async_rec`: When set to `"enabled"`, enables asynchronous APPL_STATE_DB recording (swss.rec) for improved route programming throughput.
+
+Both fields default to disabled when not present.
+
 The default value of flags in `SYSTEM_DEFAULTS` table can be set in `init_cfg.json` and loaded into db at system startup. These flags are usually set at image being build, and are unlikely to change at runtime.
 
 If the values in `config_db.json` is changed by user, it will not be rewritten back by `init_cfg.json` as `config_db.json` is loaded after `init_cfg.json` in [docker_image_ctl.j2](https://github.com/Azure/sonic-buildimage/blob/master/files/build_templates/docker_image_ctl.j2)

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -3223,18 +3223,20 @@ To have a better management of the features in SONiC, a new table `SYSTEM_DEFAUL
         "dhcp_server": {
             "status": "enabled"
         },
-        "route_performance": {
-            "zmq": "enabled",
-            "async_rec": "enabled"
+        "swss_zmq": {
+            "status": "enabled"
+        },
+        "async_rec": {
+            "status": "enabled"
         }
     }
 ```
 
-The `route_performance` entry controls route-performance optimizations:
-- `zmq`: When set to `"enabled"`, enables ZMQ-based communication between orchagent, syncd, and fpmsyncd (both southbound SAI operations and northbound route programming).
+The `swss_zmq` and `async_rec` entries control route-performance optimizations:
+- `swss_zmq`: When set to `"enabled"`, enables ZMQ-based communication between orchagent, syncd, and fpmsyncd (both southbound SAI operations and northbound route programming).
 - `async_rec`: When set to `"enabled"`, enables asynchronous APPL_STATE_DB recording (swss.rec) for improved route programming throughput.
 
-Both fields default to disabled when not present.
+Both entries default to disabled when not present.
 
 The default value of flags in `SYSTEM_DEFAULTS` table can be set in `init_cfg.json` and loaded into db at system startup. These flags are usually set at image being build, and are unlikely to change at runtime.
 

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/system_defaults.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/system_defaults.json
@@ -5,13 +5,5 @@
     "SYSTEM_DEFAULTS_WITH_INVALID_STATUS_VALUE": {
         "desc": "Referring invalid status value",
         "eStrKey": "InvalidValue"
-    },
-    "SYSTEM_DEFAULTS_ROUTE_PERF_INVALID_ZMQ": {
-        "desc": "Referring invalid value for route_performance zmq field",
-        "eStrKey": "InvalidValue"
-    },
-    "SYSTEM_DEFAULTS_ROUTE_PERF_INVALID_ASYNC_REC": {
-        "desc": "Referring invalid value for route_performance async_rec field",
-        "eStrKey": "InvalidValue"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/system_defaults.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/system_defaults.json
@@ -2,8 +2,16 @@
     "SYSTEM_DEFAULTS_WITH_CORRECT_VALUES": {
         "desc": "CONFIG SYSTEM_DEFAULTS TABLE WITH ALL THE CORRECT VALUES"
     },
-    "SYSTEM_DEFAULTS_WITH_INVALID_STATUS_VALUE" : {
+    "SYSTEM_DEFAULTS_WITH_INVALID_STATUS_VALUE": {
         "desc": "Referring invalid status value",
+        "eStrKey": "InvalidValue"
+    },
+    "SYSTEM_DEFAULTS_ROUTE_PERF_INVALID_ZMQ": {
+        "desc": "Referring invalid value for route_performance zmq field",
+        "eStrKey": "InvalidValue"
+    },
+    "SYSTEM_DEFAULTS_ROUTE_PERF_INVALID_ASYNC_REC": {
+        "desc": "Referring invalid value for route_performance async_rec field",
         "eStrKey": "InvalidValue"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
@@ -838,15 +838,6 @@
             }
         }
     },
-    "DEVICE_METADATA_VALID_ORCH_ROUTE_ZMQ": {
-        "sonic-device_metadata:sonic-device_metadata": {
-            "sonic-device_metadata:DEVICE_METADATA": {
-                "sonic-device_metadata:localhost": {
-                    "orch_northbond_route_zmq_enabled": true
-                }
-            }
-        }
-    },
     "DEVICE_METADATA_SYSLOG_WITH_OS_VERSION_ENABLED": {
         "sonic-device_metadata:sonic-device_metadata": {
             "sonic-device_metadata:DEVICE_METADATA": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/system_defaults.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/system_defaults.json
@@ -11,7 +11,11 @@
                         "name": "mux_tunnel_egress_acl",
                         "status": "enabled"
                     }
-                ]
+                ],
+                "route_performance": {
+                    "zmq": "enabled",
+                    "async_rec": "enabled"
+                }
             }
         }
     },
@@ -28,6 +32,26 @@
                         "status": "invalid_status"
                     }
                 ]
+            }
+        }
+    },
+    "SYSTEM_DEFAULTS_ROUTE_PERF_INVALID_ZMQ": {
+        "sonic-system-defaults:sonic-system-defaults": {
+            "sonic-system-defaults:SYSTEM_DEFAULTS": {
+                "route_performance": {
+                    "zmq": "invalid_value",
+                    "async_rec": "enabled"
+                }
+            }
+        }
+    },
+    "SYSTEM_DEFAULTS_ROUTE_PERF_INVALID_ASYNC_REC": {
+        "sonic-system-defaults:sonic-system-defaults": {
+            "sonic-system-defaults:SYSTEM_DEFAULTS": {
+                "route_performance": {
+                    "zmq": "enabled",
+                    "async_rec": "invalid_value"
+                }
             }
         }
     }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/system_defaults.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/system_defaults.json
@@ -10,12 +10,16 @@
                     {
                         "name": "mux_tunnel_egress_acl",
                         "status": "enabled"
+                    },
+                    {
+                        "name": "swss_zmq",
+                        "status": "enabled"
+                    },
+                    {
+                        "name": "async_rec",
+                        "status": "enabled"
                     }
-                ],
-                "route_performance": {
-                    "zmq": "enabled",
-                    "async_rec": "enabled"
-                }
+                ]
             }
         }
     },
@@ -32,26 +36,6 @@
                         "status": "invalid_status"
                     }
                 ]
-            }
-        }
-    },
-    "SYSTEM_DEFAULTS_ROUTE_PERF_INVALID_ZMQ": {
-        "sonic-system-defaults:sonic-system-defaults": {
-            "sonic-system-defaults:SYSTEM_DEFAULTS": {
-                "route_performance": {
-                    "zmq": "invalid_value",
-                    "async_rec": "enabled"
-                }
-            }
-        }
-    },
-    "SYSTEM_DEFAULTS_ROUTE_PERF_INVALID_ASYNC_REC": {
-        "sonic-system-defaults:sonic-system-defaults": {
-            "sonic-system-defaults:SYSTEM_DEFAULTS": {
-                "route_performance": {
-                    "zmq": "enabled",
-                    "async_rec": "invalid_value"
-                }
             }
         }
     }

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -19,6 +19,12 @@ module sonic-device_metadata {
 
     description "DEVICE_METADATA YANG Module for SONiC OS";
     
+    revision 2026-06-02 {
+        description "Removed route performance knobs (async_swss_rec, route_state_async_publish,
+                     orch_northbond_route_zmq_enabled, orch_southbound_zmq_enabled).
+                     Moved to SYSTEM_DEFAULTS|route_performance in sonic-system-defaults.yang.";
+    }
+
     revision 2026-04-11 {
         description "Adde use_template_render_for_restore to control the method of config restore in FRR.";
     }
@@ -261,25 +267,6 @@ module sonic-device_metadata {
                     }
                 }
 
-                leaf async_swss_rec {
-                    description "Enable asynchronous swss.rec recording in orchagent.";
-                    type enumeration {
-                        enum enabled;
-                        enum disabled;
-                    }
-                    default disabled;
-                }
-
-                leaf route_state_async_publish {
-                    description "When enabled, routeorch publishes route states asynchronously in state update thread.
-                                 When disabled, route state is published on the orch task path (synchronous).";
-                    type enumeration {
-                        enum enabled;
-                        enum disabled;
-                    }
-                    default enabled;
-                }
-
                 leaf rack_mgmt_map {
                     type string {
                         length 0..128 {
@@ -361,18 +348,6 @@ module sonic-device_metadata {
                     type boolean;
                     description "Enable ZMQ feature on APPL_DB DASH tables.";
                     default "true";
-                }
-
-                leaf orch_northbond_route_zmq_enabled {
-                    type boolean;
-                    description "Enable ZMQ feature on APPL_DB ROUTE tables.";
-                    default "false";
-                }
-
-                leaf orch_southbound_zmq_enabled {
-                    type boolean;
-                    description "Enable ZMQ feature between orchagent and syncd (southbound).";
-                    default "false";
                 }
 
                 leaf syslog_with_osversion {

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -22,7 +22,7 @@ module sonic-device_metadata {
     revision 2026-06-02 {
         description "Removed route performance knobs (async_swss_rec, route_state_async_publish,
                      orch_northbond_route_zmq_enabled, orch_southbound_zmq_enabled).
-                     Moved to SYSTEM_DEFAULTS|route_performance in sonic-system-defaults.yang.";
+                     Moved to SYSTEM_DEFAULTS list entries swss_zmq and async_rec.";
     }
 
     revision 2026-04-11 {

--- a/src/sonic-yang-models/yang-models/sonic-system-defaults.yang
+++ b/src/sonic-yang-models/yang-models/sonic-system-defaults.yang
@@ -12,7 +12,7 @@ module sonic-system-defaults{
     description "System-wide default feature settings YANG module for SONiC OS.";
 
     revision 2026-06-02 {
-        description "Added route_performance container with zmq and async_rec fields.";
+        description "Documented swss_zmq and async_rec as SYSTEM_DEFAULTS list entries.";
     }
 
     container sonic-system-defaults {
@@ -40,25 +40,6 @@ module sonic-system-defaults{
 
             }
 
-            container route_performance {
-
-                description "Route pipeline performance optimization settings.";
-
-                leaf zmq {
-                    description "Enable ZMQ for northbound (fpmsyncd to orchagent route tables)
-                                 and southbound (orchagent to syncd for all SAI operations).";
-                    type stypes:admin_mode;
-                    default "disabled";
-                }
-
-                leaf async_rec {
-                    description "Enable async swss.rec recording and async
-                                 APPL_STATE_DB route state publishing in orchagent.";
-                    type stypes:admin_mode;
-                    default "disabled";
-                }
-
-            }
         }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-system-defaults.yang
+++ b/src/sonic-yang-models/yang-models/sonic-system-defaults.yang
@@ -11,6 +11,10 @@ module sonic-system-defaults{
 
     description "System-wide default feature settings YANG module for SONiC OS.";
 
+    revision 2026-06-02 {
+        description "Added route_performance container with zmq and async_rec fields.";
+    }
+
     container sonic-system-defaults {
 
         container SYSTEM_DEFAULTS {
@@ -32,6 +36,26 @@ module sonic-system-defaults{
                 leaf status {
                     description "Default administrative state of the feature (enabled or disabled).";
                     type stypes:admin_mode;
+                }
+
+            }
+
+            container route_performance {
+
+                description "Route pipeline performance optimization settings.";
+
+                leaf zmq {
+                    description "Enable ZMQ for northbound (fpmsyncd to orchagent route tables)
+                                 and southbound (orchagent to syncd for all SAI operations).";
+                    type stypes:admin_mode;
+                    default "disabled";
+                }
+
+                leaf async_rec {
+                    description "Enable async swss.rec recording and async
+                                 APPL_STATE_DB route state publishing in orchagent.";
+                    type stypes:admin_mode;
+                    default "disabled";
                 }
 
             }


### PR DESCRIPTION
#### Why I did it

Consolidate 4 route-performance knobs from `DEVICE_METADATA|localhost` into 2 flat `SYSTEM_DEFAULTS` entries:

- `SYSTEM_DEFAULTS|swss_zmq` (status: enabled/disabled) — enables ZMQ-based communication between orchagent, syncd, and fpmsyncd
- `SYSTEM_DEFAULTS|async_rec` (status: enabled/disabled) — enables asynchronous rec writing(SWSS.rec today, ASIC_DB, APPL_STATE_DB to be added)

This simplifies configuration by:
1. Moving platform defaults out of per-device metadata into system defaults
2. Reducing 4 knobs to 2 (northbound/southbound ZMQ consolidated into one `swss_zmq` knob)
3. Following the standard `SYSTEM_DEFAULTS_LIST` pattern (same as `tunnel_qos_remap`, `dhcp_server`, etc.)

**Merge order**: sonic-swss (sonic-net/sonic-swss#4630) and sonic-sairedis (sonic-net/sonic-sairedis#1922) should merge first. Then this PR merges and bumps the submodule pointers.

Companion PRs:
- sonic-swss: https://github.com/sonic-net/sonic-swss/pull/4630
- sonic-sairedis: https://github.com/sonic-net/sonic-sairedis/pull/1922
- sonic-net/SONiC (doc): https://github.com/sonic-net/SONiC/pull/2359

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- **YANG**: Removed 4 leaves (`async_swss_rec`, `route_state_async_publish`, `orch_northbond_route_zmq_enabled`, `orch_southbound_zmq_enabled`) from `sonic-device_metadata.yang`
- **YANG**: No new container — entries use the existing `SYSTEM_DEFAULTS_LIST` (key=name, leaf=status with `admin_mode` type)
- **orchagent.sh** (generic + VS): Read `async_rec` status from `SYSTEM_DEFAULTS|async_rec`; read ZMQ via `swss_zmq` from swss_vars JSON
- **swss_vars.j2**: Read `status` from `SYSTEM_DEFAULTS|swss_zmq`, output as `swss_zmq`
- **orch_zmq_tables.conf.j2**: Use `SYSTEM_DEFAULTS.swss_zmq.status` condition for northbound ZMQ route table list
- **Configuration.md**: Document `swss_zmq` and `async_rec` entries in SYSTEM_DEFAULTS table section
- **Yang tests**: Updated test configs for flat schema

#### How to verify it

1. Build VS image and deploy on KVM testbed
2. Default state: `ps aux | grep orchagent` shows `-s` (synchronous mode), no ZMQ flags
3. Enable ZMQ:
   ```
   sonic-db-cli CONFIG_DB hset "SYSTEM_DEFAULTS|swss_zmq" status enabled
   config save -y && config reload -y
   ```
   Verify: orchagent and syncd show `-z zmq_sync` flags
4. Enable async_rec:
   ```
   sonic-db-cli CONFIG_DB hset "SYSTEM_DEFAULTS|async_rec" status enabled
   config save -y && config reload -y
   ```
   Verify: orchagent shows `-A` flag
5. Disable both: flags revert to `-s`

#### Which release branch to backport (provide reason below if selected)

#### Tested branch (Please provide the tested image version)

- [x] VS image on KVM testbed (sonic-vs built from this branch)

All 4 knob states tested:
| State | orchagent flags | syncd flags | NB ZMQ tables |
|-------|----------------|-------------|---------------|
| Both disabled (default) | `-s` | `-s` | Not rendered |
| swss_zmq=enabled | `-z zmq_sync` | `-z zmq_sync` | ROUTE_TABLE, LABEL_ROUTE_TABLE |
| async_rec=enabled | `-s -A` | `-s` | Not rendered |
| Both enabled | `-z zmq_sync -A` | `-z zmq_sync` | ROUTE_TABLE, LABEL_ROUTE_TABLE |

#### Description for the changelog

Consolidate 4 route-performance knobs from DEVICE_METADATA into 2 flat SYSTEM_DEFAULTS entries (swss_zmq, async_rec) following the standard SYSTEM_DEFAULTS_LIST pattern.

#### Link to config_db schema for YANG module changes

SYSTEM_DEFAULTS table: https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#system_defaults-table


