### PR TITLE
[monit]: Add ire_watchdog one-shot check to syslog on IRE DATA_PATH CRC errors

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -416,6 +416,8 @@ sudo cp $IMAGE_CONFIGS/monit/arp_update_checker $FILESYSTEM_ROOT/usr/bin/
 sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/arp_update_checker
 sudo cp $IMAGE_CONFIGS/monit/control_plane_drop_check $FILESYSTEM_ROOT/usr/bin/
 sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/control_plane_drop_check
+sudo cp $IMAGE_CONFIGS/monit/ire_watchdog $FILESYSTEM_ROOT/usr/bin/
+sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/ire_watchdog
 sudo cp $IMAGE_CONFIGS/monit/mgmt_oper_status.py $FILESYSTEM_ROOT/usr/bin/
 sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/mgmt_oper_status.py
 

--- a/files/image_config/monit/conf.d/sonic-host
+++ b/files/image_config/monit/conf.d/sonic-host
@@ -66,6 +66,12 @@ check program controlPlaneDropCheck with path "/usr/bin/control_plane_drop_check
     every 5 cycles
     if status != 0 for 3 cycle then alert repeat every 1 cycles
 
+# ire_watchdog: alert on Broadcom DNX IRE_DATA_PATH_CRC_ERROR_COUNTER increments.
+# DNX-only at runtime; the script exits 0 (no-op) on non-DNX ASICs and when syncd is down.
+check program ireWatchdog with path "/usr/bin/ire_watchdog"
+    every 5 cycles
+    if status != 0 for 1 cycle then alert repeat every 1 cycles
+
 # Periodically update oper status of mgmt interface in STATE_DB 
 check program mgmtOperStatus with path "/usr/bin/mgmt_oper_status.py"
     every 1 cycles

