### PR TITLE
Ensure static IP is re-applied if the bmc0 USB gadget netdev is recreated after boot.

### DIFF
--- a/device/nexthop/arm64-nexthop_b27-r0/70-usb-network.rules
+++ b/device/nexthop/arm64-nexthop_b27-r0/70-usb-network.rules
@@ -1,6 +1,14 @@
 # Aspeed BMC USB Network Gadget Interface Renaming Rule
 # Renames USB NCM gadget interface from usb0 to bmc0 for consistent naming
+#
+# In addition to renaming, pull in ifup@bmc0.service (allow-hotplug) so the
+# static IP from /etc/network/interfaces is (re)applied whenever bmc0 appears,
+# independent of the networking/interfaces-config service ordering. The literal
+# instance name "bmc0" is used (not $name) because the NAME= rename only takes
+# effect at the end of the event, so $name still holds the pre-rename kernel
+# name here. Net devices are tagged "systemd" by the builtin 99-systemd.rules,
+# so SYSTEMD_WANTS is honored.
 
-# Match USB NCM gadget interface with BMC MAC address and rename to bmc0
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="02:00:00:00:00:01", NAME="bmc0"
+# Match USB NCM gadget interface with BMC MAC address, rename to bmc0 and apply its IP
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="02:00:00:00:00:01", NAME="bmc0", ENV{SYSTEMD_WANTS}+="ifup@bmc0.service"
 

--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -34,12 +34,14 @@ iface lo inet loopback
 {%- if IS_SWITCH_BMC == 1 and bmc_addr is defined %}
 # BMC interface (Switch-BMC side)
 auto {{ bmc_if_name }}
+allow-hotplug {{ bmc_if_name }}
 iface {{ bmc_if_name }} inet static
     address {{ bmc_addr }}
     netmask {{ bmc_net_mask }}
 {%- elif IS_SWITCH_HOST == 1 and bmc_if_addr is defined %}
 # BMC interface (Switch-Host side)
 auto {{ bmc_if_name }}
+allow-hotplug {{ bmc_if_name }}
 iface {{ bmc_if_name }} inet static
     address {{ bmc_if_addr }}
     netmask {{ bmc_net_mask }}


### PR DESCRIPTION
#### Why I did it
This is not a bug but better to have

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add "allow-hotplug bmc0" alongside "auto" so the static IP is re-applied if the bmc0 USB gadget netdev is recreated after boot.

#### How to verify it
bmc0 should always have a IPv4 address

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

