### PR TITLE
Fix Handle non-responsive SFP modules gracefully in sfputil

### DIFF
--- a/src/sonic-utilities.patch/0001-sfputil-handle-non-responsive-modules-gracefully.patch
+++ b/src/sonic-utilities.patch/0001-sfputil-handle-non-responsive-modules-gracefully.patch
@@ -1,0 +1,132 @@
+diff --git a/sfputil/main.py b/sfputil/main.py
+index be335cb9..aa36cb43 100644
+--- a/sfputil/main.py
++++ b/sfputil/main.py
+@@ -688,36 +688,39 @@ def eeprom(port, dump_dom, namespace):
+                     click.echo("Sfp.get_transceiver_info() is currently not implemented for this platform")
+                     sys.exit(ERROR_NOT_IMPLEMENTED)
+ 
+-                output += convert_sfp_info_to_output_string(xcvr_info)
+-
+-                if dump_dom:
+-                    try:
+-                        api = platform_chassis.get_sfp(physical_port).get_xcvr_api()
+-                    except NotImplementedError:
+-                        output += "API is currently not implemented for this platform\n"
+-                        click.echo(output)
+-                        sys.exit(ERROR_NOT_IMPLEMENTED)
+-                    if api is None:
+-                        output += "API is none while getting DOM info!\n"
+-                        click.echo(output)
+-                        sys.exit(ERROR_NOT_IMPLEMENTED)
+-                    try:
+-                        xcvr_dom_info = platform_chassis.get_sfp(physical_port).get_transceiver_dom_real_value()
+-                    except NotImplementedError:
+-                        click.echo("Sfp.get_transceiver_dom_real_value() is currently not implemented "
+-                                   "for this platform")
+-                        sys.exit(ERROR_NOT_IMPLEMENTED)
+-
+-                    try:
+-                        xcvr_dom_threshold_info = platform_chassis.get_sfp(physical_port).get_transceiver_threshold_info()
+-                        if xcvr_dom_threshold_info:
+-                            xcvr_dom_info.update(xcvr_dom_threshold_info)
+-                    except NotImplementedError:
+-                        click.echo("Sfp.get_transceiver_threshold_info() is currently not implemented for this platform")
+-                        sys.exit(ERROR_NOT_IMPLEMENTED)
+-
+-                    output += convert_dom_to_output_string(xcvr_info['type'],
+-                                                           is_sfp_cmis, xcvr_dom_info)
++                if xcvr_info is None:
++                    output += "{}{}\n".format(' ' * 8, "Error: Failed to read EEPROM for this port")
++                else:
++                    output += convert_sfp_info_to_output_string(xcvr_info)
++
++                    if dump_dom:
++                        try:
++                            api = platform_chassis.get_sfp(physical_port).get_xcvr_api()
++                        except NotImplementedError:
++                            output += "API is currently not implemented for this platform\n"
++                            click.echo(output)
++                            sys.exit(ERROR_NOT_IMPLEMENTED)
++                        if api is None:
++                            output += "API is none while getting DOM info!\n"
++                            click.echo(output)
++                            sys.exit(ERROR_NOT_IMPLEMENTED)
++                        try:
++                            xcvr_dom_info = platform_chassis.get_sfp(physical_port).get_transceiver_dom_real_value()
++                        except NotImplementedError:
++                            click.echo("Sfp.get_transceiver_dom_real_value() is currently not implemented "
++                                       "for this platform")
++                            sys.exit(ERROR_NOT_IMPLEMENTED)
++
++                        try:
++                            xcvr_dom_threshold_info = platform_chassis.get_sfp(physical_port).get_transceiver_threshold_info()
++                            if xcvr_dom_threshold_info:
++                                xcvr_dom_info.update(xcvr_dom_threshold_info)
++                        except NotImplementedError:
++                            click.echo("Sfp.get_transceiver_threshold_info() is currently not implemented for this platform")
++                            sys.exit(ERROR_NOT_IMPLEMENTED)
++
++                        output += convert_dom_to_output_string(xcvr_info['type'],
++                                                               is_sfp_cmis, xcvr_dom_info)
+ 
+             output += '\n'
+ 
+@@ -1203,6 +1206,9 @@ def show_firmware_version(physical_port):
+     try:
+         sfp = platform_chassis.get_sfp(physical_port)
+         api = sfp.get_xcvr_api()
++        if api is None:
++            click.echo("Error: Failed to access transceiver EEPROM")
++            sys.exit(EXIT_FAIL)
+         out = api.get_module_fw_info()
+         click.echo(out['info'])
+     except NotImplementedError:
+diff --git a/tests/sfputil_test.py b/tests/sfputil_test.py
+index 551584d4..a747c184 100644
+--- a/tests/sfputil_test.py
++++ b/tests/sfputil_test.py
+@@ -689,6 +689,43 @@ Ethernet0  N/A
+         expected_output = "Ethernet16: SFP EEPROM is not applicable for RJ45 port\n\n\n"
+         assert result.output == expected_output
+ 
++    @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
++    @patch('sfputil.main.logical_port_name_to_physical_port_list', MagicMock(return_value=[1]))
++    @patch('sfputil.main.platform_sfputil', MagicMock(is_logical_port=MagicMock(return_value=1)))
++    @patch('sfputil.main.is_port_type_rj45', MagicMock(return_value=False))
++    @patch('sfputil.main.platform_chassis')
++    def test_show_eeprom_transceiver_info_none(self, mock_chassis):
++        """Test that sfputil show eeprom handles get_transceiver_info() returning None
++        (e.g. SFP present but EEPROM unreadable due to I2C timeout)."""
++        mock_sfp = MagicMock()
++        mock_sfp.get_presence.return_value = True
++        mock_sfp.get_transceiver_info.return_value = None
++        mock_chassis.get_sfp.return_value = mock_sfp
++
++        runner = CliRunner()
++        result = runner.invoke(sfputil.cli.commands['show'].commands['eeprom'], ["-p", "Ethernet16"])
++        assert result.exit_code == 0
++        assert "Error: Failed to read EEPROM for this port" in result.output
++        assert "Ethernet16: SFP EEPROM detected" in result.output
++
++    @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
++    @patch('sfputil.main.logical_port_name_to_physical_port_list', MagicMock(return_value=[1]))
++    @patch('sfputil.main.platform_sfputil', MagicMock(is_logical_port=MagicMock(return_value=1)))
++    @patch('sfputil.main.is_port_type_rj45', MagicMock(return_value=False))
++    @patch('sfputil.main.platform_chassis')
++    def test_show_eeprom_transceiver_info_none_with_dom(self, mock_chassis):
++        """Test that sfputil show eeprom -d handles get_transceiver_info() returning None
++        without crashing when trying to access DOM data."""
++        mock_sfp = MagicMock()
++        mock_sfp.get_presence.return_value = True
++        mock_sfp.get_transceiver_info.return_value = None
++        mock_chassis.get_sfp.return_value = mock_sfp
++
++        runner = CliRunner()
++        result = runner.invoke(sfputil.cli.commands['show'].commands['eeprom'], ["-p", "Ethernet16", "-d"])
++        assert result.exit_code == 0
++        assert "Error: Failed to read EEPROM for this port" in result.output
++
+     @patch('sfputil.main.logical_port_to_physical_port_index', MagicMock(return_value=1))
+     @patch('sfputil.main.logical_port_name_to_physical_port_list', MagicMock(return_value=[1]))
+     @patch('sfputil.main.platform_sfputil', MagicMock(is_logical_port=MagicMock(return_value=1)))

