### PR TITLE
[Mellanox] chassis: fall back to EEPROM part number when VPD is unavailable on simx

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -949,6 +949,14 @@ class Chassis(ChassisBase):
             if not self.vpd_data:
                 self.vpd_data = self._parse_vpd_data(VPD_DATA_FILE)
             model = self.vpd_data.get(SYS_DISPLAY, "N/A")
+            if model == "N/A" and DeviceDataManager.is_simx_platform():
+                # vpd_data is not always produced on simx; fall back to the
+                # ONIE TLV part number instead of returning "N/A".
+                logger.log_notice(
+                    "VPD SYS_DISPLAY unavailable on simx; "
+                    "falling back to EEPROM part number")
+                self.initialize_eeprom()
+                model = self._eeprom.get_part_number()
         else:
             self.initialize_eeprom()
             model = self._eeprom.get_part_number()
@@ -1149,6 +1157,10 @@ class Chassis(ChassisBase):
         result = {}
         try:
             if not os.access(filename, os.R_OK):
+                if DeviceDataManager.is_simx_platform():
+                    # Skip the inotify wait on simx — vpd_data may not
+                    # appear, and stalling every call is costly.
+                    return result
                 logger.log_info("VPD data file {} not accessible, waiting for creation".format(filename))
                 if not utils.wait_for_file_creation(filename, VPD_DATA_WAIT_TIMEOUT):
                     logger.log_error("VPD data file {} not available after timeout".format(filename))


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

On simx, `Chassis.get_model()` returns the literal string `"N/A"`.

`get_model()` reads `SYS_DISPLAY` out of `/var/run/hw-management/eeprom/vpd_data`, which is generated by hw-management once the udev `vpd_info` event fires. If the parsed vpd_data file is not produced and the lookup returns the `"N/A"` default.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

`platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py`:

- `get_model()` — when `SYS_DISPLAY` resolves to `"N/A"` **and** `DeviceDataManager.is_simx_platform()` is true, log a `notice` and fall back to `self._eeprom.get_part_number()` (the same EEPROM-TLV path already used). The function docstring already permits returning the part number.
- `_parse_vpd_data()` — when the file is missing, return `{}` immediately, skipping the inotify wait.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

```
$ ls /var/run/hw-management/eeprom/
vpd_info                                 # vpd_data absent
$ python3 -c "import sonic_platform; \
    c = sonic_platform.platform.Platform().get_chassis(); \
    print(c.get_model())"
123-456789-8765-4321                       # before fix: 'N/A'
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)