### PR TITLE
[202605] Tell p4lang to use protobuf and grpcio installed via pip

### DIFF
--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -521,8 +521,6 @@ RUN eatmydata apt-get install -y \
         libprotoc-dev \
         protobuf-compiler-grpc \
         valgrind \
-        python3-protobuf \
-        python3-grpcio \
         thrift-compiler \
         gfortran \
         libopenmpi-dev \

--- a/src/p4lang/Makefile
+++ b/src/p4lang/Makefile
@@ -10,6 +10,7 @@ $(addprefix $(DEST)/, $(P4LANG_TARGET)): $(DEST)/% :
 	dget -u p4lang-pi_$(P4LANG_PI_VERSION_FULL).dsc http://download.opensuse.org/repositories/home:/p4lang/Debian_11/p4lang-pi_$(P4LANG_PI_VERSION_FULL).dsc
 	pushd p4lang-pi-$(P4LANG_PI_VERSION)
 	patch -p1 -i ../p4lang-pi.patch/use-boost-1.83.patch
+	patch -p1 -i ../p4lang-pi.patch/remove-protobuf-from-debian-dependency.patch
 ifeq ($(CROSS_BUILD_ENVIRON), y)
 	dpkg-buildpackage -us -uc -b -a$(CONFIGURED_ARCH) -Pcross,nocheck -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)
 else
@@ -44,6 +45,7 @@ $(addprefix $(DEST)/, $(P4LANG_P4C_TARGET)): $(DEST)/% :
 	patch -p1 -i ../p4lang-p4c.patch/use-boost-1.83.patch
 	patch -p1 -i ../p4lang-p4c.patch/fix-build-for-boost-1.83.patch
 	patch -p1 -i ../p4lang-p4c.patch/update-thrift-dependency.patch
+	patch -p1 -i ../p4lang-p4c.patch/remove-protobuf-from-debian-dependency.patch
 ifeq ($(CROSS_BUILD_ENVIRON), y)
 	dpkg-buildpackage -us -uc -b -a$(CONFIGURED_ARCH) -Pcross,nocheck -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)
 else

--- a/src/p4lang/Makefile
+++ b/src/p4lang/Makefile
@@ -11,6 +11,7 @@ $(addprefix $(DEST)/, $(P4LANG_TARGET)): $(DEST)/% :
 	pushd p4lang-pi-$(P4LANG_PI_VERSION)
 	patch -p1 -i ../p4lang-pi.patch/use-boost-1.83.patch
 	patch -p1 -i ../p4lang-pi.patch/remove-protobuf-from-debian-dependency.patch
+	patch -p1 -i ../p4lang-pi.patch/remove-init-file.patch
 ifeq ($(CROSS_BUILD_ENVIRON), y)
 	dpkg-buildpackage -us -uc -b -a$(CONFIGURED_ARCH) -Pcross,nocheck -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)
 else

--- a/src/p4lang/Makefile
+++ b/src/p4lang/Makefile
@@ -17,6 +17,10 @@ ifeq ($(CROSS_BUILD_ENVIRON), y)
 else
 	dpkg-buildpackage -us -uc -b -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)
 endif
+	# dpkg-buildpackage may install google/__init__.py to the system path as a build
+	# side effect. This turns google/ into a regular package and shadows pip's protobuf
+	# (which uses implicit namespace packages), breaking imports for other components.
+	rm -f /usr/lib/python3/dist-packages/google/__init__.py
 	popd
 	mv $* $(DEST)/
 

