### PR TITLE
[sonic-yang-models]: Add params to enhance EVPN-VXLAN BGP global conf…

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1872,7 +1872,16 @@
             "default|l2vpn_evpn": {
                 "advertise-all-vni": "true",
                 "advertise-svi-ip": "true",
-                "autort": "rfc8365-compatible"
+                "autort": "rfc8365-compatible",
+                "advertise-default-gw": "true",
+                "advertise-ipv4-unicast": "true",
+                "advertise-ipv6-unicast": "true",
+                "default-originate-ipv4": "false",
+                "default-originate-ipv6": "false",
+                "flooding": "disable",
+                "dad-enabled": "true",
+                "dad-max-moves": "5",
+                "dad-time": "180"
             }
         },
         "BGP_GLOBALS_AF_AGGREGATE_ADDR": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
@@ -29,6 +29,109 @@
         "desc": "BGP Address Family l2vpn_evpn with advertise-svi-ip set to an invalid value",
         "eStr": "Invalid value \"invalid value\" in \"advertise-svi-ip\" element."
     },
+    "BGP_GLOBALS_AF_ADVERTISE_DEFAULT_GW_TRUE": {
+        "desc": "BGP Address Family l2vpn_evpn with advertise-default-gw set to true"
+    },
+    "BGP_GLOBALS_AF_ADVERTISE_IPV4_UNICAST_TRUE": {
+        "desc": "BGP Address Family l2vpn_evpn with advertise-ipv4-unicast set to true"
+    },
+    "BGP_GLOBALS_AF_ADVERTISE_IPV4_UNICAST_FALSE": {
+        "desc": "BGP Address Family l2vpn_evpn with advertise-ipv4-unicast set to false"
+    },
+    "BGP_GLOBALS_AF_ADVERTISE_IPV6_UNICAST_TRUE": {
+        "desc": "BGP Address Family l2vpn_evpn with advertise-ipv6-unicast set to true"
+    },
+    "BGP_GLOBALS_AF_ADVERTISE_IPV6_UNICAST_FALSE": {
+        "desc": "BGP Address Family l2vpn_evpn with advertise-ipv6-unicast set to false"
+    },
+    "BGP_GLOBALS_AF_DEFAULT_ORIGINATE_IPV4_TRUE": {
+        "desc": "BGP Address Family l2vpn_evpn with default-originate-ipv4 set to true"
+    },
+    "BGP_GLOBALS_AF_DEFAULT_ORIGINATE_IPV4_FALSE": {
+        "desc": "BGP Address Family l2vpn_evpn with default-originate-ipv4 set to false"
+    },
+    "BGP_GLOBALS_AF_DEFAULT_ORIGINATE_IPV6_TRUE": {
+        "desc": "BGP Address Family l2vpn_evpn with default-originate-ipv6 set to true"
+    },
+    "BGP_GLOBALS_AF_DEFAULT_ORIGINATE_IPV6_FALSE": {
+        "desc": "BGP Address Family l2vpn_evpn with default-originate-ipv6 set to false"
+    },
+    "BGP_GLOBALS_AF_FLOODING_DISABLE": {
+        "desc": "BGP Address Family l2vpn_evpn with flooding set to disable"
+    },
+    "BGP_GLOBALS_AF_DAD_ENABLED": {
+        "desc": "BGP Address Family l2vpn_evpn with DAD enabled and max-moves/time configured"
+    },
+    "BGP_GLOBALS_AF_DAD_FREEZE": {
+        "desc": "BGP Address Family l2vpn_evpn with DAD freeze configured"
+    },
+    "BGP_GLOBALS_AF_ROUTE_DISTINGUISHER": {
+        "desc": "BGP Address Family l2vpn_evpn with route-distinguisher configured"
+    },
+    "BGP_GLOBALS_AF_IMPORT_EXPORT_RTS": {
+        "desc": "BGP Address Family l2vpn_evpn with import and export route-targets configured"
+    },
+    "BGP_GLOBALS_EVPN_VNI_VALID": {
+        "desc": "BGP EVPN per-VNI configuration with rd and route-targets"
+    },
+    "BGP_GLOBALS_EVPN_RT_VALID": {
+        "desc": "BGP EVPN global route-target configuration"
+    },
+    "BGP_GLOBALS_EVPN_VNI_RT_VALID": {
+        "desc": "BGP EVPN per-VNI route-target configuration"
+    },
+    "BGP_GLOBALS_AF_FLOODING_INVALID": {
+        "desc": "BGP Address Family l2vpn_evpn with flooding set to an invalid value (enable)",
+        "eStrKey": "InvalidValue"
+    },
+    "BGP_GLOBALS_AF_ADVERTISE_IPV4_UNICAST_INVALID": {
+        "desc": "BGP Address Family l2vpn_evpn with advertise-ipv4-unicast set to an invalid value",
+        "eStr": "Invalid value \"invalid value\" in \"advertise-ipv4-unicast\" element."
+    },
+    "BGP_GLOBALS_AF_ADVERTISE_IPV6_UNICAST_INVALID": {
+        "desc": "BGP Address Family l2vpn_evpn with advertise-ipv6-unicast set to an invalid value",
+        "eStr": "Invalid value \"invalid value\" in \"advertise-ipv6-unicast\" element."
+    },
+    "BGP_GLOBALS_AF_DEFAULT_ORIGINATE_IPV4_INVALID": {
+        "desc": "BGP Address Family l2vpn_evpn with default-originate-ipv4 set to an invalid value",
+        "eStr": "Invalid value \"invalid value\" in \"default-originate-ipv4\" element."
+    },
+    "BGP_GLOBALS_AF_DEFAULT_ORIGINATE_IPV6_INVALID": {
+        "desc": "BGP Address Family l2vpn_evpn with default-originate-ipv6 set to an invalid value",
+        "eStr": "Invalid value \"invalid value\" in \"default-originate-ipv6\" element."
+    },
+    "BGP_GLOBALS_EVPN_VNI_INVALID_AFI_SAFI": {
+        "desc": "BGP EVPN VNI with afi_safi set to lowercase l2vpn_evpn (must be L2VPN_EVPN)",
+        "eStrKey": "InvalidValue"
+    },
+    "BGP_GLOBALS_EVPN_RT_INVALID_AFI_SAFI": {
+        "desc": "BGP EVPN RT with afi_safi set to lowercase l2vpn_evpn (must be L2VPN_EVPN)",
+        "eStrKey": "InvalidValue"
+    },
+    "BGP_GLOBALS_EVPN_RT_INVALID_RT_TYPE": {
+        "desc": "BGP EVPN RT with route-target-type set to an invalid value (bidirectional)",
+        "eStrKey": "InvalidValue"
+    },
+    "BGP_GLOBALS_EVPN_VNI_RT_INVALID_AFI_SAFI": {
+        "desc": "BGP EVPN VNI RT with afi_safi set to lowercase l2vpn_evpn (must be L2VPN_EVPN)",
+        "eStrKey": "InvalidValue"
+    },
+    "BGP_GLOBALS_AF_DAD_TIME_WITHOUT_MAX_MOVES": {
+        "desc": "BGP Address Family l2vpn_evpn with dad-time set but dad-max-moves missing (must be configured together)",
+        "eStr": ["dad-max-moves and dad-time must be configured together"]
+    },
+    "BGP_GLOBALS_AF_IMPORT_RTS_INVALID": {
+        "desc": "BGP Address Family l2vpn_evpn with import-rts set to a malformed value (abc)",
+        "eStrKey": "Pattern"
+    },
+    "BGP_GLOBALS_EVPN_RT_INVALID_RT_FORMAT": {
+        "desc": "BGP EVPN RT with rt set to a malformed value (abc)",
+        "eStrKey": "Pattern"
+    },
+    "BGP_GLOBALS_AF_ROUTE_DISTINGUISHER_INVALID": {
+        "desc": "BGP Address Family l2vpn_evpn with route-distinguisher set to a malformed value (abc)",
+        "eStrKey": "Pattern"
+    },
     "BGP_NEIGHBOR_ALL_VALID": {
         "desc": "Configure BGP neighbor table."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
@@ -249,6 +249,652 @@
             }
         }
     },
