### PR TITLE
[docker-dhcp-relay] Start dhcp6relay unconditionally; apply IPv6 relay config at runtime

### DIFF
--- a/dockers/docker-dhcp-relay/cli-plugin-tests/test_config_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/test_config_dhcp_relay.py
@@ -18,6 +18,15 @@ config_dhcp_relay_del_output = """\
 Removed DHCP relay address [{}] from Vlan1000
 Restarting DHCP relay service...
 """
+# dhcp6relay applies DHCP_RELAY (dhcpv6_servers) changes at runtime, so the IPv6
+# path does not restart the dhcp_relay container: no "Restarting..." line and no
+# systemctl calls.
+config_dhcp_relay_add_output_no_restart = """\
+Added DHCP relay address [{}] to Vlan1000
+"""
+config_dhcp_relay_del_output_no_restart = """\
+Removed DHCP relay address [{}] from Vlan1000
+"""
 expected_dhcp_relay_add_config_db_output = {
     "ipv4": {
         "dhcp_servers": [
@@ -140,6 +149,15 @@ class TestConfigDhcpRelay(object):
         cli = mock.MagicMock()
         dhcp_relay.register(cli)
 
+    def test_restart_dhcp_relay_service_skipped_for_ipv6(self, mock_cfgdb):
+        # dhcp6relay applies DHCP_RELAY changes at runtime, so the IPv6 path must
+        # not restart the dhcp_relay container.
+        db = Db()
+        db.cfgdb = mock_cfgdb
+        with mock.patch("utilities_common.cli.run_command") as mock_run_command:
+            dhcp_relay.restart_dhcp_relay_service(db, dhcp_relay.IPV6)
+            assert mock_run_command.call_count == 0
+
     def test_config_dhcp_relay_add_del_with_nonexist_vlanid_ipv4(self, op):
         runner = CliRunner()
 
@@ -260,10 +278,12 @@ class TestConfigDhcpRelay(object):
             print(result.output)
             assert result.exit_code == 0
             if version != "ipv4_dhcp":
-                assert result.output == config_dhcp_relay_add_output.format(test_ip)
+                expected_add = (config_dhcp_relay_add_output_no_restart if version == "ipv6"
+                                else config_dhcp_relay_add_output)
+                assert result.output == expected_add.format(test_ip)
                 assert db.cfgdb.get_entry(config_db_table, "Vlan1000") \
                     == expected_dhcp_relay_add_config_db_output[version]
-                assert mock_run_command.call_count == 3
+                assert mock_run_command.call_count == (0 if version == "ipv6" else 3)
 
             if version == "ipv4_dhcp" :
                 assert result.output == config_dhcp_relay_update_output.format(test_ip)
@@ -287,10 +307,12 @@ class TestConfigDhcpRelay(object):
             print(result.output)
             assert result.exit_code == 0
             if version != "ipv4_dhcp":
-                assert result.output == config_dhcp_relay_del_output.format(test_ip)
+                expected_del = (config_dhcp_relay_del_output_no_restart if version == "ipv6"
+                                else config_dhcp_relay_del_output)
+                assert result.output == expected_del.format(test_ip)
                 assert db.cfgdb.get_entry(config_db_table, "Vlan1000") \
                     == expected_dhcp_relay_del_config_db_output[version]
-                assert mock_run_command.call_count == 3
+                assert mock_run_command.call_count == (0 if version == "ipv6" else 3)
 
             if version == "ipv4_dhcp" :
                 assert "Removed DHCP relay address [{}] from Vlan1000".format(test_ip) in result.output
@@ -358,10 +380,12 @@ class TestConfigDhcpRelay(object):
             print(result.output)
             assert result.exit_code == 0
             if version != "ipv4_dhcp":
-                assert result.output == config_dhcp_relay_add_output.format(",".join(test_ips))
+                expected_add = (config_dhcp_relay_add_output_no_restart if version == "ipv6"
+                                else config_dhcp_relay_add_output)
+                assert result.output == expected_add.format(",".join(test_ips))
                 assert db.cfgdb.get_entry(config_db_table, "Vlan1000") \
                     == expected_dhcp_relay_add_multi_config_db_output[version]
-                assert mock_run_command.call_count == 3
+                assert mock_run_command.call_count == (0 if version == "ipv6" else 3)
 
             if version == "ipv4_dhcp" :
                 assert result.output == config_dhcp_relay_update_output.format(",".join(test_ips))
@@ -385,8 +409,10 @@ class TestConfigDhcpRelay(object):
             print(result.output)
             assert result.exit_code == 0
             if version != "ipv4_dhcp":
-                assert result.output == config_dhcp_relay_del_output.format(",".join(test_ips))
-                assert mock_run_command.call_count == 3
+                expected_del = (config_dhcp_relay_del_output_no_restart if version == "ipv6"
+                                else config_dhcp_relay_del_output)
+                assert result.output == expected_del.format(",".join(test_ips))
+                assert mock_run_command.call_count == (0 if version == "ipv6" else 3)
                 assert db.cfgdb.get_entry(config_db_table, "Vlan1000") \
                     == expected_dhcp_relay_del_config_db_output[version]
             if ip_version == "ipv4_dhcp":
@@ -446,7 +472,7 @@ class TestConfigDhcpRelay(object):
             print(result.output)
             assert result.exit_code == 0
             assert db.cfgdb.get_entry(table, "Vlan1000") == {"dhcpv6_servers": [test_ip]}
-            assert mock_run_command.call_count == 3
+            assert mock_run_command.call_count == 0
 
     def test_add_dhcpv4_relay_compatibility_check(self, mock_cfgdb):
         ip_version = "ipv4_dhcp"

--- a/dockers/docker-dhcp-relay/cli-plugin-tests/test_config_vlan_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/test_config_vlan_dhcp_relay.py
@@ -17,14 +17,15 @@ Added DHCP relay destination addresses ['192.0.0.100'] to Vlan1000
 Restarting DHCP relay service...
 """
 
+# dhcp6relay applies DHCP_RELAY (dhcpv6_servers) changes at runtime, so the IPv6
+# path does not restart the dhcp_relay container: no "Restarting..." line and no
+# systemctl calls.
 config_vlan_add_dhcpv6_relay_output="""\
 Added DHCP relay destination addresses ['fc02:2000::1'] to Vlan1000
-Restarting DHCP relay service...
 """
 
 config_vlan_add_multiple_dhcpv6_relay_output="""\
 Added DHCP relay destination addresses ['fc02:2000::1', 'fc02:2000::2', 'fc02:2000::3'] to Vlan1000
-Restarting DHCP relay service...
 """
 
 config_vlan_del_dhcp_relay_output="""\
@@ -34,12 +35,10 @@ Restarting DHCP relay service...
 
 config_vlan_del_dhcpv6_relay_output="""\
 Removed DHCP relay destination addresses ('fc02:2000::1',) from Vlan1000
-Restarting DHCP relay service...
 """
 
 config_vlan_del_multiple_dhcpv6_relay_output="""\
 Removed DHCP relay destination addresses ('fc02:2000::1', 'fc02:2000::2', 'fc02:2000::3') from Vlan1000
-Restarting DHCP relay service...
 """
 
 @pytest.fixture(scope="module", params=["isc", "new"])
@@ -199,7 +198,7 @@ class TestConfigVlanDhcpRelay(object):
             print(result.output)
             assert result.exit_code == 0
             assert result.output == config_vlan_add_dhcpv6_relay_output
-            assert mock_run_command.call_count == 3
+            assert mock_run_command.call_count == 0
             db.cfgdb.set_entry.assert_called_once_with('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1'], 'dhcpv6_servers': ['fc02:2000::1']})
 
         db.cfgdb.set_entry.reset_mock()
@@ -212,7 +211,7 @@ class TestConfigVlanDhcpRelay(object):
             print(result.output)
             assert result.exit_code == 0
             assert result.output == config_vlan_del_dhcpv6_relay_output
-            assert mock_run_command.call_count == 3
+            assert mock_run_command.call_count == 0
             db.cfgdb.set_entry.assert_called_once_with('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1']})
 
     def test_config_vlan_add_del_multiple_dhcpv6_relay_dest(self, mock_cfgdb):
