### PR TITLE
Modified code to copy RackManager config file (OEM) to the host system.d

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -806,8 +806,11 @@ sudo cp $IMAGE_CONFIGS/constants/bmc.json $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPL
 # Copy DBus policy files for sonic-redfish (aspeed BMC platform only)
 if [[ $CONFIGURED_PLATFORM == aspeed ]]; then
     sudo mkdir -p $FILESYSTEM_ROOT/etc/dbus-1/system.d
-    sudo cp src/sonic-redfish/sonic-dbus-bridge/dbus/*.conf \
+    sudo cp src/sonic-redfish/sonic-dbus-bridge/dbus/xyz.openbmc_project.*.conf \
         $FILESYSTEM_ROOT/etc/dbus-1/system.d/
+    for f in src/sonic-redfish/sonic-dbus-bridge/dbus/com.sonic.*.conf; do
+        [ -f "$f" ] && sudo cp "$f" $FILESYSTEM_ROOT/etc/dbus-1/system.d/
+    done
 fi
 
 # Copy sudoers configuration file

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -806,7 +806,7 @@ sudo cp $IMAGE_CONFIGS/constants/bmc.json $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPL
 # Copy DBus policy files for sonic-redfish (aspeed BMC platform only)
 if [[ $CONFIGURED_PLATFORM == aspeed ]]; then
     sudo mkdir -p $FILESYSTEM_ROOT/etc/dbus-1/system.d
-    sudo cp src/sonic-redfish/sonic-dbus-bridge/dbus/xyz.openbmc_project.*.conf \
+    sudo cp src/sonic-redfish/sonic-dbus-bridge/dbus/*.conf \
         $FILESYSTEM_ROOT/etc/dbus-1/system.d/
 fi
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR is needed before https://github.com/sonic-net/sonic-redfish/pull/3 gets merged. The sonic-redfish PR introduces a new config file `com.sonic.RackManager.conf` which is needed for OEM extension PRs. This config file is not copied to the host `etc/dbus-1/system.d/` location since it doesn't follow "xyz.openbmc_project" format.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Have changed the code to look for `*.conf` instead of `xyz.openbmc_project.*.conf`

#### How to verify it
Without this fix, the `sonic-dbus-bridge` (inside docker-redfish) won't come up.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

