### PR TITLE
[build] Stop installing python3-regex via apt to avoid pip uninstall-no-record-file failure

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -224,7 +224,12 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
 install_pip_package {{sonic_yang_mgmt_py3_wheel_path}}
 
 # Install some dependencies for pyangbind
-sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install python3-lxml python3-regex
+# python3-regex is intentionally NOT installed here. The Debian apt package
+# (python3-regex) installs into dist-packages without a pip RECORD file, so pip
+# cannot uninstall/upgrade it later. When a downstream wheel (e.g. sonic-utilities
+# via docker-image-py) requires a newer regex, pip fails with "uninstall-no-record-file".
+# Let pip own regex instead: it is pulled in transitively by pyangbind below.
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install python3-lxml
 
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install pyangbind==0.8.7
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 uninstall -y enum34

--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -546,6 +546,9 @@ RUN apt-get remove -y libnl-3-200
 
 RUN eatmydata apt-get -y build-dep openssh
 
+# Let pip own these (avoid apt vs pip no-RECORD uninstall conflicts)
+RUN eatmydata apt-get remove -y python3-regex || true
+
 # Build fix for ARM64 and ARMHF /etc/debian_version
 {%- if CONFIGURED_ARCH == "armhf" or CONFIGURED_ARCH == "arm64" %}
 RUN eatmydata apt upgrade -y base-files libc-bin=$(dpkg-query -W -f '${Version}' libc-bin)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
`target/python-wheels/trixie/sonic_utilities-1.2-py3-none-any.whl-install` and `sonic-marvell-prestera-armhf.bin` started failing during the `sonic-utilities` wheel install with:
```
Cannot uninstall regex 2024.11.6
╰─> The package's contents are unknown: no RECORD file was found for regex.

 hint: The package was installed by debian. You should check if it can uninstall the package.
```
`sonic-slave-trixie` and `sonic_debian_extension` installed `python3-regex` from debian apt repo in dist-packages folder without a pip RECORD file, so pip cannot uninstall it later. 
When the sonic-utilities wheel pulls in a newer regex - currently triggered by sonic-utilities -> docker-image-py (the unbounded `docker-image-py>=0.1.10` dependency now resolves to `0.2.0`, published 2026-06-29, which requires `regex>=2026.6.28`) - pip failed on `uninstall-no-record-file`.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- removed `python3-regex` from `sonic-slave-trixie/Dockerfile.j2`
- remove `python3-regex` from `sonic_debian_extension.j2`
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

