### PR TITLE
[system-health]: Skip KubeSonic services generically

### DIFF
--- a/dockers/docker-telemetry-sidecar/systemd_scripts/service_checker.py_202411
+++ b/dockers/docker-telemetry-sidecar/systemd_scripts/service_checker.py_202411
@@ -56,9 +56,16 @@ class ServiceChecker(HealthChecker):
         'Program': 'Status ok'
     }
 
-    # Whitelist of containers which are managed by KubeSonic to bypass health checking entirely.
-    # These containers will be excluded from both expected and running container sets.
-    CONTAINER_K8S_WHITELIST = {'telemetry', 'acms', 'restapi'}
+    # ServiceChecker validates native Docker containers and critical processes via supervisord.
+    # KubeSonic-managed containers are discovered from Docker labels and skipped entirely.
+    K8S_NAMESPACE_LABEL = 'io.kubernetes.pod.namespace'
+    K8S_DOCKER_TYPE_LABEL = 'io.kubernetes.docker.type'
+    K8S_CONTAINER_NAME_LABEL = 'io.kubernetes.container.name'
+    K8S_SONIC_NAMESPACE = 'sonic'
+    K8S_NAMESPACE_FILTER = '{}={}'.format(K8S_NAMESPACE_LABEL, K8S_SONIC_NAMESPACE)
+    K8S_DOCKER_CONTAINER_TYPE = 'container'
+    K8S_POD_INFRA_CONTAINER_NAME = 'POD'
+    K8S_EMPTY_LABEL_VALUE = '<no value>'
 
     def __init__(self):
         HealthChecker.__init__(self)
@@ -67,6 +74,7 @@ class ServiceChecker(HealthChecker):
         self.bad_containers = set()
 
         self.container_feature_dict = {}
+        self.k8s_managed_containers = set()
 
         self.need_save_cache = False
 
@@ -103,9 +111,10 @@ class ServiceChecker(HealthChecker):
 
         container_list = []
         for container_name in feature_table.keys():
-            # Skip containers in the whitelist
-            if container_name in ServiceChecker.CONTAINER_K8S_WHITELIST:
-                logger.log_debug("Skipping whitelisted kubesonic managed container '{}' from expected running check".format(container_name))
+            # Skip KubeSonic-managed containers instead of adding them to the running set.
+            # Their lifecycle and process health are owned by Kubernetes, not supervisord.
+            if container_name in self.k8s_managed_containers:
+                logger.log_debug("Skipping kubesonic managed container '{}' from expected running check".format(container_name))
                 continue
             # slim image does not have telemetry container and corresponding docker image
             if container_name == "telemetry":
@@ -154,17 +163,15 @@ class ServiceChecker(HealthChecker):
         DOCKER_CLIENT = docker.DockerClient(base_url='unix://var/run/docker.sock')
         running_containers = set()
         ctrs = DOCKER_CLIENT.containers
+        self.discover_k8s_managed_containers(ctrs)
         try:
             lst = ctrs.list(filters={"status": "running"})
 
             for ctr in lst:
-                # Check if this is a Kubernetes-managed container
-                labels = ctr.labels or {}
-                ns = labels.get("io.kubernetes.pod.namespace")
-                if ns == "sonic":
-                    continue
-                # Skip kubesonic managed containers in the whitelist
-                if ctr.name in ServiceChecker.CONTAINER_K8S_WHITELIST:
+                if self._is_k8s_managed_container(ctr):
+                    container_name = self._get_k8s_container_name(ctr)
+                    if container_name:
+                        self.k8s_managed_containers.add(container_name)
                     continue
                 running_containers.add(ctr.name)
                 if ctr.name not in self.container_critical_processes:
@@ -173,6 +180,35 @@ class ServiceChecker(HealthChecker):
             logger.log_error("Failed to retrieve the running container list. Error: '{}'".format(err))
 
         return running_containers
