### PR TITLE
Revert "[202511] Update DPU HWSKU context config to use DPU_COUNTERS_DB"

### DIFF
--- a/device/nvidia-bluefield/arm64-nvda_bf-bf3comdpu/Nvidia-bf3-com-dpu/context_config.json
+++ b/device/nvidia-bluefield/arm64-nvda_bf-bf3comdpu/Nvidia-bf3-com-dpu/context_config.json
@@ -4,7 +4,7 @@
             "guid" : 0,
             "name" : "syncd0",
             "dbAsic" : "ASIC_DB",
-            "dbCounters" : "DPU_COUNTERS_DB",
+            "dbCounters" : "COUNTERS_DB",
             "dbFlex": "FLEX_COUNTER_DB",
             "dbState" : "STATE_DB",
             "zmq_enable": true,

--- a/device/pensando/arm64-elba-asic-flash128-r0/Pensando-elba/context_config.json
+++ b/device/pensando/arm64-elba-asic-flash128-r0/Pensando-elba/context_config.json
@@ -4,7 +4,7 @@
             "guid" : 0,
             "name" : "syncd0",
             "dbAsic" : "ASIC_DB",
-            "dbCounters" : "DPU_COUNTERS_DB",
+            "dbCounters" : "COUNTERS_DB",
             "dbFlex": "FLEX_COUNTER_DB",
             "dbState" : "STATE_DB",
             "zmq_enable": true,


### PR DESCRIPTION
https://github.com/sonic-net/sonic-buildimage/pull/27499 updates the context_config for syncd to point at DPU_COUNTERS_DB instead of COUNTER_DB. Syncd attempts to run some lua scripts in the DPU_COUNTERS_DB redis instance (which is hosted on the NPU), and expects these scripts to be loaded into redis by orchagent. However, orchagent is still loading the scripts into the COUNTERS_DB redis instance (which is on the DPU). Since the scripts aren't loaded into the correct redis instance, syncd generates error messages in DPU syslog when trying to run these scripts:

```
2026 Jun  3 23:46:22.553392 str-8102-01-dpu-0 ERR syncd#syncd[22]: :- guard: RedisReply catches system_error: command: *8\r\n$7\r\nEVALSHA\r\n$40\r\n567234fa6d7e30a131a3a2d4d60d3b1b923a42c2\r\n$1\r\n1\r\n$19\r\noid:0x1000000000002\r\n$2\r\n18\r\n$8\r\nCOUNTERS\r\n$4\r\n1000\r\n$2\r\n''\r\n, reason: NOSCRIPT No matching script. Please use EVAL.: Input/output error
2026 Jun  3 23:46:22.553828 str-8102-01-dpu-0 ERR syncd#syncd[22]: :- runRedisScript: Caught exception while running Redis lua script: RedisReply catches system_error: command: *8\r\n$7\r\nEVALSHA\r\n$40\r\n567234fa6d7e30a131a3a2d4d60d3b1b923a42c2\r\n$1\r\n1\r\n$19\r\noid:0x1000000000002\r\n$2\r\n18\r\n$8\r\nCOUNTERS\r\n$4\r\n1000\r\n$2\r\n''\r\n, reason: NOSCRIPT No matching script. Please use EVAL.: Input/output error: Input/output error
```