### PR TITLE
[docker-fpm-frr]: Use t64 gperftools package

### DIFF
--- a/dockers/docker-fpm-frr/Dockerfile.j2
+++ b/dockers/docker-fpm-frr/Dockerfile.j2
@@ -16,7 +16,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update   && \
     apt-get install -y  \
 {% if enable_frr_tcmalloc == "y" %}
-        libgoogle-perftools4 \
+        libgoogle-perftools4t64 \
 {% endif %}
         logrotate
 


### PR DESCRIPTION
#### Why I did it

The `marvell_prestera_armhf` Trixie build can fail while building `docker-fpm-frr` with `ENABLE_FRR_TCMALLOC=y` because Trixie armhf does not provide the old `libgoogle-perftools4` package name. Apt reports `libgoogle-perftools4t64` as the replacement package.

Related to #27683.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Use the Trixie `libgoogle-perftools4t64` package name in the `docker-fpm-frr` Dockerfile template.

#### How to verify it

- Reproduced the armhf resolver failure locally using an isolated apt root against `http://packages.trafficmanager.net/snapshot/debian/20260529T000717Z`: `apt-get -s install libgoogle-perftools4 logrotate` returned `100` and reported `Package 'libgoogle-perftools4' has no installation candidate`.
- Verified the fixed package resolves for armhf: `apt-get -s install libgoogle-perftools4t64 logrotate` returned `0` and selected `libgoogle-perftools4t64 (2.16-1 Debian:13.5/stable [armhf])`.
- Rendered `dockers/docker-fpm-frr/Dockerfile.j2` with `enable_frr_tcmalloc=y` and confirmed the generated install list contains `libgoogle-perftools4t64`.
- Ran `git diff --check github/master..HEAD`.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [x] master - local package resolver and template verification only; no image build

#### Description for the changelog

Use the Trixie t64 gperftools runtime package in docker-fpm-frr.

#### Link to config_db schema for YANG module changes

N/A