### PR TITLE
[dhcp_server] make dhcpservd readiness check idempotent

### DIFF
--- a/dockers/docker-dhcp-server/wait_for_dhcpservd.sh
+++ b/dockers/docker-dhcp-server/wait_for_dhcpservd.sh
@@ -7,10 +7,13 @@
 DHCPSERVD_READY_FLAG="/tmp/dhcpservd_ready"
 TIMEOUT=120
 
+# Do NOT remove the flag: the dependent-startup plugin may launch this
+# checker more than once (the program has startsecs=0 and exits quickly).
+# dhcpservd does not restart within a container, and docker_init.sh clears the stale
+# flag on container start, so leaving it in place keeps re-runs idempotent.
 for i in $(seq 1 $TIMEOUT); do
     if [ -f "$DHCPSERVD_READY_FLAG" ]; then
-        rm -f "$DHCPSERVD_READY_FLAG"
-        logger -p daemon.info "wait_for_dhcpservd: dhcpservd is ready (flag file found and removed after ${i}s)"
+        logger -p daemon.info "wait_for_dhcpservd: dhcpservd is ready (flag file found after ${i}s)"
         exit 0
     fi
     sleep 1


### PR DESCRIPTION
#### Why I did it
The dhcpservd readiness checker (`wait_for_dhcpservd.sh`) is run twice during dhcp_server
init: it has `startsecs=0` and exits in ~13ms, so the supervisord dependent-startup plugin
re-spawns it. The first run *removed* `/tmp/dhcpservd_ready`, so the second run found no flag
and timed out after 120s, logging a spurious `ERR ... wait_for_dhcpservd: timed out ... after 120s`.
kea-dhcp4 was already up, so the container was healthy — the timeout was just log noise.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it
- `wait_for_dhcpservd.sh`: don't remove the flag, only check for it — making the checker
  idempotent so a re-spawned run exits 0 immediately. Stale-flag cleanup stays in
  `docker_init.sh`. kea gating and the #26569 SIGUSR1/SIGHUP fix are unchanged.

#### How to verify it
- After restart, `docker exec dhcp_server supervisorctl status` shows `dhcpservd` and
  `kea-dhcp4` RUNNING and `dhcpservd-ready` EXITED, and syslog no longer logs the 120s timeout.

#### Which release branch to backport (provide reason below if selected)
- [ ] None

#### Description for the changelog
[dhcp_server] make dhcpservd readiness check idempotent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DHCP server startup checker to properly handle multiple invocations without causing conflicts during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->