+
+    def discover_k8s_managed_containers(self, ctrs):
+        try:
+            lst = ctrs.list(all=True, filters={"label": ServiceChecker.K8S_NAMESPACE_FILTER})
+        except docker.errors.DockerException as err:
+            logger.log_error("Failed to retrieve kubesonic managed container list. Error: '{}'".format(err))
+            return
+
+        k8s_managed_containers = set()
+        for ctr in lst:
+            container_name = self._get_k8s_container_name(ctr)
+            if container_name:
+                k8s_managed_containers.add(container_name)
+        self.k8s_managed_containers = k8s_managed_containers
+
+    def _is_k8s_managed_container(self, ctr):
+        labels = ctr.labels or {}
+        return labels.get(ServiceChecker.K8S_NAMESPACE_LABEL) == ServiceChecker.K8S_SONIC_NAMESPACE
+
+    def _get_k8s_container_name(self, ctr):
+        labels = ctr.labels or {}
+        if labels.get(ServiceChecker.K8S_DOCKER_TYPE_LABEL) != ServiceChecker.K8S_DOCKER_CONTAINER_TYPE:
+            return None
+
+        container_name = labels.get(ServiceChecker.K8S_CONTAINER_NAME_LABEL)
+        if container_name in [ServiceChecker.K8S_EMPTY_LABEL_VALUE, ServiceChecker.K8S_POD_INFRA_CONTAINER_NAME]:
+            return None
+
+        return container_name
 
     def get_critical_process_list_from_file(self, container, critical_processes_file):
         """Read critical process name list from critical processes file
@@ -322,8 +358,8 @@ class ServiceChecker(HealthChecker):
             self.config_db = swsscommon.ConfigDBConnector(use_unix_socket_path=True)
             self.config_db.connect()
         feature_table = self.config_db.get_table("FEATURE")
-        expected_running_containers, self.container_feature_dict = self.get_expected_running_containers(feature_table)
         current_running_containers = self.get_current_running_containers()
+        expected_running_containers, self.container_feature_dict = self.get_expected_running_containers(feature_table)
 
         newly_disabled_containers = set(self.container_critical_processes.keys()).difference(expected_running_containers)
         for newly_disabled_container in newly_disabled_containers:

--- a/dockers/docker-telemetry-sidecar/systemd_scripts/service_checker.py_202412
+++ b/dockers/docker-telemetry-sidecar/systemd_scripts/service_checker.py_202412
@@ -56,9 +56,16 @@ class ServiceChecker(HealthChecker):
         'Program': 'Status ok'
     }
 
-    # Whitelist of containers which are managed by KubeSonic to bypass health checking entirely.
-    # These containers will be excluded from both expected and running container sets.
-    CONTAINER_K8S_WHITELIST = {'telemetry', 'acms', 'restapi'}
+    # ServiceChecker validates native Docker containers and critical processes via supervisord.
+    # KubeSonic-managed containers are discovered from Docker labels and skipped entirely.
+    K8S_NAMESPACE_LABEL = 'io.kubernetes.pod.namespace'
+    K8S_DOCKER_TYPE_LABEL = 'io.kubernetes.docker.type'
+    K8S_CONTAINER_NAME_LABEL = 'io.kubernetes.container.name'
+    K8S_SONIC_NAMESPACE = 'sonic'
+    K8S_NAMESPACE_FILTER = '{}={}'.format(K8S_NAMESPACE_LABEL, K8S_SONIC_NAMESPACE)
+    K8S_DOCKER_CONTAINER_TYPE = 'container'
+    K8S_POD_INFRA_CONTAINER_NAME = 'POD'
+    K8S_EMPTY_LABEL_VALUE = '<no value>'
 
     def __init__(self):
         HealthChecker.__init__(self)
@@ -67,6 +74,7 @@ class ServiceChecker(HealthChecker):
         self.bad_containers = set()
 
         self.container_feature_dict = {}
+        self.k8s_managed_containers = set()
 
         self.need_save_cache = False
 
@@ -103,9 +111,10 @@ class ServiceChecker(HealthChecker):
 
         container_list = []
         for container_name in feature_table.keys():
-            # Skip containers in the whitelist
-            if container_name in ServiceChecker.CONTAINER_K8S_WHITELIST:
-                logger.log_debug("Skipping whitelisted kubesonic managed container '{}' from expected running check".format(container_name))
+            # Skip KubeSonic-managed containers instead of adding them to the running set.
+            # Their lifecycle and process health are owned by Kubernetes, not supervisord.
+            if container_name in self.k8s_managed_containers:
+                logger.log_debug("Skipping kubesonic managed container '{}' from expected running check".format(container_name))
                 continue
             # skip frr_bmp since it's not container just bmp option used by bgpd
             if container_name == "frr_bmp":
@@ -123,6 +132,12 @@ class ServiceChecker(HealthChecker):
                     else:
                         container_list.append("gnmi")
                     continue
+            # Some platforms may not include the OTEL container; skip expecting it when image absent
+            if container_name == "otel":
+                if not check_docker_image("docker-sonic-otel"):
+                    logger.log_debug("Ignoring otel container check on image which has no corresponding docker image")
+                    continue
+
             container_list.append(container_name)
 
         for container_name in container_list:
@@ -157,17 +172,15 @@ class ServiceChecker(HealthChecker):
         DOCKER_CLIENT = docker.DockerClient(base_url='unix://var/run/docker.sock')
         running_containers = set()
         ctrs = DOCKER_CLIENT.containers
+        self.discover_k8s_managed_containers(ctrs)
         try:
             lst = ctrs.list(filters={"status": "running"})
 
             for ctr in lst:
-                # Check if this is a Kubernetes-managed container
-                labels = ctr.labels or {}
-                ns = labels.get("io.kubernetes.pod.namespace")
-                if ns == "sonic":
-                    continue
-                # Skip kubesonic managed containers in the whitelist
-                if ctr.name in ServiceChecker.CONTAINER_K8S_WHITELIST:
+                if self._is_k8s_managed_container(ctr):
+                    container_name = self._get_k8s_container_name(ctr)
+                    if container_name:
+                        self.k8s_managed_containers.add(container_name)
                     continue
                 running_containers.add(ctr.name)
                 if ctr.name not in self.container_critical_processes:
@@ -176,6 +189,35 @@ class ServiceChecker(HealthChecker):
             logger.log_error("Failed to retrieve the running container list. Error: '{}'".format(err))
 
         return running_containers
+
+    def discover_k8s_managed_containers(self, ctrs):
+        try:
+            lst = ctrs.list(all=True, filters={"label": ServiceChecker.K8S_NAMESPACE_FILTER})
+        except docker.errors.DockerException as err:
+            logger.log_error("Failed to retrieve kubesonic managed container list. Error: '{}'".format(err))
+            return
+
+        k8s_managed_containers = set()
+        for ctr in lst:
+            container_name = self._get_k8s_container_name(ctr)
+            if container_name:
+                k8s_managed_containers.add(container_name)
+        self.k8s_managed_containers = k8s_managed_containers
+
+    def _is_k8s_managed_container(self, ctr):
+        labels = ctr.labels or {}
+        return labels.get(ServiceChecker.K8S_NAMESPACE_LABEL) == ServiceChecker.K8S_SONIC_NAMESPACE
+
+    def _get_k8s_container_name(self, ctr):
+        labels = ctr.labels or {}
+        if labels.get(ServiceChecker.K8S_DOCKER_TYPE_LABEL) != ServiceChecker.K8S_DOCKER_CONTAINER_TYPE:
+            return None
+
+        container_name = labels.get(ServiceChecker.K8S_CONTAINER_NAME_LABEL)
+        if container_name in [ServiceChecker.K8S_EMPTY_LABEL_VALUE, ServiceChecker.K8S_POD_INFRA_CONTAINER_NAME]:
+            return None
+
+        return container_name
 
     def get_critical_process_list_from_file(self, container, critical_processes_file):
         """Read critical process name list from critical processes file
