### PR TITLE
sonic-yang-models: add WRED profile ECN marking threshold fields

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/qos.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/qos.json
@@ -78,7 +78,7 @@
 
     "WRED_PROFILE_ECN_THRESHOLD_WITHOUT_MODE": {
         "desc": "Configure an ECN green threshold without enabling green in the ECN mode.",
-        "eStr": ["ecn_green_min_threshold requires green ECN marking enabled in 'ecn'"]
+        "eStr": ["green_ect_min_threshold requires green ECN marking enabled in 'ecn'"]
     },
 
 

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/qos.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/qos.json
@@ -67,6 +67,20 @@
         "eStr": ["Red max threshold must be greater than or equal to min threshold"]
     },
 
+    "WRED_PROFILE_ECN_THRESHOLD_VALID": {
+        "desc": "Configure independent ECN marking thresholds with a matching ECN mode."
+    },
+
+    "WRED_PROFILE_INVALID_ECN_GREEN_THRESHOLD": {
+        "desc": "Configure ECN green max threshold less than ECN green min threshold.",
+        "eStr": ["ECN green max threshold must be greater than or equal to ECN green min threshold"]
+    },
+
+    "WRED_PROFILE_ECN_THRESHOLD_WITHOUT_MODE": {
+        "desc": "Configure an ECN green threshold without enabling green in the ECN mode.",
+        "eStr": ["ecn_green_min_threshold requires green ECN marking enabled in 'ecn'"]
+    },
+
 
     "QUEUE_VALID": {
         "desc": "Attach scheduler and wred profiles to QUEUE."

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/qos.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/qos.json
@@ -286,6 +286,67 @@
         }
     },
 
+    "WRED_PROFILE_ECN_THRESHOLD_VALID": {
+        "sonic-wred-profile:sonic-wred-profile": {
+            "sonic-wred-profile:WRED_PROFILE": {
+                "WRED_PROFILE_LIST": [
+                {
+                    "name":"WredEcn",
+                    "green_min_threshold": 4096,
+                    "green_max_threshold": 8192,
+                    "yellow_min_threshold": 2048,
+                    "yellow_max_threshold": 4096,
+                    "red_min_threshold": 1024,
+                    "red_max_threshold": 2048,
+                    "ecn": "ecn_all",
+                    "wred_green_enable": true,
+                    "wred_yellow_enable": true,
+                    "wred_red_enable": true,
+                    "ecn_green_min_threshold": 2048,
+                    "ecn_green_max_threshold": 4096,
+                    "ecn_green_mark_probability": 50,
+                    "ecn_yellow_min_threshold": 1024,
+                    "ecn_yellow_max_threshold": 2048,
+                    "ecn_yellow_mark_probability": 50,
+                    "ecn_red_min_threshold": 512,
+                    "ecn_red_max_threshold": 1024,
+                    "ecn_red_mark_probability": 100
+                }
+                ]
+            }
+        }
+    },
+
+    "WRED_PROFILE_INVALID_ECN_GREEN_THRESHOLD": {
+        "sonic-wred-profile:sonic-wred-profile": {
+            "sonic-wred-profile:WRED_PROFILE": {
+                "WRED_PROFILE_LIST": [
+                {
+                    "name":"WredEcn",
+                    "ecn": "ecn_all",
+                    "wred_green_enable": true,
+                    "ecn_green_min_threshold": 4096,
+                    "ecn_green_max_threshold": 2048
+                }
+                ]
+            }
+        }
+    },
+
+    "WRED_PROFILE_ECN_THRESHOLD_WITHOUT_MODE": {
+        "sonic-wred-profile:sonic-wred-profile": {
+            "sonic-wred-profile:WRED_PROFILE": {
+                "WRED_PROFILE_LIST": [
+                {
+                    "name":"WredEcn",
+                    "ecn": "ecn_none",
+                    "ecn_green_min_threshold": 4096
+                }
+                ]
+            }
+        }
+    },
+
 
     "QUEUE_VALID": {
         "sonic-scheduler:sonic-scheduler":{

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/qos.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/qos.json
@@ -302,15 +302,15 @@
                     "wred_green_enable": true,
                     "wred_yellow_enable": true,
                     "wred_red_enable": true,
-                    "ecn_green_min_threshold": 2048,
-                    "ecn_green_max_threshold": 4096,
-                    "ecn_green_mark_probability": 50,
-                    "ecn_yellow_min_threshold": 1024,
-                    "ecn_yellow_max_threshold": 2048,
-                    "ecn_yellow_mark_probability": 50,
-                    "ecn_red_min_threshold": 512,
-                    "ecn_red_max_threshold": 1024,
-                    "ecn_red_mark_probability": 100
+                    "green_ect_min_threshold": 2048,
+                    "green_ect_max_threshold": 4096,
+                    "green_ect_mark_probability": 50,
+                    "yellow_ect_min_threshold": 1024,
+                    "yellow_ect_max_threshold": 2048,
+                    "yellow_ect_mark_probability": 50,
+                    "red_ect_min_threshold": 512,
+                    "red_ect_max_threshold": 1024,
+                    "red_ect_mark_probability": 100
                 }
                 ]
             }
