### PR TITLE
report decoded reboot cause instead of masking it with Unknown/empty cause

### DIFF
--- a/platform/broadcom/sonic-platform-modules-nexthop/common/sonic_platform/adm1266.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/common/sonic_platform/adm1266.py
@@ -614,12 +614,19 @@ class Adm1266(DpmBase, type=DpmType.ADM1266, max_powerup_counter=65535):
         powerups = []
         for _, group in grouped_by_powerup:
             group_list = list(group)
-            last_record = group_list[-1]  # record with the highest UID determines the cause
+
+            # The cause is in the most recent record that decoded a fault 
+            power_fault_cause = None
+            for record in reversed(group_list):
+                cause = record.get_power_fault_cause()
+                if cause is not None:
+                    power_fault_cause = cause
+                    break
 
             powerups.append(
                 DpmPowerUpEntry(
-                    powerup_counter=last_record.powerup_counter,
-                    power_fault_cause=last_record.get_power_fault_cause(),
+                    powerup_counter=group_list[-1].powerup_counter,
+                    power_fault_cause=power_fault_cause,
                     dpm_records=cast(list[DpmRecord], group_list),
                 )
             )

--- a/platform/broadcom/sonic-platform-modules-nexthop/common/sonic_platform/chassis.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/common/sonic_platform/chassis.py
@@ -13,7 +13,7 @@ import sys
 import time
 
 from sonic_platform.dpm_base import timestamp_as_string
-from sonic_platform.reboot_cause_manager import RebootCauseManager, RebootCause
+from sonic_platform.reboot_cause_manager import RebootCauseManager, RebootCause, is_informative_cause
 from sonic_platform.thermal import NexthopFpgaAsicThermal
 from sonic_platform.watchdog import Watchdog
 
@@ -224,10 +224,17 @@ class Chassis(PddfChassis):
         if not reboot_causes:
             return ("Unknown", "")
 
-        if len(reboot_causes) == 1 and reboot_causes[0].type == RebootCause.Type.SOFTWARE:
+        # Report the oldest informative cause;
+        # At the end of list, uninformative ones are placed (undecodable HW "unknown" / empty SW)
+        informative, uninformative = [], []
+        for c in reboot_causes:
+            (informative if is_informative_cause(c) else uninformative).append(c)
+        ordered = informative + uninformative if informative else reboot_causes
+
+        if len(ordered) == 1 and ordered[0].type == RebootCause.Type.SOFTWARE:
             return self.REBOOT_CAUSE_NON_HARDWARE, ""
 
-        majors_and_minors: list[tuple[str, str]] = self._convert_to_majors_and_minors(reboot_causes)
+        majors_and_minors: list[tuple[str, str]] = self._convert_to_majors_and_minors(ordered)
         self._attach_reboot_cause_comment(majors_and_minors[1:])
         return majors_and_minors[0]
 

--- a/platform/broadcom/sonic-platform-modules-nexthop/common/sonic_platform/reboot_cause_manager.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/common/sonic_platform/reboot_cause_manager.py
@@ -23,14 +23,26 @@ from sonic_py_common import syslogger
 SYSLOG_IDENTIFIER = "sonic_platform.reboot_cause_manager"
 logger = syslogger.SysLogger(SYSLOG_IDENTIFIER)
 
+# Sentinel cause string for a HW power cycle whose fault could not be decoded.
+UNKNOWN_CAUSE = "unknown"
+
 UNKNOWN_HW_REBOOT_CAUSE = RebootCause(
     type=RebootCause.Type.HARDWARE,
-    source="unknown",
+    source=UNKNOWN_CAUSE,
     timestamp=UNKNOWN_TIMESTAMP,
-    cause="unknown",
-    description="unknown",
+    cause=UNKNOWN_CAUSE,
+    description=UNKNOWN_CAUSE,
     chassis_reboot_cause_category="REBOOT_CAUSE_HARDWARE_OTHER",
 )
+
+
+def is_informative_cause(cause: RebootCause) -> bool:
+    """Returns True if the cause carries a usable, decoded reason.
+
+    Excludes the UNKNOWN_HW sentinel (cause "unknown") and empty SW causes, which
+    must not be reported as the primary reboot cause ahead of a real one.
+    """
+    return bool(cause.cause) and cause.cause.lower() != UNKNOWN_CAUSE
 
 
 def ordinal(n: int) -> str:
@@ -298,7 +310,9 @@ class RebootCauseManager:
 
         with open(self._sw_reboot_cause_filepath, "r", errors="replace") as file:
             content = file.read().strip()
-            if content.lower() == "unknown":
+            # Empty/UNKNOWN_CAUSE content is not a SW cause. An empty cause lacks a
+            # timestamp, so it would sort ahead of the real HW cause and mask it.
+            if not content or content.lower() == UNKNOWN_CAUSE:
                 return None
 
             # Parse the SW cause here, so we can summarize it in Nexthop's history log.

