### PR TITLE
yang: support VLAN subinterfaces for BGP unnumbered

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vlan_sub_interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vlan_sub_interface.json
@@ -56,6 +56,13 @@
         "eStrKey" : "Pattern",
         "eStr": ["drop|forward"]
     },
+    "VLAN_SUB_INTERFACE_ENABLE_IPV6_LINK_LOCAL": {
+        "desc": "Enable the ipv6 link-local."
+    },
+    "VLAN_SUB_INTERFACE_INVALID_ENABLE_IPV6_LINK_LOCAL": {
+        "desc": "Enable the ipv6 link-local as true.",
+        "eStr": "Invalid value \"true\" in \"ipv6_use_link_local_only\" element."
+    },
     "VLAN_SUB_INTERFACE_SHORT_NAME_FORMAT_VLAN_CHECK_MUST_CONDITION_FALSE_TEST": {
         "desc": "Configure valid short name format vlan sub interface vlan must check condition false.",
         "eStrKey": "Must"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan_sub_interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan_sub_interface.json
@@ -538,6 +538,60 @@
             }
         }
     },
+    "VLAN_SUB_INTERFACE_ENABLE_IPV6_LINK_LOCAL": {
+        "sonic-vlan-sub-interface:sonic-vlan-sub-interface": {
+            "sonic-vlan-sub-interface:VLAN_SUB_INTERFACE": {
+                "VLAN_SUB_INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8.10",
+                        "ipv6_use_link_local_only": "enable"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "admin_status": "up",
+                        "alias": "Ethernet8/1",
+                        "description": "Ethernet8",
+                        "lanes": "45,46,47,48",
+                        "mtu": 9000,
+                        "speed": 100000
+                    }
+                ]
+            }
+        }
+    },
+    "VLAN_SUB_INTERFACE_INVALID_ENABLE_IPV6_LINK_LOCAL": {
+        "sonic-vlan-sub-interface:sonic-vlan-sub-interface": {
+            "sonic-vlan-sub-interface:VLAN_SUB_INTERFACE": {
+                "VLAN_SUB_INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8.10",
+                        "ipv6_use_link_local_only": "true"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "admin_status": "up",
+                        "alias": "Ethernet8/1",
+                        "description": "Ethernet8",
+                        "lanes": "45,46,47,48",
+                        "mtu": 9000,
+                        "speed": 100000
+                    }
+                ]
+            }
+        }
+    },
     "VLAN_SUB_INTERFACE_SHORT_NAME_FORMAT_VLAN_CHECK_MUST_CONDITION_FALSE_TEST": {
         "sonic-vlan-sub-interface:sonic-vlan-sub-interface": {
             "sonic-vlan-sub-interface:VLAN_SUB_INTERFACE": {

--- a/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
@@ -19,6 +19,10 @@ module sonic-bgp-neighbor {
         prefix lag;
     }
 
+    import sonic-vlan-sub-interface {
+        prefix vlan-sub-interface;
+    }
+
     // Comment sonic-vlan import here until libyang back-links issue is resolved for VLAN leaf reference.
     //import sonic-vlan {
     //    prefix vlan;
@@ -93,6 +97,9 @@ module sonic-bgp-neighbor {
                        // }
                         type string {
                             pattern 'Vlan([0-9]{1,3}|[1-3][0-9]{3}|[4][0][0-8][0-9]|[4][0][9][0-4])';
+                        }
+                        type leafref {
+                            path "/vlan-sub-interface:sonic-vlan-sub-interface/vlan-sub-interface:VLAN_SUB_INTERFACE/vlan-sub-interface:VLAN_SUB_INTERFACE_LIST/vlan-sub-interface:name";
                         }
                     }
                     description "BGP Neighbor, it will be neighbor address or interface name";

--- a/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
@@ -36,6 +36,10 @@ module sonic-vlan-sub-interface {
         description "Initial version";
     }
 
+    revision 2025-12-23 {
+        description "Add leaf ipv6_use_link_local_only";
+    }
+
     container sonic-vlan-sub-interface {
         container VLAN_SUB_INTERFACE {
 
@@ -102,6 +106,12 @@ module sonic-vlan-sub-interface {
                     type uint16 {
                         range 1..4094;
                     }
+                }
+
+                leaf ipv6_use_link_local_only {
+                    description "Enable/Disable IPv6 link local address on vlan-sub-interface";
+                    type stypes:mode-status;
+                    default disable;
                 }
             }
 


### PR DESCRIPTION
## Summary

Add YANG model support needed for BGP unnumbered over VLAN subinterfaces.

## Why

VLAN subinterfaces need schema support for IPv6 link-local-only mode and for use as BGP neighbors. This lets configuration validation accept the link-local mode used by the CLI and neighbor-sync changes, and allows BGP neighbor entries to reference VLAN subinterfaces.

## Changes

- Add `ipv6_use_link_local_only` under `VLAN_SUB_INTERFACE_LIST`.
- Add YANG model tests for the valid `enable` value and an invalid boolean-like value.
- Allow `BGP_NEIGHBOR_LIST` neighbors to reference VLAN subinterface names.

## Related

- Design proposal: https://github.com/sonic-net/SONiC/pull/2414

## Validation

- `git diff --check upstream/master..HEAD`
- `python3 -m json.tool src/sonic-yang-models/tests/yang_model_tests/tests/vlan_sub_interface.json`
- `python3 -m json.tool src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan_sub_interface.json`
- Reviewed the diff for unintended references.
