### PR TITLE
[ci] refine docker-ptf pipeline to align with image download command change

### DIFF
--- a/.azure-pipelines/docker-ptf.yml
+++ b/.azure-pipelines/docker-ptf.yml
@@ -91,6 +91,24 @@ stages:
     - publish:  $(Build.ArtifactStagingDirectory)
       artifact: 'sonic-buildimage.vs'
       displayName: "Archive docker image ptf"
+    
+    - bash: |
+        set -ex
+        docker load -i $(Build.ArtifactStagingDirectory)/target/docker-ptf.gz
+        docker tag docker-ptf:latest $REGISTRY_SERVER/docker-ptf:lastbuild
+        docker images
+      env:
+        REGISTRY_SERVER: ${{ parameters.registry_url }}
+      displayName: 'Load and tag docker-ptf as lastbuild'
+    
+    - task: Docker@2
+      displayName: 'Push docker-ptf:lastbuild to registry'
+      condition: succeeded()
+      inputs:
+        containerRegistry: ${{ parameters.registry_conn }}
+        repository: docker-ptf
+        command: push
+        tags: lastbuild
 
 - stage: Test
   dependsOn: Build
@@ -147,6 +165,7 @@ stages:
     parameters:
       CHECKOUT_SONIC_MGMT: true
       PTF_MODIFIED: 'True'
+      PTF_IMAGE_TAG: "lastbuild"
       INCLUDE_JOBS: "t0_job,t1_job,t2_job,t0_2vlans_job,t0_sonic_job,dpu_job,t1_multi_asic_job"
       OVERRIDE_PARAMS:
         REPO_NAME: "sonic-mgmt"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
During test, the previous image download workflow for docker ptf was to download the image file from artifact and use `docker load` to load the image. This results in S360 alters.
The image download command has been refined to pull docker-ptf image from ACR, this PR is to refine the docker-ptf pipeline to align with the change.
After building the docker-ptf, we publish it to ACR and tag it as `lastbuild`, then we pull this image for testing.
If test passes, we tag it as `latest` and publish to ACR.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Added Build-stage steps to load docker-ptf image, tag it as docker-ptf:lastbuild, and push it to ACR.
- Set PTF_IMAGE_TAG: "lastbuild" in the sonic-mgmt PR test template parameters.
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