@@ -325,8 +325,8 @@
                     "name":"WredEcn",
                     "ecn": "ecn_all",
                     "wred_green_enable": true,
-                    "ecn_green_min_threshold": 4096,
-                    "ecn_green_max_threshold": 2048
+                    "green_ect_min_threshold": 4096,
+                    "green_ect_max_threshold": 2048
                 }
                 ]
             }
@@ -340,7 +340,7 @@
                 {
                     "name":"WredEcn",
                     "ecn": "ecn_none",
-                    "ecn_green_min_threshold": 4096
+                    "green_ect_min_threshold": 4096
                 }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-wred-profile.yang
+++ b/src/sonic-yang-models/yang-models/sonic-wred-profile.yang
@@ -193,98 +193,98 @@ module sonic-wred-profile {
                  * compatible).
                  */
 
-                leaf ecn_green_min_threshold {
+                leaf green_ect_min_threshold {
                     type uint64;
                     units bytes;
                     must "../ecn = 'ecn_green' or ../ecn = 'ecn_green_yellow' or ../ecn = 'ecn_green_red' or ../ecn = 'ecn_all'" {
-                        error-message "ecn_green_min_threshold requires green ECN marking enabled in 'ecn'";
+                        error-message "green_ect_min_threshold requires green ECN marking enabled in 'ecn'";
                     }
                     description "Queue depth in bytes at which ECN marking begins for green-colored packets.";
                 }
 
-                leaf ecn_green_max_threshold {
+                leaf green_ect_max_threshold {
                     type uint64;
                     units bytes;
-                    must "(current() >= current()/../ecn_green_min_threshold)" {
+                    must "(current() >= current()/../green_ect_min_threshold)" {
                         error-message "ECN green max threshold must be greater than or equal to ECN green min threshold";
                     }
                     must "../ecn = 'ecn_green' or ../ecn = 'ecn_green_yellow' or ../ecn = 'ecn_green_red' or ../ecn = 'ecn_all'" {
-                        error-message "ecn_green_max_threshold requires green ECN marking enabled in 'ecn'";
+                        error-message "green_ect_max_threshold requires green ECN marking enabled in 'ecn'";
                     }
                     description "Queue depth in bytes at which all green-colored packets are ECN marked.";
                 }
 
-                leaf ecn_green_mark_probability {
+                leaf green_ect_mark_probability {
                     type uint64 {
                         range "0..100";
                     }
                     units percent;
                     must "../ecn = 'ecn_green' or ../ecn = 'ecn_green_yellow' or ../ecn = 'ecn_green_red' or ../ecn = 'ecn_all'" {
-                        error-message "ecn_green_mark_probability requires green ECN marking enabled in 'ecn'";
+                        error-message "green_ect_mark_probability requires green ECN marking enabled in 'ecn'";
                     }
                     description "Probability (percent) of ECN marking green packets between ECN min and max thresholds.";
                 }
 
-                leaf ecn_yellow_min_threshold {
+                leaf yellow_ect_min_threshold {
                     type uint64;
                     units bytes;
                     must "../ecn = 'ecn_yellow' or ../ecn = 'ecn_green_yellow' or ../ecn = 'ecn_yellow_red' or ../ecn = 'ecn_all'" {
-                        error-message "ecn_yellow_min_threshold requires yellow ECN marking enabled in 'ecn'";
+                        error-message "yellow_ect_min_threshold requires yellow ECN marking enabled in 'ecn'";
                     }
                     description "Queue depth in bytes at which ECN marking begins for yellow-colored packets.";
                 }
 
-                leaf ecn_yellow_max_threshold {
+                leaf yellow_ect_max_threshold {
                     type uint64;
                     units bytes;
-                    must "(current() >= current()/../ecn_yellow_min_threshold)" {
+                    must "(current() >= current()/../yellow_ect_min_threshold)" {
                         error-message "ECN yellow max threshold must be greater than or equal to ECN yellow min threshold";
                     }
                     must "../ecn = 'ecn_yellow' or ../ecn = 'ecn_green_yellow' or ../ecn = 'ecn_yellow_red' or ../ecn = 'ecn_all'" {
-                        error-message "ecn_yellow_max_threshold requires yellow ECN marking enabled in 'ecn'";
+                        error-message "yellow_ect_max_threshold requires yellow ECN marking enabled in 'ecn'";
                     }
                     description "Queue depth in bytes at which all yellow-colored packets are ECN marked.";
                 }
 
-                leaf ecn_yellow_mark_probability {
+                leaf yellow_ect_mark_probability {
                     type uint64 {
                         range "0..100";
                     }
                     units percent;
                     must "../ecn = 'ecn_yellow' or ../ecn = 'ecn_green_yellow' or ../ecn = 'ecn_yellow_red' or ../ecn = 'ecn_all'" {
-                        error-message "ecn_yellow_mark_probability requires yellow ECN marking enabled in 'ecn'";
+                        error-message "yellow_ect_mark_probability requires yellow ECN marking enabled in 'ecn'";
                     }
                     description "Probability (percent) of ECN marking yellow packets between ECN min and max thresholds.";
                 }
 
-                leaf ecn_red_min_threshold {
+                leaf red_ect_min_threshold {
                     type uint64;
                     units bytes;
                     must "../ecn = 'ecn_red' or ../ecn = 'ecn_green_red' or ../ecn = 'ecn_yellow_red' or ../ecn = 'ecn_all'" {
-                        error-message "ecn_red_min_threshold requires red ECN marking enabled in 'ecn'";
+                        error-message "red_ect_min_threshold requires red ECN marking enabled in 'ecn'";
                     }
                     description "Queue depth in bytes at which ECN marking begins for red-colored packets.";
                 }
 
-                leaf ecn_red_max_threshold {
+                leaf red_ect_max_threshold {
                     type uint64;
                     units bytes;
-                    must "(current() >= current()/../ecn_red_min_threshold)" {
+                    must "(current() >= current()/../red_ect_min_threshold)" {
                         error-message "ECN red max threshold must be greater than or equal to ECN red min threshold";
                     }
                     must "../ecn = 'ecn_red' or ../ecn = 'ecn_green_red' or ../ecn = 'ecn_yellow_red' or ../ecn = 'ecn_all'" {
-                        error-message "ecn_red_max_threshold requires red ECN marking enabled in 'ecn'";
+                        error-message "red_ect_max_threshold requires red ECN marking enabled in 'ecn'";
                     }
                     description "Queue depth in bytes at which all red-colored packets are ECN marked.";
                 }
 
-                leaf ecn_red_mark_probability {
+                leaf red_ect_mark_probability {
                     type uint64 {
                         range "0..100";
                     }
                     units percent;
                     must "../ecn = 'ecn_red' or ../ecn = 'ecn_green_red' or ../ecn = 'ecn_yellow_red' or ../ecn = 'ecn_all'" {
-                        error-message "ecn_red_mark_probability requires red ECN marking enabled in 'ecn'";
+                        error-message "red_ect_mark_probability requires red ECN marking enabled in 'ecn'";
                     }
                     description "Probability (percent) of ECN marking red packets between ECN min and max thresholds.";
                 }

--- a/src/sonic-yang-models/yang-models/sonic-wred-profile.yang
+++ b/src/sonic-yang-models/yang-models/sonic-wred-profile.yang
@@ -15,6 +15,12 @@ module sonic-wred-profile {
     description
         "WRED_PROFILE yang Module for SONiC OS";
 
+    revision 2026-06-23 {
+        description
+            "Add independent ECN marking thresholds (green/yellow/red min/max and
+             mark probability), distinct from the WRED drop thresholds.";
+    }
+
     revision 2021-04-01 {
         description
             "Initial revision.";
@@ -172,6 +178,115 @@ module sonic-wred-profile {
                     units percent;
                     default 100;
                     description "Maximum drop probability for red-colored packets between min and max thresholds.";
+                }
+
+                /*
+                 * Independent ECN marking thresholds.
+                 *
+                 * Distinct from the WRED drop thresholds above: they let ECN mark
+                 * packets at a (typically lower) queue depth than the depth at which
+                 * WRED starts dropping ("mark before drop"). They map to
+                 * SAI_WRED_ATTR_ECN_<COLOR>_{MIN,MAX}_THRESHOLD and
+                 * SAI_WRED_ATTR_ECN_<COLOR>_MARK_PROBABILITY. A per-color ECN
+                 * threshold is only valid when that color is enabled in "ecn". When
+                 * unset, ECN marking follows the WRED drop thresholds (backward
+                 * compatible).
+                 */
+
+                leaf ecn_green_min_threshold {
+                    type uint64;
+                    units bytes;
+                    must "../ecn = 'ecn_green' or ../ecn = 'ecn_green_yellow' or ../ecn = 'ecn_green_red' or ../ecn = 'ecn_all'" {
+                        error-message "ecn_green_min_threshold requires green ECN marking enabled in 'ecn'";
+                    }
+                    description "Queue depth in bytes at which ECN marking begins for green-colored packets.";
+                }
+
+                leaf ecn_green_max_threshold {
+                    type uint64;
+                    units bytes;
+                    must "(current() >= current()/../ecn_green_min_threshold)" {
+                        error-message "ECN green max threshold must be greater than or equal to ECN green min threshold";
+                    }
+                    must "../ecn = 'ecn_green' or ../ecn = 'ecn_green_yellow' or ../ecn = 'ecn_green_red' or ../ecn = 'ecn_all'" {
+                        error-message "ecn_green_max_threshold requires green ECN marking enabled in 'ecn'";
+                    }
+                    description "Queue depth in bytes at which all green-colored packets are ECN marked.";
+                }
+
+                leaf ecn_green_mark_probability {
+                    type uint64 {
+                        range "0..100";
+                    }
+                    units percent;
+                    must "../ecn = 'ecn_green' or ../ecn = 'ecn_green_yellow' or ../ecn = 'ecn_green_red' or ../ecn = 'ecn_all'" {
+                        error-message "ecn_green_mark_probability requires green ECN marking enabled in 'ecn'";
+                    }
+                    description "Probability (percent) of ECN marking green packets between ECN min and max thresholds.";
+                }
+
+                leaf ecn_yellow_min_threshold {
+                    type uint64;
+                    units bytes;
+                    must "../ecn = 'ecn_yellow' or ../ecn = 'ecn_green_yellow' or ../ecn = 'ecn_yellow_red' or ../ecn = 'ecn_all'" {
+                        error-message "ecn_yellow_min_threshold requires yellow ECN marking enabled in 'ecn'";
+                    }
+                    description "Queue depth in bytes at which ECN marking begins for yellow-colored packets.";
+                }
+
+                leaf ecn_yellow_max_threshold {
+                    type uint64;
+                    units bytes;
+                    must "(current() >= current()/../ecn_yellow_min_threshold)" {
+                        error-message "ECN yellow max threshold must be greater than or equal to ECN yellow min threshold";
+                    }
+                    must "../ecn = 'ecn_yellow' or ../ecn = 'ecn_green_yellow' or ../ecn = 'ecn_yellow_red' or ../ecn = 'ecn_all'" {
+                        error-message "ecn_yellow_max_threshold requires yellow ECN marking enabled in 'ecn'";
+                    }
+                    description "Queue depth in bytes at which all yellow-colored packets are ECN marked.";
+                }
+
+                leaf ecn_yellow_mark_probability {
+                    type uint64 {
+                        range "0..100";
+                    }
+                    units percent;
+                    must "../ecn = 'ecn_yellow' or ../ecn = 'ecn_green_yellow' or ../ecn = 'ecn_yellow_red' or ../ecn = 'ecn_all'" {
+                        error-message "ecn_yellow_mark_probability requires yellow ECN marking enabled in 'ecn'";
+                    }
+                    description "Probability (percent) of ECN marking yellow packets between ECN min and max thresholds.";
+                }
+
+                leaf ecn_red_min_threshold {
+                    type uint64;
+                    units bytes;
+                    must "../ecn = 'ecn_red' or ../ecn = 'ecn_green_red' or ../ecn = 'ecn_yellow_red' or ../ecn = 'ecn_all'" {
+                        error-message "ecn_red_min_threshold requires red ECN marking enabled in 'ecn'";
+                    }
+                    description "Queue depth in bytes at which ECN marking begins for red-colored packets.";
+                }
+
+                leaf ecn_red_max_threshold {
+                    type uint64;
+                    units bytes;
+                    must "(current() >= current()/../ecn_red_min_threshold)" {
+                        error-message "ECN red max threshold must be greater than or equal to ECN red min threshold";
+                    }
+                    must "../ecn = 'ecn_red' or ../ecn = 'ecn_green_red' or ../ecn = 'ecn_yellow_red' or ../ecn = 'ecn_all'" {
+                        error-message "ecn_red_max_threshold requires red ECN marking enabled in 'ecn'";
+                    }
+                    description "Queue depth in bytes at which all red-colored packets are ECN marked.";
+                }
+
+                leaf ecn_red_mark_probability {
+                    type uint64 {
+                        range "0..100";
+                    }
+                    units percent;
+                    must "../ecn = 'ecn_red' or ../ecn = 'ecn_green_red' or ../ecn = 'ecn_yellow_red' or ../ecn = 'ecn_all'" {
+                        error-message "ecn_red_mark_probability requires red ECN marking enabled in 'ecn'";
+                    }
+                    description "Probability (percent) of ECN marking red packets between ECN min and max thresholds.";
                 }
             }
         }


### PR DESCRIPTION
#### Why I did it
Add the YANG schema for independent per-WRED ECN marking thresholds — the companion to sonic-net/sonic-swss#4719 (qosorch). Lets a `WRED_PROFILE` configure an ECN marking knee independent of the WRED drop thresholds ("mark before drop").

Related to sonic-net/sonic-swss#4718

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Extend `sonic-wred-profile` with optional leaves `ecn_{green,yellow,red}_{min,max}_threshold` and `ecn_{green,yellow,red}_mark_probability`. Per-color ECN thresholds require that color enabled in `ecn`, and each ECN max >= ECN min (when/must constraints). All leaves are optional, so existing profiles are unaffected.

#### How to verify it
New positive and negative YANG test cases in `tests/yang_model_tests/{tests,tests_config}/qos.json` (valid config; ECN max < min rejected; ECN threshold without the color enabled rejected). Covered by the `sonic-yang-models` pytest.

#### Description for the changelog
sonic-yang-models: add WRED profile ECN marking threshold fields.
