### PR TITLE
[Mellanox] Fix thermalctld ValueError when reading sai.profile during reload

### DIFF
--- a/files/build_templates/pmon.service.j2
+++ b/files/build_templates/pmon.service.j2
@@ -2,9 +2,6 @@
 Description=Platform monitor container
 Requires=database.service config-setup.service
 After=database.service config-setup.service
-{% if sonic_asic_platform == 'mellanox' %}
-After=syncd.service
-{% endif %}
 BindsTo=sonic.target
 After=sonic.target
 StartLimitIntervalSec=1200

--- a/files/build_templates/pmon.service.j2
+++ b/files/build_templates/pmon.service.j2
@@ -2,6 +2,9 @@
 Description=Platform monitor container
 Requires=database.service config-setup.service
 After=database.service config-setup.service
+{% if sonic_asic_platform == 'mellanox' %}
+After=syncd.service
+{% endif %}
 BindsTo=sonic.target
 After=sonic.target
 StartLimitIntervalSec=1200

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/device_data.py
@@ -408,11 +408,9 @@ class DeviceDataManager:
     @classmethod
     @utils.read_only_cache()
     def is_module_host_management_mode(cls):
-        sai_profile_file = '/tmp/sai.profile'
-        if not os.path.exists(sai_profile_file):
-            asic_id = 0 if cls.is_multi_asic_platform() else None
-            hwsku_dir = utils.get_path_to_hwsku_directory(asic_id=asic_id)
-            sai_profile_file = os.path.join(hwsku_dir, 'sai.profile')
+        asic_id = 0 if cls.is_multi_asic_platform() else None
+        hwsku_dir = utils.get_path_to_hwsku_directory(asic_id=asic_id)
+        sai_profile_file = os.path.join(hwsku_dir, 'sai.profile')
         data = utils.read_key_value_file(sai_profile_file, delimeter='=')
         return data.get('SAI_INDEPENDENT_MODULE_MODE') == '1'
 

--- a/platform/mellanox/mlnx-platform-api/tests/test_device_data.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_device_data.py
@@ -53,13 +53,37 @@ class TestDeviceData:
     def test_get_bios_component(self):
         assert DeviceDataManager.get_bios_component() is not None
 
-    @mock.patch('sonic_platform.utils.get_path_to_hwsku_directory', mock.MagicMock(return_value='/tmp'))
+    @mock.patch('sonic_platform.device_data.DeviceDataManager.is_multi_asic_platform', mock.MagicMock(return_value=False))
+    @mock.patch('sonic_platform.utils.get_path_to_hwsku_directory')
     @mock.patch('sonic_platform.device_data.utils.read_key_value_file')
-    def test_is_module_host_management_mode(self, mock_read):
-        mock_read.return_value = {}
-        assert not DeviceDataManager.is_module_host_management_mode()
+    def test_is_module_host_management_mode(self, mock_read, mock_hwsku_dir):
+        mock_hwsku_dir.return_value = '/hwsku'
+
+        DeviceDataManager.is_module_host_management_mode.__func__.return_value = None
         mock_read.return_value = {'SAI_INDEPENDENT_MODULE_MODE': '1'}
         assert DeviceDataManager.is_module_host_management_mode()
