### PR TITLE
[Q3D] fix the interrupt stuck on clear and enable prev missed interrupt

### DIFF
--- a/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O32-C32/nh5010-default.bcm
+++ b/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O32-C32/nh5010-default.bcm
@@ -2272,3 +2272,6 @@ xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=4
 
 #Disable hardware PFC watchdog
 sai_pfc_dlr_init_capability=0
+
+#reduce the chance of stuck-clear interrupt
+appl_param_clear_fail_threshold=5

--- a/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/defaults/nh5010.bcm
+++ b/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/defaults/nh5010.bcm
@@ -2276,5 +2276,9 @@ macsec_fips_enable=1
 xflow_macsec_secure_chan_to_num_secure_assoc=4
 xflow_macsec_secure_chan_to_num_secure_assoc_encrypt=2
 xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=4
+
 #Disable hardware PFC watchdog
 sai_pfc_dlr_init_capability=0
+
+#reduce the chance of stuck-clear interrupt
+appl_param_clear_fail_threshold=5

--- a/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/sai_postinit_cmd.soc
+++ b/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/sai_postinit_cmd.soc
@@ -1,6 +1,7 @@
 setreg MSU_MACSEC_INTERRUPT_MASK_REGISTER.MSU13 0x0
 setreg MSU_MACSEC_INTERRUPT_MASK_REGISTER.MSU16 0x0
 
+# todo: remove this part when SAI 14.x DMZ has this enabled
 setreg IRE_DATA_PATH_CRC_CONFIG.IRE0 DATA_PATH_CRC_ENABLE=0x1fe
 setreg IRE_DATA_PATH_CRC_CONFIG.IRE1 DATA_PATH_CRC_ENABLE=0xff
 setreg IRE_DATA_PATH_CRC_CONFIG.IRE2 DATA_PATH_CRC_ENABLE=0xff
@@ -65,6 +66,7 @@ INTeRrupt ENAble id=2262 p=1
 INTeRrupt ENAble id=2263 p=1
 
 
+INTeRrupt ENAble id=540 p=1
 INTeRrupt ENAble id=541 p=1
 INTeRrupt ENAble id=542 p=1
 INTeRrupt ENAble id=543 p=1
@@ -92,7 +94,7 @@ INTeRrupt ENAble id=2261 p=2
 INTeRrupt ENAble id=2262 p=2
 INTeRrupt ENAble id=2263 p=2
 
-
+INTeRrupt ENAble id=540 p=2
 INTeRrupt ENAble id=541 p=2
 INTeRrupt ENAble id=542 p=2
 INTeRrupt ENAble id=543 p=2
@@ -120,7 +122,7 @@ INTeRrupt ENAble id=2261 p=3
 INTeRrupt ENAble id=2262 p=3
 INTeRrupt ENAble id=2263 p=3
 
-
+INTeRrupt ENAble id=540 p=3
 INTeRrupt ENAble id=541 p=3
 INTeRrupt ENAble id=542 p=3
 INTeRrupt ENAble id=543 p=3
@@ -148,7 +150,7 @@ INTeRrupt ENAble id=2261 p=4
 INTeRrupt ENAble id=2262 p=4
 INTeRrupt ENAble id=2263 p=4
 
-
+INTeRrupt ENAble id=540 p=4
 INTeRrupt ENAble id=541 p=4
 INTeRrupt ENAble id=542 p=4
 INTeRrupt ENAble id=543 p=4
@@ -176,7 +178,7 @@ INTeRrupt ENAble id=2261 p=5
 INTeRrupt ENAble id=2262 p=5
 INTeRrupt ENAble id=2263 p=5
 
-
+INTeRrupt ENAble id=540 p=5
 INTeRrupt ENAble id=541 p=5
 INTeRrupt ENAble id=542 p=5
 INTeRrupt ENAble id=543 p=5
@@ -204,7 +206,7 @@ INTeRrupt ENAble id=2261 p=6
 INTeRrupt ENAble id=2262 p=6
 INTeRrupt ENAble id=2263 p=6
 
-
+INTeRrupt ENAble id=540 p=6
 INTeRrupt ENAble id=541 p=6
 INTeRrupt ENAble id=542 p=6
 INTeRrupt ENAble id=543 p=6
@@ -232,6 +234,7 @@ INTeRrupt ENAble id=2261 p=7
 INTeRrupt ENAble id=2262 p=7
 INTeRrupt ENAble id=2263 p=7
 
+INTeRrupt ENAble id=540 p=7
 INTeRrupt ENAble id=541 p=7
 INTeRrupt ENAble id=542 p=7
 INTeRrupt ENAble id=543 p=7

--- a/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/templates/nh5010.bcm.j2
+++ b/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/templates/nh5010.bcm.j2
@@ -1904,3 +1904,6 @@ xflow_macsec_secure_chan_to_num_secure_assoc_decrypt=4
 
 #Disable hardware PFC watchdog
 sai_pfc_dlr_init_capability=0
+
+#reduce the chance of stuck-clear interrupt
+appl_param_clear_fail_threshold=5


### PR DESCRIPTION
master & 202605 PR: https://github.com/sonic-net/sonic-buildimage/pull/28029 
1. IRE interrupt fired, ISR handled it and raised a syslog. But when it tries to clear the interrupt, the clear fails, and the interrupt is MASKED. \ Fix for this is to make appl_param_clear_fail_threshold > 1
    CSP: CS00012467467

2. After reviewing the CRC interrupts for q3d in CSP: CS00012466936 the required CRC interrupts have already been enabled via this PR: https://githu\ b.com/sonic-net/sonic-buildimage/pull/26945 . However interrupt id 540 (DDP_EXT_MEM_ERR_PkupCpydatEcc_1bErrInt) was enabled only on core 0. this PR enab\ les it on all cores

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

