### PR TITLE
ci: pass branch-aligned ptf image tag for pr docker-ptf testing [202511]

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,6 +115,12 @@ stages:
     value: vtestbed.csv
   - name: PTF_MODIFIED
     value: $[ coalesce(stageDependencies.BuildVS.vs.outputs['PublishAndSetPtfTag.PTF_MODIFIED'], stageDependencies.BuildVS.vs.outputs['script.PTF_MODIFIED'], stageDependencies.BuildVS.vs.outputs['script1.PTF_MODIFIED'], 'False') ]
+  - name: PTF_IMAGE_TAG
+    # Branch-aligned docker-ptf image tag used for PR test. PR builds only.
+    ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      value: '202511'
+    ${{ else }}:
+      value: ''
 
 # For every test job:
 # continueOnError: false means it's a required test job and will block merge if it fails
@@ -201,3 +207,4 @@ stages:
     parameters:
       CHECKOUT_SONIC_MGMT: ${{ parameters.CHECKOUT_SONIC_MGMT }}
       PTF_MODIFIED: $(PTF_MODIFIED)
+      PTF_IMAGE_TAG: $(PTF_IMAGE_TAG)


### PR DESCRIPTION
#### Why I did it

Backport of #28154 to 202511.

202511 already enables `PTF_MODIFIED` dynamically (the `PublishAndSetPtfTag` step sets it to `True` only when the PR modifies `docker-ptf`), but `PTF_IMAGE_TAG` was never passed. As a result 202511 PR tests fell back to master's stock `docker-ptf:latest` (mismatched with the 202511 image).

This passes the branch-aligned `PTF_IMAGE_TAG=202511` so 202511 PR tests use the 202511 `docker-ptf` image.

##### Work item tracking
- Microsoft ADO **(number only)**: 38420321

#### How I did it

In the `Test` stage of `azure-pipelines.yml`:

- Added a `PTF_IMAGE_TAG` variable: `202511` for PR builds, empty otherwise (`${{ if eq(variables['Build.Reason'], 'PullRequest') }}`).
- Forwarded `PTF_IMAGE_TAG` to the `pr_test_template.yml@sonic-mgmt` template alongside the existing `PTF_MODIFIED`.

The existing dynamic `PTF_MODIFIED` value is unchanged.

#### How to verify it

1. Open a 202511 PR that modifies `dockers/docker-ptf` and let the `Test` stage run; confirm the Elastictest test plan has `test_option.ptf_modified=true` and `test_option.ptf_image_tag=202511`.
2. Confirm the `Download image` (ptf) prepare step pulls `<registry>/docker-ptf:202511` and tags it `docker-ptf:latest`, and add-topo creates the PTF container with `pull: missing`.
3. Open a 202511 PR that does NOT touch `docker-ptf`; confirm `ptf_modified=false` while the image tag is still `202511` (branch-aligned, not master's `latest`).

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

This PR is itself the 202511 backport of #28154.

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

[ci]: Pass branch-aligned PTF_IMAGE_TAG=202511 for PR docker-ptf testing (PR builds only).

#### Link to config_db schema for YANG module changes

N/A - no YANG/config_db changes.