@@ -228,7 +227,7 @@ class TestConfigVlanDhcpRelay(object):
             print(result.output)
             assert result.exit_code == 0
             assert result.output == config_vlan_add_multiple_dhcpv6_relay_output
-            assert mock_run_command.call_count == 3
+            assert mock_run_command.call_count == 0
             db.cfgdb.set_entry.assert_called_once_with('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1'], 'dhcpv6_servers': ['fc02:2000::1', 'fc02:2000::2', 'fc02:2000::3']})
 
         db.cfgdb.set_entry.reset_mock()
@@ -241,7 +240,7 @@ class TestConfigVlanDhcpRelay(object):
             print(result.output)
             assert result.exit_code == 0
             assert result.output == config_vlan_del_multiple_dhcpv6_relay_output
-            assert mock_run_command.call_count == 3
+            assert mock_run_command.call_count == 0
             db.cfgdb.set_entry.assert_called_once_with('VLAN', 'Vlan1000', {'dhcp_servers': ['192.0.0.1']})
 
     def test_config_vlan_remove_nonexist_dhcp_relay_dest(self, mock_cfgdb):

--- a/dockers/docker-dhcp-relay/cli/config/plugins/dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli/config/plugins/dhcp_relay.py
@@ -52,6 +52,10 @@ def restart_dhcp_relay_service(db, ip_version):
     """
     Restart dhcp_relay service
     """
