### PR TITLE
[ci][202605] add a pipeline to build and publish docker-ptf

### DIFF
--- a/.azure-pipelines/docker-ptf.yml
+++ b/.azure-pipelines/docker-ptf.yml
@@ -1,0 +1,201 @@
+# Starter pipeline
+# Start with a minimal pipeline that you can customize to build and deploy your code.
+# Add steps that build, run tests, deploy, and more:
+# https://aka.ms/yaml
+# Build and push docker-ptf image
+
+trigger: none
+pr:
+  branches:
+    include:
+    - master
+    - 202???
+  paths:
+    include:
+    - dockers/docker-ptf
+
+resources:
+  repositories:
+  - repository: sonic-mgmt
+    type: github
+    name: sonic-net/sonic-mgmt
+    ref: master
+    endpoint: sonic-net
+
+parameters:
+- name: registry_url
+  type: string
+  default: sonicdev-microsoft.azurecr.io
+- name: registry_conn
+  type: string
+  default: sonicdev
+
+stages:
+- stage: Prepare
+  jobs:
+  - job: Prepare
+    steps:
+    - script: |
+        DEFAULT_MIRROR_URL_PREFIX=http://packages.trafficmanager.net
+        DEBIAN_TIMESTAMP=$(curl $DEFAULT_MIRROR_URL_PREFIX/debian-snapshot/debian/latest)
+        DEBIAN_SECURITY_TIMESTAMP=$(curl $DEFAULT_MIRROR_URL_PREFIX/debian-snapshot/debian-security/latest)
+        echo "DEBIAN_TIMESTAMP=$DEBIAN_TIMESTAMP, DEBIAN_SECURITY_TIMESTAMP=$DEBIAN_SECURITY_TIMESTAMP"
+        echo "##vso[task.setvariable variable=DEBIAN_TIMESTAMP;isOutput=true]$DEBIAN_TIMESTAMP"
+        echo "##vso[task.setvariable variable=DEBIAN_SECURITY_TIMESTAMP;isOutput=true]$DEBIAN_SECURITY_TIMESTAMP"
+      name: SetVersions
+      displayName: 'Set snapshot versions'
+
+- stage: Build
+  dependsOn: Prepare
+  variables:
+  - name: DEBIAN_TIMESTAMP
+    value: $[ stageDependencies.Prepare.Prepare.outputs['SetVersions.DEBIAN_TIMESTAMP'] ]
+  - name: DEBIAN_SECURITY_TIMESTAMP
+    value: $[ stageDependencies.Prepare.Prepare.outputs['SetVersions.DEBIAN_SECURITY_TIMESTAMP'] ]
+  - name: MIRROR_SNAPSHOT
+    value: 'y'
+  jobs:
+  - job: Build
+    pool: sonicso1ES-amd64
+    timeoutInMinutes: 360
+    steps:
+    - template: cleanup.yml
+    - checkout: self
+      clean: true
+    - script: |
+        set -x
+        sudo setfacl -R -b $(Agent.BuildDirectory)
+      displayName: 'setfacl'
+
+    - script: |
+        echo "DEBIAN_TIMESTAMP=$DEBIAN_TIMESTAMP, DEBIAN_SECURITY_TIMESTAMP=$DEBIAN_SECURITY_TIMESTAMP"
+        if [ "$MIRROR_SNAPSHOT" == y ]; then
+          mkdir -p target/versions/default/
+          echo "debian==$DEBIAN_TIMESTAMP" > target/versions/default/versions-mirror
+          echo "debian-security==$DEBIAN_SECURITY_TIMESTAMP" >> target/versions/default/versions-mirror
+          cat target/versions/default/versions-mirror
+        fi
+      displayName: 'Set snapshot versions'
+
+    - bash: |
+        set -xe
+        git submodule update --init --recursive -- src/ptf src/ptf-py3 src/sonic-sairedis src/sonic-frr/frr src/sonic-swss-common
+        BUILD_OPTIONS="SONIC_BUILD_JOBS=$(nproc) DEFAULT_CONTAINER_REGISTRY=publicmirror.azurecr.io ENABLE_DOCKER_BASE_PULL=y MIRROR_SNAPSHOT=$MIRROR_SNAPSHOT 
+                      SONIC_BUILD_RETRY_COUNT=3 SONIC_BUILD_RETRY_INTERVAL=600 DOCKER_BUILDKIT=0 SONIC_VERSION_CONTROL_COMPONENTS="
+
+        make NOBUSTER=1 NOBULLSEYE=1 $BUILD_OPTIONS configure PLATFORM=vs NOTRIXIE=1 # docker-ptf is built for bookworm, disable trixie currently to save build time. will enable it after migrating to trixie.
+        make -f Makefile.work BLDENV=bookworm $BUILD_OPTIONS target/docker-ptf.gz
+        cp -r target $(Build.ArtifactStagingDirectory)/target
+      displayName: Build docker-ptf.gz
+
+    - publish:  $(Build.ArtifactStagingDirectory)
+      artifact: 'sonic-buildimage.vs'
+      displayName: "Archive docker image ptf"
+    
+    - bash: |
+        set -ex
+        docker load -i $(Build.ArtifactStagingDirectory)/target/docker-ptf.gz
+        docker tag docker-ptf:latest $REGISTRY_SERVER/docker-ptf:lastbuild-$(Build.SourceBranchName)
+        docker images
+      env:
+        REGISTRY_SERVER: ${{ parameters.registry_url }}
+      displayName: 'Load and tag docker-ptf as lastbuild'
+    
+    - task: Docker@2
+      displayName: 'Push docker-ptf:lastbuild to registry'
+      condition: succeeded()
+      inputs:
+        containerRegistry: ${{ parameters.registry_conn }}
+        repository: docker-ptf
+        command: push
+        tags: lastbuild-$(Build.SourceBranchName)
+
+- stage: Test
+  dependsOn: Build
+  condition: and(succeeded(), in(dependencies.Build.result, 'Succeeded'))
+  variables:
+  - group: SONiC-Elastictest
+  - name: BUILD_BRANCH
+    value: $(Build.Build.SourceBranchName)
+  jobs:
+  - job: trivy_scan
+    displayName: "[OPTIONAL] Trivy vulnerability scan (docker-ptf)"
+    pool: sonic-ubuntu-1c
+    continueOnError: true
+    timeoutInMinutes: 60
+    steps:
+    - checkout: self
+      clean: true
+      fetchDepth: 1
+    - download: current
+      artifact: 'sonic-buildimage.vs'
+      displayName: "Download docker-ptf artifact"
+    - script: |
+        set -ex
+        TRIVY_VERSION="0.70.0"
+        curl -fLO https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.deb
+        sudo apt install -y ./trivy_${TRIVY_VERSION}_Linux-64bit.deb
+        trivy --version
+      displayName: "Install Trivy"
+    - script: |
+        set -x
+        trivy image \
+          --input $(Pipeline.Workspace)/sonic-buildimage.vs/target/docker-ptf.gz \
+          --scanners vuln \
+          --severity MEDIUM,HIGH,CRITICAL \
+          --ignore-unfixed \
+          --exit-code 1 \
+          --format table \
+          --no-progress \
+          --timeout 30m \
+          --output $(Build.ArtifactStagingDirectory)/trivy-docker-ptf.txt
+        TRIVY_EXIT=$?
+        echo ""
+        echo "=== Trivy Scan Results (docker-ptf) ==="
+        cat $(Build.ArtifactStagingDirectory)/trivy-docker-ptf.txt
+        exit $TRIVY_EXIT
+      displayName: "Trivy scan docker-ptf"
+    - publish: $(Build.ArtifactStagingDirectory)/trivy-docker-ptf.txt
+      artifact: trivy-scan-results
+      displayName: "Publish Trivy scan results"
+      condition: always()
+      continueOnError: true
+
+  - template: .azure-pipelines/pr_test_template.yml@sonic-mgmt
+    parameters:
+      CHECKOUT_SONIC_MGMT: true
+      PTF_MODIFIED: 'True'
+      PTF_IMAGE_TAG: "lastbuild"
+      INCLUDE_JOBS: "t0_job,t1_job,t2_job,t0_2vlans_job,t0_sonic_job,dpu_job,t1_multi_asic_job"
+      OVERRIDE_PARAMS:
+        REPO_NAME: "sonic-mgmt"
+
+- stage: Publish
+  dependsOn: Test
+  condition: and(not(canceled()), ne(variables['Build.Reason'], 'PullRequest'), in(dependencies.Test.result, 'Succeeded', 'SucceededWithIssues'))
+  jobs:
+  - job: Publish
+    pool: sonicso1ES-amd64
+    timeoutInMinutes: 60
+    steps:
+    - download: current
+      artifact: 'sonic-buildimage.vs'
+      displayName: "Download docker-ptf image"
+
+    - bash: |
+        set -ex
+        docker load -i $(Pipeline.Workspace)/sonic-buildimage.vs/target/docker-ptf.gz
+        docker tag docker-ptf:latest $REGISTRY_SERVER/docker-ptf:$(Build.SourceBranchName)
+        docker images
+      env:
+        REGISTRY_SERVER: ${{ parameters.registry_url }}
+      displayName: 'Load and tag docker-ptf as $(Build.SourceBranchName)'
+
+    - task: Docker@2
+      displayName: 'Push docker-ptf:$(Build.SourceBranchName) to registry'
+      condition: succeeded()
+      inputs:
+        containerRegistry: ${{ parameters.registry_conn }}
+        repository: docker-ptf
+        command: push
+        tags: $(Build.SourceBranchName)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Cherry_pick: https://github.com/sonic-net/sonic-buildimage/pull/27987
Currently, the docker-ptf builds along with vs images and its dependency versions are refreshed only once per week. This causes docker-ptf to continuously trigger vulnerability alerts in the S360 dashboard because its packages become outdated between weekly publication.
This PR adds a dedicated pipeline to build and publish `docker-ptf` **daily** with the latest Debian mirror snapshot versions, ensuring vulnerabilities are patched promptly.
##### Work item tracking
- Microsoft ADO **(number only)**: 38114525

#### How I did it
Added a new Azure DevOps pipeline (`.azure-pipelines/docker-ptf.yml`) with the following stages:
1. Prepare — Fetches the latest Debian and Debian Security mirror snapshot timestamps.
2. Build — Builds `docker-ptf.gz` using the latest snapshot versions on a `sonicso1ES-amd64` pool (bookworm only, trixie disabled for now).
3. Test 
- Runs a Trivy vulnerability scan on the built image
- Run the standard Elastictest PR test
4. Publish — On non-PR builds, tags and pushes the image as `docker-ptf:latest`

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

