### PR TITLE
ci: enable pr docker-ptf testing via dynamic detection [202605]

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -133,9 +133,16 @@ stages:
   - name: testbed_file
     value: vtestbed.csv
   - name: PTF_MODIFIED
-    # $[ coalesce(stageDependencies.BuildVS.vs.outputs['PublishAndSetPtfTag.PTF_MODIFIED'], stageDependencies.BuildVS.vs.outputs['script.PTF_MODIFIED'], stageDependencies.BuildVS.vs.outputs['script1.PTF_MODIFIED'], 'False') ]
-    # Disable in-PR testing of docker-ptf image; To be re-enabled after image can be uploaded to approved ACR
-    value: 'False' 
+    # Enable in-PR docker-ptf testing only when the PR modifies docker-ptf; the coalesce
+    # falls back to False otherwise (including non-PR builds), so the pull-once/reuse path
+    # is taken only when needed.
+    value: $[ coalesce(stageDependencies.BuildVS.vs.outputs['PublishAndSetPtfTag.PTF_MODIFIED'], stageDependencies.BuildVS.vs.outputs['script.PTF_MODIFIED'], stageDependencies.BuildVS.vs.outputs['script1.PTF_MODIFIED'], 'False') ]
+  - name: PTF_IMAGE_TAG
+    # Branch-aligned docker-ptf image tag used for PR test. PR builds only.
+    ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      value: '202605'
+    ${{ else }}:
+      value: ''
 
 # For every test job:
 # continueOnError: false means it's a required test job and will block merge if it fails
@@ -222,6 +229,7 @@ stages:
     parameters:
       CHECKOUT_SONIC_MGMT: ${{ parameters.CHECKOUT_SONIC_MGMT }}
       PTF_MODIFIED: $(PTF_MODIFIED)
+      PTF_IMAGE_TAG: $(PTF_IMAGE_TAG)
 
 # Unified SBOM-based vulnerability scan — informational, runs after
 # both build stages so every CycloneDX SBOM produced is in scope.


### PR DESCRIPTION
#### Why I did it

Backport of #28154 to 202605.

In the KVM PR test pipeline (`azure-pipelines.yml`, `Test` stage), `PTF_MODIFIED` was hardcoded to `False` and `PTF_IMAGE_TAG` was never passed, so 202605 PRs pulled master's stock `docker-ptf:latest` (mismatched with the 202605 image) and never exercised the `ptf_modified` pull-once/reuse path.

This enables the dynamic `PTF_MODIFIED` detection (pull-once/reuse only when a PR modifies `docker-ptf`) and passes the branch-aligned `PTF_IMAGE_TAG=202605` so 202605 PR tests use the 202605 `docker-ptf` image.

##### Work item tracking
- Microsoft ADO **(number only)**: 38420321

#### How I did it

In the `Test` stage of `azure-pipelines.yml`:

- Restored the dynamic `PTF_MODIFIED` value: `$[ coalesce(stageDependencies.BuildVS.vs.outputs['PublishAndSetPtfTag.PTF_MODIFIED'], ..., 'False') ]` (True only when the PR modifies `docker-ptf`; False for non-PR builds).
- Added a `PTF_IMAGE_TAG` variable: `202605` for PR builds, empty otherwise (`${{ if eq(variables['Build.Reason'], 'PullRequest') }}`).
- Forwarded `PTF_IMAGE_TAG` to the `pr_test_template.yml@sonic-mgmt` template alongside `PTF_MODIFIED`.

#### How to verify it

1. Open a 202605 PR that modifies `dockers/docker-ptf` and let the `Test` stage run; confirm the Elastictest test plan has `test_option.ptf_modified=true` and `test_option.ptf_image_tag=202605`.
2. Confirm the `Download image` (ptf) prepare step pulls `<registry>/docker-ptf:202605` and tags it `docker-ptf:latest`, and add-topo creates the PTF container with `pull: missing`.
3. Open a 202605 PR that does NOT touch `docker-ptf`; confirm `ptf_modified=false` while the image tag is still `202605` (branch-aligned, not master's `latest`).

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

This PR is itself the 202605 backport of #28154.

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

[ci]: Enable PR docker-ptf testing via dynamic detection and pass branch-aligned PTF_IMAGE_TAG=202605 (PR builds only).

#### Link to config_db schema for YANG module changes

N/A - no YANG/config_db changes.
