### PR TITLE
[nvidia-bluefield] Ignore pdb in arm64-nvda_bf-bf3comdpu Health Check

### DIFF
--- a/device/nvidia-bluefield/arm64-nvda_bf-bf3comdpu/system_health_monitoring_config.json
+++ b/device/nvidia-bluefield/arm64-nvda_bf-bf3comdpu/system_health_monitoring_config.json
@@ -1,6 +1,6 @@
 {
     "services_to_ignore": [],
-    "devices_to_ignore": ["psu", "fan"],
+    "devices_to_ignore": ["psu", "fan", "pdb"],
     "user_defined_checkers": [],
     "polling_interval": 60
 }


### PR DESCRIPTION
#### Why I did it

On the BlueField-3 COM DPU (`arm64-nvda_bf-bf3comdpu`), `show system-health detail`
reports `Hardware: Not OK` with `Reasons: Failed to get PSU information`, even though
`psu` is already listed in the platform's health-check ignore list.

This is a regression. Adding PDB support for system-health changed the PSU/PDB check so
that it only skips when **both** `psu` and `pdb` are present in `devices_to_ignore`;
previously `psu` alone was sufficient. The DPU has no PSU/PDB hardware and runs with
`psud` disabled, so the `PSU_INFO` table is empty and the checker falls through to
"Failed to get PSU information". The DPU config only listed `["psu", "fan"]`, so the
new combined condition was never satisfied and the PSU check was no longer skipped.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

- Added `pdb` to `devices_to_ignore` in
  `device/nvidia-bluefield/arm64-nvda_bf-bf3comdpu/system_health_monitoring_config.json`
  (`["psu", "fan"]` -> `["psu", "fan", "pdb"]`) so the PSU/PDB hardware check is fully
  skipped on the DPU, matching the current "ignore both psu and pdb" condition.

#### How to verify it

On a BF3 COM DPU running the updated image:

1. Run `show system-health detail`.
2. Confirm `Hardware: Status: OK` (no `Failed to get PSU information` reason).
3. Confirm there is no `PSU  Not OK  PSU` entry in the "monitor list".
4. Confirm `psu`, `fan`, and `pdb` appear in the "ignore list".

Before the fix the monitor list showed `PSU  Not OK  PSU` and `Hardware: Status: Not OK`;
after the fix the PSU entry is listed as ignored and hardware status is OK.

#### Tested branch (Please provide the tested image version)

- [x] master

#### Description for the changelog

Ignore pdb in arm64-nvda_bf-bf3comdpu health check (fixes false "Failed to get PSU
information" on DPU)