+    if ip_version == IPV6:
+        # dhcp6relay applies DHCP_RELAY (dhcpv6_servers) changes at runtime,
+        # so no dhcp_relay container restart is required.
+        return
     if(ip_version == IPV4 and check_sonic_dhcpv4_relay_flag(db)):
         # if 'has_sonic_dhcpv4_relay' flag is present in DEVICE_METADATA['localhost'] and is 'true'
         return

--- a/dockers/docker-dhcp-relay/dhcp-relay.programs.j2
+++ b/dockers/docker-dhcp-relay/dhcp-relay.programs.j2
@@ -1,37 +1,7 @@
 [group:dhcp-relay]
-programs=dhcprelayd
-{%- if 'has_sonic_dhcpv4_relay' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] == 'True' %}
-{%- set relay_for_ipv6 = { 'flag': False } %}
-{%- set add_preceding_comma = { 'flag': True } %}
-{% for vlan_name in VLAN_INTERFACE %}
-{% if DHCP_RELAY and vlan_name in DHCP_RELAY and DHCP_RELAY[vlan_name]['dhcpv6_servers']|length > 0 %}
-{% set _dummy = relay_for_ipv6.update({'flag': True})  %}
-{%- endif %}
-{% endfor %}
-{# Append DHCPv6 agents #}
-{% if relay_for_ipv6.flag %}
-{% if add_preceding_comma.flag %},{% endif %}
-{% set _dummy = add_preceding_comma.update({'flag': True}) %}
-dhcp6relay
-{%- endif %}
-{# Create a program entry for sonic dhcpv4 relay agent #}
-{%- set add_preceding_comma = { 'flag': True } %}
-{# Append sonic DHCPv4 agent #}
-{% if add_preceding_comma.flag %},{% endif %}
-{% set _dummy = add_preceding_comma.update({'flag': True}) %}
-dhcp4relay
-{% else %}
-{%- set relay_for_ipv6 = { 'flag': False } %}
-{%- set add_preceding_comma = { 'flag': True } %}
-{% for vlan_name in VLAN_INTERFACE %}
-{% if DHCP_RELAY and vlan_name in DHCP_RELAY and DHCP_RELAY[vlan_name]['dhcpv6_servers']|length > 0 %}
-{% set _dummy = relay_for_ipv6.update({'flag': True})  %}
-{%- endif %}
-{% endfor %}
-{# Append DHCPv6 agents #}
-{% if relay_for_ipv6.flag %}
-{% if add_preceding_comma.flag %},{% endif %}
-{% set _dummy = add_preceding_comma.update({'flag': True}) %}
-dhcp6relay
-{% endif %}
+{# The DHCPv6 relay agent is always started so DHCPv6 relay configuration added at runtime is applied without a container restart #}
+{% if 'has_sonic_dhcpv4_relay' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] == 'True' -%}
+programs=dhcprelayd,dhcp6relay,dhcp4relay
+{% else -%}
+programs=dhcprelayd,dhcp6relay
 {% endif %}

--- a/dockers/docker-dhcp-relay/dhcpv6-relay.agents.j2
+++ b/dockers/docker-dhcp-relay/dhcpv6-relay.agents.j2
@@ -1,15 +1,6 @@
-{# Append DHCPv6 agents #}
-{% for vlan_name in VLAN_INTERFACE %}
-{% if DHCP_RELAY and vlan_name in DHCP_RELAY and DHCP_RELAY[vlan_name]['dhcpv6_servers']|length > 0 %}
-{% for dhcpv6_server in DHCP_RELAY[vlan_name]['dhcpv6_servers'] %}
-{% if dhcpv6_server | ipv6 %}
-{% set _dummy = relay_for_ipv6.update({'flag': True}) %}
-{% endif %}
-{% endfor %}
-{% endif %}
-{% endfor %}
-{% if relay_for_ipv6.flag %}
-{% set _dummy = relay_for_ipv6.update({'flag': False}) %}
+{# Append the DHCPv6 agent. It is always started so DHCPv6 relay configuration
+   added at runtime is applied by its config monitor without restarting the
+   dhcp_relay container. #}
 [program:dhcp6relay]
 command=/usr/sbin/dhcp6relay
 {#- Dual ToR Option #}
@@ -25,4 +16,4 @@ stderr_syslog=true
 dependent_startup=true
 dependent_startup_wait_for=start:exited
 
-{% endif %}
+

--- a/dockers/docker-dhcp-relay/wait_for_intf.sh.j2
+++ b/dockers/docker-dhcp-relay/wait_for_intf.sh.j2
@@ -1,5 +1,27 @@
 #!/usr/bin/env bash
 
+# Maximum time (in seconds) to wait for a single interface to become ready in
+# STATE_DB before proceeding with relay startup. A value of 0 means "wait
+# indefinitely" (the historical behavior).
+#
+# The bound is applied only when has_sonic_dhcpv4_relay == 'True'. In that mode
+# the relay agents reconcile a late-ready interface at runtime (dhcp4relay and
+# dhcp6relay both watch STATE_DB INTERFACE_TABLE; dhcp6relay also re-checks the
+# link-local address periodically), so an interface that becomes ready after the
+# timeout is still picked up without a restart, and one never-ready interface
+# must not block the whole container. The default (300s) covers normal startup
+# convergence.
+#
+# Otherwise (legacy ISC dhcrelay) the default stays 0 (wait forever): that agent
+# binds its interfaces at process start and does not reconcile readiness at
+# runtime, so shortening the wait could make it permanently miss an interface.
+# Operators can still opt into a bound by exporting WAIT_IFACE_READY_TIMEOUT.
+{% if 'has_sonic_dhcpv4_relay' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] == 'True' %}
+WAIT_IFACE_READY_TIMEOUT="${WAIT_IFACE_READY_TIMEOUT:-300}"
+{% else %}
+WAIT_IFACE_READY_TIMEOUT="${WAIT_IFACE_READY_TIMEOUT:-0}"
+{% endif %}
+
 function wait_until_iface_ready
 {
     IFACE_NAME=$1
@@ -8,17 +30,26 @@ function wait_until_iface_ready
     echo "Waiting until interface ${IFACE_NAME} is ready..."
 
     # Wait for the interface to come up
-    # (i.e., interface is present in STATE_DB and state is "ok")
+    # (i.e., interface is present in STATE_DB and state is "ok"). When
+    # WAIT_IFACE_READY_TIMEOUT > 0 the wait is bounded so a never-ready
+    # interface cannot hang startup forever; when it is 0 we wait indefinitely
+    # (legacy ISC dhcrelay behavior).
+    local waited=0
     while true; do
         RESULT=$(sonic-db-cli STATE_DB HGET "INTERFACE_TABLE|${IFACE_NAME}|${IFACE_CIDR}" "state" 2> /dev/null)
         if [ x"$RESULT" == x"ok" ]; then
-            break
+            echo "Interface ${IFACE_NAME} is ready!"
+            return 0
+        fi
+
+        if [ "${WAIT_IFACE_READY_TIMEOUT}" -gt 0 ] && [ "${waited}" -ge "${WAIT_IFACE_READY_TIMEOUT}" ]; then
+            echo "WARNING: interface ${IFACE_NAME} (${IFACE_CIDR}) not ready after ${WAIT_IFACE_READY_TIMEOUT}s; proceeding without it (relay agents reconcile it at runtime)"
+            return 0
         fi
 
         sleep 1
+        waited=$((waited + 1))
     done
-
-    echo "Interface ${IFACE_NAME} is ready!"
 }
 
 # Wait for all interfaces with IPv4 addresses to be up and ready

--- a/dockers/docker-dhcp-relay/wait_for_intf.sh.j2
+++ b/dockers/docker-dhcp-relay/wait_for_intf.sh.j2
@@ -2,38 +2,46 @@
 
 # Maximum time (in seconds) to wait for a single interface to become ready in
 # STATE_DB before proceeding with relay startup. A value of 0 means "wait
-# indefinitely" (the historical behavior).
+# indefinitely" (the historical behavior). Two bounds are used, one per agent:
 #
-# The bound is applied only when has_sonic_dhcpv4_relay == 'True'. In that mode
-# the relay agents reconcile a late-ready interface at runtime (dhcp4relay and
-# dhcp6relay both watch STATE_DB INTERFACE_TABLE; dhcp6relay also re-checks the
-# link-local address periodically), so an interface that becomes ready after the
-# timeout is still picked up without a restart, and one never-ready interface
-# must not block the whole container. The default (300s) covers normal startup
-# convergence.
+# WAIT_IFACE_READY_TIMEOUT governs the IPv4 interface waits (INTERFACE, VLAN and
+# PortChannel v4 addresses). It is bounded (300s) only when has_sonic_dhcpv4_relay
+# == 'True': the sonic dhcp4relay watches STATE_DB INTERFACE_TABLE and reconciles
+# a late-ready interface at runtime, so proceeding without one and picking it up
+# later is safe. For the legacy ISC dhcrelay it stays 0 (wait forever): that agent
+# binds its interfaces once at process start and never reconciles, so shortening
+# the wait could make it permanently miss an interface.
 #
-# Otherwise (legacy ISC dhcrelay) the default stays 0 (wait forever): that agent
-# binds its interfaces at process start and does not reconcile readiness at
-# runtime, so shortening the wait could make it permanently miss an interface.
-# Operators can still opt into a bound by exporting WAIT_IFACE_READY_TIMEOUT.
+# WAIT_IFACE_READY_TIMEOUT_V6 governs the IPv6 VLAN-interface waits, which are for
+# dhcp6relay. dhcp6relay is always the native v6 agent and always reconciles at
+# runtime (STATE_DB INTERFACE_TABLE + periodic link-local check), so these are
+# always bounded (300s) regardless of the v4 relay type -- a never-ready v6 VLAN
+# interface must not block container startup. Operators can override either bound
+# by exporting the corresponding variable.
 {% if 'has_sonic_dhcpv4_relay' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] == 'True' %}
 WAIT_IFACE_READY_TIMEOUT="${WAIT_IFACE_READY_TIMEOUT:-300}"
 {% else %}
 WAIT_IFACE_READY_TIMEOUT="${WAIT_IFACE_READY_TIMEOUT:-0}"
 {% endif %}
+# dhcp6relay always reconciles late-ready interfaces at runtime, so the v6
+# VLAN-interface waits below are always bounded, independent of the v4 relay type.
+WAIT_IFACE_READY_TIMEOUT_V6="${WAIT_IFACE_READY_TIMEOUT_V6:-300}"
 
 function wait_until_iface_ready
 {
     IFACE_NAME=$1
     IFACE_CIDR=$2
+    # Optional per-call timeout; defaults to WAIT_IFACE_READY_TIMEOUT (the v4/ISC
+    # bound). The IPv6 VLAN waits pass WAIT_IFACE_READY_TIMEOUT_V6 instead.
+    local timeout="${3:-${WAIT_IFACE_READY_TIMEOUT}}"
 
     echo "Waiting until interface ${IFACE_NAME} is ready..."
 
     # Wait for the interface to come up
     # (i.e., interface is present in STATE_DB and state is "ok"). When
-    # WAIT_IFACE_READY_TIMEOUT > 0 the wait is bounded so a never-ready
-    # interface cannot hang startup forever; when it is 0 we wait indefinitely
-    # (legacy ISC dhcrelay behavior).
+    # timeout > 0 the wait is bounded so a never-ready interface cannot hang
+    # startup forever; when it is 0 we wait indefinitely (legacy ISC dhcrelay
+    # behavior).
     local waited=0
     while true; do
         RESULT=$(sonic-db-cli STATE_DB HGET "INTERFACE_TABLE|${IFACE_NAME}|${IFACE_CIDR}" "state" 2> /dev/null)
@@ -42,8 +50,8 @@ function wait_until_iface_ready
             return 0
         fi
 
-        if [ "${WAIT_IFACE_READY_TIMEOUT}" -gt 0 ] && [ "${waited}" -ge "${WAIT_IFACE_READY_TIMEOUT}" ]; then
-            echo "WARNING: interface ${IFACE_NAME} (${IFACE_CIDR}) not ready after ${WAIT_IFACE_READY_TIMEOUT}s; proceeding without it (relay agents reconcile it at runtime)"
+        if [ "${timeout}" -gt 0 ] && [ "${waited}" -ge "${timeout}" ]; then
+            echo "WARNING: interface ${IFACE_NAME} (${IFACE_CIDR}) not ready after ${timeout}s; proceeding without it (relay agents reconcile it at runtime)"
             return 0
         fi
 
@@ -66,7 +74,7 @@ wait_until_iface_ready {{ name }} {{ prefix }}
 {% endif %}
 {% if prefix | ipv6 %}
 {% if DHCP_RELAY and name in DHCP_RELAY %}
-wait_until_iface_ready {{ name }} {{ prefix }}
+wait_until_iface_ready {{ name }} {{ prefix }} "${WAIT_IFACE_READY_TIMEOUT_V6}"
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/src/sonic-config-engine/tests/dhcp-relay-dualtor-sample.json
+++ b/src/sonic-config-engine/tests/dhcp-relay-dualtor-sample.json
@@ -1,0 +1,7 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "subtype": "DualToR"
+        }
+    }
+}

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-sonic-agent-no-relay-cfg.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-sonic-agent-no-relay-cfg.supervisord.conf
@@ -44,10 +44,22 @@ dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 
 [group:dhcp-relay]
-programs=dhcprelayd,dhcp4relay
+programs=dhcprelayd,dhcp6relay,dhcp4relay
 
 [program:dhcp4relay]
 command=/usr/sbin/dhcp4relay
+priority=3
+autostart=false
+autorestart=false
+stdout_logfile=NONE
+stdout_syslog=true
+stderr_logfile=NONE
+stderr_syslog=true
+dependent_startup=true
+dependent_startup_wait_for=start:exited
+
+[program:dhcp6relay]
+command=/usr/sbin/dhcp6relay
 priority=3
 autostart=false
 autorestart=false

--- a/src/sonic-config-engine/tests/sample_output/py3/wait_for_intf.sh
+++ b/src/sonic-config-engine/tests/sample_output/py3/wait_for_intf.sh
@@ -1,5 +1,23 @@
 #!/usr/bin/env bash
 
+# Maximum time (in seconds) to wait for a single interface to become ready in
+# STATE_DB before proceeding with relay startup. A value of 0 means "wait
+# indefinitely" (the historical behavior).
+#
+# The bound is applied only when has_sonic_dhcpv4_relay == 'True'. In that mode
+# the relay agents reconcile a late-ready interface at runtime (dhcp4relay and
+# dhcp6relay both watch STATE_DB INTERFACE_TABLE; dhcp6relay also re-checks the
+# link-local address periodically), so an interface that becomes ready after the
+# timeout is still picked up without a restart, and one never-ready interface
+# must not block the whole container. The default (300s) covers normal startup
+# convergence.
+#
+# Otherwise (legacy ISC dhcrelay) the default stays 0 (wait forever): that agent
+# binds its interfaces at process start and does not reconcile readiness at
+# runtime, so shortening the wait could make it permanently miss an interface.
+# Operators can still opt into a bound by exporting WAIT_IFACE_READY_TIMEOUT.
+WAIT_IFACE_READY_TIMEOUT="${WAIT_IFACE_READY_TIMEOUT:-0}"
+
 function wait_until_iface_ready
 {
     IFACE_NAME=$1
@@ -8,17 +26,26 @@ function wait_until_iface_ready
     echo "Waiting until interface ${IFACE_NAME} is ready..."
 
     # Wait for the interface to come up
-    # (i.e., interface is present in STATE_DB and state is "ok")
+    # (i.e., interface is present in STATE_DB and state is "ok"). When
+    # WAIT_IFACE_READY_TIMEOUT > 0 the wait is bounded so a never-ready
+    # interface cannot hang startup forever; when it is 0 we wait indefinitely
+    # (legacy ISC dhcrelay behavior).
+    local waited=0
     while true; do
         RESULT=$(sonic-db-cli STATE_DB HGET "INTERFACE_TABLE|${IFACE_NAME}|${IFACE_CIDR}" "state" 2> /dev/null)
         if [ x"$RESULT" == x"ok" ]; then
-            break
+            echo "Interface ${IFACE_NAME} is ready!"
+            return 0
+        fi
+
+        if [ "${WAIT_IFACE_READY_TIMEOUT}" -gt 0 ] && [ "${waited}" -ge "${WAIT_IFACE_READY_TIMEOUT}" ]; then
+            echo "WARNING: interface ${IFACE_NAME} (${IFACE_CIDR}) not ready after ${WAIT_IFACE_READY_TIMEOUT}s; proceeding without it (relay agents reconcile it at runtime)"
+            return 0
         fi
 
         sleep 1
+        waited=$((waited + 1))
     done
-
-    echo "Interface ${IFACE_NAME} is ready!"
 }
 
 # Wait for all interfaces with IPv4 addresses to be up and ready

--- a/src/sonic-config-engine/tests/sample_output/py3/wait_for_intf_v4_relay.sh
+++ b/src/sonic-config-engine/tests/sample_output/py3/wait_for_intf_v4_relay.sh
@@ -18,7 +18,7 @@
 # always bounded (300s) regardless of the v4 relay type -- a never-ready v6 VLAN
 # interface must not block container startup. Operators can override either bound
 # by exporting the corresponding variable.
-WAIT_IFACE_READY_TIMEOUT="${WAIT_IFACE_READY_TIMEOUT:-0}"
+WAIT_IFACE_READY_TIMEOUT="${WAIT_IFACE_READY_TIMEOUT:-300}"
 # dhcp6relay always reconciles late-ready interfaces at runtime, so the v6
 # VLAN-interface waits below are always bounded, independent of the v4 relay type.
 WAIT_IFACE_READY_TIMEOUT_V6="${WAIT_IFACE_READY_TIMEOUT_V6:-300}"

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -186,6 +186,15 @@ class TestJ2Files(TestCase):
         self.run_script(argument, output_file=self.output_file)
         self.assertTrue(utils.cmp(os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR, 'wait_for_intf.sh'), self.output_file))
 
+        # Test generation of wait_for_intf.sh when has_sonic_dhcpv4_relay is True.
+        # This exercises the has_sonic_dhcpv4_relay == 'True' branch: the IPv4 waits
+        # become bounded (WAIT_IFACE_READY_TIMEOUT=300), while the IPv6 VLAN waits
+        # stay bounded via WAIT_IFACE_READY_TIMEOUT_V6 (dhcp6relay always reconciles).
+        v4relay_sample_data = os.path.join(self.test_dir, "dhcp-sonic-relay-enabled-sample.json")
+        argument = ['-m', self.t0_minigraph, '-j', v4relay_sample_data, '-p', self.t0_port_config, '-t', template_path]
+        self.run_script(argument, output_file=self.output_file)
+        self.assertTrue(utils.cmp(os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR, 'wait_for_intf_v4_relay.sh'), self.output_file))
+
         template_path = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-dhcp-relay', 'docker-dhcp-relay.supervisord.conf.j2')
         argument = ['-m', self.t0_minigraph_common_dhcp_relay, '-p', self.t0_port_config, '-t', template_path]
         self.run_script(argument, output_file=self.output_file)

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -234,6 +234,25 @@ class TestJ2Files(TestCase):
         self.assertTrue(utils.cmp(os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR,
                                   'docker-dhcp-relay.supervisord.conf'), self.output_file))
 
