### PR TITLE
Remove 'nht resolve-via-default' for Public cloudtype only

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/monitors/peer-group.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/monitors/peer-group.conf.j2
@@ -6,6 +6,7 @@
 {% set voq_chassis = True %}
 {% endif %}
   neighbor BGPMON peer-group
+  neighbor BGPMON passive
 {% if voq_chassis is defined or CONFIG_DB__DEVICE_METADATA['localhost']['switch_type'] == 'chassis-packet' %}
   neighbor BGPMON update-source Loopback4096
 {% elif loopback0_ipv4 %}

--- a/dockers/docker-fpm-frr/frr/zebra/zebra.interfaces.conf.j2
+++ b/dockers/docker-fpm-frr/frr/zebra/zebra.interfaces.conf.j2
@@ -11,9 +11,11 @@ exit
 {% endblock vrf %}
 !
 {% block interfaces %}
+{% if not (DEVICE_METADATA is defined and 'localhost' in DEVICE_METADATA and DEVICE_METADATA['localhost'].get('cloudtype','').lower() == 'public') %}
 ! Enable nht through default route
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+{% endif %}
 ! Enable link-detect (default disabled)
 {% for (name, prefix) in INTERFACE|pfx_filter %}
 interface {{ name }}

--- a/src/sonic-bgpcfgd/tests/data/monitors/peer-group.conf/result_all.conf
+++ b/src/sonic-bgpcfgd/tests/data/monitors/peer-group.conf/result_all.conf
@@ -2,6 +2,7 @@
 ! template: bgpd/templates/BGPMON/peer-group.conf.j2
 !
   neighbor BGPMON peer-group
+  neighbor BGPMON passive
   neighbor BGPMON update-source 1.1.1.1
   address-family ipv4
     neighbor BGPMON activate

--- a/src/sonic-bgpcfgd/tests/data/monitors/peer-group.conf/result_chassis.conf
+++ b/src/sonic-bgpcfgd/tests/data/monitors/peer-group.conf/result_chassis.conf
@@ -2,6 +2,7 @@
 ! template: bgpd/templates/BGPMON/peer-group.conf.j2
 !
   neighbor BGPMON peer-group
+  neighbor BGPMON passive
   neighbor BGPMON update-source Loopback4096
   address-family ipv4
     neighbor BGPMON activate

--- a/src/sonic-bgpcfgd/tests/data/monitors/peer-group.conf/result_without_lo0_ipv4.conf
+++ b/src/sonic-bgpcfgd/tests/data/monitors/peer-group.conf/result_without_lo0_ipv4.conf
@@ -2,6 +2,7 @@
 ! template: bgpd/templates/BGPMON/peer-group.conf.j2
 !
   neighbor BGPMON peer-group
+  neighbor BGPMON passive
   address-family ipv4
     neighbor BGPMON activate
     neighbor BGPMON route-map FROM_BGPMON in

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/interfaces_public.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/interfaces_public.conf
@@ -1,0 +1,14 @@
+!
+! Enable link-detect (default disabled)
+interface Ethernet0
+link-detect
+!
+interface Ethernet4
+link-detect
+!
+interface PortChannel10
+link-detect
+!
+interface PortChannel20
+link-detect
+!

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/interfaces_public.json
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/interfaces_public.json
@@ -1,0 +1,15 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "cloudtype": "Public"
+        }
+    },
+    "INTERFACE": {
+        "Ethernet0|10.20.30.40/24": {},
+        "Ethernet4|20.20.30.40/24": {}
+    },
+    "PORTCHANNEL": {
+        "PortChannel10": {},
+        "PortChannel20": {}
+    }
+}

--- a/src/sonic-bgpcfgd/tests/test_sonic-cfggen.py
+++ b/src/sonic-bgpcfgd/tests/test_sonic-cfggen.py
@@ -129,6 +129,13 @@ def test_zebra_interfaces():
              "zebra/interfaces.json",
              "zebra/interfaces.conf")
 
+def test_zebra_interfaces_public_cloudtype():
+    """For cloudtype=Public, nht resolve-via-default must NOT be emitted."""
+    run_test("zebra.interfaces.conf.j2 (Public cloudtype)",
+             "zebra/zebra.interfaces.conf.j2",
+             "zebra/interfaces_public.json",
+             "zebra/interfaces_public.conf")
+
 def test_zebra_set_src():
     run_test("zebra.set_src.conf.j2",
              "zebra/zebra.set_src.conf.j2",


### PR DESCRIPTION
## Problem

This is a revision of #27482. The original PR removed `ip/ipv6 nht resolve-via-default` unconditionally. This PR scopes the removal to **Public cloudtype only**, preserving the existing behavior for Fairfax/Sovereign/unset devices.

## Background

FRR's zebra was configured with:
```
ip nht resolve-via-default
ipv6 nht resolve-via-default
```

With `resolve-via-default` enabled, zebra reports the default route as a valid nexthop for _any_ peer address, causing **BGP active (outbound) sessions to be initiated even when the peer IP has no real reachability**. This defeats the NHT reachability gate entirely.

## Changes

### 1. `zebra.interfaces.conf.j2`

Gate the two `nht resolve-via-default` lines on `cloudtype != 'Public'`:

```jinja
{% if not (DEVICE_METADATA is defined and 'localhost' in DEVICE_METADATA
           and DEVICE_METADATA['localhost'].get('cloudtype','').lower() == 'public') %}
! Enable nht through default route
ip nht resolve-via-default
ipv6 nht resolve-via-default
{% endif %}
```

| cloudtype value | nht resolve-via-default emitted? |
|---|---|
| `Public` | ❌ No (new behavior) |
| `Fairfax` / `Sovereign` / unset | ✅ Yes (unchanged) |

### 2. `bgpd/templates/monitors/peer-group.conf.j2`

Add `neighbor BGPMON passive` to explicitly configure BGP MONITOR sessions in passive mode (no outbound connections, unaffected by NHT).

## Testing

- Added `interfaces_public.json` fixture (`cloudtype=Public`) and `interfaces_public.conf` expected output (nht lines absent).
- Added `test_zebra_interfaces_public_cloudtype()` — verifies nht lines absent for Public cloudtype.
- Existing `test_zebra_interfaces()` fixture has no cloudtype set (non-Public path) — still includes nht lines, no regression.

## Relation to #27482

This supersedes #27482. Same BGPMON passive change kept; the nht removal is now conditioned on `cloudtype == 'Public'`.