### PR TITLE
Add pg_profile_lookup.ini fallback for Generic HWSKU

### DIFF
--- a/dockers/docker-orchagent/buffermgrd.sh
+++ b/dockers/docker-orchagent/buffermgrd.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+HWSKU_DIR="/usr/share/sonic/hwsku"
+PLATFORM_DIR="/usr/share/sonic/platform"
+TARGET_FILE="pg_profile_lookup.ini"
+
+HWSKU_FILE="${HWSKU_DIR}/${TARGET_FILE}"
+PLATFORM_FILE="${PLATFORM_DIR}/${TARGET_FILE}"
+
 BUFFER_CALCULATION_MODE=$(redis-cli -n 4 hget "DEVICE_METADATA|localhost" buffer_model)
 
 if [ "$BUFFER_CALCULATION_MODE" == "dynamic" ]; then
@@ -11,8 +18,13 @@ if [ "$BUFFER_CALCULATION_MODE" == "dynamic" ]; then
         BUFFERMGRD_ZERO_PROFILE_ARGS=" -z /etc/sonic/zero_profiles.json"
     fi
 else
-    # Should we use the fallback MAC in case it is not found in Device.Metadata
-    BUFFERMGRD_ARGS="-l /usr/share/sonic/hwsku/pg_profile_lookup.ini"
+    if [ -f "$HWSKU_FILE" ]; then
+        echo "Info: Found ${TARGET_FILE} in HWSKU directory: $HWSKU_FILE"
+        BUFFERMGRD_ARGS="-l $HWSKU_FILE"
+    else
+        echo "Warning: ${TARGET_FILE} not found in HWSKU. Falling back to Platform directory: $PLATFORM_FILE"
+        BUFFERMGRD_ARGS="-l $PLATFORM_FILE"
+    fi
 fi
 
 exec /usr/bin/buffermgrd ${BUFFERMGRD_ARGS} ${BUFFERMGRD_PERIPHERIAL_ARGS} ${BUFFERMGRD_ZERO_PROFILE_ARGS}

--- a/platform/vs/docker-sonic-vs/buffermgrd.sh
+++ b/platform/vs/docker-sonic-vs/buffermgrd.sh
@@ -1,17 +1,30 @@
 #!/usr/bin/env bash
 
+HWSKU_DIR="/usr/share/sonic/hwsku"
+PLATFORM_DIR="/usr/share/sonic/platform"
+TARGET_FILE="pg_profile_lookup.ini"
+
+HWSKU_FILE="${HWSKU_DIR}/${TARGET_FILE}"
+PLATFORM_FILE="${PLATFORM_DIR}/${TARGET_FILE}"
+
 BUFFER_CALCULATION_MODE=$(redis-cli -n 4 hget "DEVICE_METADATA|localhost" buffer_model)
-export ASIC_VENDOR=vs
 
 if [ "$BUFFER_CALCULATION_MODE" == "dynamic" ]; then
     BUFFERMGRD_ARGS="-a /etc/sonic/asic_table.json"
-
+    if [ -f /etc/sonic/peripheral_table.json ]; then
+        BUFFERMGRD_PERIPHERIAL_ARGS=" -p /etc/sonic/peripheral_table.json"
+    fi
     if [ -f /etc/sonic/zero_profiles.json ]; then
         BUFFERMGRD_ZERO_PROFILE_ARGS=" -z /etc/sonic/zero_profiles.json"
     fi
 else
-    # Should we use the fallback MAC in case it is not found in Device.Metadata
-    BUFFERMGRD_ARGS="-l /usr/share/sonic/hwsku/pg_profile_lookup.ini"
+    if [ -f "$HWSKU_FILE" ]; then
+        echo "Info: Found ${TARGET_FILE} in HWSKU directory: $HWSKU_FILE"
+        BUFFERMGRD_ARGS="-l $HWSKU_FILE"
+    else
+        echo "Warning: ${TARGET_FILE} not found in HWSKU. Falling back to Platform directory: $PLATFORM_FILE"
+        BUFFERMGRD_ARGS="-l $PLATFORM_FILE"
+    fi
 fi
 
-exec /usr/bin/buffermgrd ${BUFFERMGRD_ARGS} ${BUFFERMGRD_ZERO_PROFILE_ARGS}
+exec /usr/bin/buffermgrd ${BUFFERMGRD_ARGS} ${BUFFERMGRD_PERIPHERIAL_ARGS} ${BUFFERMGRD_ZERO_PROFILE_ARGS}

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1925,12 +1925,18 @@ def select_mmu_profiles(profile, platform, hwsku):
     path = os.path.join(new_path, platform, hwsku)
 
     dir_path = os.path.join(path, profile)
+    platform_path = os.path.dirname(path)
     if os.path.exists(dir_path):
         for file_item in files_to_copy:
             file_in_dir = os.path.join(dir_path, file_item)
+            base_file = os.path.join(path, file_item)
             if os.path.isfile(file_in_dir):
-                base_file = os.path.join(path, file_item)
                 exec_cmd(["sudo", "cp", file_in_dir, base_file])
+            elif file_item == 'pg_profile_lookup.ini' and not os.path.isfile(base_file):
+                platform_file = os.path.join(platform_path, file_item)
+                base_file = os.path.join(platform_path, file_item)
+                if os.path.isfile(platform_file):
+                    exec_cmd(["sudo", "cp", platform_file, base_file])
 
 def address_type(address):
     # encode and decode to unicode, because when address is bytes type, ip_network will throw AddressValueError

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -719,6 +719,10 @@ class TestJ2Files(TestCase):
 
         for file_name in files_to_copy:
             src_file = os.path.join(dir_path, file_name)
+            if file_name == 'pg_profile_lookup.ini' and not os.path.isfile(src_file):
+                platform_path = os.path.dirname(dir_path)
+                platform_src_file = os.path.join(platform_path, file_name)
+                src_file = platform_src_file
             dst_file = os.path.join(self.test_dir, file_name)
 
             if not revert:


### PR DESCRIPTION
Fixes #25716

Why I did it
The pg_profile_lookup.ini file is used by buffermgrd for buffer configuration. Previously this file was kept individually in each HWSKU directory, which caused unnecessary duplication and maintenance burden when the same configuration table was valid for all HWSKUs on a given platform. This change allows a single pg_profile_lookup.ini to be placed at the platform level and shared across all HWSKUs, while still permitting per-HWSKU overrides to preserve flexibility for platforms that require different buffer settings for different HWSKUs.

How I did it
- Updated buffermgrd.sh for both the generic docker-orchagent and the VS platform. The script now defines HWSKU_DIR and PLATFORM_DIR and looks for pg_profile_lookup.ini first in the HWSKU directory, then falls back to the platform directory with informational/warning messages.
- Modified minigraph.py `select_mmu_profiles` to copy pg_profile_lookup.ini from the platform directory when the file is not present in the HWSKU-specific profile directory.
- Extended the unit test in test_j2files.py to verify the new fallback behavior, ensuring that the file is correctly sourced from the platform directory when the HWSKU path does not contain pg_profile_lookup.ini.

How to verify it
Remove pg_profile_lookup.ini from a HWSKU directory and ensure buffermgrd starts correctly using the platform-level file.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