@@ -325,8 +367,8 @@ class ServiceChecker(HealthChecker):
             self.config_db = swsscommon.ConfigDBConnector(use_unix_socket_path=True)
             self.config_db.connect()
         feature_table = self.config_db.get_table("FEATURE")
-        expected_running_containers, self.container_feature_dict = self.get_expected_running_containers(feature_table)
         current_running_containers = self.get_current_running_containers()
+        expected_running_containers, self.container_feature_dict = self.get_expected_running_containers(feature_table)
 
         newly_disabled_containers = set(self.container_critical_processes.keys()).difference(expected_running_containers)
         for newly_disabled_container in newly_disabled_containers:

--- a/dockers/docker-telemetry-sidecar/systemd_scripts/service_checker.py_202505
+++ b/dockers/docker-telemetry-sidecar/systemd_scripts/service_checker.py_202505
@@ -56,9 +56,16 @@ class ServiceChecker(HealthChecker):
         'Program': 'Status ok'
     }
 
-    # Whitelist of containers which are managed by KubeSonic to bypass health checking entirely.
-    # These containers will be excluded from both expected and running container sets.
-    CONTAINER_K8S_WHITELIST = {'telemetry', 'acms', 'restapi'}
+    # ServiceChecker validates native Docker containers and critical processes via supervisord.
+    # KubeSonic-managed containers are discovered from Docker labels and skipped entirely.
+    K8S_NAMESPACE_LABEL = 'io.kubernetes.pod.namespace'
+    K8S_DOCKER_TYPE_LABEL = 'io.kubernetes.docker.type'
+    K8S_CONTAINER_NAME_LABEL = 'io.kubernetes.container.name'
+    K8S_SONIC_NAMESPACE = 'sonic'
+    K8S_NAMESPACE_FILTER = '{}={}'.format(K8S_NAMESPACE_LABEL, K8S_SONIC_NAMESPACE)
+    K8S_DOCKER_CONTAINER_TYPE = 'container'
+    K8S_POD_INFRA_CONTAINER_NAME = 'POD'
+    K8S_EMPTY_LABEL_VALUE = '<no value>'
 
     def __init__(self):
         HealthChecker.__init__(self)