+    "BGP_GLOBALS_AF_ADVERTISE_DEFAULT_GW_TRUE": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "advertise-default-gw": true
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_ADVERTISE_IPV4_UNICAST_TRUE": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "advertise-ipv4-unicast": true
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_ADVERTISE_IPV4_UNICAST_FALSE": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "advertise-ipv4-unicast": false
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_ADVERTISE_IPV6_UNICAST_TRUE": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "advertise-ipv6-unicast": true
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_ADVERTISE_IPV6_UNICAST_FALSE": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "advertise-ipv6-unicast": false
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_DEFAULT_ORIGINATE_IPV4_TRUE": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "default-originate-ipv4": true
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_DEFAULT_ORIGINATE_IPV4_FALSE": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "default-originate-ipv4": false
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_DEFAULT_ORIGINATE_IPV6_TRUE": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "default-originate-ipv6": true
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_DEFAULT_ORIGINATE_IPV6_FALSE": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "default-originate-ipv6": false
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_FLOODING_DISABLE": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "flooding": "disable"
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_DAD_ENABLED": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "dad-enabled": true,
+                    "dad-max-moves": 5,
+                    "dad-time": 180
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_DAD_FREEZE": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "dad-freeze": 300
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_ROUTE_DISTINGUISHER": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "route-distinguisher": "65001:100"
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_IMPORT_EXPORT_RTS": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "import-rts": ["65001:100", "65001:200"],
+                    "export-rts": ["65001:100"]
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_EVPN_VNI_VALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_EVPN_VNI": {
+                "BGP_GLOBALS_EVPN_VNI_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "L2VPN_EVPN",
+                    "vni": 10100,
+                    "route-distinguisher": "65001:100",
+                    "import-rts": ["65001:100"],
+                    "export-rts": ["65001:100"],
+                    "advertise-default-gw": true
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_EVPN_RT_VALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_EVPN_RT": {
+                "BGP_GLOBALS_EVPN_RT_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "L2VPN_EVPN",
+                    "rt": "65001:100",
+                    "route-target-type": "both"
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_EVPN_VNI_RT_VALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_EVPN_VNI_RT": {
+                "BGP_GLOBALS_EVPN_VNI_RT_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "L2VPN_EVPN",
+                    "vni": 10100,
+                    "rt": "65001:100",
+                    "route-target-type": "import"
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_FLOODING_INVALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "flooding": "enable"
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_ADVERTISE_IPV4_UNICAST_INVALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "advertise-ipv4-unicast": "invalid value"
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_ADVERTISE_IPV6_UNICAST_INVALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "advertise-ipv6-unicast": "invalid value"
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_DEFAULT_ORIGINATE_IPV4_INVALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "default-originate-ipv4": "invalid value"
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_DEFAULT_ORIGINATE_IPV6_INVALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "default-originate-ipv6": "invalid value"
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_EVPN_VNI_INVALID_AFI_SAFI": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_EVPN_VNI": {
+                "BGP_GLOBALS_EVPN_VNI_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "vni": 10100
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_EVPN_RT_INVALID_AFI_SAFI": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_EVPN_RT": {
+                "BGP_GLOBALS_EVPN_RT_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "rt": "65001:100",
+                    "route-target-type": "both"
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_EVPN_RT_INVALID_RT_TYPE": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_EVPN_RT": {
+                "BGP_GLOBALS_EVPN_RT_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "L2VPN_EVPN",
+                    "rt": "65001:100",
+                    "route-target-type": "bidirectional"
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_EVPN_VNI_RT_INVALID_AFI_SAFI": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_EVPN_VNI_RT": {
+                "BGP_GLOBALS_EVPN_VNI_RT_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "vni": 10100,
+                    "rt": "65001:100",
+                    "route-target-type": "import"
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_DAD_TIME_WITHOUT_MAX_MOVES": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "dad-enabled": true,
+                    "dad-time": 180
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_IMPORT_RTS_INVALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "import-rts": ["abc"]
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_EVPN_RT_INVALID_RT_FORMAT": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_EVPN_RT": {
+                "BGP_GLOBALS_EVPN_RT_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "L2VPN_EVPN",
+                    "rt": "abc",
+                    "route-target-type": "both"
+                }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_ROUTE_DISTINGUISHER_INVALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                {
+                    "vrf_name":"default",
+                    "local_asn": 65001
+                }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                {
+                    "vrf_name": "default",
+                    "afi_safi": "l2vpn_evpn",
+                    "route-distinguisher": "abc"
+                }
+                ]
+            }
+        }
+    },
     "BGP_NEIGHBOR_ALL_VALID": {
         "sonic-port:sonic-port": {
             "sonic-port:PORT": {

--- a/src/sonic-yang-models/yang-models/sonic-bgp-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-global.yang
@@ -33,6 +33,30 @@ module sonic-bgp-global {
             "Initial revision.";
     }
 
+    typedef rd-rt-format {
+        type union {
+            type string {
+                // Type 1: 2-octet global and 4-octet local
+                //         (AS number)        (Integer)
+                pattern '(6[0-5][0-5][0-3][0-5]|[1-5][0-9]{4}|'            +
+                        '[1-9][0-9]{1,4}|[0-9]):'                          +
+                        '(4[0-2][0-9][0-4][0-9][0-6][0-7][0-2][0-9][0-6]|' +
+                        '[1-3][0-9]{9}|[1-9]([0-9]{1,7})?[0-9]|[1-9])';
+            }
+            type string {
+                // Type 2: 4-octet global and 2-octet local
+                //         (ipv4-address)     (integer)
+                pattern '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|'      +
+                        '25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|'     +
+                        '2[0-4][0-9]|25[0-5]):'                            +
+                        '(6[0-5][0-5][0-3][0-5]|[1-5][0-9]{4}|'            +
+                        '[1-9][0-9]{1,4}|[0-9])';
+            }
+        }
+        description
+            "Route distinguisher or route target in ASN:NN or IPv4:NN format.";
+    }
+
     container sonic-bgp-global {
         container BGP_GLOBALS {
             list BGP_GLOBALS_LIST {
@@ -462,6 +486,216 @@ module sonic-bgp-global {
                 leaf advertise-svi-ip {
                     type boolean;
                     description "L2VPN advertise the local SVI IP address so that it can be accessible from remote VTEPs";
+                }
+                leaf advertise-default-gw {
+                    type boolean;
+                    description "L2VPN advertise the default gateway MAC/IP routes";
+                }
+
+                leaf advertise-ipv4-unicast {
+                    type boolean;
+                    description "L2VPN advertise IPv4 unicast routes in l2vpn evpn address family";
+                }
+
+                leaf advertise-ipv6-unicast {
+                    type boolean;
+                    description "L2VPN advertise IPv6 unicast routes in l2vpn evpn address family";
+                }
+
+                leaf default-originate-ipv4 {
+                    type boolean;
+                    description "L2VPN originate default IPv4 route in l2vpn evpn address family";
+                }
+
+                leaf default-originate-ipv6 {
+                    type boolean;
+                    description "L2VPN originate default IPv6 route in l2vpn evpn address family";
+                }
+
+                leaf flooding {
+                    type enumeration {
+                        enum disable;
+                    }
+                    description "L2VPN flood control - disable disables head-end replication";
+                }
+
+                leaf dad-enabled {
+                    type boolean;
+                    description "L2VPN EVPN duplicate address detection enable/disable";
+                }
+
+                leaf dad-max-moves {
+                    must "(boolean(../dad-time) and boolean(current())) or (not(../dad-time) and not(current()))" {
+                        error-message "dad-max-moves and dad-time must be configured together";
+                    }
+                    type uint32 {
+                        range "2..1000";
+                    }
+                    description "L2VPN EVPN DAD maximum number of moves before declaring duplicate";
+                }
+
+                leaf dad-time {
+                    must "(boolean(../dad-max-moves) and boolean(current())) or (not(../dad-max-moves) and not(current()))" {
+                        error-message "dad-max-moves and dad-time must be configured together";
+                    }
+                    type uint32 {
+                        range "2..1800";
+                    }
+                    description "L2VPN EVPN DAD time interval in seconds to detect duplicate address";
+                }
+
+                leaf dad-freeze {
+                    type union {
+                        type enumeration {
+                            enum permanent;
+                        }
+                        type uint32 {
+                            range "30..3600";
+                        }
+                    }
+                    description "L2VPN EVPN DAD freeze duration in seconds or permanent";
+                }
+
+                leaf route-distinguisher {
+                    type rd-rt-format;
+                    description "L2VPN EVPN route distinguisher in ASN:NN or IP:NN format";
+                }
+
+                leaf-list import-rts {
+                    type rd-rt-format;
+                    description "L2VPN EVPN import route targets in ASN:NN or IP:NN format";
+                }
+
+                leaf-list export-rts {
+                    type rd-rt-format;
+                    description "L2VPN EVPN export route targets in ASN:NN or IP:NN format";
+                }
+            }
+        }
+
+        container BGP_GLOBALS_EVPN_VNI {
+            description "BGP L2VPN EVPN per-VNI configuration";
+            list BGP_GLOBALS_EVPN_VNI_LIST {
+                key "vrf_name afi_safi vni";
+
+                leaf vrf_name {
+                    type leafref {
+                        path "../../../BGP_GLOBALS/BGP_GLOBALS_LIST/vrf_name";
+                    }
+                    description "VRF name";
+                }
+
+                leaf afi_safi {
+                    type enumeration {
+                        enum L2VPN_EVPN;
+                    }
+                    description "Address family identifier - must be L2VPN_EVPN";
+                }
+
+                leaf vni {
+                    type uint32 {
+                        range "1..16777215";
+                    }
+                    description "VNI number";
+                }
+
+                leaf advertise-default-gw {
+                    type boolean;
+                    description "Advertise default gateway MAC/IP routes for this VNI";
+                }
+
+                leaf route-distinguisher {
+                    type rd-rt-format;
+                    description "Route distinguisher for this VNI in ASN:NN or IP:NN format";
+                }
+
+                leaf-list import-rts {
+                    type rd-rt-format;
+                    description "Import route targets for this VNI in ASN:NN or IP:NN format";
+                }
+
+                leaf-list export-rts {
+                    type rd-rt-format;
+                    description "Export route targets for this VNI in ASN:NN or IP:NN format";
+                }
+            }
+        }
+
+        container BGP_GLOBALS_EVPN_RT {
+            description "BGP L2VPN EVPN global route-target configuration";
+            list BGP_GLOBALS_EVPN_RT_LIST {
+                key "vrf_name afi_safi rt";
+
+                leaf vrf_name {
+                    type leafref {
+                        path "../../../BGP_GLOBALS/BGP_GLOBALS_LIST/vrf_name";
+                    }
+                    description "VRF name";
+                }
+
+                leaf afi_safi {
+                    type enumeration {
+                        enum L2VPN_EVPN;
+                    }
+                    description "Address family identifier - must be L2VPN_EVPN";
+                }
+
+                leaf rt {
+                    type rd-rt-format;
+                    description "Route target value in ASN:NN or IP:NN format";
+                }
+
+                leaf route-target-type {
+                    type enumeration {
+                        enum import;
+                        enum export;
+                        enum both;
+                    }
+                    mandatory true;
+                    description "Route target direction";
+                }
+            }
+        }
+
+        container BGP_GLOBALS_EVPN_VNI_RT {
+            description "BGP L2VPN EVPN per-VNI route-target configuration";
+            list BGP_GLOBALS_EVPN_VNI_RT_LIST {
+                key "vrf_name afi_safi vni rt";
+
+                leaf vrf_name {
+                    type leafref {
+                        path "../../../BGP_GLOBALS/BGP_GLOBALS_LIST/vrf_name";
+                    }
+                    description "VRF name";
+                }
+
+                leaf afi_safi {
+                    type enumeration {
+                        enum L2VPN_EVPN;
+                    }
+                    description "Address family identifier - must be L2VPN_EVPN";
+                }
+
+                leaf vni {
+                    type uint32 {
+                        range "1..16777215";
+                    }
+                    description "VNI number";
+                }
+
+                leaf rt {
+                    type rd-rt-format;
+                    description "Route target value in ASN:NN or IP:NN format";
+                }
+
+                leaf route-target-type {
+                    type enumeration {
+                        enum import;
+                        enum export;
+                        enum both;
+                    }
+                    mandatory true;
+                    description "Route target direction for this VNI";
                 }
             }
         }


### PR DESCRIPTION
…igurations

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The existing EVPN-VXLAN YANG model does not cover several EVPN BGP address-family configuration parameters that are supported by FRR. As a result, these configurations cannot be applied through config apply-patch, preventing ConfigDB from being the complete source of truth for EVPN-VXLAN configuration.
This change extends the EVPN-VXLAN YANG model to include the missing configuration parameters so they can be validated and configured through the SONiC management framework.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Extended src/sonic-yang-models/yang-models/sonic-bgp-global.yang to add support for the missing EVPN-VXLAN BGP address-family configuration parameters.

The changes include:

- Added a reusable rd-rt-format typedef to validate Route Distinguisher (RD) and Route Target (RT) values in both ASN:NN and IPv4:NN formats.
- Added support for additional EVPN BGP address-family configuration parameters, including advertise flags, default-originate, flooding control, Duplicate Address Detection (DAD) parameters, route distinguishers, and import/export route targets.
Added a must constraint to ensure dad-max-moves and dad-time are configured together.
- Added new containers for global and per-VNI Route Distinguisher and Route Target configuration.
- Updated tests/files/sample_config_db.json.
- Added positive and negative YANG model validation tests under tests/yang_model_tests/.
#### How to verify it
- Apply an EVPN-VXLAN configuration using config apply-patch.
- Verify that the configuration is successfully written to ConfigDB.
- Verify that the expected FRR configuration is generated using:
```show runningconfiguration bgpd```
or
```vtysh -c "show running-config"```
- Verify that invalid configuration values are rejected by YANG validation when applying the patch.
- Run the positive and negative YANG model unit tests under tests/yang_model_tests/ and confirm they pass.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Add YANG model support for additional EVPN-VXLAN BGP address-family configuration parameters.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

