### PR TITLE
Fix google namespace conflict from p4lang-pi build

### DIFF
--- a/src/p4lang/Makefile
+++ b/src/p4lang/Makefile
@@ -17,6 +17,10 @@ ifeq ($(CROSS_BUILD_ENVIRON), y)
 else
 	dpkg-buildpackage -us -uc -b -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)
 endif
+	# dpkg-buildpackage may install google/__init__.py to the system path as a build
+	# side effect. This turns google/ into a regular package and shadows pip's protobuf
+	# (which uses implicit namespace packages), breaking imports for other components.
+	rm -f /usr/lib/python3/dist-packages/google/__init__.py
 	popd
 	mv $* $(DEST)/
 


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Cherry-pick of #27285. Adds a Makefile cleanup (rm -f /usr/lib/python3/dist-packages/google/__init__.py) to remove the file when dpkg-buildpackage recreates it as a build side effect.
Why: sonic-ycabled tests fail with ImportError: cannot import name 'runtime_version' from 'google.protobuf' because p4lang's google/__init__.py shadows pip's namespace-package protobuf 5.29.6. 
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
deleting the stray google/__init__.py both in package staging and from the system dist-packages path after the p4lang-pi build.
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

