### PR TITLE
[build] Honor "# SKIP_HOOK" in collect_docker_version_files.sh

### DIFF
--- a/scripts/collect_docker_version_files.sh
+++ b/scripts/collect_docker_version_files.sh
@@ -17,6 +17,17 @@ DOCKER_IMAGE_TAG=$3
 DOCKER_PATH=$4
 DOCKER_FILE=$5
 
+# Images that build FROM a foreign/pre-built base mark their Dockerfile with
+# "# SKIP_HOOK". Such images have no SONiC build hooks installed (no
+# /usr/local/share/buildinfo content and no /cache.tgz), so there are no
+# version files to collect and no build cache to clean up. prepare_docker_buildinfo.sh
+# already skips these; mirror that here, otherwise the Dockerfile.cleanup step
+# below fails with "/cache.tgz: not found" and aborts the image build.
+if grep -q "^# SKIP_HOOK" "$DOCKER_FILE" 2>/dev/null; then
+    echo "$DOCKER_FILE has '# SKIP_HOOK', skipping docker version files collection"
+    exit 0
+fi
+
 [ -z "$TARGET_PATH" ] && TARGET_PATH=./target
 
 DOCKER_IMAGE_NAME=$(echo $DOCKER_IMAGE | cut -d: -f1 | sed "s/-$DOCKER_USERNAME\$//")


### PR DESCRIPTION
#### Why I did it

`scripts/prepare_docker_buildinfo.sh` skips images whose Dockerfile starts with `# SKIP_HOOK` (foreign / pre-built base images that do not contain the SONiC build hooks, e.g. `platform/pensando/docker-dpu`). Its sibling `scripts/collect_docker_version_files.sh`, which runs right after `docker build` in the `slave.mk` docker recipe, did **not** honor the same marker.

For a `# SKIP_HOOK` image there is no `/usr/local/share/buildinfo` content and no `/cache.tgz`, so `collect_docker_version_files.sh` fails when it builds `Dockerfile.cleanup`:

```
#5 [output 1/1] COPY --from=<image>:latest /cache.tgz cache.tgz
#5 ERROR: ... "/cache.tgz": not found
...
#5 [final 2/2] RUN rm /cache.tgz
#5 0.200 rm: cannot remove '/cache.tgz': No such file or directory
#5 ERROR: process "/bin/sh -c rm /cache.tgz" did not complete successfully: exit code: 1
```

That non-zero exit aborts the make recipe before `docker-image-save`, so the image `.gz` is never refreshed and the build silently keeps shipping a stale image.

`# SKIP_HOOK` was introduced in #15978, which added the guard to `prepare_docker_buildinfo.sh` but not to `collect_docker_version_files.sh`.

Fixes #27826

#### How I did it

Add the same `# SKIP_HOOK` guard near the top of `collect_docker_version_files.sh` (after `DOCKER_FILE=$5`), mirroring `prepare_docker_buildinfo.sh`. For such images there are no version files to collect and no build cache to clean up, so the script exits early.

#### How to verify it

Build a docker image whose Dockerfile starts with `# SKIP_HOOK` and is `FROM` a pre-built base without the SONiC build hooks (e.g. `platform/pensando/docker-dpu`, or any vendor pre-built container image).

- Before: the build fails at the `Dockerfile.cleanup` stage with `"/cache.tgz": not found` and the image target is not saved.
- After: `collect_docker_version_files.sh` logs that it is skipping the `# SKIP_HOOK` image, and the image builds and is saved normally.

Normal (non-`# SKIP_HOOK`) docker images are unaffected — the guard only triggers when the Dockerfile contains the marker.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
-->

- [ ] 202511
- [ ] 202605

#### Description for the changelog

Honor the `# SKIP_HOOK` marker in `collect_docker_version_files.sh` so foreign-base docker images (e.g. pensando docker-dpu) build and save correctly instead of failing on the missing `/cache.tgz` cleanup step.