--- a/platform/broadcom/sonic-platform-modules-nexthop/test/unit/sonic_platform/test_adm1266.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/test/unit/sonic_platform/test_adm1266.py
@@ -686,3 +686,108 @@ class TestAdm1266:
             assert reboot_causes[2].dpm_records[0].uid == 1237
             assert reboot_causes[2].dpm_records[1].uid == 1238
             assert reboot_causes[2].dpm_records[2].uid == 1239
+
+    def test_get_powerup_entries_fault_not_on_highest_uid(self, adm1266_module):
+        """A fault not on the highest-UID record of a powerup must still be found.
+
+        A state-change record logged after the fault (before power is cut) would
+        otherwise mask the cause as 'Hardware - Other (unknown)'.
+        """
+        # Given: within a single powerup, a fault record (PDI1) is followed by a
+        # higher-UID record that carries no decodable fault (trailing record).
+        RECORDS = [
+            create_raw_adm1266_blackbox_record(uid=2000, powerup_counter=7),  # boot-state, no PDI
+            create_raw_adm1266_blackbox_record(
+                uid=2001,
+                powerup_counter=7,
+                pdio_in=0b0000_0000_0000_0001,  # PDI1 -> mapped fault
+            ),
+            create_raw_adm1266_blackbox_record(
+                uid=2002,
+                powerup_counter=7,
+                pdio_in=0b0000_0000_0000_0000,  # trailing record, no fault, higher UID
+            ),
+        ]
+        with temp_file(
+            content=b"".join(RECORDS), file_prefix="nvmem", dir_prefix="test_adm1266"
+        ) as nvmem_path:
+            platform_spec = {
+                "dpm": "DPM1",
+                "dpm_signal_to_fault_cause": [
+                    {
+                        "pdio_mask": "0b0000_0000_0000_0001",
+                        "gpio_mask": "0b0000_0000_0000_0000",
+                        "pdio_value": "0b0000_0000_0000_0001",
+                        "gpio_value": "0b0000_0000_0000_0000",
+                        "hw_cause": "HW_CAUSE_OF_PDI1",
+                        "hw_desc": "HW_DESC_OF_PDI1",
+                        "reboot_cause": "REBOOT_CAUSE_OF_PDI1",
+                    },
+                ],
+            }
+            pddf_device_data = {
+                "DPM1": {"i2c": {"topo_info": {"parent_bus": "0x7", "dev_addr": "0x41"}}}
+            }
+            adm1266 = adm1266_module.Adm1266("test-dpm", platform_spec, pddf_device_data)
+            adm1266._nvmem_path = nvmem_path
+
+            # When
+            reboot_causes = adm1266.get_powerup_entries()
+
+            # Then: the fault is recovered despite the trailing higher-UID record.
+            assert len(reboot_causes) == 1
+            assert len(reboot_causes[0].dpm_records) == 3
+            assert reboot_causes[0].power_fault_cause == adm1266_module.RebootCause(
+                type=adm1266_module.RebootCause.Type.HARDWARE,
+                source="test-dpm",
+                timestamp=reboot_causes[0].power_fault_cause.timestamp,
+                cause="HW_CAUSE_OF_PDI1",
+                description="HW_DESC_OF_PDI1",
+                chassis_reboot_cause_category="REBOOT_CAUSE_OF_PDI1",
+            )
+
+    def test_get_powerup_entries_no_fault_in_powerup(self, adm1266_module):
+        """When no record in a powerup decoded a fault, power_fault_cause is None.
+
+        The powerup is still reported (all records retained) so the squash logic
+        can mark it as an undetermined HW reboot.
+        """
+        # Given: a powerup whose records carry no signal that maps to a fault.
+        RECORDS = [
+            create_raw_adm1266_blackbox_record(uid=3000, powerup_counter=9),
+            create_raw_adm1266_blackbox_record(
+                uid=3001,
+                powerup_counter=9,
+                pdio_in=0b0000_0000_0000_0100,  # PDI3 - not mapped to a cause
+            ),
+        ]
+        with temp_file(
+            content=b"".join(RECORDS), file_prefix="nvmem", dir_prefix="test_adm1266"
+        ) as nvmem_path:
+            platform_spec = {
+                "dpm": "DPM1",
+                "dpm_signal_to_fault_cause": [
+                    {
+                        "pdio_mask": "0b0000_0000_0000_0001",  # PDI1 only
+                        "gpio_mask": "0b0000_0000_0000_0000",
+                        "pdio_value": "0b0000_0000_0000_0001",
+                        "gpio_value": "0b0000_0000_0000_0000",
+                        "hw_cause": "HW_CAUSE_OF_PDI1",
+                        "hw_desc": "HW_DESC_OF_PDI1",
+                        "reboot_cause": "REBOOT_CAUSE_OF_PDI1",
+                    },
+                ],
+            }
+            pddf_device_data = {
+                "DPM1": {"i2c": {"topo_info": {"parent_bus": "0x7", "dev_addr": "0x41"}}}
+            }
+            adm1266 = adm1266_module.Adm1266("test-dpm", platform_spec, pddf_device_data)
+            adm1266._nvmem_path = nvmem_path
+
+            # When
+            reboot_causes = adm1266.get_powerup_entries()
+
+            # Then
+            assert len(reboot_causes) == 1
+            assert reboot_causes[0].power_fault_cause is None
+            assert len(reboot_causes[0].dpm_records) == 2

