### PR TITLE
[sonic-yang-models]: Add optional ACL_TABLE priority leaf

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
@@ -95,6 +95,28 @@
             "value": "INGRESS"
         }
     },
+    "ACL_TABLE_DEFAULT_VALUE_PRIORITY": {
+        "desc": "ACL_TABLE with no priority leaf inherits the YANG default 100.",
+        "eStrKey" : "Verify",
+        "verify": {
+            "xpath": "/sonic-acl:sonic-acl/ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME='NO-NSW-PACL-V4']/ACL_TABLE_NAME",
+            "key": "sonic-acl:priority",
+            "value": 100
+        }
+    },
+    "ACL_TABLE_VALID_PRIORITY": {
+        "desc": "ACL_TABLE LOAD PRIORITY FIELD SUCCESSFULLY.",
+        "eStrKey" : "Verify",
+        "verify": {
+            "xpath": "/sonic-acl:sonic-acl/ACL_TABLE/ACL_TABLE_LIST[ACL_TABLE_NAME='NO-NSW-PACL-V4']/ACL_TABLE_NAME",
+            "key": "sonic-acl:priority",
+            "value": 200
+        }
+    },
+    "ACL_TABLE_INVALID_PRIORITY": {
+        "desc": "Configure ACL_TABLE priority out of the uint32 range.",
+        "eStrKey" : "Bounds"
+    },
     "ACL_TABLE_STAGE_SERVICES": {
         "desc": "ACL_TABLE LOAD STAGE SERVICES SUCCESSFULLY.",
         "eStrKey" : "Verify",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
@@ -933,6 +933,47 @@
             }
         }
     },
+    "ACL_TABLE_DEFAULT_VALUE_PRIORITY": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "NO-NSW-PACL-V4",
+                        "policy_desc": "Filter IPv4",
+                        "type": "L3"
+                    }
+                ]
+            }
+        }
+    },
+    "ACL_TABLE_VALID_PRIORITY": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "NO-NSW-PACL-V4",
+                        "policy_desc": "Filter IPv4",
+                        "priority": 200,
+                        "type": "L3"
+                    }
+                ]
+            }
+        }
+    },
+    "ACL_TABLE_INVALID_PRIORITY": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "NO-NSW-PACL-V4",
+                        "policy_desc": "Filter IPv4",
+                        "priority": 4294967296,
+                        "type": "L3"
+                    }
+                ]
+            }
+        }
+    },
     "ACL_TABLE_EMPTY_PORTS": {
         "sonic-acl:sonic-acl": {
             "sonic-acl:ACL_TABLE": {

--- a/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
@@ -428,6 +428,17 @@ module sonic-acl {
 					default "INGRESS";
 				}
 
+				leaf priority {
+					description "ACL table group member priority. Determines the table
+						lookup order within an ACL table group on a shared bind point for
+						SEQUENTIAL groups, and action-conflict resolution for PARALLEL
+						groups. A higher value indicates higher priority.
+						Defaults to 100 when unspecified, preserving the historical
+						hardcoded behavior.";
+					type uint32;
+					default 100;
+				}
+
 				leaf-list services {
 					description "List of services this ACL table is applied to (for control plane ACLs)";
 					type string;


### PR DESCRIPTION
#### Why I did it

Adds an optional `priority` leaf to `ACL_TABLE_LIST` in `sonic-acl.yang`. It maps to the ACL table group member priority and lets operators control table lookup order (SEQUENTIAL groups) and action-conflict resolution (PARALLEL groups) on a shared bind point. Defaults to `100`, preserving existing behavior when unspecified.

Companion to sonic-net/sonic-swss#4688, which plumbs this value into `SAI_ACL_TABLE_GROUP_MEMBER_ATTR_PRIORITY` (tracks sonic-net/sonic-swss#4687).

#### How I did it

- Added an optional `uint32` `priority` leaf to `ACL_TABLE_LIST` in `yang-templates/sonic-acl.yang.j2`, with `default 100`.

#### How I verified it

Added YANG model tests for the new leaf:
- `ACL_TABLE_DEFAULT_VALUE_PRIORITY` — leaf absent inherits the default `100`.
- `ACL_TABLE_VALID_PRIORITY` — a valid configured value loads and round-trips.
- `ACL_TABLE_INVALID_PRIORITY` — an out-of-`uint32`-range value is rejected.
