### PR TITLE
Override bootconf env variable from installer.conf

### DIFF
--- a/platform/aspeed/platform_arm64.conf
+++ b/platform/aspeed/platform_arm64.conf
@@ -53,12 +53,12 @@ echo "Installing SONiC from ${install_env:-unknown} on Platform $onie_platform"
 # AST2700 platform default configurations
 disk_interface="mmc"
 mmc_bus="mmc0:0001" 
-bootconf=${bootconf:-"ast2700-evb"}
 
 # Device tree and FIT image configuration
 # DTB is embedded in FIT image, selected by bootconf U-Boot variable
 # FIT configuration is selected by U-Boot bootconf variable
-# bootconf is set by U-Boot based on hardware detection
+# bootconf can be set by either U-Boot based on hardware detection or
+# from device/<vendor>/<platform>/installer.conf
 # Example: bootconf="ast2700-evb" selects #conf-ast2700-evb from FIT image
 
 # U-Boot memory addresses for AST2700
@@ -318,7 +318,11 @@ prepare_boot_menu() {
     fw_setenv ${FW_ARG}  kernel_addr $kernel_addr
     fw_setenv ${FW_ARG}  fdt_addr $fdt_addr
     fw_setenv ${FW_ARG}  initrd_addr $initrd_addr
-    fw_setenv ${FW_ARG}  bootconf $bootconf
+
+    # bootconf is overrided with device/<vendor>/<platform>/installer.conf
+    if [ -n "${bootconf}" ]; then
+        fw_setenv ${FW_ARG}  bootconf $bootconf
+    fi
 
     # Display installation summary
     echo ""


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Update bootconf uboot env variable only if it is defined in device specific installer.conf. This change will help to preserve default bootconf set by uboot on platforms that do not define bootconf in installer.conf

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Updated platform_arm64.conf 

#### How to verify it

Create a build sonic-aspeed-arm64.bin by including these changes and verify the bootconf is updated only if defined in installer.conf

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