+        # Test that the DualToR option (-u Loopback0) is rendered for the dhcp6relay agent only when
+        # DEVICE_METADATA.localhost.subtype is 'DualToR'. This is asserted on the rendered content
+        # directly (not only through a golden file) so the template-to-command-line contract is pinned
+        # independently of golden regeneration: the dhcp6relay binary treats '-u' as "enable Dual-ToR
+        # mode", so an unconditional '-u' would silently turn every device into Dual-ToR.
+        template_path = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-dhcp-relay',
+                                     'docker-dhcp-relay.supervisord.conf.j2')
+        # Non-DualToR (no subtype): dhcp6relay must start without '-u Loopback0'.
+        argument = ['-m', self.t0_minigraph_common_dhcp_relay, '-p', self.t0_port_config, '-t', template_path]
+        output = self.run_script(argument)
+        self.assertIn('command=/usr/sbin/dhcp6relay\n', output)
+        self.assertNotIn('dhcp6relay -u Loopback0', output)
+        # DualToR (subtype=DualToR): dhcp6relay must start with '-u Loopback0'.
+        dualtor_sample_data = os.path.join(self.test_dir, "dhcp-relay-dualtor-sample.json")
+        argument = ['-m', self.t0_minigraph_common_dhcp_relay, '-j', dualtor_sample_data,
+                    '-p', self.t0_port_config, '-t', template_path]
+        output = self.run_script(argument)
+        self.assertIn('command=/usr/sbin/dhcp6relay -u Loopback0', output)
+
     def test_radv(self):
         # Test generation of radvd.conf with multiple ipv6 prefixes
         template_path = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-router-advertiser', 'radvd.conf.j2')


