### PR TITLE
[sonic-yang-models] Mark sonic-event and sonic-alarm as config false (operational state)

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-alarm.yang
+++ b/src/sonic-yang-models/yang-models/sonic-alarm.yang
@@ -78,6 +78,11 @@
 
     container sonic-alarm {
 
+      // This module describes operational state (alarms raised by the
+      // system), not configuration; `config false` applies to every
+      // descendant so the data is correctly modeled as read-only state.
+      config false;
+
       container ALARM {
 
         list ALARM_LIST {

--- a/src/sonic-yang-models/yang-models/sonic-event.yang
+++ b/src/sonic-yang-models/yang-models/sonic-event.yang
@@ -83,6 +83,11 @@
 
     container sonic-event {
 
+      // This module describes operational state (events raised by the
+      // system), not configuration; `config false` applies to every
+      // descendant so the data is correctly modeled as read-only state.
+      config false;
+
       container EVENT {
 
         list EVENT_LIST {


### PR DESCRIPTION
#### Why I did it

The `sonic-event` and `sonic-alarm` YANG models describe **operational state**, not configuration, but neither marks its data `config false`, so the containers default to `config true`. Tooling that derives the settable CONFIG_DB surface from the YANG models (CLIs, config generators, tab-completion) therefore wrongly treats these state tables as configurable.

**What these models actually are** (for reviewers, since it isn't obvious): they model the tables in **`EVENT_DB` (database 19)** — a dedicated event/alarm store, *not* `CONFIG_DB`:

- `sonic-event` → `EVENT` (event history) and `EVENT_STATS` (aggregate counters: total events, raised, acked, cleared). `EVENT_LIST` rows are the events the system has raised — `id`, `resource`, `text`, `time-created`, `type-id`, `severity`, `action`.
- `sonic-alarm` → `ALARM` (currently-raised alarms, including operator `acknowledged` / `acknowledge-time`) and `ALARM_STATS` (counts by severity).

These rows are populated by the system as events/alarms are raised and acknowledged — they are read-only state surfaced for monitoring (e.g. show commands / gNMI state queries), never written by an operator. Both modules already state this in their own `description` ("This module defines operational state data for SONiC events/alarms"); they simply omit `config false`. (Cross-reference: the related `sonic-events-*` notification-payload models are already recognized as non-config via their `sonic-events-common` severity extension — e.g. `tests/yang_model_pytests/test_configdb_layout.py::_is_event_schema` — but `sonic-event`/`sonic-alarm` carry no such marker.)

#### How I did it

Added `config false;` to the top-level `sonic-event` and `sonic-alarm` containers. In YANG this is inherited by every descendant (the `EVENT`/`ALARM`/`EVENT_STATS`/`ALARM_STATS` containers, their lists, and the `uses`'d groupings), so the whole subtree is correctly modeled as read-only state.

#### How to verify it

- The models compile and validate (no CONFIG_DB sample-config fixtures exist for `sonic-event`/`sonic-alarm`, so no `tests/yang_model_tests` cases change; `test_configdb_layout` is unaffected — the tables still have their `list` row layer).
- After the change, `pyang`/`libyang` reports the `sonic-event` / `sonic-alarm` subtrees as `config false`, and config-deriving tooling no longer offers `EVENT`/`ALARM`/`EVENT_STATS`/`ALARM_STATS` as settable config.

#### Which release branch to backport (provide reason below if selected)

<!-- Model-classification correction; no functional/data-plane change. Master is sufficient; no backport requested. -->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Description for the changelog

sonic-yang-models: mark sonic-event and sonic-alarm models as `config false` (they describe EVENT_DB operational state, not configuration).

#### Link to config_db schema for YANG module changes

N/A — these models describe `EVENT_DB` operational state, not a `CONFIG_DB` table, so there is no `Configuration.md` schema entry. This change reclassifies them as `config false` accordingly.