### PR TITLE
[docker-ptf] Fix easy-install.pth quoting that breaks switch_sai_thrift import

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -445,7 +445,7 @@ ENV PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 # a different Python minor (e.g. py3.13 from a Trixie/OS13 DUT image).
 # saithrift is thrift-generated pure Python, so the egg loads across py3.x.
 RUN PYVER=$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])') \
-    && echo "import glob, sys; sys.path.extend(glob.glob('"'"'/usr/lib/python3/dist-packages/saithrift-0.9-py3.*.egg'"'"'))" \
+    && echo "import glob, sys; sys.path.extend(glob.glob('/usr/lib/python3/dist-packages/saithrift-0.9-py3.*.egg'))" \
        >> "/root/env-python3/lib/python${PYVER}/site-packages/easy-install.pth"
 {% endif %}
 

--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -447,6 +447,9 @@ ENV PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 RUN PYVER=$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])') \
     && echo "import glob, sys; sys.path.extend(glob.glob('/usr/lib/python3/dist-packages/saithrift-0.9-py3.*.egg'))" \
        >> "/root/env-python3/lib/python${PYVER}/site-packages/easy-install.pth"
+
+# Fail the build if saithrift is not importable the way the QoS saitests use it.
+RUN /root/env-python3/bin/python -c "import switch_sai_thrift.switch_sai_rpc"
 {% endif %}
 
 # {% if PTF_ENV_PY_VER == "py3" %}


### PR DESCRIPTION
#### Why I did it

Follow-up fix to #27947. That PR replaced the hardcoded saithrift egg path in the `docker-ptf` virtualenv with a dynamic glob `.pth` line, but the shell quoting used the `'"'"'` single-quote-escape idiom **inside a double-quoted `echo`**. Since single quotes are already literal inside double quotes, that idiom injected literal double quotes into the generated `easy-install.pth`:

```python
import glob, sys; sys.path.extend(glob.glob('"/usr/lib/python3/dist-packages/saithrift-0.9-py3.*.egg"'))
```

`glob.glob()` then searches for a path that literally begins with a `"`, matches nothing, and the saithrift egg is never added to the PTF virtualenv `sys.path`:

```
ModuleNotFoundError: No module named 'switch_sai_thrift'
```

This breaks the qos saithrift tests (`qos/test_qos_sai.py`, `qos/test_qos_probe.py` — `ReleaseAllPorts`) on **all** platforms, since the system Python sees system site-packages but the venv interpreter does not.

Reported in sonic-net/sonic-buildimage#28163.

#### How I did it

In `dockers/docker-ptf/Dockerfile.j2` (py3 branch), drop the `'"'"'` escape idiom and use a plain single quote, so the emitted line is correct:

```python
import glob, sys; sys.path.extend(glob.glob('/usr/lib/python3/dist-packages/saithrift-0.9-py3.*.egg'))
```

Single quotes are already literal inside the double-quoted `echo`; no escaping is needed.

#### How to verify it

Run the exact `RUN` block from the Dockerfile and inspect the generated `.pth`, then import `switch_sai_thrift` through the venv interpreter (no system site-packages):

```bash
cat /root/env-python3/lib/python*/site-packages/easy-install.pth
# import glob, sys; sys.path.extend(glob.glob('/usr/lib/python3/dist-packages/saithrift-0.9-py3.*.egg'))   # no embedded quotes
/root/env-python3/bin/python -c "import switch_sai_thrift.switch_sai_rpc; print('SUCCESS')"
```

Validated locally with a faithful harness (real venv without system-site-packages + saithrift egg):
- fixed line → import OK, `.pth` has no embedded `"`
- old buggy line → `ModuleNotFoundError` (negative control)
- fixed line + `py3.13`-named egg under a `py3.x` venv → import OK (preserves #27947's cross-py3.x purpose)

Fixes #28163

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>