### PR TITLE
Align container timezone at docker create time

### DIFF
--- a/platform/template/docker-syncd-base.mk
+++ b/platform/template/docker-syncd-base.mk
@@ -35,6 +35,7 @@ endif
 $(DOCKER_SYNCD_BASE)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_BASE)_RUN_OPT += --privileged -t
 $(DOCKER_SYNCD_BASE)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
+$(DOCKER_SYNCD_BASE)_RUN_OPT += -v /etc/localtime:/etc/localtime:ro
 $(DOCKER_SYNCD_BASE)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 
 SONIC_BUSTER_DOCKERS += $(DOCKER_SYNCD_BASE)

--- a/platform/template/docker-syncd-bookworm.mk
+++ b/platform/template/docker-syncd-bookworm.mk
@@ -25,6 +25,7 @@ endif
 $(DOCKER_SYNCD_BASE)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_BASE)_RUN_OPT += --privileged -t
 $(DOCKER_SYNCD_BASE)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
+$(DOCKER_SYNCD_BASE)_RUN_OPT += -v /etc/localtime:/etc/localtime:ro
 $(DOCKER_SYNCD_BASE)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 
 SONIC_BOOKWORM_DOCKERS += $(DOCKER_SYNCD_BASE)

--- a/platform/template/docker-syncd-bullseye.mk
+++ b/platform/template/docker-syncd-bullseye.mk
@@ -25,6 +25,7 @@ endif
 $(DOCKER_SYNCD_BASE)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_BASE)_RUN_OPT += --privileged -t
 $(DOCKER_SYNCD_BASE)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
+$(DOCKER_SYNCD_BASE)_RUN_OPT += -v /etc/localtime:/etc/localtime:ro
 $(DOCKER_SYNCD_BASE)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 
 SONIC_BULLSEYE_DOCKERS += $(DOCKER_SYNCD_BASE)

--- a/platform/template/docker-syncd-trixie.mk
+++ b/platform/template/docker-syncd-trixie.mk
@@ -23,6 +23,7 @@ endif
 $(DOCKER_SYNCD_BASE)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_BASE)_RUN_OPT += --privileged -t
 $(DOCKER_SYNCD_BASE)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
+$(DOCKER_SYNCD_BASE)_RUN_OPT += -v /etc/localtime:/etc/localtime:ro
 $(DOCKER_SYNCD_BASE)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 
 SONIC_TRIXIE_DOCKERS += $(DOCKER_SYNCD_BASE)


### PR DESCRIPTION
#### Why I did it

When the host timezone is not UTC (e.g. `Asia/Jerusalem`), host syslog and `date` show local time (IDT) while container logs from `syncd#` / `swss#` can stay on UTC. That makes `/var/log/syslog` hard to read because host
and container lines are offset by several hours.

Root cause at **docker create** time:

1. Per-container `docker-*.mk` rules mounted host `/etc/localtime` as a **symlink**. Inside the container that symlink resolves against the image rootfs (often `Etc/UTC`), not the host zoneinfo file.
2. Mounts and timezone settings are fixed when the container is created. They are **not** updated when the host timezone changes later.

This PR centralizes timezone handling in `docker_image_ctl.j2` for all containers rendered from that template.

#### How I did it

- Add `get_host_timezone_mounts()` in `docker_image_ctl.j2`:
  - `readlink -f /etc/localtime` on the host and bind the resolved zoneinfo **file** to container `/etc/localtime` (not the symlink).
  - If host `/etc/timezone` exists, bind it read-only as well (SONiC hosts often do not have this file; mount is skipped in that case).
- Wire `$(get_host_timezone_mounts)` into the shared `docker create` path used by swss, syncd, pmon, and other containers.
- Remove duplicate `-v /etc/localtime:/etc/localtime:ro` entries from individual `rules/docker-*.mk` files so all containers use the same logic.

**Known limitation (by design of Docker):** if the host timezone is
changed **after** a container was created (e.g. `sudo timedatectl set-timezone Asia/Jerusalem`), existing containers
keep the timezone snapshot from create time. **Recreate** the affected containers (e.g. `systemctl restart swss syncd`, or stop/remove/start via `/usr/bin/*.sh`) to pick up the new host timezone. This PR does not add runtime timezone sync.

Example on sonic-testbed after changing host timezone without recreating containers:
```bash
admin@sonic-testbed:~$ sudo timedatectl set-timezone Asia/Jerusalem
admin@sonic-testbed:~$ date
Thu Jun 11 12:51:07 PM IDT 2026
admin@sonic-testbed:~$ docker exec swss date
Thu Jun 11 09:51:11 UTC 2026
admin@sonic-testbed:~$ docker exec syncd date
Thu Jun 11 09:51:17 UTC 2026
```

Host is IDT; swss/syncd still show UTC until recreated with the new image/scripts.

#### How to verify it
On a switch with non-UTC host timezone (or after `timedatectl set-timezone` **before** container create):

```bash
date
docker exec swss date
docker exec syncd date
```

Expect container `/etc/localtime` mount source to match host `readlink -f /etc/localtime`, and `docker exec … date` to match host `date` **when the container was created after the host timezone was already correct**.

After a **runtime** host timezone change, expect mismatch until containers are recreated (see limitation above).

#### Tested branch (Please provide the tested image version)
- [x] master_RC

#### Description for the changelog
Align container timezone with host at docker create time via docker_image_ctl.j2.