### PR TITLE
[Aspeed BMC] Exclude ztp.service to fix systemd-sonic-generator boot errors

### DIFF
--- a/files/build_scripts/aspeed_bmc_filter_services.py
+++ b/files/build_scripts/aspeed_bmc_filter_services.py
@@ -30,6 +30,9 @@ BMC_EXCLUDED_SERVICES = {
     'dhcp_dos_logger.service',       # DHCP DoS detection - no switch ports on BMC
     'warmboot-finalizer.service',    # Warm boot reconciliation - no SWSS/BGP on BMC
 
+    # ZTP - not needed for BMC
+    'ztp.service',
+
     # UUID daemon - not needed
     'uuidd.service',                 # UUID daemon - kernel provides UUID generation
     'uuidd.socket',                  # UUID daemon socket activation
@@ -57,9 +60,6 @@ BMC_REQUIRED_SERVICES = {
 
     # Time synchronization
     'chrony.service',                 # Chrony time synchronization
-
-    # Zero Touch Provisioning
-    'ztp.service',                    # ZTP for automated device provisioning
 
     # System health monitoring
     'system-health.service',          # SONiC system health monitor


### PR DESCRIPTION
#### Why I did it
On Aspeed BMC images, `ztp.service` (Zero Touch Provisioning) is pulled into the boot
even though ZTP does not apply to the BMC. Its presence produces
`systemd-sonic-generator` boot errors. ZTP should be excluded from BMC images.

#### How I did it
In `files/build_scripts/aspeed_bmc_filter_services.py`, moved `ztp.service` from
`BMC_REQUIRED_SERVICES` into `BMC_EXCLUDED_SERVICES` so the BMC service filter masks it.

#### How to verify it
On a BMC image build, confirm `ztp.service` is in the excluded (masked) set and no longer
in the required set, and that the `systemd-sonic-generator` boot errors related to
`ztp.service` no longer occur.
