### PR TITLE
Faster dependency calculation for libyang3-py3 and ptf-py3 targets

### DIFF
--- a/rules/libyang3-py3.dep
+++ b/rules/libyang3-py3.dep
@@ -2,7 +2,7 @@
 SPATH       := $($(LIBYANG3_PY3)_SRC_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/libyang3-py3.mk rules/libyang3-py3.dep
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
-SMDEP_FILES := $(addprefix $(SPATH)/,$(shell cd $(SPATH) && find . -type f -exec sh -c 'git ls-files --error-unmatch "$0" >/dev/null 2>&1' {} \; -printf '%P\n'))
+SMDEP_FILES := $(addprefix $(SPATH)/,$(shell cd $(SPATH) && git ls-files))
 
 $(LIBYANG3_PY3)_CACHE_MODE  := GIT_CONTENT_SHA
 $(LIBYANG3_PY3)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)

--- a/rules/ptf-py3.dep
+++ b/rules/ptf-py3.dep
@@ -1,10 +1,10 @@
 
 SPATH       := $($(PTF_PY3)_SRC_PATH)
-DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/ptf-py3.mk rules/ptf-py3.dep   
+DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/ptf-py3.mk rules/ptf-py3.dep
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
-SMDEP_FILES := $(addprefix $(SPATH)/,$(shell cd $(SPATH) && find . -type f -exec sh -c 'git ls-files --error-unmatch "$0" >/dev/null 2>&1' {} \; -printf '%P\n'))
+SMDEP_FILES := $(addprefix $(SPATH)/,$(shell cd $(SPATH) && git ls-files | xargs -d\\n sh -c 'find -L "$$@" -type f' -))
 
-$(PTF_PY3)_CACHE_MODE  := GIT_CONTENT_SHA 
+$(PTF_PY3)_CACHE_MODE  := GIT_CONTENT_SHA
 $(PTF_PY3)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)
 $(PTF_PY3)_DEP_FILES   := $(DEP_FILES)
 $(PTF_PY3)_SMDEP_FILES := $(SMDEP_FILES)


### PR DESCRIPTION
As the dependency calculation code is executed on every `make` invocation, this change reduces response time and improves interactive use of the build system.

Improve calculation of `SMDEP_FILES`:

- for libyang3-py3, replace `find . -exec git ls-files --error-unmatch` with plain `git ls-files`, as there are no dangling symlinks to handle in this repository.
- for ptf-py3, replace `find . -exec git ls-files --error-unmatch` with `git ls-files | xargs -d\\n sh -c 'find -L "$$@" -type f' -`. This uses `find -L` to filter out dangling symlinks, but can handle multiple paths in one process instead of spawning a separate process for each path.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

Faster dependency calculation for libyang3-py3 and ptf-py3 targets.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

