### PR TITLE
chore: fix security issue with Go stdlib docker-ptf

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -104,18 +104,18 @@ RUN apt-get update          \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Go toolchain for building grpcurl and gnmic from source
-# to ensure they use a patched Go stdlib (GO-2026-4337: crypto/tls)
+# to ensure they use a patched Go stdlib (GO-2026-5039: net/textproto)
 {% if CONFIGURED_ARCH == "armhf" %}
 RUN GO_ARCH=armv6l \
-    && GO_SHA256=39f168f158e693887d3ad006168af1b1a3007b19c5993cae4d9d57f82f52aaf8 \
+    && GO_SHA256=492d69badee59cae12e9a36282dfce94041bd4aac88fdddea575a7d99a2bd05d \
 {% elif CONFIGURED_ARCH == "arm64" %}
 RUN GO_ARCH=arm64 \
-    && GO_SHA256=654da1f9b50a5d1c2a85ccf8ed405aa89c06e94d18384628bf186f7712677b08 \
+    && GO_SHA256=c30bf9e156a54ea4e31fbbbf31a712b32734b58cc9a22426fa5ee632d0885124 \
 {% else %}
 RUN GO_ARCH=amd64 \
-    && GO_SHA256=42d4f7a32316aa66591eca7e89867256057a4264451aca10570a715b3637ba70 \
+    && GO_SHA256=34f14304e856893f4ba30c2cacfe93906e9de7915c5f6aaaf3a81cdccd7ba30b \
 {% endif %}
-    && GO_VERSION=1.25.10 \
+    && GO_VERSION=1.25.11 \
     && curl -L "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz" -o /tmp/go.tar.gz \
     && echo "${GO_SHA256}  /tmp/go.tar.gz" | sha256sum -c - \
     && tar -C /usr/local -xzf /tmp/go.tar.gz \


### PR DESCRIPTION
#### Why I did it

S360 / AzSecPack container image scanning flagged the `docker-ptf` image
(`sonicdev-microsoft.azurecr.io/docker-ptf`) for vulnerable Go standard library
code embedded in the `grpcurl` binary (`/usr/local/bin/grpcurl`), which is built
from source using the pinned Go 1.25.10 toolchain.

The flagged stdlib advisories — all fixed in Go **1.25.11** — are:

- **GO-2026-5037** (CVE-2026-27145) — `crypto/x509`: quadratic complexity in
  `Certificate.VerifyHostname` with large DNS SAN lists (DoS).
- **GO-2026-5038** (CVE-2026-42504) — `mime`: excessive CPU when decoding
  maliciously-crafted MIME headers (DoS).
- **GO-2026-5039** (CVE-2026-42507) — `net/textproto`: input echoed into returned
  errors, allowing misleading content to be injected into logs/errors.

The same toolchain also builds `gnmic` (`/usr/local/bin/gnmic`), so it is
remediated by the same change even though the scan only surfaced `grpcurl`.

##### Work item tracking
- Microsoft ADO **(number only)**: 384246404

#### How I did it

In `dockers/docker-ptf/Dockerfile.j2`, bumped the pinned Go toolchain used to
build `grpcurl` and `gnmic` from **1.25.10 → 1.25.11** and updated the per-arch
download `GO_SHA256` checksums (amd64 / arm64 / armv6l) to the official values
from the Go release feed (`https://go.dev/dl/?mode=json`).

The toolchain stays pinned with checksum verification (rather than tracking
"latest") to keep builds reproducible and the download integrity-checked; the
`golang.org/x/*` module dependencies continue to be pulled at `@latest` as before.

#### How to verify it

1. Build the docker-ptf image:
   ```
   make configure PLATFORM=vs
   make target/docker-ptf.gz
   ```
2. Confirm the binaries are compiled with Go 1.25.11 (`go version <binary>`
   prints the toolchain version embedded in the binary):
   ```
   docker run --rm docker-ptf go version /usr/local/bin/grpcurl /usr/local/bin/gnmic
   # /usr/local/bin/grpcurl: go1.25.11
   # /usr/local/bin/gnmic:   go1.25.11
   ```
3. Re-run the container security scan against the rebuilt image and confirm
   GO-2026-5037 / GO-2026-5038 / GO-2026-5039 no longer report against
   `usr/local/bin/grpcurl`.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

[docker-ptf] Bump Go build toolchain to 1.25.11 to fix stdlib vulnerabilities (GO-2026-5037/5038/5039) in grpcurl/gnmic

#### Link to config_db schema for YANG module changes

N/A — no YANG / config_db schema changes.
