### PR TITLE
[srv6] update yang model for srv6 uA

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/srv6.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/srv6.json
@@ -36,5 +36,9 @@
     "SRV6_MY_SID_UA_MISSING_BOTH": {
         "desc": "A SID configured with action uA but missing both interface and adj",
         "eStr": ["interface is mandatory when action is 'uA'"]
+    },
+    "SRV6_MY_SID_ADJ_INVALID_ACTION": {
+        "desc": "A SID with adj set but action is not uA",
+        "eStr": ["adj is only applicable when action is 'uA'"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/srv6.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/srv6.json
@@ -20,8 +20,21 @@
         "eStrKey" : "Pattern"
     },
     "SRV6_MY_SID_INVALID_ACTION": {
-        "desc": "A SID configured with invalid action",
-        "eStrKey" : "InvalidValue",
-        "eStr": ["action"]
+        "desc": "A SID with action uA but missing interface (must constraint)",
+        "eStr": ["interface is mandatory when action is 'uA'"]
+    },
+    "SRV6_MY_SID_UA_VALID": {
+        "desc": "Valid config with action uA"
+    },
+    "SRV6_MY_SID_UA_MISSING_INTERFACE": {
+        "desc": "A SID configured with action uA but missing interface",
+        "eStr": ["interface is mandatory when action is 'uA'"]
+    },
+    "SRV6_MY_SID_UA_MISSING_ADJ": {
+        "desc": "Valid config with action uA (adj is optional)"
+    },
+    "SRV6_MY_SID_UA_MISSING_BOTH": {
+        "desc": "A SID configured with action uA but missing both interface and adj",
+        "eStr": ["interface is mandatory when action is 'uA'"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/srv6.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/srv6.json
@@ -256,6 +256,28 @@
             }
         }
     },
