### PR TITLE
[system-health] Fix sysready-status for stopped static services

### DIFF
--- a/src/system-health/health_checker/sysmonitor.py
+++ b/src/system-health/health_checker/sysmonitor.py
@@ -305,7 +305,7 @@ class Sysmonitor(ThreadTaskBase):
 
     #Gets the service properties
     def run_systemctl_show(self, service):
-        command = ('systemctl show {} --property=Id,LoadState,UnitFileState,Type,ActiveState,SubState,Result,ConditionResult'.format(service))
+        command = ('systemctl show {} --property=Id,LoadState,UnitFileState,Type,ActiveState,SubState,Result,ConditionResult,ConditionTimestampMonotonic'.format(service))
         output = utils.run_command(command)
         srv_properties = output.split('\n')
         prop_dict = {}
@@ -382,14 +382,17 @@ class Sysmonitor(ThreadTaskBase):
                         service_up_status = "Stopping"
                     elif active_state == "inactive":
                         condition_result = sysctl_show.get('ConditionResult', 'yes')
+                        condition_ts = sysctl_show.get('ConditionTimestampMonotonic', '0')
+                        condition_unmet = (condition_result == "no"
+                                and condition_ts not in ("0", "", None))
                         is_known_non_blocking = (srv_type == "oneshot"
                                 or service_name in spl_srv_list
                                 or fail_reason in NON_BLOCKING_INACTIVE_REASONS)
-                        if is_known_non_blocking or condition_result == "no":
+                        if is_known_non_blocking or condition_unmet:
                             service_status = "OK"
                             service_up_status = "OK"
                             unit_status = "OK"
-                            if not is_known_non_blocking and condition_result == "no":
+                            if not is_known_non_blocking and condition_unmet:
                                 fail_reason = "condition-unmet"
                         else:
                             unit_status = "NOT OK"

--- a/src/system-health/health_checker/sysmonitor.py
+++ b/src/system-health/health_checker/sysmonitor.py
@@ -383,6 +383,8 @@ class Sysmonitor(ThreadTaskBase):
                     elif active_state == "inactive":
                         condition_result = sysctl_show.get('ConditionResult', 'yes')
                         condition_ts = sysctl_show.get('ConditionTimestampMonotonic', '0')
+                        # Require a nonzero timestamp: ConditionResult=no alone can't tell a real
+                        # condition-skip from a GC'd/reloaded stopped static service (ts stays 0).
                         condition_unmet = (condition_result == "no"
                                 and condition_ts not in ("0", "", None))
                         is_known_non_blocking = (srv_type == "oneshot"

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -1520,7 +1520,20 @@ mock_condition_unmet_props = {
     'Type': 'notify', 'Result': 'success',
     'Id': 'mock_smartmon.service', 'LoadState': 'loaded',
     'ActiveState': 'inactive', 'SubState': 'dead',
-    'UnitFileState': 'enabled', 'ConditionResult': 'no'
+    'UnitFileState': 'enabled', 'ConditionResult': 'no',
+    # A condition-skipped unit records when systemd evaluated its condition.
+    'ConditionTimestampMonotonic': '863854692'
+}
+
+# A stopped static service can be garbage-collected and subsequently reloaded
+# by systemd. In that state ConditionResult=no with a zero timestamp does not
+# mean it was skipped by a condition, and must be reported as down.
+mock_condition_unmet_gc_props = {
+    'Type': 'simple', 'Result': 'success',
+    'Id': 'mock_snmp.service', 'LoadState': 'loaded',
+    'ActiveState': 'inactive', 'SubState': 'dead',
+    'UnitFileState': 'static', 'ConditionResult': 'no',
+    'ConditionTimestampMonotonic': '0'
 }
 
 mock_condition_met_inactive_props = {
@@ -1541,14 +1554,29 @@ mock_masked_props = {
 @patch('health_checker.sysmonitor.Sysmonitor.run_systemctl_show', MagicMock(return_value=mock_condition_unmet_props))
 @patch('health_checker.sysmonitor.Sysmonitor.post_unit_status', MagicMock())
 def test_get_unit_status_condition_unmet_ok():
-    """Inactive service with ConditionResult=no should be treated as OK."""
+    """A service whose condition was evaluated and failed stays non-blocking."""
     sysmon = Sysmonitor()
     result = sysmon.get_unit_status('mock_smartmon.service')
     assert result == 'OK'
     sysmon.post_unit_status.assert_called_once()
     call_args = sysmon.post_unit_status.call_args[0]
     assert call_args[1] == 'OK'              # service_status
+    assert call_args[2] == 'OK'              # app_ready_status
     assert call_args[3] == 'condition-unmet'  # fail_reason
+
+
+@patch('health_checker.sysmonitor.Sysmonitor.run_systemctl_show', MagicMock(return_value=mock_condition_unmet_gc_props))
+@patch('health_checker.sysmonitor.Sysmonitor.post_unit_status', MagicMock())
+def test_get_unit_status_stopped_static_gc_not_ok():
+    """A stopped static service must be reported as Down, not condition-skipped."""
+    sysmon = Sysmonitor()
+    result = sysmon.get_unit_status('mock_snmp.service')
+    assert result == 'NOT OK'
+    sysmon.post_unit_status.assert_called_once()
+    call_args = sysmon.post_unit_status.call_args[0]
+    assert call_args[1] == 'Down'        # service_status
+    assert call_args[2] == 'Down'        # app_ready_status
+    assert call_args[3] == 'Inactive'    # fail_reason
 
 
 @patch('health_checker.sysmonitor.Sysmonitor.run_systemctl_show', MagicMock(return_value=mock_condition_met_inactive_props))


### PR DESCRIPTION
#### Why I did it

`show system-health sysready-status` could report a manually stopped static SONiC feature service as `OK` with the reason `condition-unmet`. As a result, the command could still report `System is ready` even though the service and its container were no longer running.

The issue is triggered when a static service is stopped and systemd later garbage-collects and reloads its inactive unit. The reloaded unit can report `ConditionResult=no` with `ConditionTimestampMonotonic=0`. The zero timestamp means no condition was evaluated, but the previous logic treated every `ConditionResult=no` as a genuinely condition-skipped service. This incorrectly classified the stopped service as healthy.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Request `ConditionTimestampMonotonic` together with the existing systemd properties. An inactive service is treated as condition-skipped only when both of the following are true:

- `ConditionResult=no`
- `ConditionTimestampMonotonic` is non-zero

A non-zero timestamp shows that systemd evaluated the unit conditions. A zero timestamp on a reloaded, stopped static unit is instead reported as `Down` / `Inactive`. Existing non-blocking services and active, activating, deactivating, oneshot, masked, and per-ASIC paths are unchanged.

The focused tests cover both cases:

- A real condition-skipped service remains `OK` with `condition-unmet`.
- A stopped, garbage-collected static service is reported as `Down` / `Inactive`.

#### How to verify it

1. Ensure a static feature service is running, for example `sudo systemctl start snmp`.
2. Confirm `show system-health sysready-status` reports `System is ready` and the service as `OK`.
3. Stop the service: `sudo systemctl stop snmp`.
4. Confirm `show system-health sysready-status` reports `System is not ready` and the service as `Down` / `Down` with reason `Inactive`.
5. Start the service again and confirm the system returns to ready.
6. Verify a service genuinely skipped by a systemd condition remains `OK` with `condition-unmet`.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

- [ ] Not run locally

#### Description for the changelog

Fix sysready-status reporting stopped static services as healthy.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)
