### PR TITLE
sonic-yang-models: add POLICER_ACTION leafref to ACL_RULE

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
@@ -38,6 +38,13 @@
         "desc": "Configure non-existing ACL_TABLE in ACL_RULE.",
         "eStrKey" : "LeafRef"
     },
+    "ACL_RULE_WITH_VALID_POLICER_ACTION": {
+        "desc": "Configure ACL_RULE with valid POLICER_ACTION."
+    },
+    "ACL_RULE_WITH_INVALID_POLICER_ACTION": {
+        "desc": "Configure ACL_RULE with non-existing POLICER_ACTION.",
+        "eStrKey" : "LeafRef"
+    },
     "ACL_RULE_IP_TYPE_SRC_IPV6ANY": {
         "desc": "Configure IP_TYPE as ipv6any and SRC_IPV6 in ACL_RULE."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
@@ -1545,6 +1545,76 @@
             }
         }
     },
+    "ACL_RULE_WITH_VALID_POLICER_ACTION": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "DATAACL",
+                        "POLICER_ACTION": "test_policer",
+                        "PRIORITY": 9999,
+                        "RULE_NAME": "Rule_20",
+                        "SRC_IP": "10.0.0.1/32"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "DATAACL",
+                        "policy_desc": "DATAACL",
+                        "ports": [
+                            ""
+                        ],
+                        "stage": "ingress",
+                        "type": "L3"
+                    }
+                ]
+            }
+        },
+        "sonic-policer:sonic-policer": {
+            "sonic-policer:POLICER": {
+                "POLICER_LIST": [
+                    {
+                        "name": "test_policer",
+                        "meter_type": "packets",
+                        "mode": "sr_tcm",
+                        "cir": "5000",
+                        "cbs": "5000",
+                        "red_packet_action": "drop"
+                    }
+                ]
+            }
+        }
+    },
+    "ACL_RULE_WITH_INVALID_POLICER_ACTION": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "DATAACL",
+                        "POLICER_ACTION": "non_existent_policer",
+                        "PRIORITY": 9999,
+                        "RULE_NAME": "Rule_20",
+                        "SRC_IP": "10.0.0.1/32"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "DATAACL",
+                        "policy_desc": "DATAACL",
+                        "ports": [
+                            ""
+                        ],
+                        "stage": "ingress",
+                        "type": "L3"
+                    }
+                ]
+            }
+        }
+    },
     "ACL_RULE_VALID_TCP_FLAGS": {
         "sonic-acl:sonic-acl": {
             "sonic-acl:ACL_RULE": {

--- a/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
@@ -41,6 +41,10 @@ module sonic-acl {
 		prefix sms;
 	}
 
+	import sonic-policer {
+		prefix policer;
+	}
+
 	description "ACL YANG Module for SONiC OS";
 
 	revision 2019-07-01 {
@@ -94,6 +98,13 @@ module sonic-acl {
 				leaf INNER_SRC_MAC_REWRITE_ACTION {
 					description "Inner Source Mac-adress rewrite action mapped to mac address";
 					type yang:mac-address;
+				}
+
+				leaf POLICER_ACTION {
+					description "Policer to apply to matching packets, referencing a POLICER entry";
+					type leafref {
+						path "/policer:sonic-policer/policer:POLICER/policer:POLICER_LIST/policer:name";
+					}
 				}
 
 				leaf IP_TYPE {


### PR DESCRIPTION
#### Why I did it
A `CONFIG_DB` ACL rule cannot carry a policer action. `ACL_RULE` in the `sonic-acl` YANG model has no policer leaf, so a rule referencing a policer is rejected at YANG validation (`config reload`, GCU, `load_minigraph`) before it ever reaches orchagent. This adds the model support that the SET_POLICER ACL action (sonic-swss companion PR) needs to be configurable from `config_db.json`.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- `src/sonic-yang-models/yang-templates/sonic-acl.yang.j2`: import  `sonic-policer` and add `leaf POLICER_ACTION` to `ACL_RULE` as a leafref to  `/policer:sonic policer/policer:POLICER/policer:POLICER_LIST/policer:name`  (modeled on the existing `MIRROR_INGRESS_ACTION` leafref to mirror sessions).
- Added positive case `ACL_RULE_WITH_VALID_POLICER_ACTION` (rule + matching `POLICER` entry) and negative `ACL_RULE_WITH_INVALID_POLICER_ACTION`  (non-existent policer -> `LeafRef` error) in   `tests/yang_model_tests/tests/acl.json` and `.../tests_config/acl.json`.

#### How to verify it
- `cd src/sonic-yang-models && pytest tests/` (yang_model_tests).
- Locally validated leafref resolution with `pyang` against the rendered
  `sonic-policer.yang` (exit 0).

#### Which release branch to backport (provide reason below if selected)
<!-- feature, not a fix: none -->
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)
- [ ] <!-- master -->

#### Description for the changelog
sonic-yang-models: add POLICER_ACTION leafref to ACL_RULE (policer action support).

#### Link to config_db schema for YANG module changes
https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#acl_rule
<!-- also add POLICER_ACTION to the ACL_RULE section of Configuration.md in this PR -->

#### A picture of a cute animal (not mandatory but encouraged)