### PR TITLE
[ci] refine docker-ptf pipeline to align with image download command change

### DIFF
--- a/.azure-pipelines/docker-ptf.yml
+++ b/.azure-pipelines/docker-ptf.yml
@@ -13,6 +13,7 @@ pr:
   paths:
     include:
     - dockers/docker-ptf
+    - .azure-pipelines/docker-ptf.yml
 
 resources:
   repositories:
@@ -54,6 +55,8 @@ stages:
     value: $[ stageDependencies.Prepare.Prepare.outputs['SetVersions.DEBIAN_SECURITY_TIMESTAMP'] ]
   - name: MIRROR_SNAPSHOT
     value: 'y'
+  - name: BUILD_BRANCH
+    value: $[ coalesce(variables['System.PullRequest.TargetBranchName'], variables['Build.SourceBranchName']) ]
   jobs:
   - job: Build
     pool: sonicso1ES-amd64
@@ -66,6 +69,19 @@ stages:
         set -x
         sudo setfacl -R -b $(Agent.BuildDirectory)
       displayName: 'setfacl'
+
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Fetch VS images from VS pipeline'
+      inputs:
+        source: specific
+        project: build
+        pipeline: Azure.sonic-buildimage
+        artifact: sonic-buildimage.vs
+        runVersion: latestFromBranch
+        runBranch: 'refs/heads/$(BUILD_BRANCH)'
+        patterns: '**/sonic*-vs.img.gz'
+        allowPartiallySucceededBuilds: true
+        targetPath: $(Pipeline.Workspace)/vs-images
 
     - script: |
         echo "DEBIAN_TIMESTAMP=$DEBIAN_TIMESTAMP, DEBIAN_SECURITY_TIMESTAMP=$DEBIAN_SECURITY_TIMESTAMP"
@@ -80,35 +96,19 @@ stages:
     - bash: |
         set -xe
         git submodule update --init --recursive -- src/ptf src/ptf-py3 src/sonic-sairedis src/sonic-frr/frr src/sonic-swss-common
+        # TODO: ENABLE_SBOM=y
         BUILD_OPTIONS="SONIC_BUILD_JOBS=$(nproc) DEFAULT_CONTAINER_REGISTRY=publicmirror.azurecr.io ENABLE_DOCKER_BASE_PULL=y MIRROR_SNAPSHOT=$MIRROR_SNAPSHOT 
                       SONIC_BUILD_RETRY_COUNT=3 SONIC_BUILD_RETRY_INTERVAL=600 DOCKER_BUILDKIT=0 SONIC_VERSION_CONTROL_COMPONENTS="
 
         make NOBUSTER=1 NOBULLSEYE=1 $BUILD_OPTIONS configure PLATFORM=vs NOTRIXIE=1 # docker-ptf is built for bookworm, disable trixie currently to save build time. will enable it after migrating to trixie.
         make -f Makefile.work BLDENV=bookworm $BUILD_OPTIONS target/docker-ptf.gz
         cp -r target $(Build.ArtifactStagingDirectory)/target
+        cp $(Pipeline.Workspace)/vs-images/target/sonic*-vs.img.gz $(Build.ArtifactStagingDirectory)/target/
       displayName: Build docker-ptf.gz
 
     - publish:  $(Build.ArtifactStagingDirectory)
       artifact: 'sonic-buildimage.vs'
       displayName: "Archive docker image ptf"
-    
-    - bash: |
-        set -ex
-        docker load -i $(Build.ArtifactStagingDirectory)/target/docker-ptf.gz
-        docker tag docker-ptf:latest $REGISTRY_SERVER/docker-ptf:lastbuild
-        docker images
-      env:
-        REGISTRY_SERVER: ${{ parameters.registry_url }}
-      displayName: 'Load and tag docker-ptf as lastbuild'
-    
-    - task: Docker@2
-      displayName: 'Push docker-ptf:lastbuild to registry'
-      condition: succeeded()
-      inputs:
-        containerRegistry: ${{ parameters.registry_conn }}
-        repository: docker-ptf
-        command: push
-        tags: lastbuild
 
 - stage: Test
   dependsOn: Build
@@ -116,7 +116,9 @@ stages:
   variables:
   - group: SONiC-Elastictest
   - name: BUILD_BRANCH