--- a/files/image_config/monit/ire_watchdog
+++ b/files/image_config/monit/ire_watchdog
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""
+    One-shot monit check for the Broadcom DNX IRE data-path CRC error counter.
+
+    Reads the per-core IRE_DATA_PATH_CRC_ERROR_COUNTER register via
+    `docker exec syncd bcmcmd "getreg IRE_DATA_PATH_CRC_ERROR_COUNTER"`. The
+    register is clear-on-read, so any non-zero per-core value means new
+    data-path CRC errors occurred since the previous poll. When that happens the
+    check logs every per-core count (with a timestamp) to a /tmp JSON log,
+    writes a fixed syslog (LOG_ERR) message mirroring the syncd
+    dnxc_interrupt_print_info interrupt line, and exits non-zero so monit alerts.
+
+    Adapted from the upstream nexthop-ai sonic-host-services `ire_watchdog`
+    by keeping its bcmcmd parsing / syncd / platform-detection robustness but
+    dropping the poll loop and the port-shutdown action. Modeled on
+    files/image_config/monit/control_plane_drop_check (read counter -> syslog on
+    error -> sys.exit(1 if res else 0)).
+
+    The check is DNX-only at runtime: on non-DNX ASICs the register is unknown
+    (PlatformNotSupported) and when syncd is unavailable (SyncdUnavailable) the
+    script exits 0 with no alert and without writing the log.
+"""
+import datetime
+import json
+import os
+import re
+import subprocess
+import sys
+import syslog
+
+SYNCD_CONTAINER = 'syncd'
+BCMCMD = ['docker', 'exec', SYNCD_CONTAINER, 'bcmcmd']
+COUNTER_REG = 'IRE_DATA_PATH_CRC_ERROR_COUNTER'
+BCMCMD_TIMEOUT_SEC = 5.0
+
+# Rolling JSON log of per-core counter readings that triggered an alert. Each
+# entry is {"timestamp": <iso8601>, "counters": {"<core_id>": <count>, ...}}.
+# Capped at MAX_LOG_ENTRIES so it cannot grow unbounded in /tmp.
+ERROR_LOG = '/tmp/ire_crc_error_count.json'
+MAX_LOG_ENTRIES = 1000
+
+# Fixed syslog message emitted at LOG_ERR when a per-core
+# IRE_DATA_PATH_CRC_ERROR_COUNTER increment is detected. Hardcoded to mirror the
+# syncd dnxc_interrupt_print_info interrupt line so downstream log tooling keying
+# on that interrupt string also catches this watchdog's alert.
+INTERRUPT_LOG_MSG = (
+    "syncd#supervisord: syncd:dnxc_interrupt_print_info: "
+    "name=RQP_PACKET_REASSEMBLY_CdcPktSizeErrInt, id=487, index=0, "
+    "block=0, unit=0, recurring_action=0 | Check Configuration | None#015"
+)
+
+# IRE_DATA_PATH_CRC_ERROR_COUNTER.IRE3[0x169]=42: <DATA_PATH_CRC_ERROR_COUNTER=0x2a>
+# Value before the colon may be decimal (e.g. =0) or hex (e.g. =0x42); accept either.
+LINE_RE = re.compile(
+    r'IRE_DATA_PATH_CRC_ERROR_COUNTER\.IRE(\d+)\[[^\]]+\]=(0x[0-9a-fA-F]+|\d+)'
+)
+
+
+class SyncdUnavailable(Exception):
+    """syncd container is not running or otherwise unreachable."""
+
+
+class PlatformNotSupported(Exception):
+    """ASIC doesn't expose IRE_DATA_PATH_CRC_ERROR_COUNTER (i.e. not DNX)."""
+
+
+def _parse_int(s: str) -> int:
+    return int(s, 16) if s.startswith('0x') else int(s)
+
+
+def _is_syncd_unavailable_error(stderr: str) -> bool:
+    """Heuristics for stderr indicating syncd container isn't usable."""
+    s = stderr.lower()
+    return (
+        'is not running' in s
+        or 'no such container' in s
+        or 'error response from daemon' in s
+        or 'cannot connect to the docker daemon' in s
+    )
+
+
+def _is_unknown_register_output(output: str) -> bool:
+    """Heuristics for bcmcmd output indicating the register doesn't exist
+    on this ASIC (non-DNX platform). The bcm shell typically responds with
+    'Symbol not found' or similar when given an unknown register name."""
+    s = output.lower()
+    return (
+        'symbol not found' in s
+        or 'symbol unknown' in s
+        or 'unknown symbol' in s
+        or 'no such symbol' in s
+        or 'not a valid register' in s
+    )
+
+
+def syncd_running() -> bool:
+    """Quick check: is the syncd container in the running state?"""
+    try:
+        r = subprocess.run(
+            ['docker', 'inspect', '--format', '{{.State.Running}}', SYNCD_CONTAINER],
+            capture_output=True, text=True, timeout=5,
+        )
+        return r.returncode == 0 and r.stdout.strip() == 'true'
+    except Exception:
+        return False
+
+
+def _reap_leaked_bcmcmd() -> None:
+    """Kill bcmcmd processes left inside syncd by previous timeouts.
+
+    `docker exec` does NOT propagate SIGKILL into the container, so when
+    `subprocess.run(timeout=...)` fires we leak one bcmcmd process per call.
+    Worse, if the bcm shell is in a non-default mode (e.g. cint) every
+    queued `getreg` blocks until a human exits that mode, so the orphan
+    count grows monotonically.
+
+    Pattern-match on our specific command line so we only reap our own
+    orphans. An interactive `bcmcmd` session a human may have open shows
+    up as bare `bcmcmd` (no args) and won't match.
+    """
+    try:
+        subprocess.run(
+            ['docker', 'exec', SYNCD_CONTAINER, 'pkill', '-9', '-f',
+             f'bcmcmd.*getreg.*{COUNTER_REG}'],
+            capture_output=True, timeout=5,
+        )
+    except Exception:
+        # Best-effort cleanup — never let reap failures crash the check.
+        pass
+
+
+def read_counters() -> dict[int, int]:
+    """Read IRE_DATA_PATH_CRC_ERROR_COUNTER and return {core_id: count}.
+
+    Raises SyncdUnavailable if syncd is not running.
+    Raises PlatformNotSupported if the register is unknown (non-DNX ASIC).
+    Raises RuntimeError on other bcmcmd/parsing failures (including
+    timeouts; the orphan bcmcmd inside syncd is reaped before re-raising).
+    """
+    try:
+        out = subprocess.run(
+            BCMCMD + [f'getreg {COUNTER_REG}'],
+            capture_output=True, text=True, timeout=BCMCMD_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired as e:
+        _reap_leaked_bcmcmd()
+        raise RuntimeError(f'bcmcmd timed out after {BCMCMD_TIMEOUT_SEC}s') from e
+    except FileNotFoundError as e:
+        raise SyncdUnavailable(f'docker binary not found: {e}')
+
+    if out.returncode != 0:
+        stderr = out.stderr.strip()
+        if _is_syncd_unavailable_error(stderr) or not syncd_running():
+            raise SyncdUnavailable(stderr or 'syncd container not running')
+        raise RuntimeError(f'bcmcmd failed (rc={out.returncode}): {stderr}')
+
+    # On non-DNX platforms, bcmcmd accepts the command but reports an unknown
+    # symbol. Treat as "platform not supported" and let the caller exit clean.
+    if _is_unknown_register_output(out.stdout) or _is_unknown_register_output(out.stderr):
+        raise PlatformNotSupported(
+            f'{COUNTER_REG} is not a valid register on this ASIC'
+        )
+
+    counters: dict[int, int] = {}
+    for line in out.stdout.splitlines():
+        m = LINE_RE.search(line)
+        if m:
+            counters[int(m.group(1))] = _parse_int(m.group(2))
+    if not counters:
+        # Empty/garbage output sometimes seen during syncd start before bcm
+        # shell is ready. Distinguish from "syncd is fine but parser broke".
+        if not syncd_running():
+            raise SyncdUnavailable('syncd not running during read')
+        raise RuntimeError(f'no counters parsed from bcmcmd output: {out.stdout!r}')
+    return counters
+
+
+def nonzero_cores(counters: dict) -> list:
+    """Return the sorted core ids reporting a non-zero CRC error count.
+
+    IRE_DATA_PATH_CRC_ERROR_COUNTER is clear-on-read, so any non-zero value is
+    new errors since the previous read -- no baseline comparison is needed.
+    """
+    return sorted(c for c in counters if counters[c] > 0)
+
+
+def write_syslog(message):
+    """Write an error-level message to syslog (model: control_plane_drop_check)."""
+    syslog.syslog(syslog.LOG_ERR, message)
+
+
+def log_counters(counters: dict) -> None:
+    """Append a timestamped snapshot of all per-core counters to ERROR_LOG.
+
+    Each entry records every core's count (not just the non-zero ones). The log
+    is a JSON list capped at MAX_LOG_ENTRIES (oldest dropped first). A corrupt
+    or unreadable log is reset rather than allowed to crash the check.
+    """
+    entry = {
+        'timestamp': datetime.datetime.now().astimezone().isoformat(),
+        'counters': {str(c): counters[c] for c in sorted(counters)},
+    }
+    history = []
+    if os.path.exists(ERROR_LOG):
+        try:
+            with open(ERROR_LOG) as f:
+                loaded = json.load(f)
+            if isinstance(loaded, list):
+                history = loaded
+        except (ValueError, OSError):
+            history = []
+    history.append(entry)
+    if len(history) > MAX_LOG_ENTRIES:
+        history = history[-MAX_LOG_ENTRIES:]
+    with open(ERROR_LOG, 'w') as f:
+        json.dump(history, f)
+
+
+def check_ire_crc_errors() -> bool:
+    """Return True if any core reports a non-zero IRE CRC error count.
+
+    The register is clear-on-read: a non-zero value means new data-path CRC
+    errors occurred since the previous poll. When that happens we log every
+    per-core count (with a timestamp) to ERROR_LOG and emit a LOG_ERR syslog so
+    monit alerts. Propagates PlatformNotSupported / SyncdUnavailable so the
+    caller can exit 0 without writing the log.
+    """
+    current = read_counters()
+    if nonzero_cores(current):
+        log_counters(current)
+        write_syslog(INTERRUPT_LOG_MSG)
+        return True
+    return False
+
+
+def main() -> int:
+    syslog.openlog("ire_watchdog")
+    try:
+        res = check_ire_crc_errors()
+    except PlatformNotSupported:
+        # Non-DNX ASIC: register is unknown. No-op; nothing logged.
+        return 0
+    except SyncdUnavailable:
+        # syncd not running / unreachable. No-op; nothing logged.
+        return 0
+    except Exception as e:
+        # Transient bcmcmd/parse error: never false-alert; nothing logged.
+        syslog.syslog(syslog.LOG_WARNING,
+                      "ire_watchdog: skipping check after transient error: {}".format(e))
+        return 0
+
+    return 1 if res else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/files/image_config/monit/tests/device_test_ire_watchdog.py
+++ b/files/image_config/monit/tests/device_test_ire_watchdog.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""On-device test harness for the monit ``ire_watchdog`` check.
+
+Run this on an actual SONiC switch (a Broadcom DNX platform for the live path)
+to validate the deployed ``/usr/bin/ire_watchdog`` one-shot monit check.
+
+This is **not** a pytest unit test (it is named ``device_test_*`` so pytest does
+not auto-collect it); it is a standalone diagnostic you copy onto a switch and
+run by hand.
+
+Two test groups:
+
+* **Simulated** (default, always safe): imports the deployed script and drives
+  ``main()`` / ``log_counters()`` / ``nonzero_cores()`` with *mocked* register
+  reads. No ASIC access, no side effects -- safe on a production switch. This
+  validates that the deployed script's clear-on-read alert logic is correct.
+
+* **Live** (``--live``): exercises the real hardware path -- reads the actual
+  ``IRE_DATA_PATH_CRC_ERROR_COUNTER`` register and runs the deployed script as
+  monit would, then checks syslog / the JSON error log.
+  NOTE: the register is **clear-on-read**, so a live read consumes any pending
+  per-core error counts (the same side effect as a normal monit cycle).
+
+Usage::
+
+    sudo python3 device_test_ire_watchdog.py [--script /usr/bin/ire_watchdog]
+                                             [--live] [--verbose]
+
+Exit status is 0 if all selected tests pass, non-zero otherwise.
+"""
+import argparse
+import importlib.machinery
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from unittest import mock
+
+DEFAULT_SCRIPT = '/usr/bin/ire_watchdog'
+SYSLOG_PATHS = ['/var/log/syslog', '/var/log/messages']
+# A stable, unique fragment of INTERRUPT_LOG_MSG to grep for in syslog.
+MSG_FRAGMENT = 'RQP_PACKET_REASSEMBLY_CdcPktSizeErrInt'
+
+
+class Results:
+    """Tiny pass/fail/skip tracker with printed output."""
+
+    def __init__(self):
+        self.passed = 0
+        self.failed = 0
+        self.skipped = 0
+
+    def ok(self, name, detail=''):
+        self.passed += 1
+        print('  [PASS] {}{}'.format(name, ' -- ' + detail if detail else ''))
+
+    def fail(self, name, detail=''):
+        self.failed += 1
+        print('  [FAIL] {}{}'.format(name, ' -- ' + detail if detail else ''))
+
+    def skip(self, name, detail=''):
+        self.skipped += 1
+        print('  [SKIP] {}{}'.format(name, ' -- ' + detail if detail else ''))
+
+
+def section(title):
+    print('\n=== {} ==='.format(title))
+
+
+def load_module(path):
+    """Load the extension-less deployed script as a module."""
+    loader = importlib.machinery.SourceFileLoader('ire_watchdog', path)
+    spec = importlib.util.spec_from_file_location('ire_watchdog', path,
+                                                  loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
+
+
+def _grep_syslog(fragment=MSG_FRAGMENT, paths=SYSLOG_PATHS):
+    """Return True if ``fragment`` appears in the tail of any syslog file."""
+    for path in paths:
+        if not os.path.exists(path):
+            continue
+        try:
+            proc = subprocess.run(['tail', '-n', '1000', path],
+                                  capture_output=True, text=True, timeout=10)
+            if fragment in proc.stdout:
+                return True
+        except (OSError, subprocess.SubprocessError):
+            continue
+    return False
+
+
+def run_simulated_tests(mod, res):
+    section('Simulated logic tests (no ASIC access -- safe on production)')
+
+    # 1. nonzero_cores() pure logic.
+    try:
+        assert mod.nonzero_cores({0: 0, 1: 3, 2: 0}) == [1]
+        assert mod.nonzero_cores({0: 5, 1: 2}) == [0, 1]
+        assert mod.nonzero_cores({0: 0, 1: 0}) == []
+        res.ok('nonzero_cores() reports only non-zero cores (clear-on-read)')
+    except AssertionError as e:
+        res.fail('nonzero_cores()', repr(e))
+
+    # 2. Any non-zero core -> exit 1, LOG_ERR, timestamped log entry.
+    tmpdir = tempfile.mkdtemp()
+    logpath = os.path.join(tmpdir, 'ire_crc_error_count.json')
+    try:
+        with mock.patch.object(mod, 'ERROR_LOG', logpath), \
+                mock.patch.object(mod, 'read_counters',
+                                  return_value={0: 0, 1: 4}), \
+                mock.patch.object(mod.syslog, 'syslog') as msys:
+            rc = mod.main()
+        assert rc == 1, 'exit {} != 1'.format(rc)
+        assert msys.call_args == mock.call(mod.syslog.LOG_ERR,
+                                           mod.INTERRUPT_LOG_MSG), \
+            'syslog call mismatch: {}'.format(msys.call_args)
+        with open(logpath) as f:
+            entries = json.load(f)
+        assert len(entries) == 1 and 'timestamp' in entries[0]
+        assert entries[0]['counters'] == {'0': 0, '1': 4}
+        res.ok('non-zero read -> exit 1, LOG_ERR, timestamped log',
+               'logged counters={}'.format(entries[0]['counters']))
+    except AssertionError as e:
+        res.fail('non-zero alert path', repr(e))
+
+    # 3. All-zero read -> exit 0, no alert, no log.
+    tmpdir = tempfile.mkdtemp()
+    logpath = os.path.join(tmpdir, 'ire_crc_error_count.json')
+    try:
+        with mock.patch.object(mod, 'ERROR_LOG', logpath), \
+                mock.patch.object(mod, 'read_counters',
+                                  return_value={0: 0, 1: 0}), \
+                mock.patch.object(mod.syslog, 'syslog') as msys:
+            rc = mod.main()
+        assert rc == 0, 'exit {} != 0'.format(rc)
+        assert not msys.called, 'syslog called on all-zero read'
+        assert not os.path.exists(logpath), 'log written on all-zero read'
+        res.ok('all-zero read -> exit 0, no alert, no log')
+    except AssertionError as e:
+        res.fail('all-zero path', repr(e))
+
+    # 4. Non-DNX / syncd-down / transient -> exit 0, no alert, no log.
+    for label, exc in (
+        ('non-DNX (PlatformNotSupported)', mod.PlatformNotSupported('not dnx')),
+        ('syncd down (SyncdUnavailable)', mod.SyncdUnavailable('syncd down')),
+        ('transient error (RuntimeError)', RuntimeError('boom')),
+    ):
+        tmpdir = tempfile.mkdtemp()
+        logpath = os.path.join(tmpdir, 'ire_crc_error_count.json')
+        try:
+            with mock.patch.object(mod, 'ERROR_LOG', logpath), \
+                    mock.patch.object(mod, 'read_counters', side_effect=exc), \
+                    mock.patch.object(mod.syslog, 'syslog') as msys:
+                rc = mod.main()
+            assert rc == 0, 'exit {} != 0'.format(rc)
+            for call in msys.call_args_list:
+                assert call.args[0] != mod.syslog.LOG_ERR, 'false LOG_ERR alert'
+            assert not os.path.exists(logpath), 'log written on no-op path'
+            res.ok('{} -> exit 0, no alert, no log'.format(label))
+        except AssertionError as e:
+            res.fail(label, repr(e))
+
+
+def run_live_tests(mod, script_path, res):
+    section('Live hardware tests (touches ASIC -- register is CLEAR-ON-READ)')
+    print('  WARNING: a live read consumes pending IRE CRC error counts.')
+
+    print('  syncd running: {}'.format(mod.syncd_running()))
+
+    # 1. Real register read.
+    try:
+        counters = mod.read_counters()
+        res.ok('read_counters() succeeded',
+               '{} cores, non-zero={}'.format(len(counters),
+                                              mod.nonzero_cores(counters)))
+        print('    counters: {}'.format(counters))
+    except mod.PlatformNotSupported as e:
+        res.skip('read_counters() -- not a DNX platform', str(e))
+    except mod.SyncdUnavailable as e:
+        res.skip('read_counters() -- syncd unavailable', str(e))
+    except Exception as e:  # noqa: BLE001 - diagnostic harness
+        res.fail('read_counters()', repr(e))
+
+    # 2. Run the deployed script exactly as monit invokes it.
+    try:
+        proc = subprocess.run([script_path], capture_output=True, text=True,
+                              timeout=30)
+        rc = proc.returncode
+        if rc in (0, 1):
+            res.ok('deployed script ran', 'exit={}'.format(rc))
+        else:
+            res.fail('deployed script unexpected exit',
+                     'exit={} stderr={!r}'.format(rc, proc.stderr.strip()))
+
+        if rc == 1:
+            # A real increment was seen this cycle: verify the side effects.
+            if _grep_syslog():
+                res.ok('LOG_ERR interrupt message found in syslog')
+            else:
+                res.fail('LOG_ERR interrupt message NOT found in syslog')
+            if os.path.exists(mod.ERROR_LOG):
+                with open(mod.ERROR_LOG) as f:
+                    entries = json.load(f)
+                res.ok('error log updated', '{} ({} entries)'.format(
+                    mod.ERROR_LOG, len(entries)))
+            else:
+                res.fail('error log NOT written', mod.ERROR_LOG)
+        else:
+            res.skip('alert side-effects (no non-zero counters this cycle)')
+    except Exception as e:  # noqa: BLE001 - diagnostic harness
+        res.fail('deployed script run', repr(e))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--script', default=DEFAULT_SCRIPT,
+                        help='path to the deployed ire_watchdog (default: %(default)s)')
+    parser.add_argument('--live', action='store_true',
+                        help='also run live hardware tests (reads+clears the register)')
+    parser.add_argument('--verbose', action='store_true', help='verbose output')
+    args = parser.parse_args()
+
+    print('ire_watchdog device test harness')
+    print('script under test: {}'.format(args.script))
+
+    if not os.path.exists(args.script):
+        print('ERROR: {} not found -- is the image with ire_watchdog installed?'
+              .format(args.script))
+        return 2
+
+    try:
+        mod = load_module(args.script)
+    except Exception as e:  # noqa: BLE001 - diagnostic harness
+        print('ERROR: could not load {}: {!r}'.format(args.script, e))
+        return 2
+
+    res = Results()
+    run_simulated_tests(mod, res)
+    if args.live:
+        run_live_tests(mod, args.script, res)
+    else:
+        section('Live hardware tests')
+        print('  (skipped -- pass --live to read the real register; '
+              'note it is clear-on-read)')
+
+    section('Summary')
+    print('  passed={} failed={} skipped={}'.format(
+        res.passed, res.failed, res.skipped))
+    return 0 if res.failed == 0 else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/files/image_config/monit/tests/test_ire_watchdog.py
+++ b/files/image_config/monit/tests/test_ire_watchdog.py
@@ -1,0 +1,215 @@
+"""Unit tests for the monit ``ire_watchdog`` one-shot check.
+
+The script under test (``files/image_config/monit/ire_watchdog``) has no ``.py``
+extension, so it is loaded via :class:`importlib.machinery.SourceFileLoader`,
+mirroring ``src/system-health/tests/test_system_health.py``.
+
+The IRE_DATA_PATH_CRC_ERROR_COUNTER register is clear-on-read, so the check
+alerts whenever any core reports a non-zero count (no baseline comparison).
+
+Covered behaviour:
+    * ``nonzero_cores()`` pure logic.
+    * Any non-zero core -> a single ``LOG_ERR`` alert plus a timestamped entry
+      appended to the error log (recording every per-core count).
+    * All-zero reading -> no alert, no log written.
+    * ``PlatformNotSupported`` / ``SyncdUnavailable`` / transient error ->
+      exit 0, no false alert, error log not written.
+    * ``log_counters()`` appends timestamped snapshots, caps history, and
+      recovers from a corrupt log.
+    * ``read_counters()`` bcmcmd output parsing (hex + decimal), the
+      unknown-register (non-DNX) path and the syncd-down path.
+
+The tests are self-contained: stdlib + pytest + ``unittest.mock`` only, with no
+dependency on ``swsscommon`` or a live ASIC/syncd.
+"""
+import importlib.machinery
+import importlib.util
+import json
+import os
+import sys
+
+from unittest.mock import patch
+
+import pytest
+
+
+def load_source(modname, filename):
+    """Load an extension-less script as a module (mirrors system-health test)."""
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is executed and cached in sys.modules under its own name.
+    sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
+
+
+mod = load_source(
+    'ire_watchdog',
+    os.path.join(os.path.dirname(__file__), '..', 'ire_watchdog'),
+)
+
+
+class _FakeProc:
+    """Minimal stand-in for :class:`subprocess.CompletedProcess`."""
+
+    def __init__(self, returncode=0, stdout='', stderr=''):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _read_json(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def _assert_no_log_err(mock_syslog):
+    """Fail if ``syslog.syslog`` was ever called at ``LOG_ERR`` level."""
+    for c in mock_syslog.call_args_list:
+        assert c.args[0] != mod.syslog.LOG_ERR
+
+
+# --- pure logic -------------------------------------------------------------
+
+def test_nonzero_cores():
+    # Clear-on-read: any non-zero core is reported, sorted ascending.
+    assert mod.nonzero_cores({0: 0, 1: 3, 2: 0}) == [1]
+    assert mod.nonzero_cores({0: 5, 1: 2}) == [0, 1]
+    # All-zero (or empty) reading -> nothing to report.
+    assert mod.nonzero_cores({0: 0, 1: 0}) == []
+    assert mod.nonzero_cores({}) == []
+
+
+# --- high-level main() paths (read_counters patched) ------------------------
+
+def test_nonzero_triggers_alert(tmp_path, monkeypatch):
+    log = tmp_path / 'ire_crc_error_count.json'
+    monkeypatch.setattr(mod, 'ERROR_LOG', str(log))
+    with patch.object(mod, 'read_counters', return_value={0: 0, 1: 3}), \
+            patch.object(mod.syslog, 'syslog') as mock_syslog:
+        assert mod.main() == 1
+        mock_syslog.assert_called_once_with(mod.syslog.LOG_ERR,
+                                            mod.INTERRUPT_LOG_MSG)
+    # One timestamped entry recording every per-core count (zeros included).
+    entries = _read_json(str(log))
+    assert len(entries) == 1
+    assert 'timestamp' in entries[0]
+    assert entries[0]['counters'] == {'0': 0, '1': 3}
+
+
+def test_all_zero_no_alert(tmp_path, monkeypatch):
+    log = tmp_path / 'ire_crc_error_count.json'
+    monkeypatch.setattr(mod, 'ERROR_LOG', str(log))
+    with patch.object(mod, 'read_counters', return_value={0: 0, 1: 0}), \
+            patch.object(mod.syslog, 'syslog') as mock_syslog:
+        assert mod.main() == 0
+        mock_syslog.assert_not_called()
+    # No errors -> nothing logged.
+    assert not log.exists()
+
+
+def test_platform_not_supported(tmp_path, monkeypatch):
+    log = tmp_path / 'ire_crc_error_count.json'
+    monkeypatch.setattr(mod, 'ERROR_LOG', str(log))
+    with patch.object(mod, 'read_counters',
+                      side_effect=mod.PlatformNotSupported('not dnx')), \
+            patch.object(mod.syslog, 'syslog') as mock_syslog:
+        assert mod.main() == 0
+        _assert_no_log_err(mock_syslog)
+    # Non-DNX no-op: nothing logged.
+    assert not log.exists()
+
+
+def test_syncd_unavailable(tmp_path, monkeypatch):
+    log = tmp_path / 'ire_crc_error_count.json'
+    monkeypatch.setattr(mod, 'ERROR_LOG', str(log))
+    with patch.object(mod, 'read_counters',
+                      side_effect=mod.SyncdUnavailable('syncd down')), \
+            patch.object(mod.syslog, 'syslog') as mock_syslog:
+        assert mod.main() == 0
+        _assert_no_log_err(mock_syslog)
+    assert not log.exists()
+
+
+def test_transient_error_no_false_alert(tmp_path, monkeypatch):
+    log = tmp_path / 'ire_crc_error_count.json'
+    monkeypatch.setattr(mod, 'ERROR_LOG', str(log))
+    with patch.object(mod, 'read_counters', side_effect=RuntimeError('boom')), \
+            patch.object(mod.syslog, 'syslog') as mock_syslog:
+        assert mod.main() == 0
+        # A LOG_WARNING is acceptable here, but never a LOG_ERR false alert.
+        _assert_no_log_err(mock_syslog)
+    assert not log.exists()
+
+
+# --- log_counters() ---------------------------------------------------------
+
+def test_log_counters_appends_with_timestamp(tmp_path, monkeypatch):
+    log = tmp_path / 'ire_crc_error_count.json'
+    monkeypatch.setattr(mod, 'ERROR_LOG', str(log))
+    mod.log_counters({0: 1, 1: 0})
+    mod.log_counters({0: 0, 1: 7})
+    entries = _read_json(str(log))
+    assert len(entries) == 2
+    assert all('timestamp' in e and 'counters' in e for e in entries)
+    assert entries[0]['counters'] == {'0': 1, '1': 0}
+    assert entries[1]['counters'] == {'0': 0, '1': 7}
+
+
+def test_log_counters_caps_history(tmp_path, monkeypatch):
+    log = tmp_path / 'ire_crc_error_count.json'
+    monkeypatch.setattr(mod, 'ERROR_LOG', str(log))
+    monkeypatch.setattr(mod, 'MAX_LOG_ENTRIES', 3)
+    for i in range(1, 6):
+        mod.log_counters({0: i})
+    entries = _read_json(str(log))
+    # Capped to the most recent MAX_LOG_ENTRIES entries (oldest dropped first).
+    assert len(entries) == 3
+    assert [e['counters']['0'] for e in entries] == [3, 4, 5]
+
+
+def test_log_counters_resets_corrupt_log(tmp_path, monkeypatch):
+    log = tmp_path / 'ire_crc_error_count.json'
+    monkeypatch.setattr(mod, 'ERROR_LOG', str(log))
+    log.write_text('not valid json{{{')
+    mod.log_counters({0: 2})
+    entries = _read_json(str(log))
+    assert len(entries) == 1
+    assert entries[0]['counters'] == {'0': 2}
+
+
+# --- read_counters() parsing (subprocess patched) ---------------------------
+
+def test_read_counters_parses_hex_and_dec():
+    stdout = (
+        'IRE_DATA_PATH_CRC_ERROR_COUNTER.IRE0[0x100]=10: '
+        '<DATA_PATH_CRC_ERROR_COUNTER=10>\n'
+        'IRE_DATA_PATH_CRC_ERROR_COUNTER.IRE1[0x101]=0x2a: '
+        '<DATA_PATH_CRC_ERROR_COUNTER=0x2a>\n'
+    )
+    with patch.object(mod.subprocess, 'run',
+                      return_value=_FakeProc(returncode=0, stdout=stdout)):
+        # Decimal "10" and hex "0x2a" (== 42) are both accepted.
+        assert mod.read_counters() == {0: 10, 1: 42}
+
+
+def test_read_counters_unknown_register():
+    with patch.object(mod.subprocess, 'run',
+                      return_value=_FakeProc(returncode=0,
+                                             stdout='Symbol not found')):
+        with pytest.raises(mod.PlatformNotSupported):
+            mod.read_counters()
+
+
+def test_read_counters_syncd_down():
+    stderr = 'Error response from daemon: Container syncd is not running'
+    with patch.object(mod.subprocess, 'run',
+                      return_value=_FakeProc(returncode=1, stderr=stderr)), \
+            patch.object(mod, 'syncd_running', return_value=False):
+        with pytest.raises(mod.SyncdUnavailable):
+            mod.read_counters()
+
+
+if __name__ == '__main__':
+    sys.exit(pytest.main([__file__, '-v']))


### PR DESCRIPTION
#### Why I did it

On Broadcom DNX platforms, IRE data-path CRC errors are surfaced by the `IRE_DATA_PATH_CRC_ERROR_COUNTER` register. There was no host-level monit check to alert on these. This adds a one-shot monit check that detects IRE data-path CRC errors and raises a syslog alert, so operators are notified. It is adapted from the nexthop-ai sonic-host-services `ire_watchdog`, but **emits a syslog alert instead of shutting down ports** (non-disruptive).

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- New one-shot script `files/image_config/monit/ire_watchdog` (installed to `/usr/bin/ire_watchdog`, mode 755), modeled on the existing `files/image_config/monit/control_plane_drop_check`. It reads `IRE_DATA_PATH_CRC_ERROR_COUNTER` via `docker exec syncd bcmcmd getreg ...`.
- The register is **clear-on-read**: any non-zero per-core value means new CRC errors occurred since the previous poll. When any core is non-zero, the check writes a syslog message at `LOG_ERR`, logs every per-core count with a timestamp to `/tmp/ire_crc_error_count.json` (a rolling JSON list, capped), and exits non-zero so monit alerts.
- The alert message is a fixed string mirroring the syncd `dnxc_interrupt_print_info` interrupt line: `syncd#supervisord: syncd:dnxc_interrupt_print_info: name=RQP_PACKET_REASSEMBLY_CdcPktSizeErrInt, id=487, index=0, block=0, unit=0, recurring_action=0 | Check Configuration | None#015`.
- DNX-only at runtime: on non-DNX ASICs the register is unknown (`PlatformNotSupported`) and when `syncd` is unavailable (`SyncdUnavailable`) the script exits 0 with no alert and writes nothing (no false positives). It reuses the upstream bcmcmd/syncd robustness (timeout + orphan reap) and drops the upstream poll loop and port-shutdown action.
- Added a monit stanza `check program ireWatchdog with path "/usr/bin/ire_watchdog" / every 5 cycles / if status != 0 for 1 cycle then alert repeat every 1 cycles` in `files/image_config/monit/conf.d/sonic-host`, and the install (cp + chmod 755) in `files/build_templates/sonic_debian_extension.j2` next to `control_plane_drop_check`.

#### How to verify it

- **Unit tests:** `files/image_config/monit/tests/test_ire_watchdog.py` (12 cases) — **passing** in `sonic-slave-bookworm` (`python3 -m pytest test_ire_watchdog.py -v`). Covers non-zero-triggers-alert, all-zero, non-DNX/syncd-down/transient no-false-alert, the timestamped/​capped/​corrupt-safe JSON log, and `bcmcmd` output parsing (hex+dec, unknown-register, syncd-down).
- **On a Broadcom DNX switch:** `files/image_config/monit/tests/device_test_ire_watchdog.py` is an on-device harness. Run `sudo python3 device_test_ire_watchdog.py` for safe simulated logic tests, or `sudo python3 device_test_ire_watchdog.py --live` to read the real register and run the deployed check (note: the register is clear-on-read). When `IRE_DATA_PATH_CRC_ERROR_COUNTER` is non-zero for a core, monit's `ireWatchdog` check fails and `/var/log/syslog` shows the `dnxc_interrupt_print_info ... RQP_PACKET_REASSEMBLY_CdcPktSizeErrInt ...` LOG_ERR message; on non-DNX (e.g. VS) the check is a no-op (exit 0).
- **NOTE (draft):** a local `target/sonic-vs.img.gz` image build is still pending — this PR is a DRAFT until that is run. Unit tests are added and passing.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

- [ ] <!-- not yet built/tested on an image; draft -->

#### Description for the changelog

[monit] Add ire_watchdog one-shot check that syslogs on Broadcom DNX IRE DATA_PATH CRC errors (clear-on-read; no port shutdown)

#### Link to config_db schema for YANG module changes

N/A — no YANG/CONFIG_DB changes (reads the ASIC via bcmcmd; persists only a /tmp JSON log).
