### PR TITLE
[github]: Add 202512 and 202608 to backport release branch list in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,6 +40,7 @@ If PR needs to be backported, then the PR must be tested against the base branch
 - [ ] 202511
 - [ ] 202512
 - [ ] 202605
+- [ ] 202608
 
 #### Tested branch (Please provide the tested image version)
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,6 +38,7 @@ If PR needs to be backported, then the PR must be tested against the base branch
 - [ ] 202411
 - [ ] 202505
 - [ ] 202511
+- [ ] 202512
 - [ ] 202605
 
 #### Tested branch (Please provide the tested image version)


### PR DESCRIPTION
#### Why I did it

The 202512 and 202608 release branches exist but were missing from the "Which release branch to backport" checklist in the PR template.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added `202512` (between `202511` and `202605`) and `202608` (after `202605`) entries to the backport checklist in `.github/pull_request_template.md`.

#### How to verify it

Open a new PR in sonic-buildimage and verify the "Which release branch to backport" section now includes `202512` and `202608` as checkbox options.

#### Which release branch to backport (provide reason below if selected)

N/A - template update only.

#### Tested branch (Please provide the tested image version)

N/A - documentation change only.

#### Description for the changelog

Add 202512 and 202608 to backport release branch list in PR template.

#### Link to config_db schema for YANG module changes

N/A