### PR TITLE
[srv6] add support for SRv6 uA into bgpcfgd

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_srv6.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_srv6.py
@@ -5,6 +5,7 @@ from swsscommon import swsscommon
 
 supported_SRv6_behaviors = {
     'uN',
+    'uA',
     'uDT46',
 }
 
@@ -68,13 +69,6 @@ class SRv6Mgr(Manager):
                 self.directory.subscribe([(self.db_name, "SRV6_MY_LOCATORS", locator_name)], self.on_deps_change)
             return False
 
-        locator = self.directory.get(self.db_name, "SRV6_MY_LOCATORS", locator_name)
-        locator_prefix = IPv6Network(locator.prefix)
-        sid_prefix = IPv6Network(ip_prefix)
-        if not locator_prefix.supernet_of(sid_prefix):
-            log_err("Found a SRv6 SID config entry that does not match the locator prefix: {} | {}; locator {}".format(key, data, locator))
-            return False
-
         if 'action' not in data:
             log_err("Found a SRv6 SID config entry that does not specify action: {} | {}".format(key, data))
             return False
@@ -82,13 +76,33 @@ class SRv6Mgr(Manager):
         if data['action'] not in supported_SRv6_behaviors:
             log_err("Found a SRv6 SID config entry associated with unsupported action: {} | {}".format(key, data))
             return False
+            
+        locator = self.directory.get(self.db_name, "SRV6_MY_LOCATORS", locator_name)
+        locator_prefix = IPv6Network(locator.prefix)
+        sid_prefix = IPv6Network(ip_prefix)
+        locator_block = locator_prefix.supernet(new_prefix=locator.block_len)
+        if not locator_block.supernet_of(sid_prefix):
+            log_err("Found a SRv6 SID config entry with action {} that does not match the locator block: {} | {}; locator {}".format(data['action'], key, data, locator))
+            return False
 
+        if data['action'] == 'uN' and not locator_prefix.supernet_of(sid_prefix):
+            log_err("Found a SRv6 SID config entry with action {} that does not match the locator prefix: {} | {}; locator {}".format(data['action'], key, data, locator))
+            return False
+        
         sid = SID(locator_name, ip_prefix, data) # the information in data will be parsed into SID's attributes
 
         cmd_list = ['segment-routing', 'srv6', 'static-sids']
         sid_cmd = 'sid {} locator {} behavior {}'.format(ip_prefix, locator_name, sid.action)
         if sid.decap_vrf != DEFAULT_VRF:
             sid_cmd += ' vrf {}'.format(sid.decap_vrf)
+        if sid.action == 'uA':
+            if sid.interface:
+                sid_cmd += ' interface {}'.format(sid.interface)
+            else:
+                log_err("Found a SRv6 SID config entry that does not specify interface for action uA: {} | {}".format(key, data))
+                return False
+            if sid.adj:
+                sid_cmd += ' nexthop {}'.format(sid.adj)
         cmd_list.append(sid_cmd)
 
         self.cfg_mgr.push_list(cmd_list)
@@ -148,4 +162,5 @@ class SID:
 
         self.action = data['action']
         self.decap_vrf = data['decap_vrf'] if 'decap_vrf' in data else DEFAULT_VRF
-        self.adj = data['adj'].split(',') if 'adj' in data else []
+        self.interface = data['interface'] if 'interface' in data else None
+        self.adj = data['adj'] if 'adj' in data else None

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_srv6.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_srv6.py
@@ -76,7 +76,7 @@ class SRv6Mgr(Manager):
         if data['action'] not in supported_SRv6_behaviors:
             log_err("Found a SRv6 SID config entry associated with unsupported action: {} | {}".format(key, data))
             return False
-            
+
         locator = self.directory.get(self.db_name, "SRV6_MY_LOCATORS", locator_name)
         locator_prefix = IPv6Network(locator.prefix)
         sid_prefix = IPv6Network(ip_prefix)
@@ -85,10 +85,11 @@ class SRv6Mgr(Manager):
             log_err("Found a SRv6 SID config entry with action {} that does not match the locator block: {} | {}; locator {}".format(data['action'], key, data, locator))
             return False
 
+        # uN SIDs must fit within the locator node prefix; uA/uDT46 may use function bits beyond it.
         if data['action'] == 'uN' and not locator_prefix.supernet_of(sid_prefix):
             log_err("Found a SRv6 SID config entry with action {} that does not match the locator prefix: {} | {}; locator {}".format(data['action'], key, data, locator))
             return False
-        
+
         sid = SID(locator_name, ip_prefix, data) # the information in data will be parsed into SID's attributes
 
         cmd_list = ['segment-routing', 'srv6', 'static-sids']