--- a/src/sonic-utilities.patch/series
+++ b/src/sonic-utilities.patch/series
@@ -1,0 +1,1 @@
+0001-sfputil-handle-non-responsive-modules-gracefully.patch


### PR DESCRIPTION
When an SFP module is physically present but non-responsive (e.g. due to I2C timeout), sfputil commands crash instead of handling the error gracefully. Add None guards to prevent unhandled exceptions.

#### Why I did it
sfputil commands crash on non-responsive SFP modules.

When an SFP module is physically present but non-responsive (e.g. due to I2C timeout), the platform API calls `get_transceiver_info()` and `get_xcvr_api()` return None. The existing code does not check for None before attempting to use the return values, causing unhandled exceptions.

The Problem:
In `sfputil show eeprom`, `get_transceiver_info()` returns None for a non-responsive module but the code immediately passes the result to `convert_sfp_info_to_output_string()`, which crashes.
In `sfputil show fwversion`, `get_xcvr_api()` returns None but the code immediately calls `api.get_module_fw_info()`, which crashes with AttributeError.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added explicit None checks:
- In eeprom command: check `xcvr_info` before processing, print error and continue to next port if None
- In fwversion command: check `api` before calling `get_module_fw_info()`, print error and exit gracefully if None

#### How to verify it
- Test with a non-responsive SFP module present:
`sfputil show eeprom -p EthernetX`
(should print error message instead of crashing)

- Test firmware version with non-responsive module:
`sfputil show fwversion -p EthernetX`
(should print error message instead of crashing)

- Test with responsive modules (regression):
`sfputil show eeprom`
`sfputil show fwversion -p EthernetX`
(should work normally)

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ]

#### Description for the changelog
Handle non-responsive SFP modules gracefully in sfputil show eeprom and show fwversion commands

#### A picture of a cute animal (not mandatory but encouraged)