@@ -67,6 +74,7 @@ class ServiceChecker(HealthChecker):
         self.bad_containers = set()
 
         self.container_feature_dict = {}
+        self.k8s_managed_containers = set()
 
         self.need_save_cache = False
 
@@ -103,9 +111,10 @@ class ServiceChecker(HealthChecker):
 
         container_list = []
         for container_name in feature_table.keys():
-            # Skip containers in the whitelist
-            if container_name in ServiceChecker.CONTAINER_K8S_WHITELIST:
-                logger.log_debug("Skipping whitelisted kubesonic managed container '{}' from expected running check".format(container_name))
+            # Skip KubeSonic-managed containers instead of adding them to the running set.
+            # Their lifecycle and process health are owned by Kubernetes, not supervisord.
+            if container_name in self.k8s_managed_containers:
+                logger.log_debug("Skipping kubesonic managed container '{}' from expected running check".format(container_name))
                 continue
             # skip frr_bmp since it's not container just bmp option used by bgpd
             if container_name == "frr_bmp":
@@ -157,17 +166,15 @@ class ServiceChecker(HealthChecker):
         DOCKER_CLIENT = docker.DockerClient(base_url='unix://var/run/docker.sock')
         running_containers = set()
         ctrs = DOCKER_CLIENT.containers
+        self.discover_k8s_managed_containers(ctrs)
         try:
             lst = ctrs.list(filters={"status": "running"})
 
             for ctr in lst:
