### PR TITLE
[docker-ptf] Cherry-pick Dockerfile.j2 changes from master to 202605

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -104,18 +104,18 @@ RUN apt-get update          \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Go toolchain for building grpcurl and gnmic from source
-# to ensure they use a patched Go stdlib (GO-2026-4337: crypto/tls)
+# to ensure they use a patched Go stdlib (GO-2026-5039: net/textproto)
 {% if CONFIGURED_ARCH == "armhf" %}
 RUN GO_ARCH=armv6l \
-    && GO_SHA256=39f168f158e693887d3ad006168af1b1a3007b19c5993cae4d9d57f82f52aaf8 \
+    && GO_SHA256=492d69badee59cae12e9a36282dfce94041bd4aac88fdddea575a7d99a2bd05d \
 {% elif CONFIGURED_ARCH == "arm64" %}
 RUN GO_ARCH=arm64 \
-    && GO_SHA256=654da1f9b50a5d1c2a85ccf8ed405aa89c06e94d18384628bf186f7712677b08 \
+    && GO_SHA256=c30bf9e156a54ea4e31fbbbf31a712b32734b58cc9a22426fa5ee632d0885124 \
 {% else %}
 RUN GO_ARCH=amd64 \
-    && GO_SHA256=42d4f7a32316aa66591eca7e89867256057a4264451aca10570a715b3637ba70 \
+    && GO_SHA256=34f14304e856893f4ba30c2cacfe93906e9de7915c5f6aaaf3a81cdccd7ba30b \
 {% endif %}
-    && GO_VERSION=1.25.10 \
+    && GO_VERSION=1.25.11 \
     && curl -L "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz" -o /tmp/go.tar.gz \
     && echo "${GO_SHA256}  /tmp/go.tar.gz" | sha256sum -c - \
     && tar -C /usr/local -xzf /tmp/go.tar.gz \
@@ -415,14 +415,38 @@ RUN cd gnxi \
 # Deactivating a virtualenv.
 # ENV PATH="$BACKUP_OF_PATH"
 
+# Build gnmic from source at a pinned upstream main commit. Picks up the
+# dependency fixes merged after v0.45.0 (grpc 1.79.3, otel-sdk 1.43.0,
+# go-git 5.19.0, prometheus 0.311.3, etc.) that address the CVEs which
+# forced removal in #27059. The golang.org/x/* modules are additionally
+# upgraded to latest to clear current/future golang.org/x/* CVEs (the
+# pinned commit still locks older x/crypto, x/net, etc.). Temporary until
+# the next tagged gnmic release ships.
+RUN GNMIC_REV=653dc5dd4ddcd3bd4197317875a10c1ce8b06653 \
+    && git clone https://github.com/openconfig/gnmic.git /tmp/gnmic \
+    && cd /tmp/gnmic \
+    && git checkout "${GNMIC_REV}" \
+    && go get golang.org/x/crypto@latest golang.org/x/net@latest golang.org/x/text@latest golang.org/x/sys@latest golang.org/x/oauth2@latest \
+    && go mod tidy \
+    && go build -o /usr/local/bin/gnmic . \
+    && chmod +x /usr/local/bin/gnmic \
+    && rm -rf /tmp/gnmic /root/go/pkg/mod /root/.cache/go-build
 
 # Remove Go toolchain to reduce image size
 RUN rm -rf /usr/local/go "$(go env GOPATH 2>/dev/null || echo $HOME/go)"
 ENV PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 {% if PTF_ENV_PY_VER == "py3" %}
-# Install the python-saithrift into the virtual environment
-RUN echo "/usr/lib/python3/dist-packages/saithrift-0.9-py3.11.egg" >> /root/env-python3/lib/python3.11/site-packages/easy-install.pth
+# Register the python-saithrift egg on the virtualenv path. Use an
+# executable .pth line that globs for the egg at every interpreter
+# startup, so the path is resolved dynamically rather than pinned to a
+# specific Python minor version. This keeps switch_sai_thrift importable
+# even after test_update_saithrift_ptf swaps in a saithrift deb built for
+# a different Python minor (e.g. py3.13 from a Trixie/OS13 DUT image).
+# saithrift is thrift-generated pure Python, so the egg loads across py3.x.
+RUN PYVER=$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])') \
+    && echo "import glob, sys; sys.path.extend(glob.glob('"'"'/usr/lib/python3/dist-packages/saithrift-0.9-py3.*.egg'"'"'))" \
+       >> "/root/env-python3/lib/python${PYVER}/site-packages/easy-install.pth"
 {% endif %}
 
 # {% if PTF_ENV_PY_VER == "py3" %}


### PR DESCRIPTION
#### Why I did it

`dockers/docker-ptf/Dockerfile.j2` on `202605` had drifted from `master`. This cherry-picks the latest docker-ptf changes so the PTF image on `202605` matches `master`.

Brings over the following upstream PRs (docker-ptf portion): #27340, #28038, #27947, #27801.

##### Work item tracking
- Microsoft ADO **(number only)**: 38614512

#### How I did it

Aligned `dockers/docker-ptf/Dockerfile.j2` with `master`, resulting in three net changes: bump the Go toolchain 1.25.10 -> 1.25.11 (new SHAs, stdlib fix GO-2026-5039), add the gnmic build-from-source block (pinned upstream commit with golang.org/x/* upgraded), and resolve the python-saithrift egg path dynamically across py3.x. The `p4lang-pi` version already matched, so nothing else changed.

#### How to verify it

Build the PTF docker on 202605 and confirm the image builds: `make target/docker-ptf.gz`. Inside the image, verify `gnmic version` works and `python3 -c "import switch_sai_thrift"` imports successfully.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ]

#### Description for the changelog

[docker-ptf] cherry-pick latest Dockerfile.j2 changes from master to 202605
