### PR TITLE
[202605][smartswitch]: Add dpu_auto_recovery flag to SmartSwitch NPU default config (#27385)

### DIFF
--- a/src/sonic-config-engine/config_samples.py
+++ b/src/sonic-config-engine/config_samples.py
@@ -81,6 +81,7 @@ def generate_t1_sample_config(data):
 def generate_t1_smartswitch_switch_sample_config(data, ss_config):
     data = generate_t1_sample_config(data)
     data['DEVICE_METADATA']['localhost']['subtype'] = 'SmartSwitch'
+    data['DEVICE_METADATA']['localhost']['dpu_auto_recovery'] = 'enable'
 
     mpbr_prefix = '169.254.200'
     mpbr_address = '{}.254'.format(mpbr_prefix)

--- a/src/sonic-config-engine/tests/sample_output/t1-smartswitch.json
+++ b/src/sonic-config-engine/tests/sample_output/t1-smartswitch.json
@@ -292,6 +292,7 @@
 	"DEVICE_METADATA": {
 		"localhost": {
 			"bgp_asn": "65100",
+			"dpu_auto_recovery": "enable",
 			"hostname": "sonic",
 			"hwsku": "SSwitch-32x1000Gb",
 			"subtype": "SmartSwitch",

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -98,7 +98,7 @@
   * [SYSTEM_DEFAULTS table](#systemdefaults-table)
   * [RADIUS](#radius)
   * [Static DNS](#static-dns)
-  * [ASIC_SENSORS](#asic_sensors)  
+  * [ASIC_SENSORS](#asic_sensors)
   * [SRv6](#srv6)
   * [DPU](#dpu-configuration)
   * [REMOTE_DPU](#remote_dpu-configuration)
@@ -460,7 +460,7 @@ ASIC/SDK health event related configuration is defined in **SUPPRESS_ASIC_SDK_HE
 
 ### BGP Device Global
 
-The **BGP_DEVICE_GLOBAL** table contains device-level BGP global state.  
+The **BGP_DEVICE_GLOBAL** table contains device-level BGP global state.
 It has a STATE object containing device state like **tsa_enabled**, **wcmp_enabled** and **idf_isolation_state**.
 
 When **tsa_enabled** is set to true, the device is isolated using traffic-shift-away (TSA) route-maps in BGP.
@@ -474,7 +474,7 @@ When **tsa_enabled** is set to true, the device is isolated using traffic-shift-
 }
 ```
 
-When **wcmp_enabled** is set to true, the device is configured to use BGP Link Bandwidth Extended Community.  
+When **wcmp_enabled** is set to true, the device is configured to use BGP Link Bandwidth Extended Community.
 Weighted ECMP load balances traffic between the equal cost paths in proportion to the capacity of the local links.
 
 ```json
@@ -497,8 +497,8 @@ The IDF isolation state **idf_isolation_state** could be one of isolated_no_expo
 }
 ```
 
-The **CONFED** object contains BGP confederation configuration for disaggregated T2 devices (LowerSpineRouter, UpperSpineRouter, FabricSpineRouter).  
-**asn** is the confederation identifier (the ASN visible to external peers).  
+The **CONFED** object contains BGP confederation configuration for disaggregated T2 devices (LowerSpineRouter, UpperSpineRouter, FabricSpineRouter).
+**asn** is the confederation identifier (the ASN visible to external peers).
 **peers** is a semicolon-separated list of sub-AS numbers that are members of the confederation.
 
 ```json
@@ -1112,7 +1112,8 @@ instance is supported in SONiC.
         "rack_mgmt_map": "dummy_value",
         "timezome": "Europe/Kiev",
         "bgp_router_id": "8.8.8.8",
-        "use_template_render_for_restore": "true"
+        "use_template_render_for_restore": "true",
+        "dpu_auto_recovery": "enable"
     }
   }
 }
@@ -1286,7 +1287,7 @@ The FG_NHG table provides information on Next Hop Groups, including a specified 
         "bucket_size": "120",
         "match_mode": "prefix-based",
         "max_next_hops": "6"
-    }    
+    }
 }
 ```
 
@@ -1326,7 +1327,7 @@ The FG_NHG_PREFIX table provides the FG_NHG_PREFIX for which FG behavior is desi
     },
     "fd:06::/128": {
         "FG_NHG": "dynamic_fgnhg_v6"
-	}    
+	}
 }
 ```
 
@@ -1695,7 +1696,7 @@ lossless traffic for dynamic buffer calculation
 ```
 
 ### Memory Statistics
-The memory statistics configuration is stored in the **MEMORY_STATISTICS** table. This table is used by the memory statistics daemon to manage memory monitoring settings. The configuration allows enabling or disabling memory collection, specifying how frequently memory statistics are sampled, and defining how long the memory data is retained. 
+The memory statistics configuration is stored in the **MEMORY_STATISTICS** table. This table is used by the memory statistics daemon to manage memory monitoring settings. The configuration allows enabling or disabling memory collection, specifying how frequently memory statistics are sampled, and defining how long the memory data is retained.
 
 ```
 {
@@ -2680,11 +2681,11 @@ example mux tunnel configuration for when tunnel_qos_remap is enabled
 
 When the lossy queue exceeds a buffer threshold, it drops packets without any notification to the destination host.
 
-When a packet is lost, it can be recovered through fast retransmission or by using timeouts.  
+When a packet is lost, it can be recovered through fast retransmission or by using timeouts.
 Retransmission triggered by timeouts typically incurs significant latency.
 
-To help the host recover data more quickly and accurately, packet trimming is introduced.  
-This feature upon a failed packet admission to a shared buffer, will trim a packet to a configured size,  
+To help the host recover data more quickly and accurately, packet trimming is introduced.
+This feature upon a failed packet admission to a shared buffer, will trim a packet to a configured size,
 and try sending it on a different queue to deliver a packet drop notification to an end host.
 
 ***TRIMMING***
@@ -3520,7 +3521,7 @@ The **VDPU** table introduces the configuration for the VDPUs (Virtual Data Proc
 The **DASH_HA_GLOBAL_CONFIG** table introduces the configuration for the DASH High Availability global settings available on the platform.
 Like NTP global configuration, DASH HA global configuration must have one entry with the key "global".
 
-`vnet_name` will be deprecated with the introduction of `dpu_vnet`. 
+`vnet_name` will be deprecated with the introduction of `dpu_vnet`.
 
 ```json
 {

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -354,7 +354,7 @@
             },
             "SRC-MAC-REWRITE-TABLE|RULE0": {
                 "PRIORITY": "960",
-                "INNER_SRC_MAC_REWRITE_ACTION": "22:33:44:55:66:11",                     
+                "INNER_SRC_MAC_REWRITE_ACTION": "22:33:44:55:66:11",
                 "INNER_SRC_IP": "1.1.1.1/32",
                 "TUNNEL_VNI": "45"
             },
@@ -424,7 +424,8 @@
                 "slice_type": "AZNG_Production",
                 "nexthop_group": "disabled",
                 "zebra_nexthop": "disabled",
-                "use_template_render_for_restore": "true"
+                "use_template_render_for_restore": "true",
+                "dpu_auto_recovery": "enable"
             }
         },
         "VLAN": {
@@ -1159,7 +1160,7 @@
                 "stage": "INGRESS",
                 "type": "CUSTOM_L3_L4_PORT"
             }
-        }, 
+        },
         "PBH_HASH_FIELD": {
             "inner_ip_proto": {
                 "hash_field": "INNER_IP_PROTOCOL",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -281,5 +281,17 @@
     },
     "DEVICE_METADATA_USE_TEMPLATE_RENDER_FOR_RESTORE": {
         "desc": "Verifying use_template_render_for_restore configuration."
+    },
+    "DEVICE_METADATA_VALID_DPU_AUTO_RECOVERY": {
+        "desc": "Verifying valid dpu_auto_recovery configuration."
+    },
+    "DEVICE_METADATA_DEFAULT_DPU_AUTO_RECOVERY": {
+        "desc": "DEVICE_METADATA DEFAULT VALUE FOR DPU_AUTO_RECOVERY FIELD.",
+        "eStrKey" : "Verify",
+        "verify": {
+            "xpath": "/sonic-device_metadata:sonic-device_metadata/DEVICE_METADATA/localhost/hostname",
+            "key": "sonic-device_metadata:dpu_auto_recovery",
+            "value": "disable"
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
@@ -873,5 +873,23 @@
                 }
             }
         }
+    },
+    "DEVICE_METADATA_VALID_DPU_AUTO_RECOVERY": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "dpu_auto_recovery": "enable"
+                }
+            }
+        }
+    },
+    "DEVICE_METADATA_DEFAULT_DPU_AUTO_RECOVERY": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "hostname": "sonic"
+                }
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -18,11 +18,14 @@ module sonic-device_metadata {
     }
 
     description "DEVICE_METADATA YANG Module for SONiC OS";
-    
+
+    revision 2026-06-05 {
+        description "Added dpu_auto_recovery to enable/disable automatic DPU recovery on SmartSwitch.";
+    }
+
     revision 2026-04-11 {
         description "Adde use_template_render_for_restore to control the method of config restore in FRR.";
     }
-
 
     revision 2026-04-11 {
         description "Added route_state_async_publish to control async route state publishing.";
@@ -406,6 +409,15 @@ module sonic-device_metadata {
                     type boolean;
                     description "When set to true, use template rendering to generate FRR configurations during startup in unified mode. When set to false, restore FRR configurations from cached DB tables. This field only takes effect in unified mode.";
                     default "true";
+                }
+
+                leaf dpu_auto_recovery {
+                    description "Enable or disable automatic DPU recovery on SmartSwitch platforms.";
+                    type enumeration {
+                        enum enable;
+                        enum disable;
+                    }
+                    default disable;
                 }
             }
             /* end of container localhost */


### PR DESCRIPTION
#### Why I did it

Manual cherry-pick of #27385 to the 202605 branch. The automatic cherry-pick failed due to a merge conflict in `sonic-device_metadata.yang`.

Add the `dpu_auto_recovery` flag entry to the CONFIG_DB `DEVICE_METADATA|localhost` table so that `chassisd` can read it to determine whether automatic DPU power-cycle recovery is enabled on SmartSwitch platforms.

This is part of the enhance-dpu-robustness HLD.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Cherry-picked the merged commit `c7d5fe61f` from master onto 202605.

Conflict resolution: the merged commit's YANG diff also carried an unrelated `2026-06-02` revision note (route performance knobs removal from a different change that is not present on 202605). That unrelated revision was dropped during conflict resolution; only the `dpu_auto_recovery` revision (`2026-06-05`) and the `dpu_auto_recovery` leaf were kept.

- Added YANG model changes for `dpu_auto_recovery` flag.
- Added `dpu_auto_recovery` flag entry to the SmartSwitch NPU default config in `config_samples.py` (`generate_t1_smartswitch_switch_sample_config()`).
- SmartSwitch NPU only: `dpu_auto_recovery:enable`.

#### How to verify it

1. Build a SmartSwitch VS image
2. Verify `dpu_auto_recovery` is `enable` on SmartSwitch NPU

#### Which release branch to backport (provide reason below if selected)

This is the 202605 backport.

#### Description for the changelog

Add dpu_auto_recovery feature flag to SmartSwitch NPU default config for DPU auto-recovery support

#### Link to config_db schema for YANG module changes

`DEVICE_METADATA|localhost|dpu_auto_recovery` (enable/disable, default disable)