-                # Check if this is a Kubernetes-managed container
-                labels = ctr.labels or {}
-                ns = labels.get("io.kubernetes.pod.namespace")
-                if ns == "sonic":
-                    continue
-                # Skip kubesonic managed containers in the whitelist
-                if ctr.name in ServiceChecker.CONTAINER_K8S_WHITELIST:
+                if self._is_k8s_managed_container(ctr):
+                    container_name = self._get_k8s_container_name(ctr)
+                    if container_name:
+                        self.k8s_managed_containers.add(container_name)
                     continue
                 running_containers.add(ctr.name)
                 if ctr.name not in self.container_critical_processes:
@@ -176,6 +183,35 @@ class ServiceChecker(HealthChecker):
             logger.log_error("Failed to retrieve the running container list. Error: '{}'".format(err))
 
         return running_containers
+
+    def discover_k8s_managed_containers(self, ctrs):
+        try:
+            lst = ctrs.list(all=True, filters={"label": ServiceChecker.K8S_NAMESPACE_FILTER})
+        except docker.errors.DockerException as err:
+            logger.log_error("Failed to retrieve kubesonic managed container list. Error: '{}'".format(err))
+            return
+
+        k8s_managed_containers = set()
+        for ctr in lst:
+            container_name = self._get_k8s_container_name(ctr)
+            if container_name:
+                k8s_managed_containers.add(container_name)
+        self.k8s_managed_containers = k8s_managed_containers
+
+    def _is_k8s_managed_container(self, ctr):
+        labels = ctr.labels or {}
+        return labels.get(ServiceChecker.K8S_NAMESPACE_LABEL) == ServiceChecker.K8S_SONIC_NAMESPACE
+
+    def _get_k8s_container_name(self, ctr):
+        labels = ctr.labels or {}
+        if labels.get(ServiceChecker.K8S_DOCKER_TYPE_LABEL) != ServiceChecker.K8S_DOCKER_CONTAINER_TYPE:
+            return None
+
+        container_name = labels.get(ServiceChecker.K8S_CONTAINER_NAME_LABEL)
+        if container_name in [ServiceChecker.K8S_EMPTY_LABEL_VALUE, ServiceChecker.K8S_POD_INFRA_CONTAINER_NAME]:
+            return None
+
+        return container_name
 
     def get_critical_process_list_from_file(self, container, critical_processes_file):
         """Read critical process name list from critical processes file
@@ -325,8 +361,8 @@ class ServiceChecker(HealthChecker):
             self.config_db = swsscommon.ConfigDBConnector(use_unix_socket_path=True)
             self.config_db.connect()
         feature_table = self.config_db.get_table("FEATURE")
-        expected_running_containers, self.container_feature_dict = self.get_expected_running_containers(feature_table)
         current_running_containers = self.get_current_running_containers()
+        expected_running_containers, self.container_feature_dict = self.get_expected_running_containers(feature_table)
 
         newly_disabled_containers = set(self.container_critical_processes.keys()).difference(expected_running_containers)
         for newly_disabled_container in newly_disabled_containers:

--- a/src/system-health/health_checker/service_checker.py
+++ b/src/system-health/health_checker/service_checker.py
@@ -51,9 +51,16 @@ class ServiceChecker(HealthChecker):
     # Monit 5.34.3+ (Debian 13) uses 'OK' for all service types
     EXPECTED_STATUS = 'OK'
 
-    # Whitelist of containers which are managed by KubeSonic to bypass health checking entirely.
-    # These containers will be excluded from both expected and running container sets.
-    CONTAINER_K8S_WHITELIST = {'telemetry', 'acms', 'restapi'}
+    # ServiceChecker validates native Docker containers and critical processes via supervisord.
+    # KubeSonic-managed containers are discovered from Docker labels and skipped entirely.
+    K8S_NAMESPACE_LABEL = 'io.kubernetes.pod.namespace'
+    K8S_DOCKER_TYPE_LABEL = 'io.kubernetes.docker.type'
+    K8S_CONTAINER_NAME_LABEL = 'io.kubernetes.container.name'
+    K8S_SONIC_NAMESPACE = 'sonic'
+    K8S_NAMESPACE_FILTER = '{}={}'.format(K8S_NAMESPACE_LABEL, K8S_SONIC_NAMESPACE)
+    K8S_DOCKER_CONTAINER_TYPE = 'container'
+    K8S_POD_INFRA_CONTAINER_NAME = 'POD'
+    K8S_EMPTY_LABEL_VALUE = '<no value>'
 
     def __init__(self):
         HealthChecker.__init__(self)
@@ -62,6 +69,7 @@ class ServiceChecker(HealthChecker):
         self.bad_containers = set()
 
         self.container_feature_dict = {}
+        self.k8s_managed_containers = set()
 
         self.need_save_cache = False
 
@@ -96,9 +104,10 @@ class ServiceChecker(HealthChecker):
 
         container_list = []
         for container_name in feature_table.keys():
-            # Skip containers in the whitelist
-            if container_name in ServiceChecker.CONTAINER_K8S_WHITELIST:
-                logger.log_debug("Skipping whitelisted kubesonic managed container '{}' from expected running check".format(container_name))
+            # Skip KubeSonic-managed containers instead of adding them to the running set.
+            # Their lifecycle and process health are owned by Kubernetes, not supervisord.
+            if container_name in self.k8s_managed_containers:
+                logger.log_debug("Skipping kubesonic managed container '{}' from expected running check".format(container_name))
                 continue
             # skip frr_bmp since it's not container just bmp option used by bgpd
             if container_name == "frr_bmp":
@@ -156,17 +165,15 @@ class ServiceChecker(HealthChecker):
         DOCKER_CLIENT = docker.DockerClient(base_url='unix://var/run/docker.sock')
         running_containers = set()
         ctrs = DOCKER_CLIENT.containers
+        self.discover_k8s_managed_containers(ctrs)
         try:
             lst = ctrs.list(filters={"status": "running"})
 
             for ctr in lst:
-                # Check if this is a Kubernetes-managed container
-                labels = ctr.labels or {}
-                ns = labels.get("io.kubernetes.pod.namespace")
-                if ns == "sonic":
-                    continue
-                # Skip kubesonic managed containers in the whitelist
-                if ctr.name in ServiceChecker.CONTAINER_K8S_WHITELIST:
+                if self._is_k8s_managed_container(ctr):
+                    container_name = self._get_k8s_container_name(ctr)
+                    if container_name:
+                        self.k8s_managed_containers.add(container_name)
                     continue
                 running_containers.add(ctr.name)
                 if ctr.name not in self.container_critical_processes:
@@ -175,6 +182,35 @@ class ServiceChecker(HealthChecker):
             logger.log_error("Failed to retrieve the running container list. Error: '{}'".format(err))
 
         return running_containers
+
+    def discover_k8s_managed_containers(self, ctrs):
+        try:
+            lst = ctrs.list(all=True, filters={"label": ServiceChecker.K8S_NAMESPACE_FILTER})
+        except docker.errors.DockerException as err:
+            logger.log_error("Failed to retrieve kubesonic managed container list. Error: '{}'".format(err))
+            return
+
+        k8s_managed_containers = set()
+        for ctr in lst:
+            container_name = self._get_k8s_container_name(ctr)
+            if container_name:
+                k8s_managed_containers.add(container_name)
+        self.k8s_managed_containers = k8s_managed_containers
+
+    def _is_k8s_managed_container(self, ctr):
+        labels = ctr.labels or {}
+        return labels.get(ServiceChecker.K8S_NAMESPACE_LABEL) == ServiceChecker.K8S_SONIC_NAMESPACE
+
+    def _get_k8s_container_name(self, ctr):
+        labels = ctr.labels or {}
+        if labels.get(ServiceChecker.K8S_DOCKER_TYPE_LABEL) != ServiceChecker.K8S_DOCKER_CONTAINER_TYPE:
+            return None
+
+        container_name = labels.get(ServiceChecker.K8S_CONTAINER_NAME_LABEL)
+        if container_name in [ServiceChecker.K8S_EMPTY_LABEL_VALUE, ServiceChecker.K8S_POD_INFRA_CONTAINER_NAME]:
+            return None
+
+        return container_name
 
     def get_critical_process_list_from_file(self, container, critical_processes_file):
         """Read critical process and group name lists from critical processes file
