### PR TITLE
Fix p4lang file removal path

### DIFF
--- a/src/p4lang/p4lang-pi.patch/remove-init-file.patch
+++ b/src/p4lang/p4lang-pi.patch/remove-init-file.patch
@@ -7,4 +7,4 @@ Index: p4lang-pi-0.1.0/debian/rules
  	find $(CURDIR)/debian/p4lang-pi -name "*.pyc" | xargs rm -f
  	find $(CURDIR)/debian/p4lang-pi -name "*.pyo" | xargs rm -f
 +	# Workaround to encourage/force the use of the pip-installed protobuf library
-+	rm -f $(CURDIR)/debian/p4lang-pi/usr/lib/python3/dist-packages/google/__init__.py
++	rm $(CURDIR)/debian/p4lang-pi/usr/lib/python3.13/site-packages/google/__init__.py

--- a/src/p4lang/p4lang-pi.patch/remove-init-file.patch
+++ b/src/p4lang/p4lang-pi.patch/remove-init-file.patch
@@ -7,4 +7,4 @@ Index: p4lang-pi-0.1.0/debian/rules
  	find $(CURDIR)/debian/p4lang-pi -name "*.pyc" | xargs rm -f
  	find $(CURDIR)/debian/p4lang-pi -name "*.pyo" | xargs rm -f
 +	# Workaround to encourage/force the use of the pip-installed protobuf library
-+	rm $(CURDIR)/debian/p4lang-pi/usr/lib/python3.13/site-packages/google/__init__.py
++	rm $(CURDIR)/debian/p4lang-pi/usr/lib/python3.*/site-packages/google/__init__.py


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Correction of #27790

Correct the path of the file to remove. The `dh_python` command is moving the file to a Python-independent directory. The `-f` flag masked the error that would have appeared.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Local build passed, and ycabled was built after p4lang-pi was installed (which is the trigger for this issue). CI run for this PR also passed with the same ordering of build targets.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