### PR DESCRIPTION
Fixes #28048

#### Why I did it
With the SONiC-native `dhcp6relay` applying `DHCP_RELAY` changes at runtime (sonic-net/sonic-dhcp-relay#116), the agent no longer needs to be gated on the presence of `dhcpv6_servers` at render time, and the `dhcp_relay` container no longer needs to be restarted for an IPv6 relay configuration change.

#### How I did it
- `dhcpv6-relay.agents.j2` / `dhcp-relay.programs.j2`: start `dhcp6relay` unconditionally. The dual ToR `-u Loopback0` option is unchanged from upstream — it is still passed only when `DEVICE_METADATA` `subtype` is `DualToR`.
- `cli/config/plugins/dhcp_relay.py`: skip the `dhcp_relay` container restart on the IPv6 path, since `dhcp6relay` reconciles `DHCP_RELAY` at runtime.
- `wait_for_intf.sh.j2`: bound the per-interface readiness waits so a never-ready interface cannot block startup. The IPv4 waits (`WAIT_IFACE_READY_TIMEOUT`) are bounded (300s) only when `has_sonic_dhcpv4_relay` is set; legacy ISC dhcrelay keeps the wait-forever default. The IPv6 VLAN waits (`WAIT_IFACE_READY_TIMEOUT_V6`) are always bounded (300s) since `dhcp6relay` reconciles at runtime, independent of the v4 relay type.
- Regenerated the docker-dhcp-relay supervisord / wait_for_intf goldens (incl. a new `wait_for_intf_v4_relay.sh` golden for the `has_sonic_dhcpv4_relay=True` branch) and made the cli-plugin tests version-aware. Added `test_j2files` cases asserting the `has_sonic_dhcpv4_relay=True` wait rendering and that `-u Loopback0` renders only for `subtype == DualToR`.

#### How to verify it
- `src/sonic-config-engine`: `test_j2files.py::TestJ2Files::test_dhcp_relay` passes (goldens + the `has_sonic_dhcpv4_relay=True` and Dual-ToR render assertions).
- docker-dhcp-relay cli-plugin tests: 36 passed.

> **Dependency:** pairs with sonic-net/sonic-dhcp-relay#116 — the unconditional start relies on the runtime-reconfig + warning-throttle behavior in that PR. The `src/dhcprelay` submodule should be bumped to that change before this merges.

Companion PRs: sonic-net/sonic-dhcp-relay#116 (core) · sonic-net/sonic-mgmt sonic-net/sonic-mgmt#25589 (tests) · sonic-net/SONiC sonic-net/SONiC#2402 (HLD)


