### PR TITLE
[202511] Upgrade Broadcom xgs SAI version to 14.3.0.0.0.0.21.0

### DIFF
--- a/platform/broadcom/sai-xgs.mk
+++ b/platform/broadcom/sai-xgs.mk
@@ -1,5 +1,5 @@
 # Broadcom XGS SAI definitions
-LIBSAIBCM_XGS_VERSION = 14.3.0.0.0.0.16.0
+LIBSAIBCM_XGS_VERSION = 14.3.0.0.0.0.21.0
 LIBSAIBCM_XGS_BRANCH_NAME = SAI_14.3.0_GA
 
 LIBSAIBCM_XGS_URL_PREFIX = "https://packages.trafficmanager.net/public/sai/sai-broadcom/$(LIBSAIBCM_XGS_BRANCH_NAME)/$(LIBSAIBCM_XGS_VERSION)/xgs"


### PR DESCRIPTION
#### Why I did it
 Upgrade the xgs SAI version on 202511 to 14.3.0.0.0.0.21.0 (17.0 and 18.0 are subsumed by 19.0):
 - 14.3.0.0.0.0.19.0: TH6C-B1 SDK fixes (also folds in 17.0 + 18.0 incremental fixes)
 - 14.3.0.0.0.0.20.0: CSP CS00012458649 â Uplift SDK-457303 to SAI 14.3
 - 14.3.0.0.0.0.21.0: Uplift SONIC-123420 â Lots of RX Signal Detect Invalid Port ERRs throughout operation (matches CSP CS00012461973)

##### Work item tracking
 - Microsoft ADO **(number only)**: 38131319

#### How I did it
 Bump LIBSAIBCM_XGS_VERSION in platform/broadcom/sai-xgs.mk.
#### How to verify it

 Build a 202511 sonic-aboot-broadcom.swi from this PR, install on a TD3X2 DUT, and run the canonical SAI upgrade test set (12 scripts) via Elastictest.

#### Which release branch to backport (provide reason below if selected)

 N/A - this PR targets 202511 directly (master is on 15.2).

#### Tested branch (Please provide the tested image version)

 - [ ] Not yet tested â will qualify via Elastictest after build completes

#### Description for the changelog
Upgrade Broadcom XGS SAI version from 14.3.0.0.0.0.16.0 to 14.3.0.0.0.0.21.0 on 202511

#### Link to config_db schema for YANG module changes
N/A - no YANG changes

Signed-off-by: Aaron Bernardino <aaronber@microsoft.com>

