### PR TITLE
[sonic-frr]: suppress full BGP route re-download when tcpdump toggles interface promiscuity

### DIFF
--- a/src/sonic-frr/patch/0115-zebra-Update-promiscuity-flag-silently-without-route.patch
+++ b/src/sonic-frr/patch/0115-zebra-Update-promiscuity-flag-silently-without-route.patch
@@ -1,0 +1,153 @@
+From 7057094a332dbf76dbb45ab7363705dd8a40f02f Mon Sep 17 00:00:00 2001
+From: Rajasekar Raja <rajasekarr@nvidia.com>
+Date: Tue, 23 Jun 2026 05:31:29 +0000
+Subject: [PATCH] zebra: Update promiscuity flag silently without route resets
+
+When promiscuity changes on an interface, the flag was not being
+updated in FRR's internal state, causing "show interface" to display
+incorrect PROMISC status even after the kernel state changed.
+
+This also ensures promiscuity changes don't trigger unnecessary route
+resets on tunnel/uplink interfaces. In SONiC this manifests as a full
+BGP route re-download whenever tcpdump (or any AF_PACKET socket) toggles
+IFF_PROMISC on a BGP-enabled port/PortChannel (sonic-net/sonic-buildimage#28026).
+
+Backport of upstream FRR commit 257edcc948e0179c75933cdb862fe1ac4ac14085
+(FRRouting/frr PR #20181) onto frr-10.5.4. The upstream frrtrace()
+if_dplane_ifp_handling_new tracepoint does not exist on 10.5.4 and is
+omitted; the routing-notification suppression logic is unchanged.
+
+Signed-off-by: Vijayalaxmi Basavaraj <vbasavaraj@nvidia.com>
+Signed-off-by: Rajasekar Raja <rajasekarr@nvidia.com>
+Signed-off-by: Deepak Singhal <deepsinghal@microsoft.com>
+---
+ zebra/if_netlink.c   |  1 +
+ zebra/interface.c    | 24 +++++++++++++++++++++---
+ zebra/zebra_dplane.c | 15 +++++++++++++++
+ zebra/zebra_dplane.h |  2 ++
+ 4 files changed, 39 insertions(+), 3 deletions(-)
+
+diff --git a/zebra/if_netlink.c b/zebra/if_netlink.c
+index 930aa964a2..318657a65b 100644
+--- a/zebra/if_netlink.c
++++ b/zebra/if_netlink.c
+@@ -1436,6 +1436,7 @@ int netlink_link_change(struct nlmsghdr *h, ns_id_t ns_id, int startup)
+ 			dplane_ctx_set_ifp_vrf_id(ctx, ns_id);
+ 
+ 		dplane_ctx_set_ifp_flags(ctx, ifi->ifi_flags & 0x0000fffff);
++		dplane_ctx_set_ifp_change_flags(ctx, ifi->ifi_change & 0x0000fffff);
+ 
+ 		if (tb[IFLA_PROTO_DOWN]) {
+ 			dplane_ctx_set_ifp_protodown_set(ctx, true);
+diff --git a/zebra/interface.c b/zebra/interface.c
+index 5567769d34..68a119cf28 100644
+--- a/zebra/interface.c
++++ b/zebra/interface.c
+@@ -1930,6 +1930,7 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
+ 		uint8_t old_hw_addr[INTERFACE_HWADDR_MAX];
+ 		char *desc;
+ 		uint8_t family;
++		uint64_t change_flags;
+ 
+ 		/* If VRF, create or update the VRF structure itself. */
+ 		if (zif_type == ZEBRA_IF_VRF && !vrf_is_backend_netns())
+@@ -1951,6 +1952,7 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
+ 		startup = dplane_ctx_get_ifp_startup(ctx);
+ 		desc = dplane_ctx_get_ifp_desc(ctx);
+ 		family = dplane_ctx_get_ifp_family(ctx);
++		change_flags = dplane_ctx_get_ifp_change_flags(ctx);
+ 
+ #ifndef AF_BRIDGE
+ 		/*
+@@ -2058,6 +2060,25 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
+ 					   name, ifp->ifindex, zif_slave_type, master_ifindex,
+ 					   (unsigned long long)flags);
+ 
++			/* Update flags - all paths need this */
++			ifp->flags = flags;
++
++			/*
++			 * A promiscuity-only flag change (e.g. tcpdump or any
++			 * AF_PACKET socket opening on the interface) must not be
++			 * treated as an operational-state change: that emits a
++			 * spurious interface-up and triggers a full route
++			 * re-evaluation/re-download. Skip routing notifications;
++			 * the flags were already updated above.
++			 */
++			if (change_flags == IFF_PROMISC) {
++				/* Flags already updated above, skip routing notifications */
++				if (IS_ZEBRA_DEBUG_KERNEL)
++					zlog_debug("%s: PROMISC-only update for %s(%u), no routing notification",
++						   __func__, name, ifp->ifindex);
++				return;
++			}
++
+ 			set_ifindex(ifp, ifindex, zns);
+ 			if_update_state_mtu(ifp, mtu);
+ 			if_update_state_mtu6(ifp, mtu);
+@@ -2085,8 +2106,6 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
+ 						       rc_bitfield);
+ 
+ 			if (if_is_no_ptm_operative(ifp)) {
+-
+-				ifp->flags = flags;
+ 				bool is_up = if_is_operative(ifp);
+ 
+ 				if (!if_is_no_ptm_operative(ifp) ||
+@@ -2138,7 +2157,6 @@ static void zebra_if_dplane_ifp_handling(struct zebra_dplane_ctx *ctx)
+ 					}
+ 				}
+ 			} else {
+-				ifp->flags = flags;
+ 				if (if_is_operative(ifp) &&
+ 				    !CHECK_FLAG(zif->flags,
+ 						ZIF_FLAG_PROTODOWN)) {
+diff --git a/zebra/zebra_dplane.c b/zebra/zebra_dplane.c
+index fcef52d2f3..17adb665c5 100644
+--- a/zebra/zebra_dplane.c
++++ b/zebra/zebra_dplane.c
+@@ -237,6 +237,7 @@ struct dplane_intf_info {
+ 
+ 	uint32_t metric;
+ 	uint32_t flags;
++	uint32_t change_flags;
+ 
+ 	bool protodown;
+ 	bool protodown_set;
+@@ -1495,6 +1496,20 @@ uint64_t dplane_ctx_get_ifp_flags(const struct zebra_dplane_ctx *ctx)
+ 	return ctx->u.intf.flags;
+ }
+ 
++void dplane_ctx_set_ifp_change_flags(struct zebra_dplane_ctx *ctx, uint64_t change_flags)
++{
++	DPLANE_CTX_VALID(ctx);
++
++	ctx->u.intf.change_flags = change_flags;
++}
++
++uint64_t dplane_ctx_get_ifp_change_flags(const struct zebra_dplane_ctx *ctx)
++{
++	DPLANE_CTX_VALID(ctx);
++
++	return ctx->u.intf.change_flags;
++}
++
+ void dplane_ctx_set_ifp_bypass(struct zebra_dplane_ctx *ctx, uint8_t bypass)
+ {
+ 	DPLANE_CTX_VALID(ctx);
+diff --git a/zebra/zebra_dplane.h b/zebra/zebra_dplane.h
+index 8c635d2b87..fc61b31043 100644
+--- a/zebra/zebra_dplane.h
++++ b/zebra/zebra_dplane.h
+@@ -429,6 +429,8 @@ void dplane_ctx_set_ifp_bypass(struct zebra_dplane_ctx *ctx, uint8_t bypass);
+ uint8_t dplane_ctx_get_ifp_bypass(const struct zebra_dplane_ctx *ctx);
+ void dplane_ctx_set_ifp_flags(struct zebra_dplane_ctx *ctx, uint64_t flags);
+ uint64_t dplane_ctx_get_ifp_flags(const struct zebra_dplane_ctx *ctx);
++void dplane_ctx_set_ifp_change_flags(struct zebra_dplane_ctx *ctx, uint64_t change_flags);
++uint64_t dplane_ctx_get_ifp_change_flags(const struct zebra_dplane_ctx *ctx);
+ void dplane_ctx_set_ifp_protodown(struct zebra_dplane_ctx *ctx, bool protodown);
+ bool dplane_ctx_get_ifp_protodown(const struct zebra_dplane_ctx *ctx);
+ void dplane_ctx_set_ifp_startup(struct zebra_dplane_ctx *ctx, bool startup);
+-- 
+2.34.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -83,3 +83,4 @@
 0112-SONiC-ONLY-lib-build-add-configure-check-for-tc_mallinfo2-and-fallback.patch
 0113-zebra-Refactor-SRv6-netlink-code-to-remove-duplication.patch
 0114-Provide-interface-when-installing-uninstalling-SRv6-uA-SIDs.patch
+0115-zebra-Update-promiscuity-flag-silently-without-route.patch


### PR DESCRIPTION
#### Why I did it

Fixes https://github.com/sonic-net/sonic-buildimage/issues/28026

On a BGP-enabled port or PortChannel, running `tcpdump` (or opening any `AF_PACKET` socket) toggles `IFF_PROMISC`. FRR 10.5.4 zebra does not filter a promiscuity-only netlink change in `zebra_if_dplane_ifp_handling`, so it emits a spurious `ZEBRA_INTERFACE_UP`. bgpd then re-evaluates every nexthop tracked via that interface and re-advertises/re-installs the full RIB (thousands of routes, ~10 s of control-plane churn). A routine packet capture on a production device should never trigger a routing storm.

Root cause: the netlink `ifi_change` mask carrying `IFF_PROMISC` (`0x100`) is not inspected before the interface is treated as having changed operational state.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Add SONiC FRR patch `0115`, a backport of upstream [FRRouting/frr PR 20181](https://github.com/FRRouting/frr/pull/20181) (commit `257edcc948e0179c75933cdb862fe1ac4ac14085`, "zebra: Update promiscuity flag silently without route resets").

The patch plumbs the netlink `ifi_change` mask through the dplane (`dplane_ctx_set/get_ifp_change_flags`) and, in `zebra_if_dplane_ifp_handling`, skips the routing notification when promiscuity is the **only** changed flag (`change_flags == IFF_PROMISC`, exact match on the masked value). The interface flags are still updated, so `show interface` reflects the correct PROMISC state.

PR scope — patch-based, **no submodule pointer change**:
- `src/sonic-frr/patch/0115-zebra-Update-promiscuity-flag-silently-without-route.patch`
- `src/sonic-frr/patch/series`

Porting note: upstream's `frrtrace(... if_dplane_ifp_handling_new ...)` tracepoint does not exist on `frr-10.5.4` and is omitted; the suppression logic is otherwise verbatim. Upstream PR 20181 is not yet in a released `stable/10.5`, hence the SONiC patch.

#### How to verify it

- **Patch apply:** full series `0001`–`0115` applies cleanly on a pristine `frr-10.5.4` tree (0 rejects).
- **Compile:** `frr_10.5.4-sonic-0_amd64.deb` builds clean with the patch applied (and the `docker-fpm-frr` container assembles).
- **Functional (KVM t1-lag, cEOS neighbors, before/after container swap):** Trigger (both runs): `tcpdump -ni PortChannel102 'tcp port 179'` (open+close) on a LAG uplink. DUT had 24 BGP sessions Established, RIB ~12.8k.

  | Metric | BEFORE (unfixed FRR 10.5.4) | AFTER (patch 0115) |
  |---|---:|---:|
  | swss.rec `ROUTE_TABLE` ops | **25,512** | **0** |
  | bgpd `eval path` lines | 10,059 | 0 |
  | zebra `ZEBRA_INTERFACE_UP PortChannel102` | yes | no |
  | zebra `PROMISC-only update … no routing notification` (fix firing) | n/a | yes |
  | RIB ebgp routes (steady) | 6,427 | 6,427 |

BEFORE: the promisc toggle produced a spurious `ZEBRA_INTERFACE_UP`, bgpd re-evaluated the paths, and the full RIB was re-downloaded (25,512 `ROUTE_TABLE` ops). AFTER: the same toggle produced **zero** route ops, zero path re-evaluation, and no `ZEBRA_INTERFACE_UP`; `not_offloaded` stayed 0. `ip monitor` confirmed the netlink delta is `promiscuity` only (`ifi_change == IFF_PROMISC`, `0x100`), not allmulti.
- **sonic-mgmt:** `bgp/test_bgp_suppress_fib.py::test_bgp_update_relay_latency` → **PASS**.

#### Which release branch to backport (provide reason below if selected)

<!-- Not requesting a backport in this PR: the fix is specific to the frr-10.5.4 tree pinned on master and was validated on master only. A backport to a release branch on an earlier FRR would require a separately authored/validated port. -->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

- [x] master — base image `sonic-vs` build `1145536` (master, 2026-06-22) with the patched `docker-fpm-frr` container swapped in.

#### Description for the changelog

[sonic-frr] zebra: suppress full BGP route re-download on interface promiscuity-only changes (tcpdump toggling `IFF_PROMISC`).

#### Link to config_db schema for YANG module changes

N/A — no CONFIG_DB schema or YANG changes.

#### A picture of a cute animal (not mandatory but encouraged)

🦦