+    "SRV6_MY_SID_ADJ_INVALID_ACTION": {
+        "sonic-srv6:sonic-srv6": {
+            "sonic-srv6:SRV6_MY_LOCATORS": {
+                "SRV6_MY_LOCATORS_LIST": [
+                    {
+                        "locator_name": "MAIN",
+                        "prefix": "FCBB:BBBB:20::"
+                    }
+                ]
+            },
+            "sonic-srv6:SRV6_MY_SIDS": {
+                "SRV6_MY_SIDS_LIST": [
+                    {
+                        "ip_prefix": "FCBB:BBBB:20::/48",
+                        "locator": "MAIN",
+                        "action": "uN",
+                        "adj": "fe80::1"
+                    }
+                ]
+            }
+        }
+    },
     "SRV6_MY_SID_UA_MISSING_BOTH": {
         "sonic-srv6:sonic-srv6": {
             "sonic-srv6:SRV6_MY_LOCATORS": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/srv6.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/srv6.json
@@ -144,7 +144,7 @@
             "sonic-srv6:SRV6_MY_SIDS": {
                 "SRV6_MY_SIDS_LIST": [
                     {
-                        "ip_prefix": "FCBB:BBBB:20::/48",
+                        "ip_prefix": "FCBB:BBBB:FE00::/48",
                         "locator": "MAIN",
                         "action": "uA"
                     },
@@ -186,7 +186,7 @@
             "sonic-srv6:SRV6_MY_SIDS": {
                 "SRV6_MY_SIDS_LIST": [
                     {
-                        "ip_prefix": "FCBB:BBBB:20::/48",
+                        "ip_prefix": "FCBB:BBBB:FE00::/48",
                         "locator": "MAIN",
                         "action": "uA",
                         "interface": "Ethernet0",
@@ -209,7 +209,7 @@
             "sonic-srv6:SRV6_MY_SIDS": {
                 "SRV6_MY_SIDS_LIST": [
                     {
-                        "ip_prefix": "FCBB:BBBB:20::/48",
+                        "ip_prefix": "FCBB:BBBB:FE00::/48",
                         "locator": "MAIN",
                         "action": "uA",
                         "adj": "fe80::1"
@@ -247,7 +247,7 @@
             "sonic-srv6:SRV6_MY_SIDS": {
                 "SRV6_MY_SIDS_LIST": [
                     {
-                        "ip_prefix": "FCBB:BBBB:20::/48",
+                        "ip_prefix": "FCBB:BBBB:FE00::/48",
                         "locator": "MAIN",
                         "action": "uA",
                         "interface": "Ethernet0"
@@ -269,7 +269,7 @@
             "sonic-srv6:SRV6_MY_SIDS": {
                 "SRV6_MY_SIDS_LIST": [
                     {
-                        "ip_prefix": "FCBB:BBBB:20::/48",
+                        "ip_prefix": "FCBB:BBBB:FE00::/48",
                         "locator": "MAIN",
                         "action": "uA"
                     }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/srv6.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/srv6.json
@@ -156,5 +156,125 @@
                 ]
             }
         }
+    },
+    "SRV6_MY_SID_UA_VALID": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "tpid": "0x8100",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-srv6:sonic-srv6": {
+            "sonic-srv6:SRV6_MY_LOCATORS": {
+                "SRV6_MY_LOCATORS_LIST": [
+                    {
+                        "locator_name": "MAIN",
+                        "prefix": "FCBB:BBBB:20::"
+                    }
+                ]
+            },
+            "sonic-srv6:SRV6_MY_SIDS": {
+                "SRV6_MY_SIDS_LIST": [
+                    {
+                        "ip_prefix": "FCBB:BBBB:20::/48",
+                        "locator": "MAIN",
+                        "action": "uA",
+                        "interface": "Ethernet0",
+                        "adj": "fe80::1"
+                    }
+                ]
+            }
+        }
+    },
+    "SRV6_MY_SID_UA_MISSING_INTERFACE": {
+        "sonic-srv6:sonic-srv6": {
+            "sonic-srv6:SRV6_MY_LOCATORS": {
+                "SRV6_MY_LOCATORS_LIST": [
+                    {
+                        "locator_name": "MAIN",
+                        "prefix": "FCBB:BBBB:20::"
+                    }
+                ]
+            },
+            "sonic-srv6:SRV6_MY_SIDS": {
+                "SRV6_MY_SIDS_LIST": [
+                    {
+                        "ip_prefix": "FCBB:BBBB:20::/48",
+                        "locator": "MAIN",
+                        "action": "uA",
+                        "adj": "fe80::1"
+                    }
+                ]
+            }
+        }
+    },
+    "SRV6_MY_SID_UA_MISSING_ADJ": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "tpid": "0x8100",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-srv6:sonic-srv6": {
+            "sonic-srv6:SRV6_MY_LOCATORS": {
+                "SRV6_MY_LOCATORS_LIST": [
+                    {
+                        "locator_name": "MAIN",
+                        "prefix": "FCBB:BBBB:20::"
+                    }
+                ]
+            },
+            "sonic-srv6:SRV6_MY_SIDS": {
+                "SRV6_MY_SIDS_LIST": [
+                    {
+                        "ip_prefix": "FCBB:BBBB:20::/48",
+                        "locator": "MAIN",
+                        "action": "uA",
+                        "interface": "Ethernet0"
+                    }
+                ]
+            }
+        }
+    },
+    "SRV6_MY_SID_UA_MISSING_BOTH": {
+        "sonic-srv6:sonic-srv6": {
+            "sonic-srv6:SRV6_MY_LOCATORS": {
+                "SRV6_MY_LOCATORS_LIST": [
+                    {
+                        "locator_name": "MAIN",
+                        "prefix": "FCBB:BBBB:20::"
+                    }
+                ]
+            },
+            "sonic-srv6:SRV6_MY_SIDS": {
+                "SRV6_MY_SIDS_LIST": [
+                    {
+                        "ip_prefix": "FCBB:BBBB:20::/48",
+                        "locator": "MAIN",
+                        "action": "uA"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-srv6.yang
+++ b/src/sonic-yang-models/yang-models/sonic-srv6.yang
@@ -158,6 +158,9 @@ module sonic-srv6 {
 
                 leaf adj {
                     type inet:ipv6-address;
+                    must "../action = 'uA'" {
+                        error-message "adj is only applicable when action is 'uA'";
+                    }
                     description "IPv6 adjacency address";
                 }
             }

--- a/src/sonic-yang-models/yang-models/sonic-srv6.yang
+++ b/src/sonic-yang-models/yang-models/sonic-srv6.yang
@@ -11,6 +11,10 @@ module sonic-srv6 {
 		prefix vrf;
 	}
 
+    import sonic-port {
+        prefix prt;
+    }
+
     description
         "Segment Routing over IPv6 (SRv6) configuration for SONiC.";
 
@@ -111,9 +115,10 @@ module sonic-srv6 {
                 }
 
                 leaf action {
-                    description "SRv6 endpoint behavior (uN for prefix SID, uDT46 for decap with VRF lookup).";
+                    description "SRv6 endpoint behavior (uN for prefix SID, uA for adjacency SID, uDT46 for decap with VRF lookup).";
                     type enumeration {
                         enum uN;
+                        enum uA;
                         enum uDT46;
                     }
                 }
@@ -138,6 +143,22 @@ module sonic-srv6 {
                         enum uniform;
                         enum pipe;
                     }
+                }
+
+                leaf interface {
+                    type leafref {
+                        path "/prt:sonic-port/prt:PORT/prt:PORT_LIST/prt:name";
+                    }
+                    description "Reference of port which is used by srv6 SID";
+                }
+                // Constraint: interface is mandatory when action is uA
+                must "not(action = 'uA') or interface" {
+                    error-message "interface is mandatory when action is 'uA'";
+                }
+
+                leaf adj {
+                    type inet:ipv6-address;
+                    description "IPv6 adjacency address";
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Add `uA` endpoint behavior to `sonic-srv6.yang` with `interface` leafref and optional `adj` IPv6 address
- Require `interface` when `action` is `uA`
- Add yang model test cases for uA valid/invalid configurations

## Test plan
- [x] Run SRv6 yang model tests: `pytest src/sonic-yang-models/tests/yang_model_tests/ -k srv6`