### PR TITLE
[dhcp-relay] Change default DHCPv4 relay from isc to sonic-dhcpv4-relay

### DIFF
--- a/src/sonic-dhcp-utilities/dhcp_utilities/dhcprelayd/dhcprelayd.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/dhcprelayd/dhcprelayd.py
@@ -109,7 +109,7 @@ class DhcpRelayd(object):
         self._disable_checkers(checkers_to_be_disabled)
 
         feature_table = self.db_connector.get_config_db_table("DEVICE_METADATA")
-        if feature_table.get("localhost", {}).get("has_sonic_dhcpv4_relay", "False") == "False":
+        if feature_table.get("localhost", {}).get("has_sonic_dhcpv4_relay", "True") == "False":
            self._start_dhcrelay_process(dhcp_interfaces, dhcp_server_ip, force_kill)
 
         # TODO dhcpmon is not ready for count packet for dhcp_server, hence comment invoke it for now

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -368,7 +368,7 @@ module sonic-device_metadata {
                 leaf has_sonic_dhcpv4_relay {
                      description "This configuration controls the dhcpv4 relay process";
                      type stypes:boolean_type;
-                     default "false";
+                     default "true";
                 }
 
                 leaf zebra_nexthop {


### PR DESCRIPTION
#### Why I did it

Change the default DHCPv4 relay implementation from isc-dhcpv4-relay to sonic-dhcpv4-relay. Devices that do not explicitly set `has_sonic_dhcpv4_relay` in `DEVICE_METADATA` (e.g. old configs that pre-date the feature) should now default to sonic-dhcpv4-relay.

##### Work item tracking
- Microsoft ADO:

#### How I did it

Two places enforce the default when `has_sonic_dhcpv4_relay` is absent:

1. **YANG model** (`src/sonic-yang-models/yang-models/sonic-device_metadata.yang`) — `default "false"` → `default "true"`, governs the value emitted by `sonic-cfggen`.
2. **Runtime fallback** (`src/sonic-dhcp-utilities/dhcp_utilities/dhcprelayd/dhcprelayd.py`) — `.get("has_sonic_dhcpv4_relay", "False")` → `.get("has_sonic_dhcpv4_relay", "True")`, governs behavior when the key is missing from ConfigDB at runtime.

Devices that explicitly set `has_sonic_dhcpv4_relay: false` are unaffected.

#### How to verify it

On a device with no `has_sonic_dhcpv4_relay` key in `DEVICE_METADATA`, confirm that `dhcprelayd` starts sonic-dhcpv4-relay instead of `dhcrelay` (isc).

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

Change default DHCPv4 relay from isc-dhcpv4-relay to sonic-dhcpv4-relay.

#### Link to config_db schema for YANG module changes

https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md

#### A picture of a cute animal (not mandatory but encouraged)