### PR TITLE
[pddf] cpldmux: Suppress routine channel switching logs by default

### DIFF
--- a/platform/pddf/i2c/modules/cpldmux/driver/pddf_cpldmux_driver.c
+++ b/platform/pddf/i2c/modules/cpldmux/driver/pddf_cpldmux_driver.c
@@ -26,6 +26,8 @@
 #include "pddf_cpldmux_defs.h"
 #include "pddf_multifpgapci_defs.h"
 
+#define DEBUG 0
+
 extern PDDF_CPLDMUX_DATA pddf_cpldmux_data;
 
 /* Users may overwrite these select and delsect functions as per their requirements
@@ -100,12 +102,14 @@ int pddf_cpldmux_select_default(struct i2c_mux_core *muxc, uint32_t chan)
         switch (pdata->dev_type) {
         case CPLD_MUX:
             // cpld_mux
+#if DEBUG
             pddf_dbg(
                 CPLDMUX,
                 KERN_INFO
                 "%s: Writing 0x%x at 0x%x offset of cpld 0x%x to enable chan %d\n",
                 __FUNCTION__, sdata->cpld_sel,
                 sdata->cpld_offset, sdata->cpld_devaddr, chan);
+#endif
             ret = cpldmux_byte_write(
                 pdata->cpld, sdata->cpld_offset,
                 (uint8_t)(sdata->cpld_sel & 0xff));
@@ -148,12 +152,14 @@ int pddf_cpldmux_deselect_default(struct i2c_mux_core *muxc, uint32_t chan)
     sdata = &pdata->chan_data[chan];
     switch (pdata->dev_type) {
     case CPLD_MUX:
+#if DEBUG
         pddf_dbg(
             CPLDMUX,
             KERN_INFO
             "%s: Writing 0x%x at 0x%x offset of cpld 0x%x to disable chan %d",
             __FUNCTION__, sdata->cpld_desel, sdata->cpld_offset,
             sdata->cpld_devaddr, chan);
+#endif
         ret = cpldmux_byte_write(pdata->cpld, sdata->cpld_offset,
                      (uint8_t)(sdata->cpld_desel));
         break;

--- a/platform/pddf/i2c/modules/cpldmux/driver/pddf_cpldmux_driver.c
+++ b/platform/pddf/i2c/modules/cpldmux/driver/pddf_cpldmux_driver.c
@@ -26,8 +26,6 @@
 #include "pddf_cpldmux_defs.h"
 #include "pddf_multifpgapci_defs.h"
 
-#define DEBUG 0
-
 extern PDDF_CPLDMUX_DATA pddf_cpldmux_data;
 
 /* Users may overwrite these select and delsect functions as per their requirements
@@ -102,14 +100,6 @@ int pddf_cpldmux_select_default(struct i2c_mux_core *muxc, uint32_t chan)
         switch (pdata->dev_type) {
         case CPLD_MUX:
             // cpld_mux
-#if DEBUG
-            pddf_dbg(
-                CPLDMUX,
-                KERN_INFO
-                "%s: Writing 0x%x at 0x%x offset of cpld 0x%x to enable chan %d\n",
-                __FUNCTION__, sdata->cpld_sel,
-                sdata->cpld_offset, sdata->cpld_devaddr, chan);
-#endif
             ret = cpldmux_byte_write(
                 pdata->cpld, sdata->cpld_offset,
                 (uint8_t)(sdata->cpld_sel & 0xff));
@@ -152,14 +142,6 @@ int pddf_cpldmux_deselect_default(struct i2c_mux_core *muxc, uint32_t chan)
     sdata = &pdata->chan_data[chan];
     switch (pdata->dev_type) {
     case CPLD_MUX:
-#if DEBUG
-        pddf_dbg(
-            CPLDMUX,
-            KERN_INFO
-            "%s: Writing 0x%x at 0x%x offset of cpld 0x%x to disable chan %d",
-            __FUNCTION__, sdata->cpld_desel, sdata->cpld_offset,
-            sdata->cpld_devaddr, chan);
-#endif
         ret = cpldmux_byte_write(pdata->cpld, sdata->cpld_offset,
                      (uint8_t)(sdata->cpld_desel));
         break;


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

During normal operation, certain system processes routinely switch MUX channels by invoking the default select and deselect functions. 

Since these functions execute `pddf_dbg()` on every invocation, each channel switch generates a log entry. This behavioral pattern results in a high volume of routine channel status messages being recorded in both `dmesg` and `syslog`. 

This change is intended to reduce the log density from these frequent, recurring events.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Completely removed the verbose `pddf_dbg()` log calls from both `pddf_cpldmux_select_default()` and `pddf_cpldmux_deselect_default()`.
- Since these routine channel-switching events happen frequently on hot paths and hold no diagnostic value at runtime, removing them entirely eliminates unnecessary syslog noise and keeps the system logs clean.

#### How to verify it
```bash
cat /var/log/syslog | grep 'offset of cpld'
```

###### Without Fix (Current Behavior)
```bash
....
2026 Jun  9 02:05:10.426837 sonic WARNING kernel: [ 2812.091596] PDDF_CPLDMUX   pddf_cpldmux_deselect_default: Writing 0x80 at 0xa5 offset of cpld 0x32 to disable chan 17
2026 Jun  9 02:05:10.426840 sonic WARNING kernel: [ 2812.092656] PDDF_CPLDMUX   pddf_cpldmux_select_default: Writing 0x92 at 0xa5 offset of cpld 0x32 to enable chan 17
2026 Jun  9 02:05:10.430831 sonic WARNING kernel: [ 2812.094711] PDDF_CPLDMUX   pddf_cpldmux_deselect_default: Writing 0x80 at 0xa5 offset of cpld 0x32 to disable chan 17
2026 Jun  9 02:05:10.430837 sonic WARNING kernel: [ 2812.095699] PDDF_CPLDMUX   pddf_cpldmux_select_default: Writing 0x92 at 0xa5 offset of cpld 0x32 to enable chan 17
2026 Jun  9 02:05:10.434824 sonic WARNING kernel: [ 2812.097750] PDDF_CPLDMUX   pddf_cpldmux_deselect_default: Writing 0x80 at 0xa5 offset of cpld 0x32 to disable chan 17
2026 Jun  9 02:05:10.434830 sonic WARNING kernel: [ 2812.098804] PDDF_CPLDMUX   pddf_cpldmux_select_default: Writing 0x92 at 0xa5 offset of cpld 0x32 to enable chan 17
2026 Jun  9 02:05:10.438829 sonic WARNING kernel: [ 2812.100857] PDDF_CPLDMUX   pddf_cpldmux_deselect_default: Writing 0x80 at 0xa5 offset of cpld 0x32 to disable chan 17
2026 Jun  9 02:05:10.438836 sonic WARNING kernel: [ 2812.101845] PDDF_CPLDMUX   pddf_cpldmux_select_default: Writing 0x92 at 0xa5 offset of cpld 0x32 to enable chan 17
2026 Jun  9 02:05:10.438839 sonic WARNING kernel: [ 2812.104018] PDDF_CPLDMUX   pddf_cpldmux_deselect_default: Writing 0x80 at 0xa5 offset of cpld 0x32 to disable chan 17
2026 Jun  9 02:05:10.438841 sonic WARNING kernel: [ 2812.105059] PDDF_CPLDMUX   pddf_cpldmux_select_default: Writing 0x92 at 0xa5 offset of cpld 0x32 to enable chan 17
2026 Jun  9 02:05:10.442824 sonic WARNING kernel: [ 2812.107128] PDDF_CPLDMUX   pddf_cpldmux_deselect_default: Writing 0x80 at 0xa5 offset of cpld 0x32 to disable chan 17
2026 Jun  9 02:05:10.442833 sonic WARNING kernel: [ 2812.108161] PDDF_CPLDMUX   pddf_cpldmux_select_default: Writing 0x92 at 0xa5 offset of cpld 0x32 to enable chan 17
2026 Jun  9 02:05:10.446818 sonic WARNING kernel: [ 2812.110216] PDDF_CPLDMUX   pddf_cpldmux_deselect_default: Writing 0x80 at 0xa5 offset of cpld 0x32 to disable chan 17
2026 Jun  9 02:05:10.446826 sonic WARNING kernel: [ 2812.111250] PDDF_CPLDMUX   pddf_cpldmux_select_default: Writing 0x92 at 0xa5 offset of cpld 0x32 to enable chan 17
2026 Jun  9 02:05:10.522827 sonic WARNING kernel: [ 2812.113301] PDDF_CPLDMUX   pddf_cpldmux_deselect_default: Writing 0x80 at 0xa5 offset of cpld 0x32 to disable chan 17
2026 Jun  9 02:05:10.522842 sonic WARNING kernel: [ 2812.186879] PDDF_CPLDMUX   pddf_cpldmux_select_default: Writing 0x92 at 0xa5 offset of cpld 0x32 to enable chan 17
2026 Jun  9 02:05:21.174856 sonic WARNING kernel: [ 2812.188946] PDDF_CPLDMUX   pddf_cpldmux_deselect_default: Writing 0x80 at 0xa5 offset of cpld 0x32 to disable chan 17
2026 Jun  9 02:05:21.174883 sonic WARNING kernel: [ 2822.841480] PDDF_CPLDMUX   pddf_cpldmux_select_default: Writing 0x8b at 0xa5 offset of cpld 0x32 to enable chan 10
2026 Jun  9 02:05:21.178835 sonic WARNING kernel: [ 2822.843593] PDDF_CPLDMUX   pddf_cpldmux_deselect_default: Writing 0x80 at 0xa5 offset of cpld 0x32 to disable chan 10
2026 Jun  9 02:05:21.178848 sonic WARNING kernel: [ 2822.844667] PDDF_CPLDMUX   pddf_cpldmux_select_default: Writing 0x8b at 0xa5 offset of cpld 0x32 to enable chan 10
2026 Jun  9 02:05:21.182847 sonic WARNING kernel: [ 2822.846775] PDDF_CPLDMUX   pddf_cpldmux_deselect_default: Writing 0x80 at 0xa5 offset of cpld 0x32 to disable chan 10
2026 Jun  9 02:05:21.182864 sonic WARNING kernel: [ 2822.847881] PDDF_CPLDMUX   pddf_cpldmux_select_default: Writing 0x8b at 0xa5 offset of cpld 0x32 to enable chan 10
2026 Jun  9 02:05:21.190853 sonic WARNING kernel: [ 2822.849974] PDDF_CPLDMUX   pddf_cpldmux_deselect_default: Writing 0x80 at 0xa5 offset of cpld 0x32 to disable chan 10
2026 Jun  9 02:05:21.190877 sonic WARNING kernel: [ 2822.856385] PDDF_CPLDMUX   pddf_cpldmux_select_default: Writing 0x8b at 0xa5 offset of cpld 0x32 to enable chan 10
....
```
###### With Fix (Expected Behavior)
```bash
root@sonic:~# cat /var/log/syslog | grep 'offset of cpld'
root@sonic:~# 
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