--- a/platform/broadcom/sonic-platform-modules-nexthop/test/unit/sonic_platform/test_chassis.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/test/unit/sonic_platform/test_chassis.py
@@ -326,3 +326,50 @@ class TestChassis:
             )
             # Then
             assert chassis.get_reboot_cause() == ("REBOOT_CAUSE_HARDWARE_OTHER", "unknown, time: unknown, src: unknown")
+
+    def test_chassis_get_reboot_cause_unknown_hw_does_not_mask_real_cause(
+        self, chassis_module, reboot_cause_manager_module
+    ):
+        """An undecodable HW power-up (UNKNOWN_HW) aligned as the oldest power
+        cycle must not mask a real cause decoded for a more recent reboot: the
+        real cause is reported and the unknown is demoted to the comment.
+        """
+        with (
+            patch.object(
+                chassis_module.Chassis, "REBOOT_CAUSE_POWER_LOSS", "Power Loss", create=True
+            ),
+            patch.object(
+                reboot_cause_manager_module.RebootCauseManager,
+                "summarize_reboot_causes",
+                Mock(
+                    return_value=[
+                        reboot_cause_manager_module.UNKNOWN_HW_REBOOT_CAUSE,  # oldest, no info
+                        reboot_cause_manager_module.RebootCause(
+                            type=reboot_cause_manager_module.RebootCause.Type.HARDWARE,
+                            source="switch_card_2",
+                            timestamp=datetime.datetime(
+                                2026, 6, 15, 18, 55, 9, tzinfo=datetime.timezone.utc
+                            ),
+                            cause="PSU_PWR_LOSS",
+                            description="All PSUs lost input power",
+                            chassis_reboot_cause_category="REBOOT_CAUSE_POWER_LOSS",
+                        ),
+                    ]
+                ),
+            ),
+            temp_file(content="") as sw_reboot_cause_filepath,
+        ):
+            chassis = chassis_module.Chassis(
+                pddf_data=mock_pddf_data({}),
+                pddf_plugin_data={"REBOOT_CAUSE": {"reboot_cause_file": sw_reboot_cause_filepath}},
+            )
+            # The real cause is reported, not "Hardware - Other (unknown)".
+            assert chassis.get_reboot_cause() == (
+                "Power Loss",
+                "All PSUs lost input power, time: 2026-06-15 18:55:09 UTC, src: switch_card_2",
+            )
+            with open(sw_reboot_cause_filepath, "r") as file:
+                assert file.read() == (
+                    "System rebooted 1 more time: "
+                    "REBOOT_CAUSE_HARDWARE_OTHER (unknown, time: unknown, src: unknown)"
+                )


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixes Issue:  https://github.com/sonic-net/sonic-buildimage/issues/28178
`show reboot-cause` could intermittently report Hardware - Other (unknown, time: unknown, src: unknown) after watchdog or power-off reboots even when a real reboot cause had been decoded.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

* Updated `chassis.py` so `get_reboot_cause()` reports the oldest informative cause and demotes uninformative causes such as unknown hardware causes or empty software causes into the comment instead of letting them mask the real cause.
* Updated `reboot_cause_manager.py` so an empty software reboot-cause file is treated as no software cause.
* Added a shared `UNKNOWN_CAUSE` constant and an `is_informative_cause()` helper to centralize the unknown/empty cause check.
* Updated `adm1266.py` so power-up decoding uses the most recent record in a power-up sequence that actually decoded a fault, rather than letting a trailing non-informative record mask the real cause.
* Added regression tests for unknown hardware causes, empty software causes, and power-up groups where the relevant decoded fault is not on the highest-UID record.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

* Unit tests:
  * `cd platform/broadcom/sonic-platform-modules-nexthop`
  * `python3 -m pytest test/unit/sonic_platform/test_adm1266.py test/unit/sonic_platform/test_chassis.py test/unit/sonic_platform/test_reboot_cause_manager.py`
* On hardware:
  * Run repeated power-off reboot testing and confirm `show reboot-cause` consistently reports `Power Loss`.
  * Run watchdog reboot testing and confirm `show reboot-cause` reports `Watchdog`.
  * Confirm the relevant reboot platform tests pass.


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Fix reboot-cause reporting so decoded watchdog and power-loss causes are not masked by unknown or empty causes.


#### Link to config_db schema for YANG module changes
N/A (no YANG module changes)


#### A picture of a cute animal (not mandatory but encouraged)

