### PR TITLE
[broadcom] Make libsai-dev a build prereq of libsairedis to fix make -j race

### DIFF
--- a/platform/broadcom/rules.mk
+++ b/platform/broadcom/rules.mk
@@ -57,7 +57,8 @@ SONIC_ONLINE_FILES += $(BCMCMD) $(DSSERVE)
 SONIC_ALL += $(SONIC_ONE_IMAGE) $(SONIC_ONE_ABOOT_IMAGE) \
              $(DOCKER_FPM)
 
-# Inject brcm sai into syncd
+# Inject brcm sai into syncd and sairedis
+$(LIBSAIREDIS)_DEPENDS += $(BRCM_XGS_SAI_DEV)
 $(SYNCD)_DEPENDS += $(BRCM_XGS_SAI) $(BRCM_XGS_SAI_DEV)
 $(SYNCD)_UNINSTALLS += $(BRCM_XGS_SAI_DEV) $(BRCM_XGS_SAI)
 


### PR DESCRIPTION
#### Why I did it
Fixes https://github.com/sonic-net/sonic-buildimage/issues/27751
Related to https://github.com/sonic-net/sonic-buildimage/issues/7734

`sonic-sairedis` builds `libsairedis*.deb` **and** `syncd*.deb` from a single `dpkg-buildpackage` invocation. `configure.ac` (line 76) unconditionally runs `AC_CHECK_LIB([sai], main, ..., AC_MSG_ERROR(libsai is required for syncd))` for any non-SAIVS build, so the `-lsai` probe fires during the `LIBSAIREDIS` build target — not just `SYNCD`'s.

`platform/broadcom/rules.mk` already declares
`$(SYNCD)_DEPENDS += $(BRCM_XGS_SAI) $(BRCM_XGS_SAI_DEV)`, but
`$(LIBSAIREDIS)_DEPENDS` (from `rules/sairedis.mk`) only lists
`$(LIBSWSSCOMMON_DEV)`. With `make -j`, `BRCM_XGS_SAI_DEV-install` therefore
runs as a **sibling** of the `libsairedis` build target rather than a prerequisite, and the `libsairedis` `./configure` can race ahead of the `libsai-dev` `dpkg -i` and fail with:
configure: error: libsai is required for syncd

This is hidden  because `BRCM_XGS_SAI` is sourced from `SONIC_ONLINE_DEBS` (cached download, sub-second install). It is reproducible on downstream forks that route the vendor deb through `SONIC_COPY_DEBS` from slower storage (e.g. larger copy time), where `libsai-dev` install loses the race against `libsairedis` configure.

There is precedent for declaring such an edge — `LIBSWSSCOMMON_DEV` is listed as a prereq of every consumer (`LIBSAIREDIS`, `SYNCD`, `SWSS`, `SONIC_EVENTD`, `STP`, `SONIC_P4RT`, `SYSMGR`, `WPASUPPLICANT`, `TELEMETRY`, `SONIC_LINKMGRD`, etc.) for the exact same reason. Vendor SAI -dev should follow the same pattern.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added one line to `platform/broadcom/rules.mk`, right above the existing
`$(SYNCD)_DEPENDS` block, promoting `BRCM_XGS_SAI_DEV` from a sibling of
`LIBSAIREDIS` to a prerequisite:

```make
# Inject brcm sai into syncd
$(LIBSAIREDIS)_DEPENDS += $(BRCM_XGS_SAI_DEV)
$(SYNCD)_DEPENDS += $(BRCM_XGS_SAI) $(BRCM_XGS_SAI_DEV)
$(SYNCD)_UNINSTALLS += $(BRCM_XGS_SAI_DEV) $(BRCM_XGS_SAI)
```
A symmetric addition to $(SYNCD)_DEPENDS is not needed — it is already
covered by the existing line. $(SYNCD)_UNINSTALLS is also unchanged: the
-uninstall rule runs once after the entire SYNCD build target completes,
so it has no race interaction with the new prereq.

#### How to verify it
On a workspace where the race reproduces (vendor SAI sourced via SONIC_COPY_DEBS):
```
rm -f target/debs/bookworm/{libsairedis,libsaimetadata,syncd}*.deb
rm -f target/debs/bookworm/*-install.log
make PLATFORM=broadcom SONIC_CONFIG_MAKE_JOBS=8 SONIC_BUILD_JOBS=1 \ ENABLE_DEBUG_SYMBOLS=n SKIP_BUILD_TEST=y \ target/debs/bookworm/syncd_1.0.0_amd64.deb
```
Expected order in the build log (observed after this patch):
```
[ finished ] libsaibcm_<ver>_amd64.deb-install
[ finished ] libsaibcm-dev_<ver>_amd64.deb-install
[ building ] libsairedis_1.0.0_amd64.deb           ← starts AFTER libsai-dev install
[ finished ] libsairedis_1.0.0_amd64.deb
[ finished ] syncd_1.0.0_amd64.deb
```
Without the patch, `libsairedis_1.0.0_amd64.deb` build is scheduled as a sibling of `libsaibcm-dev-install` and fails its `./configure` step with `libsai is required for syncd` whenever the dpkg install is the slower of the two.

#### Which release branch to backport (provide reason below if selected)
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

Reason: identical race exists on 202505 (same rules.mk shape, same sonic-sairedis configure.ac); we already carry an equivalent local patch on a 202505-based downstream fork. Backport is trivial.

#### Tested branch (Please provide the tested image version)
master — verified by inspection (same rules.mk:60 anchor; same sonic-sairedis configure.ac:76 AC_CHECK_LIB).
202505 — built syncd_1.0.0_amd64.deb on a 202505-based workspace with this change applied; libsairedis build now serialises after libsaibcm-dev install; no libsai is required for syncd errors.

#### Description for the changelog
[broadcom] Make libsai-dev a build prereq of libsairedis to fix make -j race that intermittently aborted libsairedis ./configure with libsai is required for syncd.

#### Link to config_db schema for YANG module changes
N/A — build-system only, no runtime / YANG / config_db changes.

#### A picture of a cute animal (not mandatory but encouraged)
