### PR TITLE
[memory_checker] Skip containers removed during listing to avoid spurious dockerd 404

### DIFF
--- a/files/image_config/monit/memory_checker
+++ b/files/image_config/monit/memory_checker
@@ -248,7 +248,8 @@ def get_running_container_names():
     """
     try:
         docker_client = docker.DockerClient(base_url='unix://var/run/docker.sock')
-        running_container_list = docker_client.containers.list(filters={"status": "running"})
+        running_container_list = docker_client.containers.list(filters={"status": "running"},
+                                                               ignore_removed=True)
         running_container_names = [ container.name for container in running_container_list ]
     except (docker.errors.APIError, docker.errors.DockerException) as err:
         if not is_service_active("docker"):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To address intermittent errors like the following:

```
2026 May 21 09:32:49.818977 xxxx413 ERR memory_checker: Failed to retrieve the running container list from docker daemon! Error message is: '404 Client Error for http+docker://localhost/v1.43/containers/<hash>/json: Not Found ("No such container: <hash>")'
```

##### Work item tracking
- Microsoft ADO **(number only)**: 27992

Fixes: https://github.com/sonic-net/sonic-buildimage/issues/27992

#### How I did it

This issue looks very similar to https://github.com/docker/docker-py/issues/2451

By default, `containers.list()` lists the containers and then inspects each one. If a container is restarted or removed between the list and the per-container inspect, dockerd returns a transient 404 ("No such container") and the whole call raises NotFound.

Adding `ignore_removed=True` to ignore failures due to missing containers when attempting to inspect containers from the original list.

Reference: https://docker-py.readthedocs.io/en/stable/containers.html#docker.models.containers.ContainerCollection.list

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

The failure is a race — a container removed between docker's container list and its
per-container inspect — so it is verified **deterministically** by running the actual
`get_running_container_names()` from the unpatched and patched files while injecting that
exact race (a throwaway container is removed right before the first inspect). No flaky
timing, no load. Run on an DUT (`SONiC`, docker-py 7.1.0).

<details>
<summary><code>verify_fix.py</code></summary>

```python
#!/usr/bin/env python3
# Deterministically reproduce the dockerd-404 race and verify the fix.
# Usage: verify_fix.py <original_memory_checker> <patched_memory_checker>
import importlib.machinery as m, importlib.util as u, sys, syslog, docker
from docker.api.client import APIClient
syslog.openlog(ident="memory_checker")   # so the ERR line is tagged like the daemon's
cli = docker.DockerClient(base_url="unix://var/run/docker.sock")
IMG = next(i for im in cli.images.list() for i in im.tags
           if "orchagent" in i or "database" in i)
NAME = "abc1234_verify"

def load(path):
    l = m.SourceFileLoader(path, path); s = u.spec_from_loader(path, l)
    mod = u.module_from_spec(s); l.exec_module(mod); return mod

def case(label, path):
    try: cli.containers.get(NAME).remove(force=True)
    except Exception: pass
    cli.containers.run(IMG, command=["sleep", "3600"], name=NAME,
                       detach=True, network_mode="none", entrypoint=[""])
    real = APIClient.inspect_container; fired = []
    def racing(self, c):                      # remove throwaway just before the
        if not fired:                         # first inspect == the documented race
            fired.append(1)
            try: cli.containers.get(NAME).remove(force=True)
            except Exception: pass
        return real(self, c)
    APIClient.inspect_container = racing
    print(f"\n== {label} ==")
    try:
        names = load(path).get_running_container_names()
        print(f"RESULT: returned {len(names)} names, exit 0 (no error)")
    except SystemExit as e:
        print(f"RESULT: logged ERR and sys.exit({e.code})")
    finally:
        APIClient.inspect_container = real
        try: cli.containers.get(NAME).remove(force=True)
        except Exception: pass

case("WITHOUT fix (containers.list)", sys.argv[1])
case("WITH fix    (ignore_removed=True)", sys.argv[2])
```
</details>

**Run on the DUT:**

```bash
cp -a /usr/bin/memory_checker /tmp/memory_checker.original      # unpatched baseline
# scp the patched file -> /tmp/memory_checker and harness -> /tmp/verify_fix.py
MARK="abc1234-$$"; logger -t harness "$MARK BEGIN"
sudo python3 /tmp/verify_fix.py /tmp/memory_checker.original /tmp/memory_checker
logger -t harness "$MARK END"
sudo awk -v s="$MARK BEGIN" -v e="$MARK END" '$0~s{on=1} on{print} $0~e{on=0}' \
  /var/log/syslog | grep "ERR memory_checker: Failed to retrieve the running container list"
```

**Result:**

| | Outcome |
|---|---|
| **Without fix** (`containers.list()`) | inspect of the removed container → `404` → logs `ERR` and `sys.exit(1)` ❌ |
| **With fix** (`ignore_removed=True`) | removed container skipped → returns the live container list, exit 0, **no ERR** ✅ |

Harness output:

```
== WITHOUT fix (containers.list) ==
RESULT: logged ERR and sys.exit(1)

== WITH fix    (ignore_removed=True) ==
RESULT: returned 15 names, exit 0 (no error)
```

Actual syslog line emitted by the **without-fix** run — identical to the reported error,
and **not** emitted by the with-fix run:

```
2026 Jun 19 00:21:01 xxxx107 ERR memory_checker: Failed to retrieve the running container list from docker daemon! Error message is: '404 Client Error for http+docker://localhost/v1.43/containers/1be32c43dce0897d1394455344bfaa46ddf5195b1b0ecf9b67d38b06982c0b86/json: Not Found ("No such container: 1be32c43dce0897d1394455344bfaa46ddf5195b1b0ecf9b67d38b06982c0b86")'
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

