### PR TITLE
[init-cfg] Default switch-BMC platforms to NetworkBmc device type

### DIFF
--- a/src/sonic-config-engine/config_samples.py
+++ b/src/sonic-config-engine/config_samples.py
@@ -6,6 +6,8 @@ from natsort import natsorted
 
 import smartswitch_config
 
+from sonic_py_common import device_info
+
 #TODO: Remove once Python 2 support is removed
 if sys.version_info.major == 3:
     UNICODE_TYPE = str
@@ -220,7 +222,12 @@ def generate_empty_config(data):
     if 'hostname' not in new_data['DEVICE_METADATA']['localhost']:
         new_data['DEVICE_METADATA']['localhost']['hostname'] = 'sonic'
     if 'type' not in new_data['DEVICE_METADATA']['localhost']:
-        new_data['DEVICE_METADATA']['localhost']['type'] = 'LeafRouter'
+        # Switch-BMC platforms (switch_bmc=1) must be NetworkBmc so the device
+        # self-identifies as a BMC; others keep the LeafRouter default.
+        if device_info.is_switch_bmc():
+            new_data['DEVICE_METADATA']['localhost']['type'] = 'NetworkBmc'
+        else:
+            new_data['DEVICE_METADATA']['localhost']['type'] = 'LeafRouter'
     return new_data
 
 def generate_global_dualtor_tables():


### PR DESCRIPTION
#### Why I did it

On switch-BMC platforms (`switch_bmc=1` in `platform_env.conf`, e.g. `arm64-aspeed_nvidia_ast2700_bmc-r0`),
the default init config booted the device as `LeafRouter` instead of `NetworkBmc`, so `is_bmc()` returned
False and the BMC was treated like a front-panel switch.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

`config_samples.generate_empty_config()` defaults the missing `type` to `NetworkBmc` when
`is_switch_bmc()`, else `LeafRouter`. Type lives only in the preset (`config_db.json` overrides
`init_cfg.json` at boot anyway); `NetworkBmc` is already valid in the YANG model.

#### How to verify it

1. Build an internal BMC image with these changes and install on an AST2700
   (`arm64-aspeed_nvidia_ast2700_bmc-r0`).
2. `sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" type` → `NetworkBmc`; `is_bmc()` → True.
3. `grep '^DEVICE_TYPE=' /etc/sonic/sonic-environment` → `NetworkBmc` (regenerated from CONFIG_DB on
   the next install).
4. `config reload -y -f` → values survive.
5. Regression: on any non-BMC platform, `--preset empty` still yields `LeafRouter`.

Local validation done (host): `py_compile`; `generate_empty_config()` yields NetworkBmc/LeafRouter
with `is_switch_bmc()` mocked.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] 
- [ ] 

#### Description for the changelog

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)