+        mock_hwsku_dir.assert_called_once_with(asic_id=None)
+        mock_read.assert_called_once_with('/hwsku/sai.profile', delimeter='=')
+
+        DeviceDataManager.is_module_host_management_mode.__func__.return_value = None
+        mock_read.reset_mock()
+        mock_hwsku_dir.reset_mock()
+        mock_read.return_value = {}
+        assert not DeviceDataManager.is_module_host_management_mode()
+        mock_hwsku_dir.assert_called_once_with(asic_id=None)
+        mock_read.assert_called_once_with('/hwsku/sai.profile', delimeter='=')
+
+    @mock.patch('sonic_platform.device_data.DeviceDataManager.is_multi_asic_platform', mock.MagicMock(return_value=True))
+    @mock.patch('sonic_platform.utils.get_path_to_hwsku_directory')
+    @mock.patch('sonic_platform.device_data.utils.read_key_value_file')
+    def test_is_module_host_management_mode_multi_asic(self, mock_read, mock_hwsku_dir):
+        mock_hwsku_dir.return_value = '/hwsku/0'
+
+        DeviceDataManager.is_module_host_management_mode.__func__.return_value = None
+        mock_read.return_value = {'SAI_INDEPENDENT_MODULE_MODE': '1'}
+        assert DeviceDataManager.is_module_host_management_mode()
+        mock_hwsku_dir.assert_called_once_with(asic_id=0)
+        mock_read.assert_called_once_with('/hwsku/0/sai.profile', delimeter='=')
 
     @mock.patch('sonic_py_common.device_info.get_path_to_platform_dir', mock.MagicMock(return_value='/tmp'))
     @mock.patch('sonic_platform.device_data.utils.load_json_file')

--- a/platform/mellanox/mlnx-platform-api/tests/test_device_data.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_device_data.py
@@ -59,13 +59,13 @@ class TestDeviceData:
     def test_is_module_host_management_mode(self, mock_read, mock_hwsku_dir):
         mock_hwsku_dir.return_value = '/hwsku'
 
-        DeviceDataManager.is_module_host_management_mode.__func__.return_value = None
+        DeviceDataManager.is_module_host_management_mode.__func__.__wrapped__.return_value = None
         mock_read.return_value = {'SAI_INDEPENDENT_MODULE_MODE': '1'}
         assert DeviceDataManager.is_module_host_management_mode()
         mock_hwsku_dir.assert_called_once_with(asic_id=None)
         mock_read.assert_called_once_with('/hwsku/sai.profile', delimeter='=')
 
-        DeviceDataManager.is_module_host_management_mode.__func__.return_value = None
+        DeviceDataManager.is_module_host_management_mode.__func__.__wrapped__.return_value = None
         mock_read.reset_mock()
         mock_hwsku_dir.reset_mock()
         mock_read.return_value = {}
@@ -79,7 +79,7 @@ class TestDeviceData:
     def test_is_module_host_management_mode_multi_asic(self, mock_read, mock_hwsku_dir):
         mock_hwsku_dir.return_value = '/hwsku/0'
 
-        DeviceDataManager.is_module_host_management_mode.__func__.return_value = None
+        DeviceDataManager.is_module_host_management_mode.__func__.__wrapped__.return_value = None
         mock_read.return_value = {'SAI_INDEPENDENT_MODULE_MODE': '1'}
         assert DeviceDataManager.is_module_host_management_mode()
         mock_hwsku_dir.assert_called_once_with(asic_id=0)


### PR DESCRIPTION
#### Why I did it

`is_module_host_management_mode()` was changed in #19261 to prefer `/tmp/sai.profile` at runtime. That file is written non-atomically by syncd's init script; if thermalctld reads it during a `config reload` or warm-boot while the write is in progress, `read_key_value_file()` receives an empty/partial file and raises `ValueError`, crashing thermalctld.

##### Work item tracking
- Microsoft ADO:

#### How I did it

Revert `is_module_host_management_mode()` to always read `hwsku/sai.profile` (the static platform file). The sysfs-readiness concern from #19261 is already handled by the existing `wait_sysfs_ready()` / `wait_module_ready()` chain inside `module_host_mgmt_init`, so reading the runtime file is unnecessary.

#### How to verify it

Run `sudo config reload` or warm-boot on a Mellanox platform with independent module mode enabled. Confirm thermalctld stays running and no `ValueError` appears in `/var/log/syslog`.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version -->

#### Description for the changelog

[Mellanox] Fix thermalctld ValueError caused by non-atomic write to /tmp/sai.profile during config reload or warm-boot.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)
