### PR TITLE
[docker-ptf]: Upgrade gnmic golang.org/x/* deps to fix security vulne…

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -418,12 +418,16 @@ RUN cd gnxi \
 # Build gnmic from source at a pinned upstream main commit. Picks up the
 # dependency fixes merged after v0.45.0 (grpc 1.79.3, otel-sdk 1.43.0,
 # go-git 5.19.0, prometheus 0.311.3, etc.) that address the CVEs which
-# forced removal in #27059. Temporary until the next tagged gnmic
-# release ships.
+# forced removal in #27059. The golang.org/x/* modules are additionally
+# upgraded to latest to clear current/future golang.org/x/* CVEs (the
+# pinned commit still locks older x/crypto, x/net, etc.). Temporary until
+# the next tagged gnmic release ships.
 RUN GNMIC_REV=653dc5dd4ddcd3bd4197317875a10c1ce8b06653 \
     && git clone https://github.com/openconfig/gnmic.git /tmp/gnmic \
     && cd /tmp/gnmic \
     && git checkout "${GNMIC_REV}" \
+    && go get golang.org/x/crypto@latest golang.org/x/net@latest golang.org/x/text@latest golang.org/x/sys@latest golang.org/x/oauth2@latest \
+    && go mod tidy \
     && go build -o /usr/local/bin/gnmic . \
     && chmod +x /usr/local/bin/gnmic \
     && rm -rf /tmp/gnmic /root/go/pkg/mod /root/.cache/go-build


### PR DESCRIPTION
#### Why I did it
S360 / Trivy container scanning flags the `docker-ptf` image's `gnmic` binary
(`/usr/local/bin/gnmic`) with HIGH `golang.org/x/*` CVEs. The gnmic build was
changed (#27059) to build from a pinned upstream commit (`653dc5dd`), which
locks older modules — `golang.org/x/crypto v0.50.0`, `x/net v0.53.0`,
`x/text v0.36.0`, `x/sys v0.43.0`. Unlike the `grpcurl` build step in the same
Dockerfile, the gnmic step did **not** upgrade these, so the vulnerable
versions ship in the image.

##### Work item tracking
- Microsoft ADO: 38538287

#### How I did it
In `dockers/docker-ptf/Dockerfile.j2`, added
`go get golang.org/x/crypto@latest golang.org/x/net@latest golang.org/x/text@latest golang.org/x/sys@latest golang.org/x/oauth2@latest && go mod tidy`
before `go build` in the gnmic `RUN` block, matching the existing grpcurl step.

#### How to verify it
Build `target/docker-ptf.gz`, load it, and scan:
```
trivy image docker-ptf:latest --scanners vuln --ignore-unfixed
```
`usr/local/bin/gnmic` should report 0 fixable vulns (x/* upgraded to latest).

#### Which release branch to backport (provide reason below if selected)
<!-- check any active release branches that also ship docker-ptf if needed -->

#### Tested branch (Please provide the tested image version)
- docker-ptf built from this branch on latest master

#### Description for the changelog
[docker-ptf]: Upgrade gnmic golang.org/x/* dependencies to address HIGH CVEs