### PR TITLE
[build] Add timeout for apt-get build hook to prevent long hangs (#26…

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -120,8 +120,7 @@ sudo LANG=C chroot $FILESYSTEM_ROOT mount
 ## Pointing apt to public apt mirrors and getting latest packages, needed for latest security updates
 scripts/build_mirror_config.sh files/apt $CONFIGURED_ARCH $IMAGE_DISTRO
 sudo cp files/apt/sources.list.$CONFIGURED_ARCH $FILESYSTEM_ROOT/etc/apt/sources.list
-sudo cp files/apt/apt-retries-count $FILESYSTEM_ROOT/etc/apt/apt.conf.d/
-sudo cp files/apt/apt.conf.d/{81norecommends,apt-{clean,gzip-indexes,no-languages},no-check-valid-until} $FILESYSTEM_ROOT/etc/apt/apt.conf.d/
+sudo cp files/apt/apt.conf.d/{81norecommends,apt-{clean,gzip-indexes,no-languages,timeout-n-retries},no-check-valid-until} $FILESYSTEM_ROOT/etc/apt/apt.conf.d/
 
 ## Note: set lang to prevent locale warnings in your chroot
 sudo LANG=C chroot $FILESYSTEM_ROOT apt-get -y update

--- a/dockers/docker-base-bookworm/Dockerfile.j2
+++ b/dockers/docker-base-bookworm/Dockerfile.j2
@@ -28,8 +28,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Configure data sources for apt/dpkg
 COPY ["dpkg_01_drop", "/etc/dpkg/dpkg.cfg.d/01_drop"]
 COPY ["sources.list.{{ CONFIGURED_ARCH }}", "/etc/apt/sources.list"]
-COPY ["no_install_recommend_suggest", "/etc/apt/apt.conf.d"]
-COPY ["no-check-valid-until", "/etc/apt/apt.conf.d"]
+COPY ["files/apt/apt.conf.d/", "/etc/apt/apt.conf.d/"]
+# Install certificates by disabling the peer verification
+RUN apt -o Acquire::https::Verify-Peer=false update && \
+    apt -o Acquire::https::Verify-Peer=false install -y ca-certificates
 
 # Update apt cache and
 # pre-install fundamental packages

--- a/dockers/docker-base-bookworm/no-check-valid-until
+++ b/dockers/docker-base-bookworm/no-check-valid-until
@@ -1,4 +1,0 @@
-# Instruct apt-get to NOT check the "Valid Until" date in Release files
-# Once the Debian team archives a repo, they stop updating this date
-
-Acquire::Check-Valid-Until "false";

--- a/dockers/docker-base-bookworm/no_install_recommend_suggest
+++ b/dockers/docker-base-bookworm/no_install_recommend_suggest
@@ -1,5 +1,0 @@
-# Instruct apt-get to NOT install "recommended" or "suggested" packages by
-# default when installing a package.
-
-APT::Install-Recommends "false";
-APT::Install-Suggests "false";

--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -17,8 +17,8 @@ WORKDIR /root
 LABEL maintainer="Pavel Shirshov"
 
 COPY ["sources.list.{{ CONFIGURED_ARCH }}", "/etc/apt/sources.list"]
-COPY ["no-check-valid-until", "/etc/apt/apt.conf.d"]
-COPY ["apt-retries-count", "/etc/apt/apt.conf.d"]
+COPY ["files/apt/apt.conf.d/no-check-valid-until", "/etc/apt/apt.conf.d/"]
+COPY ["files/apt/apt.conf.d/apt-timeout-n-retries", "/etc/apt/apt.conf.d/"]
 
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/dockers/docker-ptf/no-check-valid-until
+++ b/dockers/docker-ptf/no-check-valid-until
@@ -1,4 +1,0 @@
-# Instruct apt-get to NOT check the "Valid Until" date in Release files
-# Once the Debian team archives a repo, they stop updating this date
-
-Acquire::Check-Valid-Until "false";

--- a/files/apt/apt.conf.d/81norecommends
+++ b/files/apt/apt.conf.d/81norecommends
@@ -1,3 +1,4 @@
 APT::Install-Recommends "false";
+APT::Install-Suggests "false";
 APT::AutoRemove::RecommendsImportant "false";
 APT::AutoRemove::SuggestsImportant "false";

--- a/files/apt/apt.conf.d/apt-multiple-retries
+++ b/files/apt/apt.conf.d/apt-multiple-retries
@@ -1,4 +1,0 @@
-# Instruct apt to retry downloads on failures
-# This is required only for bullseye.
-
-Acquire::Retries "3";

--- a/files/apt/apt.conf.d/apt-timeout-n-retries
+++ b/files/apt/apt.conf.d/apt-timeout-n-retries
@@ -1,0 +1,7 @@
+# Instruct apt-get to timeout after 20 seconds and retry 3 times before giving up. 
+# This can help mitigate issues with slow or unreliable network connections when using apt-get in Docker builds.
+
+Acquire::http::Timeout "20";
+Acquire::https::Timeout "20";
+Acquire::ftp::Timeout "20";
+Acquire::Retries "3";

--- a/scripts/prepare_docker_buildinfo.sh
+++ b/scripts/prepare_docker_buildinfo.sh
@@ -42,6 +42,8 @@ fi
 
 if [[ "$IMAGENAME" == sonic-slave-* ]] || [[ "$IMAGENAME" == docker-base-* ]] || [[ "$IMAGENAME" == docker-ptf ]]; then
     scripts/build_mirror_config.sh ${DOCKERFILE_PATH} $ARCH $DISTRO
+	mkdir -p "${DOCKERFILE_PATH}/files/apt/apt.conf.d"
+	cp -f files/apt/apt.conf.d/* "${DOCKERFILE_PATH}/files/apt/apt.conf.d/"
 fi
 
 # add script for reproducible build. using sha256 instead of tag for docker base image.

--- a/sonic-slave-bookworm/Dockerfile.j2
+++ b/sonic-slave-bookworm/Dockerfile.j2
@@ -21,7 +21,8 @@ FROM {{ prefix }}debian:bookworm
 
 MAINTAINER gulv@microsoft.com
 
-COPY ["no-check-valid-until", "/etc/apt/apt.conf.d/"]
+COPY ["files/apt/apt.conf.d/no-check-valid-until", "/etc/apt/apt.conf.d/"]
+COPY ["files/apt/apt.conf.d/apt-timeout-n-retries", "/etc/apt/apt.conf.d/"]
 
 {%- if CROSS_BUILD_ENVIRON != "y" %}
 COPY ["sources.list.{{ CONFIGURED_ARCH }}", "/etc/apt/sources.list"]

--- a/sonic-slave-bookworm/no-check-valid-until
+++ b/sonic-slave-bookworm/no-check-valid-until
@@ -1,4 +1,0 @@
-# Instruct apt-get to NOT check the "Valid Until" date in Release files
-# Once the Debian team archives a repo, they stop updating this date
-
-Acquire::Check-Valid-Until "false";

--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -21,8 +21,8 @@ FROM {{ prefix }}debian:bullseye
 
 MAINTAINER gulv@microsoft.com
 
-COPY ["no-check-valid-until", "/etc/apt/apt.conf.d/"]
-COPY ["apt-retries-count", "/etc/apt/apt.conf.d"]
+COPY ["files/apt/apt.conf.d/no-check-valid-until", "/etc/apt/apt.conf.d/"]
+COPY ["files/apt/apt.conf.d/apt-timeout-n-retries", "/etc/apt/apt.conf.d/"]
 
 {%- if CROSS_BUILD_ENVIRON != "y" %}
 COPY ["sources.list.{{ CONFIGURED_ARCH }}", "/etc/apt/sources.list"]

--- a/sonic-slave-buster/Dockerfile.j2
+++ b/sonic-slave-buster/Dockerfile.j2
@@ -20,8 +20,8 @@ FROM {{ prefix }}debian:buster
 
 MAINTAINER gulv@microsoft.com
 
-COPY ["no-check-valid-until", "/etc/apt/apt.conf.d/"]
-COPY ["apt-retries-count", "/etc/apt/apt.conf.d"]
+COPY ["files/apt/apt.conf.d/no-check-valid-until", "/etc/apt/apt.conf.d/"]
+COPY ["files/apt/apt.conf.d/apt-timeout-n-retries", "/etc/apt/apt.conf.d/"]
 
 {%- if CROSS_BUILD_ENVIRON != "y" %}
 COPY ["sources.list.{{ CONFIGURED_ARCH }}", "/etc/apt/sources.list"]


### PR DESCRIPTION
#### Why I did it
Backport of #26865 to the 202505 release branch.

The original change adds apt-get download timeout + retries to prevent Docker/image
builds from hanging on slow or unreliable networks, and centralizes the apt.conf.d
files under `files/apt/apt.conf.d/`.

#### How I did it
Cherry-picked 888760b9 (#26865). Resolved backport conflicts:
- Dropped the trixie changes (`docker-base-trixie`, `sonic-slave-trixie`) — trixie does not exist on 202505.
- `docker-ptf`: applied only the apt.conf.d path change.
- `docker-base-bookworm`: applied the apt.conf.d path change **and** added the early `ca-certificates` install (`Acquire::https::Verify-Peer=false`), matching master's docker-base-bookworm. This is required for fork/non-mirror builds that fetch over HTTPS before ca-certificates is otherwise available (e.g. the rust toolchain `curl https://sh.rustup.rs` in docker-*-watchdog), which otherwise fail with `curl: (77)` → `cargo: not found`.

#### How to verify it
Rebuild the affected docker-base / sonic-slave images on 202505 and confirm apt-get
picks up `apt-timeout-n-retries` (20s timeout, 3 retries) and builds succeed.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