-    value: $(Build.SourceBranchName)
+    value: $[ coalesce(variables['System.PullRequest.TargetBranchName'], variables['Build.SourceBranchName']) ]
+  - name: PTF_IMAGE_TAG
+    value: $[ replace(variables['BUILD_BRANCH'], 'master', 'latest') ]
   jobs:
   - job: trivy_scan
     displayName: "[OPTIONAL] Trivy vulnerability scan (docker-ptf)"
@@ -124,9 +126,6 @@ stages:
     continueOnError: true
     timeoutInMinutes: 60
     steps:
-    - checkout: self
-      clean: true
-      fetchDepth: 1
     - download: current
       artifact: 'sonic-buildimage.vs'
       displayName: "Download docker-ptf artifact"
@@ -165,10 +164,13 @@ stages:
     parameters:
       CHECKOUT_SONIC_MGMT: true
       PTF_MODIFIED: 'True'
-      PTF_IMAGE_TAG: "lastbuild"
+      PTF_IMAGE_TAG: '$(PTF_IMAGE_TAG)'
+      KVM_BUILD_ID: $(Build.BuildId)
       INCLUDE_JOBS: "t0_job,t1_job,t2_job,t0_2vlans_job,t0_sonic_job,dpu_job,t1_multi_asic_job"
+      KVM_IMAGE_BRANCH: '$(BUILD_BRANCH)'
+      MGMT_BRANCH: '$(BUILD_BRANCH)'
       OVERRIDE_PARAMS:
-        REPO_NAME: "sonic-mgmt"
+        REPO_NAME: "docker-ptf"
 
 - stage: Publish
   dependsOn: Test
@@ -184,18 +186,26 @@ stages:
 
     - bash: |
         set -ex
+        BRANCH=$(Build.SourceBranchName)
+        [[ "$BRANCH" == "master" ]] && TAG="latest" || TAG="$BRANCH"
+        echo "Docker tag: $TAG"
+        echo "##vso[task.setvariable variable=DOCKER_TAG]$TAG"
+      displayName: 'Compute Docker tag'
+
+    - bash: |
+        set -ex
         docker load -i $(Pipeline.Workspace)/sonic-buildimage.vs/target/docker-ptf.gz
-        docker tag docker-ptf:latest $REGISTRY_SERVER/docker-ptf:latest
+        docker tag docker-ptf:latest $REGISTRY_SERVER/docker-ptf:$(DOCKER_TAG)
         docker images
       env:
         REGISTRY_SERVER: ${{ parameters.registry_url }}
-      displayName: 'Load and tag docker-ptf as latest'
+      displayName: 'Load and tag docker-ptf'
 
     - task: Docker@2
-      displayName: 'Push docker-ptf:latest to registry'
+      displayName: 'Push docker-ptf to registry'
       condition: succeeded()
       inputs:
         containerRegistry: ${{ parameters.registry_conn }}
         repository: docker-ptf
         command: push
-        tags: latest
+        tags: $(DOCKER_TAG)


### PR DESCRIPTION
#### Why I did it

The `docker-ptf` pipeline needs to align with the new Elastictest image download command logic so that `docker-ptf` built in a PR can be used for in-PR testing. Previously the pipeline pushed a `lastbuild` tag to the registry and referenced it directly; the new image download command resolves the PTF image by branch/tag, so the pipeline should provide the branch and image tag instead.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

In `.azure-pipelines/docker-ptf.yml`:
- Added `.azure-pipelines/docker-ptf.yml` to the PR trigger `paths` so changes to the pipeline itself trigger it.
- Removed the steps that loaded, tagged, and pushed `docker-ptf:lastbuild` to the registry (no longer needed for in-PR testing).
- Set `BUILD_BRANCH` from `System.PullRequest.TargetBranchName` (falling back to `Build.SourceBranchName`) and derived `PTF_IMAGE_TAG` by mapping `master` to `latest`.
- Removed the redundant `checkout: self` in the Trivy scan job (uses the downloaded artifact).
- Updated the Elastictest test stage to pass `KVM_IMAGE_BRANCH` / `MGMT_BRANCH` from `BUILD_BRANCH`, set `REPO_NAME` to `docker-ptf`, and dropped the hardcoded `PTF_IMAGE_TAG: "lastbuild"` in favor of the new image download command logic.

#### How to verify it

- Run the `docker-ptf` pipeline on a PR and confirm the in-PR built `docker-ptf` image is downloaded and used by the Elastictest test stage.
- Confirm the branch/tag resolution works for both `master` (→ `latest`) and release branches.

#### Description for the changelog

Refine docker-ptf pipeline to align with the new Elastictest image download command and support in-PR docker-ptf testing.
