### PR TITLE
[Mellanox] Enable amd_iommu for SN6810 platform

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn6810_ld-r0/installer.conf
+++ b/device/mellanox/x86_64-nvidia_sn6810_ld-r0/installer.conf
@@ -1,1 +1,1 @@
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="libata.force=noncq tpm_tis.interrupts=0 nosgx ima_hash=sha384 amd_iommu=off cpufreq.default_governor=performance"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="libata.force=noncq tpm_tis.interrupts=0 nosgx ima_hash=sha384 cpufreq.default_governor=performance"


### PR DESCRIPTION
#### Why I did it

Enable AMD IOMMU on SN6810_LD to speed up firmware image upgrade via `mlxfwmanager`.

#### How I did it

Remove `amd_iommu=off` from `ONIE_PLATFORM_EXTRA_CMDLINE_LINUX` in `device/mellanox/x86_64-nvidia_sn6810_ld-r0/installer.conf` so IOMMU is enabled by default at boot.

#### How to verify it

Run `mlxfwmanager update` and verify firmware update is faster than with `amd_iommu=off`.

---