@@ -349,8 +385,8 @@ class ServiceChecker(HealthChecker):
             self.config_db = swsscommon.ConfigDBConnector(use_unix_socket_path=True)
             self.config_db.connect()
         feature_table = self.config_db.get_table("FEATURE")
-        expected_running_containers, self.container_feature_dict = self.get_expected_running_containers(feature_table)
         current_running_containers = self.get_current_running_containers()
+        expected_running_containers, self.container_feature_dict = self.get_expected_running_containers(feature_table)
 
         newly_disabled_containers = set(self.container_critical_processes.keys()).difference(expected_running_containers)
         for newly_disabled_container in newly_disabled_containers:

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -526,9 +526,12 @@ def test_service_checker_k8s_containers(mock_config_db, mock_run, mock_docker_cl
     checker = ServiceChecker()
     config = Config()
     checker.check(config)
+    assert 'snmp' not in checker.container_feature_dict
+    assert 'restapi' not in checker.container_feature_dict
     
     # Verify all K8s containers (namespace=sonic) are excluded from running containers
     running_containers = checker.get_current_running_containers()
+    assert checker.k8s_managed_containers == {'snmp', 'restapi'}
     assert 'snmp' not in running_containers
     assert 'restapi' not in running_containers
     assert 'POD' not in running_containers
@@ -600,6 +603,34 @@ def test_service_checker_mixed_containers(mock_config_db, mock_run, mock_docker_
     # Verify only regular Docker containers are monitored for critical processes
     assert 'swss' in checker.container_critical_processes
     assert 'database' not in checker.container_critical_processes  # k8s container, skipped entirely
+
+
+@patch('sonic_py_common.multi_asic.is_multi_asic', MagicMock(return_value=False))
+def test_service_checker_discovers_stopped_k8s_containers():
+    """Test that stopped Kubernetes-managed containers are still skipped from expected containers"""
+    checker = ServiceChecker()
+    mock_containers = MagicMock()
+    mock_database_container = MagicMock()
+    mock_database_container.labels = {
+        'io.kubernetes.pod.namespace': 'sonic',
+        'io.kubernetes.docker.type': 'container',
+        'io.kubernetes.container.name': 'database'
+    }
+    mock_containers.list = MagicMock(return_value=[mock_database_container])
+
+    checker.discover_k8s_managed_containers(mock_containers)
+
+    feature_table = {
+        'database': {
+            'state': 'enabled',
+            'has_global_scope': 'True',
+            'has_per_asic_scope': 'False',
+        }
+    }
+    expected_running_containers, container_feature_dict = checker.get_expected_running_containers(feature_table)
+
+    assert 'database' not in expected_running_containers
+    assert 'database' not in container_feature_dict
 
 
 def test_hardware_checker():


### PR DESCRIPTION
Replace the hardcoded KubeSonic container whitelist in service_checker with generic discovery from Docker Kubernetes labels (namespace 'sonic'), so new services rolled out via k8s are skipped without code changes. Apply the same change to the docker-telemetry-sidecar service_checker copies for the 202411, 202412 and 202505 branches.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
hardcoded KubeSonic container whitelist in service_checker is not generic, so new services rolled out via k8s will need code changes.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Replace the hardcoded KubeSonic container whitelist in service_checker with generic discovery from Docker Kubernetes labels (namespace 'sonic'), so new services rolled out via k8s are skipped without code changes. Apply the same change to the docker-telemetry-sidecar service_checker copies for the 202411, 202412 and 202505 branches.

#### How to verify it
Unit test verify.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

