### PR TITLE
[build] remove distro python protobuf/grpc packages to fix ycabled test import failure

### DIFF
--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -521,7 +521,6 @@ RUN eatmydata apt-get install -y \
         libprotoc-dev \
         protobuf-compiler-grpc \
         valgrind \
-        python3-protobuf \
         python3-grpcio \
         thrift-compiler \
         gfortran \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When building `target/python-wheels/trixie/sonic_ycabled-1.0-py3-none-any.whl`, test failed with following error:
```
==================================== ERRORS ====================================
________________ ERROR collecting tests/test_y_cable_helper.py _________________
ImportError while importing test module '/sonic/src/sonic-platform-daemons/sonic-ycabled/tests/test_y_cable_helper.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.13/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_y_cable_helper.py:5: in <module>
    from ycable.ycable_utilities.y_cable_helper import *
ycable/ycable_utilities/y_cable_helper.py:21: in <module>
    from proto_out import linkmgr_grpc_driver_pb2_grpc
proto_out/linkmgr_grpc_driver_pb2_grpc.py:6: in <module>
    from proto_out import linkmgr_grpc_driver_pb2 as proto__out_dot_linkmgr__grpc__driver__pb2
proto_out/linkmgr_grpc_driver_pb2.py:9: in <module>
    from google.protobuf import runtime_version as _runtime_version
E   ImportError: cannot import name 'runtime_version' from 'google.protobuf' (/usr/lib/python3/dist-packages/google/protobuf/__init__.py)
```
The build environment contains two protobuf installations:

- a pip-installed protobuf (new, in /usr/local/lib/python3.13/dist-packages)
```
Step 30/78 : RUN pip3 install grpcio==1.71.0 grpcio-tools==1.71.0
 ---> Running in 47803f5069b2
Collecting grpcio==1.71.0
  Downloading grpcio-1.71.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (3.8 kB)
Collecting grpcio-tools==1.71.0
  Downloading grpcio_tools-1.71.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (5.3 kB)
Collecting protobuf<6.0dev,>=5.26.1 (from grpcio-tools==1.71.0)
  .
  .
  .
Successfully installed grpcio-1.71.0 grpcio-tools-1.71.0 protobuf-5.29.6 setuptools-75.8.0
```
- a distro protobuf from apt (older, in /usr/lib/python3/dist-packages)
```
Step 20/78 : RUN eatmydata apt-get install -y         ...        python3-protobuf         python3-grpcio 
.
.
.
Setting up python3-protobuf (3.21.12-11) ...
```
During dependency install, pip confirms the new protobuf satisfies ycabled (protobuf>=5.26.0). But during pytest import, Python loads google.protobuf from the distro path (/usr/lib/...) first. The generated gRPC file expects a newer protobuf API (runtime_version), which does not exist in that older distro package, so test collection fails with ImportError.
- Microsoft ADO **(number only)**:

#### How I did it
removed distro Python protobuf/grpc packages from the trixie slave apt install block
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

