### PR TITLE
Fix KeyError on stop and unclosed file in startup_tsa_tsb.py

### DIFF
--- a/files/scripts/startup_tsa_tsb.py
+++ b/files/scripts/startup_tsa_tsb.py
@@ -17,8 +17,8 @@ logger.set_min_log_priority_info()
 def get_tsb_timer_interval():
     platform = device_info.get_platform()
     conf_file = '/usr/share/sonic/device/{}/startup-tsa-tsb.conf'.format(platform)
-    file = open(conf_file, 'r')
-    Lines = file.readlines()
+    with open(conf_file, 'r') as file:
+        Lines = file.readlines()
     for line in Lines:
         field = line.split('=')[0].strip()
         if field == "STARTUP_TSB_TIMER":
@@ -126,7 +126,7 @@ def print_usage():
 
 def reset_env_variables():
     logger.log_info("Resetting environment variable")
-    os.environ.pop('STARTED_BY_TSA_TSB_SERVICE')
+    os.environ.pop('STARTED_BY_TSA_TSB_SERVICE', None)
     return
 
 def start_tsa_tsb(timer):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

