### PR TITLE
[orchagent] Honor createSwitchTimeout from sai.profile for all platforms

### DIFF
--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -97,13 +97,19 @@ elif [ "$platform" == "pensando" ]; then
     ORCHAGENT_ARGS+="-m $MAC_ADDRESS"
 elif [ "$platform" == "marvell-prestera" ]; then
     ORCHAGENT_ARGS+="-m $MAC_ADDRESS"
-    CREATE_SWITCH_TIMEOUT=`cat $HWSKU_DIR/sai.profile | grep "createSwitchTimeout" | cut -d'=' -f 2`
-    if [[ ! -z $CREATE_SWITCH_TIMEOUT ]]; then
-        ORCHAGENT_ARGS+=" -t $CREATE_SWITCH_TIMEOUT"
-    fi
 else
     # Should we use the fallback MAC in case it is not found in Device.Metadata
     ORCHAGENT_ARGS+="-m $MAC_ADDRESS"
+fi
+
+# Pass the create switch timeout to orchagent when it is defined in the
+# sai.profile. This is platform-agnostic: a vendor opts in simply by defining
+# createSwitchTimeout in its sai.profile, so no per-platform check is needed.
+if [[ -f $HWSKU_DIR/sai.profile ]]; then
+    CREATE_SWITCH_TIMEOUT=$(grep "createSwitchTimeout" "$HWSKU_DIR/sai.profile" | cut -d'=' -f 2)
+    if [[ ! -z $CREATE_SWITCH_TIMEOUT ]]; then
+        ORCHAGENT_ARGS+=" -t $CREATE_SWITCH_TIMEOUT"
+    fi
 fi
 
 # Enable ZMQ


### PR DESCRIPTION
#### Why I did it

On platforms with ASICs that have a long SAI `create_switch` time, `create_switch` can take longer than orchagent's default 60s create-switch timeout. When that happens, `create_switch` returns `SAI_STATUS_FAILURE`, orchagent aborts, and swss crash-loops on boot.

SONiC already supports a per-hwsku `createSwitchTimeout` knob in `sai.profile`, but `orchagent.sh` only consulted it inside a single vendor-specific branch. This change makes the knob platform-agnostic so any vendor whose hardware needs a longer initialization window can opt in, without adding a per-platform check to common code.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Reworked `dockers/docker-orchagent/orchagent.sh` to read `createSwitchTimeout` from the hwsku `sai.profile` for all platforms and pass it to orchagent as `-t <seconds>`. Removed the vendor-specific block and added a single platform-agnostic block after the per-platform MAC handling.

A vendor opts in purely by defining `createSwitchTimeout` in its `sai.profile`; if the key is absent, behavior is unchanged (orchagent default timeout). Any platform that previously defined the key in its `sai.profile` continues to work exactly as before.

#### How to verify it

Add `createSwitchTimeout=<seconds>` to the hwsku `sai.profile` and restart swss (`config reload` / `systemctl restart swss`). Verify:
- `ps -o args= -C orchagent` shows `... -t <seconds> ...`
- syslog: `orchagent: setRedisExtensionAttribute: set response timeout to <ms> ms`

If the key is not present, orchagent starts without `-t` (default), confirming the change is opt-in and non-intrusive for other platforms.

Verified on hardware whose SAI `create_switch` exceeds the default 60s timeout:

| Scenario | `createSwitchTimeout` | create duration | result |
|---|---|---|---|
| long create, timeout set | `120` | ~71s | switch created, orchagent OK |
| long create, no timeout | unset (60s default) | >60s | `SAI_STATUS_FAILURE` -> orchagent abort/crash |
| short create, no timeout | unset (60s default) | ~38s | switch created, orchagent OK |

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport to default supported branches please.
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Description for the changelog

[orchagent] Honor `createSwitchTimeout` from `sai.profile` for all platforms (not just a single vendor branch), so platforms with long SAI `create_switch` times can extend orchagent's create-switch timeout via `sai.profile`.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)
