### PR TITLE
[202511] fix(docker-sonic-mgmt): migrate to uv and fix USN-8221-1 wheel vulnerability (#27299)

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -30,8 +30,6 @@ RUN apt-get update && apt-get install -y \
     psmisc \
     python3 \
     python3-dev \
-    python3-pip \
-    python3-venv \
     python-is-python3 \
     rsyslog \
     shellcheck \
@@ -43,9 +41,13 @@ RUN apt-get update && apt-get install -y \
     telnet \
     vim
 
-# Ubuntu 24.04 recommends installing pip packages in a virtual environment
-# Create a virtual environment at /opt/venv and install all required python packages there
-RUN python3 -m venv --system-site-packages /opt/venv
+# Install uv - a fast Python package manager that replaces pip/venv/wheel.
+# This eliminates the need for python3-pip, python3-venv, and python3-wheel
+# system packages, avoiding vulnerabilities like USN-8221-1.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+# Create a virtual environment at /opt/venv using uv
+RUN uv venv --system-site-packages /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
 # Configure system-wide PATH and sudo secure_path for /opt/venv/bin access
@@ -53,7 +55,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN sed -i 's|^PATH="|PATH="/opt/venv/bin:|' /etc/environment \
     && sed -i 's|secure_path="\([^"]*\)"|secure_path="/opt/venv/bin:\1"|' /etc/sudoers
 
-RUN pip install --no-cache-dir \
+RUN uv pip install --no-cache \
     aiohttp \
     allure-pytest \
     ansible==11.10.0 \
@@ -138,7 +140,7 @@ RUN pip install --no-cache-dir \
     && cd ../..            \
     && rm -fr nanomsg-1.2.1  \
     && rm -f 1.2.1.tar.gz  \
-    && python3 -m pip install --no-cache-dir nnpy
+    && uv pip install --no-cache nnpy
 
 # Install docker-ce-cli, azure-cli
 RUN install -m 0755 -d /etc/apt/keyrings \
@@ -172,7 +174,7 @@ RUN tmpdir=$(mktemp -d) \
     && python3 /usr/bin/github_get.py https://api.github.com/repos/sonic-net/DASH/contents/dash-pipeline/utils \
     && cd utils \
     && python3 setup.py bdist_wheel \
-    && python3 -m pip install dist/dash_pipeline_utils*.whl \
+    && uv pip install --no-cache dist/dash_pipeline_utils*.whl \
     && cd / \
     && rm -rf "$tmpdir"
 


### PR DESCRIPTION
Manual cherry-pick of #27299 to **202511** (the automatic cherry-pick failed with a conflict — label `Cherry Pick Conflict_202511`).

#### Conflict

`dockers/docker-sonic-mgmt/Dockerfile.j2` — on 202511 the package install is a single-line `RUN pip install --no-cache-dir \`, whereas master had the two-line `pip install --no-cache-dir --upgrade pip \` + `&& pip install --no-cache-dir \` form. The original PR combined the venv-migration and the pip-install change into one hunk, so it did not apply on 202511.

#### Resolution

Applied the uv migration on top of 202511's single-line form. Net change is identical in intent to #27299:
- Remove `python3-pip` and `python3-venv` from apt (eliminates the vulnerable `python3-wheel` — USN-8221-1)
- `COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/` and `RUN uv venv --system-site-packages /opt/venv`
- `RUN pip install --no-cache-dir` -> `RUN uv pip install --no-cache`
- `python3 -m pip install ... nnpy` -> `uv pip install --no-cache nnpy`
- `python3 -m pip install dist/dash_pipeline_utils*.whl` -> `uv pip install --no-cache dist/dash_pipeline_utils*.whl`

Only the uv migration is applied; no other lines changed.

#### How to verify it

```
docker run --rm docker-sonic-mgmt uv --version
docker run --rm docker-sonic-mgmt dpkg -l python3-wheel 2>&1 | grep -c "no packages found"
docker run --rm docker-sonic-mgmt python3 -c "import ansible; print(ansible.__version__)"
```

Original PR: #27299 (cherry picked from commit 88d44d3c3bd500855e4f2679282cbc1b86ae18b8)