### PR TITLE
marvell-platfrom: add SAI dependency to DOCKER_MGMT_FRAMEWORK

### DIFF
--- a/platform/marvell-prestera/sai.mk
+++ b/platform/marvell-prestera/sai.mk
@@ -13,6 +13,11 @@ MRVL_SAI_URL_PREFIX = https://github.com/Marvell-switching/sonic-marvell-binarie
 MRVL_SAI = mrvllibsai_$(MRVL_SAI_VERSION)_$(PLATFORM_ARCH).deb
 $(MRVL_SAI)_URL = $(MRVL_SAI_URL_PREFIX)/$(MRVL_SAI)
 
+# The MRVL_SAI now has shlibs-based dependency description, is included
+# into build dependency graph. libsai.so consumers also should be updated.
+DOCKER_MGMT_FRAMEWORK = docker-sonic-mgmt-framework.gz
+$(DOCKER_MGMT_FRAMEWORK)_DEPENDS += $(MRVL_SAI)
+
 SONIC_ONLINE_DEBS += $(MRVL_SAI)
 $(MRVL_SAI)_SKIP_VERSION=y
 $(eval $(call add_conflict_package,$(MRVL_SAI),$(LIBSAIVS_DEV)))


### PR DESCRIPTION
#### Why I did it
The "next gen eSAI" MRVL_SAI has DEBIAN/shlibs dependency description.
So MRVL_SAI is included into build dependency graph and
all libsai.so consumers also should be updated/expanded with SAI-dependency.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
platform/marvell-prestera/sai.mk adds dependency for the
  DOCKER_MGMT_FRAMEWORK = docker-sonic-mgmt-framework.gz
  $(DOCKER_MGMT_FRAMEWORK)_DEPENDS += $(MRVL_SAI)

#### How to verify it
Check the Build for vendor/platform "marvell-prestera" passed successfully for Marvell-eSAI version

#### Which release branch to backport (provide reason below if selected)
master and 202611

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)
N/A

#### Description for the changelog

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

