### PR TITLE
[docker-fpm-frr]: Fix tcmalloc package name for Trixie armhf

### DIFF
--- a/dockers/docker-fpm-frr/Dockerfile.j2
+++ b/dockers/docker-fpm-frr/Dockerfile.j2
@@ -16,7 +16,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update   && \
     apt-get install -y  \
 {% if enable_frr_tcmalloc == "y" %}
-        libgoogle-perftools4 \
+        libgoogle-perftools4t64 \
 {% endif %}
         logrotate
 


### PR DESCRIPTION
#### Why I did it
PR #27580 (FRR tcmalloc build) introduced `libgoogle-perftools4` as a runtime dependency in the docker-fpm-frr Dockerfile. This breaks the marvell-prestera-armhf build because on Debian Trixie armhf, the time64 transition renames this package to `libgoogle-perftools4t64` — the old name has no installation candidate.

The CI did not catch this because docker-fpm-frr was cached for the armhf build during the original PR validation.

#### How I did it
Changed `libgoogle-perftools4` → `libgoogle-perftools4t64` in `dockers/docker-fpm-frr/Dockerfile.j2`.

Since docker-fpm-frr is always Trixie-based (`DOCKER_SWSS_LAYER_TRIXIE`), `libgoogle-perftools4t64` is the correct package name for all architectures (amd64, arm64, armhf). This matches the pattern used by:
- `sonic-slave-trixie/Dockerfile.j2` (line 227): `libgoogle-perftools4t64`
- `dockers/docker-platform-monitor/Dockerfile.j2`: `librrd8t64`
- `dockers/docker-sonic-mgmt-framework/Dockerfile.j2`: `libcurl4t64`

#### How to verify it
- Verified `libgoogle-perftools4t64` exists on Trixie for both [armhf](https://packages.debian.org/trixie/armhf/libgoogle-perftools4t64) and [amd64](https://packages.debian.org/trixie/amd64/libgoogle-perftools4t64) via Debian package tracker
- CI pipeline should rebuild docker-fpm-frr for marvell-prestera-armhf (cache miss due to Dockerfile change)

#### Which release branch to backport
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch
master

#### Description for the changelog
Fix docker-fpm-frr tcmalloc dependency package name for Trixie armhf (time64 transition)

#### Link to config_db schema for YANG module changes
N/A