### PR TITLE
feat: add pynng support for docker-ptf

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -257,7 +257,15 @@ RUN rm -rf /debs \
 {% endif %}
     && mkdir -p /opt       \
     && cd /opt             \
+{# ptf_nn_agent.py is pinned per Python env: the "mixed" image runs the agent
+   under Python 2 (nnpy), so it stays on the last nnpy-compatible upstream
+   commit; the py3 image ships pynng and tracks a p4lang/ptf main commit that
+   uses pynng (see #26912 / upstream p4lang/ptf#234). #}
+{% if PTF_ENV_PY_VER == "mixed" %}
     && wget https://raw.githubusercontent.com/p4lang/ptf/23ebe7237f3c284032bda02fbd1f4a98f1bc12f4/ptf_nn/ptf_nn_agent.py
+{% else %}
+    && wget https://raw.githubusercontent.com/p4lang/ptf/main/ptf_nn/ptf_nn_agent.py
+{% endif %}
 
 {% if PTF_ENV_PY_VER == "py3" %}
 RUN curl -L -o tacacs.tar.gz https://shrubbery.net/pub/tac_plus/tacacs-F4.0.4.31.tar.gz\
@@ -329,6 +337,9 @@ RUN pip3 install Flask   \
     && pip3 install Cython \
     && pip3 install cffi    \
     && pip3 install nnpy    \
+{% if PTF_ENV_PY_VER == "py3" %}
+    && pip3 install pynng   \
+{% endif %}
     && pip3 install dpkt    \
     && pip3 install ipaddress \
     && pip3 install pysubnettree \


### PR DESCRIPTION
#### Why I did it

PTF tests on scale topologies frequently fail with `nnpy.errors.NNError: Connection timed out` coming from `ptf_nn_agent.py`.

Upstream `p4lang/ptf` has already replaced `nnpy` with `pynng` (p4lang/ptf#234). SONiC tried to pick this up but had to pin `ptf_nn_agent.py` back to an older `nnpy`-compatible commit in #26912, because `docker-ptf` did not ship the `pynng` package.

This PR adds `pynng` to `docker-ptf` and moves the Python 3 image's `ptf_nn_agent.py` onto the upstream `pynng`-based agent, aligning SONiC with `p4lang/ptf` master and unblocking the migration off `nnpy`.

##### Work item tracking
- Microsoft ADO **(number only)**: 38213269

#### How I did it

In `dockers/docker-ptf/Dockerfile.j2`, gated the change on `PTF_ENV_PY_VER` so the two PTF images keep working independently:

- **py3 image (default)**: install `pynng` into the virtualenv, and fetch `ptf_nn_agent.py` from `p4lang/ptf` master (the `pynng`-based agent).
- **mixed image (legacy Python 2 / buster)**: unchanged — keeps `nnpy` and the `nnpy`-pinned agent commit from #26912, because `pynng` requires Python 3.7+ and the agent there runs under Python 2.

`docker-ptf-sai` builds `FROM docker-ptf`, so it inherits the change automatically.

#### How to verify it

1. Build the PTF image:
   ```
   make configure PLATFORM=vs
   make target/docker-ptf.gz
   ```
2. Start the container and confirm the agent dependency is present and the agent is running:
   ```
   docker run --rm -it docker-ptf bash
   python -c "import pynng; print(pynng.__version__)"
   grep -n "import pynng" /opt/ptf_nn_agent.py
   supervisorctl status ptf_nn_agent      # -> RUNNING
   ```
3. Run a PTF test that exercises the nn agent on a scale topology and confirm there is no `nnpy.errors.NNError: Connection timed out`.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

[docker-ptf]: Add pynng package and move py3 ptf_nn_agent off nnpy to pynng (aligns with p4lang/ptf master; addresses NNError connection timeouts on scale topologies)

#### Link to config_db schema for YANG module changes

N/A — no YANG/config_db changes.
