### PR TITLE
ctrmgrd: default Kubernetes join to secure TLS verification

### DIFF
--- a/src/sonic-ctrmgrd/ctrmgr/ctrmgrd.py
+++ b/src/sonic-ctrmgrd/ctrmgr/ctrmgrd.py
@@ -73,7 +73,7 @@ dflt_cfg_ser = {
         CFG_SER_IP: "",
         CFG_SER_PORT: "6443",
         CFG_SER_DISABLE: "false",
-        CFG_SER_INSECURE: "true"
+        CFG_SER_INSECURE: "false"
         }
 
 dflt_st_ser = {

--- a/src/sonic-ctrmgrd/ctrmgr/kube_commands.py
+++ b/src/sonic-ctrmgrd/ctrmgr/kube_commands.py
@@ -249,7 +249,7 @@ users:
     client-certificate-data: {{ ame_crt }}
     client-key-data: {{ ame_key }}
     """
-    if insecure:
+    if insecure.lower() == "true":
         r = requests.get(K8S_CA_URL.format(server, port), cert=(AME_CRT, AME_KEY), verify=False)
     else:
         r = requests.get(K8S_CA_URL.format(server, port), cert=(AME_CRT, AME_KEY))

--- a/src/sonic-ctrmgrd/tests/ctrmgrd_test.py
+++ b/src/sonic-ctrmgrd/tests/ctrmgrd_test.py
@@ -106,7 +106,7 @@ server_test_data = {
             common_test.KUBE_JOIN: {
                 "ip": "10.10.10.10",
                 "port": "6443",
-                "insecure": "true"
+                "insecure": "false"
             }
         }
     },
@@ -151,7 +151,7 @@ server_test_data = {
             common_test.KUBE_JOIN: {
                 "ip": "10.10.10.10",
                 "port": "6443",
-                "insecure": "true"
+                "insecure": "false"
             },
             common_test.KUBE_RESET: {
                 "flag": "true"

--- a/src/sonic-ctrmgrd/tests/kube_commands_test.py
+++ b/src/sonic-ctrmgrd/tests/kube_commands_test.py
@@ -105,7 +105,7 @@ join_test_data = {
     0: {
         common_test.DESCR: "Regular insecure join",
         common_test.RETVAL: 0,
-        common_test.ARGS: ["10.3.157.24", 6443, True, False],
+        common_test.ARGS: ["10.3.157.24", 6443, "true", False],
         common_test.PROC_CMD: [
             "kubectl --kubeconfig {} --request-timeout 20s drain none \
 --ignore-daemonsets".format(KUBE_ADMIN_CONF),
@@ -129,7 +129,7 @@ none".format(KUBE_ADMIN_CONF),
     1: {
         common_test.DESCR: "Regular secure join",
         common_test.RETVAL: 0,
-        common_test.ARGS: ["10.3.157.24", 6443, False, False],
+        common_test.ARGS: ["10.3.157.24", 6443, "false", False],
         common_test.PROC_CMD: [
             "kubectl --kubeconfig {} --request-timeout 20s drain none \
 --ignore-daemonsets".format(KUBE_ADMIN_CONF),
@@ -153,7 +153,7 @@ none".format(KUBE_ADMIN_CONF),
     2: {
         common_test.DESCR: "Skip join as already connected",
         common_test.RETVAL: 0,
-        common_test.ARGS: ["10.3.157.24", 6443, True, False],
+        common_test.ARGS: ["10.3.157.24", 6443, "true", False],
         common_test.NO_INIT: True,
         common_test.PROC_CMD: [
             "systemctl start kubelet"
@@ -162,7 +162,7 @@ none".format(KUBE_ADMIN_CONF),
     3: {
         common_test.DESCR: "Regular join: fail due to unable to lock",
         common_test.RETVAL: -1,
-        common_test.ARGS: ["10.3.157.24", 6443, False, False],
+        common_test.ARGS: ["10.3.157.24", 6443, "false", False],
         common_test.FAIL_LOCK: True
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-kubernetes_master.yang
+++ b/src/sonic-yang-models/yang-models/sonic-kubernetes_master.yang
@@ -50,7 +50,7 @@ module sonic-kubernetes_master {
                 leaf insecure {
                     description "Whether to use HTTP instead of HTTPS for downloading Kubernetes CA certificate";
                     type stypes:boolean_type;
-                    default "true";
+                    default "false";
                 }
 
             }


### PR DESCRIPTION
#### Why I did it

The default value of `CFG_SER_INSECURE` in `dflt_cfg_ser` was set to `"true"`, causing `kube_commands.py` to skip TLS certificate verification when downloading the Kubernetes CA certificate during cluster join. Additionally, the insecure flag comparison used bare Python truthiness (`if insecure:`), which evaluates the string `"false"` as truthy — making the flag ineffective regardless of its value.

##### Work item tracking
- Microsoft ADO:

#### How I did it

- Changed `CFG_SER_INSECURE` default in `dflt_cfg_ser` from `"true"` to `"false"` in `ctrmgrd.py`
- Fixed `kube_commands.py` to compare the flag as a string: `insecure.lower() == "true"` instead of bare truthiness
- Updated `sonic-kubernetes_master.yang` default to `"false"` to align with runtime behavior

#### How to verify it

Set up a SONiC device configured to join a Kubernetes master with no explicit `insecure` field in ConfigDB `KUBERNETES_MASTER|SERVER`. Confirm that `kube_join_master` uses verified TLS by default. Confirm that setting `insecure=true` in ConfigDB restores the previous behavior.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

- [ ]

#### Description for the changelog

ctrmgrd: default Kubernetes cluster join to use verified TLS; fix insecure flag string comparison

#### Link to config_db schema for YANG module changes

https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md