### PR TITLE
[Mellanox] Add PDB (Power Distribution Board) definition to SN6810_LD platform.json for both hardware and SimX platforms

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn6810_ld-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn6810_ld-r0/platform.json
@@ -30,6 +30,11 @@
         "fans": [],
         "fan_drawers": [],
         "psus": [],
+        "pdbs": [
+            {
+                "name": "PDB 1"
+            }
+        ],
         "leak_sensors": [
             {
                 "name": "leakage1"

--- a/device/mellanox/x86_64-nvidia_sn6810_ld_simx-r0/platform.json
+++ b/device/mellanox/x86_64-nvidia_sn6810_ld_simx-r0/platform.json
@@ -30,6 +30,11 @@
         "fans": [],
         "fan_drawers": [],
         "psus": [],
+        "pdbs": [
+            {
+                "name": "PDB 1"
+            }
+        ],
         "leak_sensors": [
             {
                 "name": "leakage1"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

- SN6810_LD hardware includes a PDB, but platform.json previously had empty psus and no pdbs entry.
- Without pdbs in platform.json, DeviceDataManager.get_pdb_count() returns 0 and chassis.initialize_pdb() does not instantiate PDB objects, so PDB status/telemetry is unavailable via platform API.
- Adding PDB metadata keeps SN6810_LD consistent with other LD platforms and unblocks PDB-related monitoring and validation.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Updated device/mellanox/x86_64-nvidia_sn6810_ld-r0/platform.json
- Updated device/mellanox/x86_64-nvidia_sn6810_ld_simx-r0/platform.json
- Added under `chassis`:
```json
"pdbs": [
    {
        "name": "PDB 1"
    }
]
```

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

- Build image for x86_64-nvidia_sn6810_ld-r0 / SimX SKU
- After boot, verify PDB is initialized:
  - show platform pdb status (or equivalent platform CLI)
  - Python: sonic_platform.chassis.Chassis().get_num_pdbs() returns 1
- Confirm no regression on SimX platform bring-up

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

