### PR TITLE
ci: enable pr docker-ptf testing via dynamic detection

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -133,9 +133,16 @@ stages:
   - name: testbed_file
     value: vtestbed.csv
   - name: PTF_MODIFIED
-    # $[ coalesce(stageDependencies.BuildVS.vs.outputs['PublishAndSetPtfTag.PTF_MODIFIED'], stageDependencies.BuildVS.vs.outputs['script.PTF_MODIFIED'], stageDependencies.BuildVS.vs.outputs['script1.PTF_MODIFIED'], 'False') ]
-    # Disable in-PR testing of docker-ptf image; To be re-enabled after image can be uploaded to approved ACR
-    value: 'False' 
+    # Enable in-PR docker-ptf testing only when the PR modifies docker-ptf; the coalesce
+    # falls back to False otherwise (including non-PR builds), so the pull-once/reuse path
+    # is taken only when needed.
+    value: $[ coalesce(stageDependencies.BuildVS.vs.outputs['PublishAndSetPtfTag.PTF_MODIFIED'], stageDependencies.BuildVS.vs.outputs['script.PTF_MODIFIED'], stageDependencies.BuildVS.vs.outputs['script1.PTF_MODIFIED'], 'False') ]
+  - name: PTF_IMAGE_TAG
+    # Branch-aligned docker-ptf image tag used for PR test. PR builds only.
+    ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      value: 'latest'
+    ${{ else }}:
+      value: ''
 
 # For every test job:
 # continueOnError: false means it's a required test job and will block merge if it fails
@@ -222,6 +229,7 @@ stages:
     parameters:
       CHECKOUT_SONIC_MGMT: ${{ parameters.CHECKOUT_SONIC_MGMT }}
       PTF_MODIFIED: $(PTF_MODIFIED)
+      PTF_IMAGE_TAG: $(PTF_IMAGE_TAG)
 
 # Unified SBOM-based vulnerability scan — informational, runs after
 # both build stages so every CycloneDX SBOM produced is in scope.


### PR DESCRIPTION
#### Why I did it

In the KVM PR test pipeline (`azure-pipelines.yml`, `Test` stage), `PTF_MODIFIED` was hardcoded to `False` and `PTF_IMAGE_TAG` was never passed. As a result every PR test pulled the stock `docker-ptf:latest` from ACR via the add-topo `pull: always` path, and the `ptf_modified` testbed preparation path (pull-once + reuse) was never exercised.

This change re-enables the dynamic `PTF_MODIFIED` detection so the pull-once/reuse path is taken only when a PR actually modifies `docker-ptf`, and forwards a branch-aligned `PTF_IMAGE_TAG` so PR tests use the correct `docker-ptf` image.

##### Work item tracking
- Microsoft ADO **(number only)**: 38420321

#### How I did it

In the `Test` stage of `azure-pipelines.yml`:

- Restored the dynamic `PTF_MODIFIED` value: `$[ coalesce(stageDependencies.BuildVS.vs.outputs['PublishAndSetPtfTag.PTF_MODIFIED'], ..., 'False') ]`, which the `PublishAndSetPtfTag` step sets to `True` only when the PR modifies `docker-ptf` (and `False` for non-PR builds).
- Added a `PTF_IMAGE_TAG` variable: `latest` for PR builds, empty otherwise (compile-time `${{ if eq(variables['Build.Reason'], 'PullRequest') }}`).
- Forwarded `PTF_IMAGE_TAG` to the `pr_test_template.yml@sonic-mgmt` template alongside `PTF_MODIFIED`.

#### How to verify it

1. Open a PR that modifies `dockers/docker-ptf` and let the `Test` stage run; confirm the created Elastictest test plan has `test_option.ptf_modified=true` and `test_option.ptf_image_tag=latest`.
2. Confirm the `Download image` (ptf) prepare step runs `docker pull <registry>/docker-ptf:latest` and `docker tag ... docker-ptf:latest`, and that add-topo creates the PTF container with `pull: missing`.
3. Open a PR that does NOT touch `docker-ptf`; confirm `ptf_modified=false` (no pre-pull) while the image tag is still branch-aligned.
4. Confirm a non-PR (merge/CI) build still resolves `PTF_MODIFIED=False`.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Backporting to 202511 and 202605 so release-branch PRs use the branch-aligned `docker-ptf` image instead of master's `latest`.

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

[ci]: Enable PR docker-ptf testing via dynamic detection and pass a branch-aligned PTF_IMAGE_TAG (PR builds only).

#### Link to config_db schema for YANG module changes

N/A - no YANG/config_db changes.