--- a/src/p4lang/p4lang-p4c.patch/remove-protobuf-from-debian-dependency.patch
+++ b/src/p4lang/p4lang-p4c.patch/remove-protobuf-from-debian-dependency.patch
@@ -1,0 +1,34 @@
+Don't depend on Debian's version of the Python 3 protobuf package. Instead,
+have it use the version that we install with pip. This is so that there's a
+single copy of the protobuf package present in the slave container and the
+installed environment.
+
+Index: p4lang-p4c-1.2.4.2/debian/control
+===================================================================
+--- p4lang-p4c-1.2.4.2.orig/debian/control
++++ p4lang-p4c-1.2.4.2/debian/control
+@@ -23,10 +23,8 @@ Build-Depends:
+     iproute2,
+     net-tools,
+     python3-all,
+-    python3-grpcio,
+     python3-pyroute2,
+     python3-ply,
+-    python3-protobuf,
+     python3-scapy,
+     python3-setuptools,
+     python3-thrift,
+@@ -64,13 +62,11 @@ Depends:
+     clang,
+     iproute2,
+     net-tools,
+-    python3-grpcio,
+     python3-pyroute2,
+     python3-ply,
+     python3-scapy,
+     python3-setuptools,
+     python3-thrift,
+-    python3-protobuf,
+     libprotobuf-dev,
+     libprotoc-dev,
+     protobuf-compiler,

--- a/src/p4lang/p4lang-pi.patch/remove-init-file.patch
+++ b/src/p4lang/p4lang-pi.patch/remove-init-file.patch
@@ -1,0 +1,10 @@
+Index: p4lang-pi-0.1.0/debian/rules
+===================================================================
+--- p4lang-pi-0.1.0.orig/debian/rules
++++ p4lang-pi-0.1.0/debian/rules
+@@ -33,3 +33,5 @@ override_dh_auto_install:
+ 	dh_auto_install -- DESTDIR=$(CURDIR)/debian/p4lang-pi install
+ 	find $(CURDIR)/debian/p4lang-pi -name "*.pyc" | xargs rm -f
+ 	find $(CURDIR)/debian/p4lang-pi -name "*.pyo" | xargs rm -f
++	# Workaround to encourage/force the use of the pip-installed protobuf library
++	rm -f $(CURDIR)/debian/p4lang-pi/usr/lib/python3/dist-packages/google/__init__.py

--- a/src/p4lang/p4lang-pi.patch/remove-protobuf-from-debian-dependency.patch
+++ b/src/p4lang/p4lang-pi.patch/remove-protobuf-from-debian-dependency.patch
@@ -1,0 +1,22 @@
+Don't depend on Debian's version of the Python 3 protobuf package. Instead,
+have it use the version that we install with pip. This is so that there's a
+single copy of the protobuf package present in the slave container and the
+installed environment.
+
+Index: p4lang-pi-0.1.0/debian/control
+===================================================================
+--- p4lang-pi-0.1.0.orig/debian/control
++++ p4lang-pi-0.1.0/debian/control
+@@ -43,11 +43,9 @@ Depends:
+     libprotobuf-dev,
+     libprotoc-dev,
+     protobuf-compiler,
+-    python3-protobuf,
+     libgrpc++-dev,
+     libgrpc-dev,
+-    protobuf-compiler-grpc,
+-    python3-grpcio
++    protobuf-compiler-grpc
+ Description: Implementation framework of a P4Runtime server
+  Protocol Independent API (PI or P4 Runtime) defines a set of APIs that allow
+  interacting with entities defined in a P4 program.


### PR DESCRIPTION
#### Why I did it

Cherry-pick of [#27790](https://github.com/sonic-net/sonic-buildimage/pull/27790) to 202605.

The 202605 branch has **never had a successful pipeline 142 build** — all attempts fail because `sonic-ycabled` tests hit `ImportError: cannot import name 'runtime_version' from 'google.protobuf'`. This is caused by p4lang installing an `__init__.py` into the system-wide `google` module namespace, making Python load the old apt `python3-protobuf` instead of the pip-installed 5.29.6.

Without a successful build, no artifacts are published, blocking **all** sonic-utilities 202605 CI (including [sonic-utilities#4596](https://github.com/sonic-net/sonic-utilities/pull/4596) which fixes the SED test failure blocking [#27773](https://github.com/sonic-net/sonic-buildimage/pull/27773)).

See [#27809](https://github.com/sonic-net/sonic-buildimage/issues/27809) for details.

#### How I did it

Cherry-pick of commits:
- `824e659` — Tell p4lang to use protobuf and grpcio installed via pip
- `309d33e` — Remove __init__.py file from google module

#### How to verify it

Pipeline 142 should produce a successful 202605 build with artifacts, unblocking downstream CI.