### PR TITLE
[docker-sonic-mgmt] bump cryptography to >=48.0.1 (GHSA-537c-gmf6-5ccf)

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -71,7 +71,7 @@ RUN uv pip install --no-cache \
     celery[redis] \
     cffi \
     contextlib2 \
-    "cryptography>=46.0.7,<47" \
+    "cryptography>=48.0.1" \
     ctypesgen \
     debugpy \
     dpkt \
@@ -161,10 +161,10 @@ RUN install -m 0755 -d /etc/apt/keyrings \
     && apt-get install -y docker-ce-cli \
     && curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
-# Patch Azure CLI's bundled cryptography for CVE-2026-39892
+# Patch Azure CLI's bundled cryptography for CVE-2026-39892 and GHSA-537c-gmf6-5ccf (bundled OpenSSL)
 RUN az_site_packages=$(/opt/az/bin/python -c "import site; print(site.getsitepackages()[0])") \
-    && /opt/az/bin/python -m pip install --no-cache-dir --target "$az_site_packages" 'cryptography>=46.0.7,<47' \
-    && find "$az_site_packages" -name 'cryptography-46.0.6*' -type d -exec rm -rf {} + 2>/dev/null; true
+    && /opt/az/bin/python -m pip install --no-cache-dir --target "$az_site_packages" 'cryptography>=48.0.1' \
+    && find "$az_site_packages" -name 'cryptography-4[0-7].*' -type d -exec rm -rf {} + 2>/dev/null; true
 
 # Install dash-api
 RUN tmpdir=$(mktemp -d) \


### PR DESCRIPTION
#### Why I did it

S360 flags **cryptography (GHSA-537c-gmf6-5ccf)** on the docker-sonic-mgmt image. cryptography wheels prior to **48.0.1** statically bundle a vulnerable OpenSSL (OpenSSL security advisory 2026-06-09, HIGH).

The image pins `cryptography>=46.0.7,<47` (added by the April 2026 fix #26695 for CVE-2026-39892), so both `/opt/venv` and `/opt/az` stay at **46.0.7** — below the 48.0.1 fix. The `<47` upper bound is exactly what blocks the upgrade.

This is **independent of the ansible pin** (#28103): ansible-core (2.20.x from `ansible==13.6.0`, and any newer) requires `cryptography` with **no upper bound**, so pinning/bumping ansible neither causes nor fixes this — only the explicit cryptography pin controls the version.

#### How I did it

- `/opt/venv` install (L74): `"cryptography>=46.0.7,<47"` -> `"cryptography>=48.0.1"`
- Azure CLI patch (L166): `'cryptography>=46.0.7,<47'` -> `'cryptography>=48.0.1'`
- Broaden the `/opt/az` cleanup to remove any pre-48 bundled copy (`cryptography-46.0.6*` -> `cryptography-4[0-7].*`)

Dropped the upper cap (no `<49`) so a future security bump is not blocked again — the previous `<47` cap is precisely why this vuln lingered.

#### How to verify it

Build docker-sonic-mgmt and confirm no pre-48 cryptography remains:

```
$ for p in /opt/venv /opt/az; do \/bin/python -c "import cryptography; print('', cryptography.__version__)"; done
/opt/venv 49.0.0
/opt/az 49.0.0
$ find / -name 'cryptography-4[0-7].*.dist-info' -o -name 'cryptography-3*.dist-info'   # (system apt copy excluded)
```

Compatibility: verified `cryptography` resolves to 49.0.0 with no dependency conflict (ansible-core requires cryptography unbounded); paramiko + ansible import and RSA keygen/serialize work.

> Note: the S360 scan is on the currently deployed image; this needs a rebuild + rollout to clear. The Ubuntu apt `python3-cryptography` (41.0.7) is a separate distro-built package and is not the PyPI-wheel GHSA-537c target.