### PR TITLE
Add support for secure boot installation

### DIFF
--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -368,52 +368,74 @@ demo_install_uefi_shim()
 
     local demo_mnt="$1"
     local blk_dev="$2"
+    local uefi_part=0
 
-    # make sure /boot/efi is mounted
-    if ! mount | grep -q "/boot/efi"; then
-        mount /boot/efi || {
-            echo "Error: Unable to mount /boot/efi"
+    # If /boot/efi is already mounted (e.g. sonic-in-sonic where fstab mounts the EFI
+    # partition at boot), derive blk_dev and uefi_part directly from the mount table.
+    # This also avoids the nvme partition suffix problem (p1 vs 1) in the manual mount path.
+    if mountpoint -q /boot/efi 2>/dev/null; then
+        local boot_efi_dev
+        boot_efi_dev=$(awk '$2=="/boot/efi" {print $1; exit}' /proc/mounts)
+        blk_dev=$(echo "$boot_efi_dev" | sed -e 's/[1-9][0-9]*$//' -e 's/\([0-9]\)\(p\)/\1/')
+        uefi_part=$(echo "$boot_efi_dev" | grep -o '[0-9]*$')
+        echo "demo_install_uefi_shim(): /boot/efi already mounted at $boot_efi_dev (disk=$blk_dev part=$uefi_part)"
+    else
+        # If blk_dev was not set (create_partition() skipped in sonic-in-sonic),
+        # derive the disk from the /host mount point.
+        if [ -z "$blk_dev" ]; then
+            local host_dev
+            host_dev=$(awk '$2=="/host" {print $1; exit}' /proc/mounts)
+            if [ -n "$host_dev" ]; then
+                blk_dev=$(echo "$host_dev" | sed -e 's/[1-9][0-9]*$//' -e 's/\([0-9]\)\(p\)/\1/')
+                echo "demo_install_uefi_shim(): derived blk_dev=$blk_dev from /host mount ($host_dev)"
+            fi
+        fi
+
+        # Look for the EFI system partition UUID on the same block device as
+        # the ONIE-BOOT partition.
+        local blk_suffix=
+        echo "$blk_dev" | grep -q nvme && blk_suffix="p"
+        for p in $(seq 8) ; do
+            if sgdisk -i $p $blk_dev | grep -q C12A7328-F81F-11D2-BA4B-00A0C93EC93B ; then
+                uefi_part=$p
+                break
+            fi
+        done
+
+        [ $uefi_part -eq 0 ] && {
+            echo "ERROR: Unable to determine UEFI system partition"
             exit 1
         }
+
+        mkdir -p /boot/efi
+        mount ${blk_dev}${blk_suffix}${uefi_part} /boot/efi
     fi
-
-    # Look for the EFI system partition UUID on the same block device as
-    # the ONIE-BOOT partition.
-    local uefi_part=0
-    for p in $(seq 8) ; do
-        if sgdisk -i $p $blk_dev | grep -q C12A7328-F81F-11D2-BA4B-00A0C93EC93B ; then
-            uefi_part=$p
-            break
-        fi
-    done
-
-    [ $uefi_part -eq 0 ] && {
-        echo "ERROR: Unable to determine UEFI system partition"
-        exit 1
-    }
 
     echo "creating demo_volume_label=$demo_volume_label in dir: /boot/efi/EFI/ ."
     mkdir -p /boot/efi/EFI/$demo_volume_label
 
-    if [ ! -f $demo_mnt/$image_dir/boot/mmx64.efi ]; then
-        echo "ERROR: $demo_mnt/$image_dir/boot/mmx64.efi file does not exist"
-        exit 1
+    #
+    src_dir="$demo_mnt/$image_dir/boot"
+    if [ "$install_env" = "sonic" ] && [ "$firmware" = "uefi" ]; then
+        echo "Using locally signed EFI binaries from /boot"
+        src_dir="/boot"
     fi
 
-    if [ ! -f $demo_mnt/$image_dir/boot/shimx64.efi ]; then
-        echo "ERROR: $demo_mnt/$image_dir/boot/shimx64.efi file does not exist"
-        exit 1
-    fi
+    #
+    # Validate required files
+    #
+    for f in mmx64.efi shimx64.efi grubx64.efi; do
+        if [ ! -f "$src_dir/$f" ]; then
+            echo "ERROR: $src_dir/$f file does not exist"
+            exit 1
+        fi
+    done
 
-    if [ ! -f $demo_mnt/$image_dir/boot/grubx64.efi ]; then
-        echo "ERROR: $demo_mnt/$image_dir/boot/grubx64.efi file does not exist"
-        exit 1
-    fi
+    echo "copying signed shim, mm, grub from $src_dir to /boot/efi/EFI/$demo_volume_label directory"
+    cp "$src_dir/mmx64.efi" /boot/efi/EFI/$demo_volume_label/mmx64.efi
+    cp "$src_dir/shimx64.efi" /boot/efi/EFI/$demo_volume_label/shimx64.efi
+    cp "$src_dir/grubx64.efi" /boot/efi/EFI/$demo_volume_label/grubx64.efi
 
-    echo "copying signed shim, mm, grub, grub.cfg from $demo_mnt/$image_dir/boot/ to /boot/efi/EFI/$demo_volume_label directory"
-    cp $demo_mnt/$image_dir/boot/mmx64.efi /boot/efi/EFI/$demo_volume_label/mmx64.efi
-    cp $demo_mnt/$image_dir/boot/shimx64.efi /boot/efi/EFI/$demo_volume_label/shimx64.efi
-    cp $demo_mnt/$image_dir/boot/grubx64.efi /boot/efi/EFI/$demo_volume_label/grubx64.efi
 
     # Configure EFI NVRAM Boot variables.  --create also sets the
     # new boot number as active.
@@ -429,6 +451,15 @@ demo_install_uefi_shim()
 
 bootloader_menu_config()
 {
+
+    # Detect firmware type if not already set
+    if [ -z "$firmware" ]; then
+        if [ -d "/sys/firmware/efi/efivars" ] ; then
+            firmware="uefi"
+        else
+            firmware="bios"
+        fi
+    fi
 
     if [ "$install_env" = "onie" ]; then
         # Store installation log in target file system
@@ -459,6 +490,23 @@ bootloader_menu_config()
             fi
         else
         demo_install_grub "$demo_mnt" "$blk_dev"
+        fi
+    fi
+
+    if [ "$install_env" = "sonic" ]; then
+	    if [ "$firmware" = "uefi" ] ; then
+            secure_boot=no
+            ENABLED=1
+            # This image was built with secureboot support if the shim and grub EFI images are in the expected paths.
+            echo "checking if image was built with secure boot support"
+            if [ -f "$demo_mnt/$image_dir/boot/shimx64.efi" -a -f "$demo_mnt/$image_dir/boot/grubx64.efi" ]; then
+                secure_boot=yes
+            fi
+            echo secure_boot=$secure_boot
+            if [ "${secure_boot}" = "yes" ]; then
+                echo "UEFI Secure Boot image detected - Installing shim bootloader for sonic"
+                demo_install_uefi_shim "$demo_mnt" "$blk_dev"
+            fi
         fi
     fi
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

