### PR TITLE
Fix the console speed for the Nexthop's BMC card

### DIFF
--- a/device/nexthop/arm64-nexthop_b27-r0/switch_cpu_console.conf
+++ b/device/nexthop/arm64-nexthop_b27-r0/switch_cpu_console.conf
@@ -2,7 +2,7 @@
 # This file defines console port settings for the switch CPU console
 
 # Baud rate for the switch CPU console (default: 115200)
-CONSOLE_BAUD_RATE=9600
+CONSOLE_BAUD_RATE=115200
 
 # Flow control: 0=disabled, 1=enabled (default: 0)
 CONSOLE_FLOW_CONTROL=0


### PR DESCRIPTION
#### Why I did it
The conf file from which the DB is initialized had an incorrect value for the console speed

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Changed the value to 115200

#### How to verify it
Console speed matches h/w settings


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

