### PR TITLE
[installer]: Support install SONiC by ONIE from other NVME

### DIFF
--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -41,7 +41,7 @@ create_partition()
 
         # check if we have an nvme device
         blk_suffix=
-        echo $blk_dev | grep -q nvme0 && blk_suffix="p"
+        echo $blk_dev | grep -q nvme && blk_suffix="p"
 
         # Note: ONIE has no mount setting for / with device node, so below will be empty string
 
@@ -82,7 +82,7 @@ mount_partition()
 {
 
     demo_dev=$(echo $blk_dev | sed -e 's/\(mmcblk[0-9]\)/\1p/')$demo_part
-    echo $blk_dev | grep -q nvme0 && demo_dev=$(echo $blk_dev | sed -e 's/\(nvme[0-9]n[0-9]\)/\1p/')$demo_part
+    echo $blk_dev | grep -q nvme && demo_dev=$(echo $blk_dev | sed -e 's/\(nvme[0-9]n[0-9]\)/\1p/')$demo_part
 
     # Make filesystem
     mkfs.ext4 -L $demo_volume_label $demo_dev


### PR DESCRIPTION
 [installer]: Support install SONiC by ONIE from other NVME
  
  [List of changes]
    Remove the '0' in the grep command

    This code change generalizes the installer's handling of NVMe storage devices so that it works with multiple or non-zero NVMe drives,
    rather than being hardcoded specifically to nvme0.

    Signed-off-by: patchi.liu@celestica.com

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
I need to install sonic image by ONIE from NVME1
##### Work item tracking
- Microsoft ADO **(number only)**: NA

#### How I did it
Remove the '0' in the grep command

#### How to verify it
Build the image and verify it in Celestica platforms(ds6000 and ds6001).  The image could be upgraded successfully in NVME1.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->
- [x ] 202505
- [x ] 202511
- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

