### PR TITLE
[Mellanox] mlnx-fw-manager.service: escape backslashes in ExecCondition to silence systemd parser warning

### DIFF
--- a/platform/mellanox/files/mlnx-fw-manager.service
+++ b/platform/mellanox/files/mlnx-fw-manager.service
@@ -22,7 +22,7 @@ Description=Mellanox Firmware Manager Service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecCondition=/bin/grep -qv '\<SONIC_BOOT_TYPE=fastfast\>' /proc/cmdline
+ExecCondition=/bin/grep -qv '\\<SONIC_BOOT_TYPE=fastfast\\>' /proc/cmdline
 ExecStart=/usr/local/bin/mlnx-fw-manager --clear-semaphore --verbose
 TimeoutSec=300
 User=root


### PR DESCRIPTION
#### Why I did it
`https://github.com/sonic-net/sonic-buildimage/pull/26549` added an `ExecCondition` to `platform/mellanox/files/mlnx-fw-manager.service`:

```ini
ExecCondition=/bin/grep -qv '\<SONIC_BOOT_TYPE=fastfast\>' /proc/cmdline

```

systemd's unit-file parser treats `\` as an escape character and does not recognize `\<` or `\>`, so on every boot and on every `systemctl daemon-reload` it logs the following warning, polluting syslog:

```text
systemd[1]: /usr/lib/systemd/system/mlnx-fw-manager.service:25: Ignoring unknown escape sequences: "<SONIC_BOOT_TYPE=fastfast>"
```

#### How I did it

* Escaped the backslashes in the `ExecCondition` so that systemd hands the literal `\<` / `\>` word-boundary anchors through to `grep`:

```ini
ExecCondition=/bin/grep -qv '\\<SONIC_BOOT_TYPE=fastfast\\>' /proc/cmdline

```

* `\\` is a documented systemd escape that resolves to a single `\`, so the `argv[]` passed to `/bin/grep` is byte-identical to the previous version. Only the parser warning is removed; runtime behavior is unchanged.

#### How to verify it
```bash
### test before fix applies, warning produced
$ sudo cp /tmp/mlnx-fw-manager.service.old /usr/lib/systemd/system/mlnx-fw-manager.service 
$ sudo systemd-analyze verify /usr/lib/systemd/system/mlnx-fw-manager.service 2>&1 | tee /tmp/sd-old.log 
/usr/lib/systemd/system/mlnx-fw-manager.service:25: Ignoring unknown escape sequences: "<SONIC_BOOT_TYPE=fastfast>" 
$ grep -q 'Ignoring unknown escape' /tmp/sd-old.log && echo 'OLD: WARNING REPRODUCED (expected)' || echo 'OLD: NO WARNING (unexpected)' 
OLD: WARNING REPRODUCED (expected)

### test after fix applied, warning disappear
$ sudo cp /tmp/mlnx-fw-manager.service.new /usr/lib/systemd/system/mlnx-fw-manager.service 
$ sudo systemd-analyze verify /usr/lib/systemd/system/mlnx-fw-manager.service 2>&1 | tee /tmp/sd-new.log 
$ grep -q 'Ignoring unknown escape' /tmp/sd-new.log && echo 'NEW: WARNING (unexpected) - FAIL' || echo 'NEW: NO WARNING (expected) - PASS' 
NEW: NO WARNING (expected) - PASS

```

Additional checks performed on the same DUT (parity / no behavior change):

* `systemctl show mlnx-fw-manager.service -p ExecCondition` for OLD and NEW produces a byte-identical `argv[]` (`/bin/grep -qv \<SONIC_BOOT_TYPE=fastfast\> /proc/cmdline`); `diff` of the two outputs is empty.
* `systemctl start mlnx-fw-manager.service` reports `Result=success`, `ConditionResult=yes`, `ActiveState=active`, `SubState=exited` with both forms.
* Direct `grep -qv` regression with the parsed pattern returns `1 / 0 / 0 / 0` for cmdlines `SONIC_BOOT_TYPE=fastfast` / `=fast` / `=fastfastX` / `no_match_here` under both forms — word-boundary semantics preserved.

#### Which release branch to backport (provide reason below if selected)

* [ ] 201811
* [ ] 201911
* [ ] 202012
* [ ] 202106
* [ ] 202111
* [ ] 202205
* [ ] 202211
* [ ] 202305
* [ ] 202311
* [ ] 202405
* [ ] 202411

(Backport is only relevant to branches that already carry PR #26549. Tick the matching release branches if needed.)

#### Description for the changelog

[mellanox] Fix systemd "Ignoring unknown escape sequences" warning in `mlnx-fw-manager.service` by doubling the backslashes in the `ExecCondition` word-boundary anchors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Mellanox firmware manager service condition so it correctly detects and skips execution when the system boot type indicates a fast boot.
  * Improved reliability of firmware manager startup behavior during special boot scenarios to prevent unintended runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nvidia-sonic/sonic-buildimage/pull/878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->