@@ -163,4 +164,5 @@ class SID:
         self.action = data['action']
         self.decap_vrf = data['decap_vrf'] if 'decap_vrf' in data else DEFAULT_VRF
         self.interface = data['interface'] if 'interface' in data else None
+        # uA supports a single nexthop; keep as a string for direct FRR emission.
         self.adj = data['adj'] if 'adj' in data else None

--- a/src/sonic-bgpcfgd/tests/test_srv6.py
+++ b/src/sonic-bgpcfgd/tests/test_srv6.py
@@ -91,6 +91,83 @@ def test_uN_add():
     print(loc_mgr.directory.data)
     assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1::\\48")
 
+def test_uA_add_del():
+    loc_mgr, sid_mgr = constructor()
+    assert loc_mgr.set_handler("loc1", {'prefix': 'fcbb:bbbb:1::'})
+
+    op_test(sid_mgr, 'SET', ("loc1|FCBB:BBBB:1:FE01::/64", {
+        'action': 'uA',
+        'interface': 'Ethernet0',
+        'adj': '2001:db8::1'
+    }), expected_ret=True, expected_cmds=[
+        'segment-routing',
+        'srv6',
+        'static-sids',
+        'sid fcbb:bbbb:1:fe01::/64 locator loc1 behavior uA interface Ethernet0 nexthop 2001:db8::1'
+    ])
+
+    print(loc_mgr.directory.data)
+    assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1:fe01::\\64")
+
+    # test the deletion
+    op_test(sid_mgr, 'DEL', ("loc1|FCBB:BBBB:1:FE01::/64",),
+            expected_ret=True, expected_cmds=[
+            'segment-routing',
+            'srv6',
+            'static-sids',
+            'no sid fcbb:bbbb:1:fe01::/64 locator loc1 behavior uA interface Ethernet0 nexthop 2001:db8::1'
+    ])
+    print(loc_mgr.directory.data)
+    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1:fe01::\\64")
+
+    op_test(sid_mgr, 'SET', ("loc1|FCBB:BBBB:FE01::/48", {
+        'action': 'uA',
+        'interface': 'Ethernet0',
+        'adj': '2001:db8::1'
+    }), expected_ret=True, expected_cmds=[
+        'segment-routing',
+        'srv6',
+        'static-sids',
+        'sid fcbb:bbbb:fe01::/48 locator loc1 behavior uA interface Ethernet0 nexthop 2001:db8::1'
+    ])
+
+    print(loc_mgr.directory.data)
+    assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:fe01::\\48")
+
+    # test the deletion
+    op_test(sid_mgr, 'DEL', ("loc1|FCBB:BBBB:FE01::/48",),
+            expected_ret=True, expected_cmds=[
+            'segment-routing',
+            'srv6',
+            'static-sids',
+            'no sid fcbb:bbbb:fe01::/48 locator loc1 behavior uA interface Ethernet0 nexthop 2001:db8::1'
+    ])
+    print(loc_mgr.directory.data)
+    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:fe01::\\48")
+
+    # test missing interface
+    op_test(sid_mgr, 'SET', ("loc1|FCBB:BBBB:1:FE01::/64", {
+        'action': 'uA',
+        'adj': '2001:db8::1'
+    }), expected_ret=False, expected_cmds=[])
+
+    print(loc_mgr.directory.data)
+    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1:fe01::\\64")
+
+    # test missing adj (adj is optional)
+    op_test(sid_mgr, 'SET', ("loc1|FCBB:BBBB:1:FE01::/64", {
+        'action': 'uA',
+        'interface': 'Ethernet0'
+    }), expected_ret=True, expected_cmds=[
+        'segment-routing',
+        'srv6',
+        'static-sids',
+        'sid fcbb:bbbb:1:fe01::/64 locator loc1 behavior uA interface Ethernet0'
+    ])
+
+    print(loc_mgr.directory.data)
+    assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1:fe01::\\64")
+
 def test_uDT46_add_vrf1():
     loc_mgr, sid_mgr = constructor()
     assert loc_mgr.set_handler("loc1", {'prefix': 'fcbb:bbbb:1::'})


### PR DESCRIPTION
## Summary
- Add `uA` endpoint behavior support in `bgpcfgd` for SRv6 static SID configuration
- Generate FRR commands with `interface` (mandatory) and optional `nexthop` for uA SIDs
- Relax SID prefix validation to locator block level for uA, while keeping strict locator prefix check for uN
- Add unit tests for uA add/delete, missing interface, and optional adjacency

## Test plan
- [ ] Run bgpcfgd SRv6 tests: `pytest src/sonic-bgpcfgd/tests/test_srv6.py -k uA`
- [ ] Verify uA SID configuration is pushed to FRR with correct `interface` and `nexthop` commands