### PR TITLE
gnmi: restrict --noTLS fallback to loopback interface

### DIFF
--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -57,7 +57,7 @@ elif [ -n "$X509" ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
 else
-    TELEMETRY_ARGS+=" --noTLS"
+    TELEMETRY_ARGS+=" --noTLS --bind_address 127.0.0.1"
 fi
 
 # If no configuration entry exists for TELEMETRY, create one default port

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -77,7 +77,7 @@ elif [ -n "$X509" ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
 else
-    TELEMETRY_ARGS+=" --noTLS"
+    TELEMETRY_ARGS+=" --noTLS --bind_address 127.0.0.1"
 fi
 
 # If no configuration entry exists for TELEMETRY, create one default port


### PR DESCRIPTION
#### Why I did it

When no TLS certificates are configured in CONFIG_DB, `gnmi-native.sh` and `telemetry.sh` fall back to `--noTLS`, which binds the gNMI listener on all network interfaces over cleartext.

Add `--bind_address 127.0.0.1` to the fallback so the cleartext endpoint is only accessible from localhost. Operators who configure real certs continue to bind to all interfaces with TLS (unchanged).

##### Work item tracking
- Microsoft ADO:

#### How I did it

One-line change in each script: `--noTLS` → `--noTLS --bind_address 127.0.0.1` in the else-branch (no certs configured).

Devices with certificates configured are unaffected — those paths use `--insecure` or real cert/key and do not set `--bind_address`.

#### How to verify it

1. Boot a VS image with no `GNMI|certs` in CONFIG_DB.
2. `ps aux | grep telemetry` — should show `--noTLS --bind_address 127.0.0.1`.
3. Confirm gNMI port (8080) is not reachable from an external host.
4. Configure `GNMI|certs` with empty cert fields; restart telemetry — should show `--insecure` with no bind restriction and be reachable externally.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

- [ ]

#### Description for the changelog

gnmi: restrict --noTLS fallback listener to loopback interface

#### Link to config_db schema for YANG module changes

N/A