### PR TITLE
[pmon]: Install libyaml-cpp runtime dependency

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -13,11 +13,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV IMAGE_VERSION=$image_version
 
 # Install required packages
+# libyaml-cpp0.8 is required by Cisco SmartSwitch platform modules loaded by PMON.
 RUN apt-get update &&   \
     apt-get install -y  \
         build-essential \
         python3-dev     \
         ipmitool        \
+        libyaml-cpp0.8  \
         librrd8t64      \
         librrd-dev      \
         rrdtool         \

--- a/files/build/versions-public/dockers/docker-platform-monitor/versions-deb-trixie
+++ b/files/build/versions-public/dockers/docker-platform-monitor/versions-deb-trixie
@@ -129,6 +129,7 @@ libxdmcp6==1:1.1.5-1
 libxext6==2:1.3.4-1+b3
 libxml2==2.12.7+dfsg+really2.9.14-2.1+deb13u2
 libxrender1==1:0.9.12-1
+libyaml-cpp0.8==0.8.0+dfsg-7
 libyang3-dbgsym==3.12.2-1
 linux-libc-dev==6.12.90-2
 lm-sensors==1:3.6.0-7.1

--- a/files/build/versions-public/dockers/docker-platform-monitor/versions-deb-trixie-armhf
+++ b/files/build/versions-public/dockers/docker-platform-monitor/versions-deb-trixie-armhf
@@ -5,3 +5,4 @@ g++-14-arm-linux-gnueabihf==14.2.0-19
 g++-arm-linux-gnueabihf==4:14.2.0-1
 gcc-14-arm-linux-gnueabihf==14.2.0-19
 gcc-arm-linux-gnueabihf==4:14.2.0-1
+libyaml-cpp0.8==0.8.0+dfsg-7


### PR DESCRIPTION
#### Why I did it

PMON was upgraded to a Trixie-based container, but `docker-platform-monitor` does not install the Trixie runtime package that provides `libyaml-cpp.so.0.8`. This is not expected to affect every Trixie-based PMON platform. The impact is platform-specific: platforms whose PMON-loaded platform API or daemon dependency chain requires `libyaml-cpp.so.0.8` can fail with ImportError, while platforms without that dependency can continue to run normally.

The issue was reproduced on affected Cisco 8102 SmartSwitch NPU images, where the host had the library while the `pmon` container did not. This caused platform daemons such as `chassisd`, `thermalctld`, `syseepromd`, `xcvrd`, `psud`, and `sensormond` to exit with ImportError. When `chassisd` was down, chassis/DPU state was not initialized and DPU management reachability failed.

Evidence from affected 8102 SmartSwitch NPUs:

```text
pmon#supervisord: thermalctld   File "/usr/local/lib/python3.13/dist-packages/sonic_platform/thermal.py", line 15, in <module>
pmon#supervisord: thermalctld   File "/usr/local/lib/python3.13/dist-packages/sonic_platform/psu_tray.py", line 10, in <module>
pmon#supervisord: thermalctld   File "/usr/local/lib/python3.13/dist-packages/sonic_platform/psu.py", line 20, in <module>
pmon#supervisord: thermalctld   File "/usr/local/lib/python3.13/dist-packages/sonic_platform/thermal.py", line 21, in <module>
pmon#supervisord: thermalctld     raise ImportError (str(e) + "- required module not found")
pmon#supervisord: thermalctld ImportError: libyaml-cpp.so.0.8: cannot open shared object file: No such file or directory- required module not found
pmon#supervisord: thermalctld   File "/usr/local/lib/python3.13/dist-packages/sonic_platform/chassis.py", line 20, in <module>
pmon#supervisord: thermalctld   File "/usr/local/lib/python3.13/dist-packages/sonic_platform/psu_tray.py", line 17, in <module>
pmon#supervisord: thermalctld     raise ImportError (str(e) + "- required module not found")
pmon#supervisord: thermalctld ImportError: libyaml-cpp.so.0.8: cannot open shared object file: No such file or directory- required module not found- required module not found
pmon#supervisord: thermalctld   File "/usr/local/lib/python3.13/dist-packages/sonic_platform/platform.py", line 12, in <module>
pmon#supervisord: thermalctld   File "/usr/local/lib/python3.13/dist-packages/sonic_platform/chassis.py", line 63, in <module>
pmon#supervisord: thermalctld     raise ImportError (str(e) + "- required module not found")
pmon#supervisord: thermalctld ImportError: libyaml-cpp.so.0.8: cannot open shared object file: No such file or directory- required module not found- required module not found- required module not found
pmon#supervisord: thermalctld   File "/usr/local/bin/thermalctld", line 20, in <module>
pmon#supervisord: thermalctld   File "/usr/local/lib/python3.13/dist-packages/sonic_platform/__init__.py", line 2, in <module>
pmon#supervisord: thermalctld   File "/usr/local/lib/python3.13/dist-packages/sonic_platform/platform.py", line 14, in <module>
pmon#supervisord: thermalctld     raise ImportError(str(e) + "- required module not found")
pmon#supervisord: thermalctld ImportError: libyaml-cpp.so.0.8: cannot open shared object file: No such file or directory- required module not found- required module not found- required module not found- required module not found
```

`pmon` supervisor state before live mitigation:

```text
chassisd      FATAL  Exited too quickly
psud          FATAL  Exited too quickly
sensormond    FATAL  Exited too quickly
syseepromd    FATAL  Exited too quickly
thermalctld   FATAL  Exited too quickly
xcvrd         FATAL  Exited too quickly
```

Library presence check before live mitigation:

```text
HOST
/usr/lib/x86_64-linux-gnu/libyaml-cpp.so.0.8

PMON
# no libyaml-cpp.so.0.8 found
```

After copying `libyaml-cpp.so.0.8` into the running `pmon` container and restarting the daemons, the platform daemons recovered and required DPU state became ready again:

```text
chassisd      RUNNING
psud          RUNNING
sensormond    RUNNING
syseepromd    RUNNING
thermalctld   RUNNING
xcvrd         RUNNING

Required DPUs: Online/up/Ready=true
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Install the Trixie runtime package `libyaml-cpp0.8` in the `docker-platform-monitor` image so PMON platform daemon dependencies are present inside the container when a platform plugin requires this shared library.

#### How to verify it

- Verified `libyaml-cpp0.8` exists in Debian Trixie:
  `docker run --rm debian:trixie bash -lc 'apt-get update -qq && apt-cache policy libyaml-cpp0.8'`
- Ran `make configure PLATFORM=vs` and `make SONIC_BUILD_JOBS=4 target/docker-platform-monitor.gz`.
- Loaded the built PMON image and verified the runtime package and shared object exist:

```bash
gzip -dc target/docker-platform-monitor.gz | docker load
docker run --rm --entrypoint bash docker-platform-monitor:latest -lc \
  'dpkg -l | grep libyaml-cpp0.8; dpkg -L libyaml-cpp0.8 | grep libyaml-cpp.so.0.8'
```

Observed:

```text
ii  libyaml-cpp0.8:amd64  0.8.0+dfsg-7  amd64  YAML parser and emitter for C++
/usr/lib/x86_64-linux-gnu/libyaml-cpp.so.0.8.0
/usr/lib/x86_64-linux-gnu/libyaml-cpp.so.0.8
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [x] master

#### Description for the changelog

Install libyaml-cpp runtime dependency in the PMON container for platforms that require it.

#### Link to config_db schema for YANG module changes

N/A
