### PR TITLE
[Nokia-BMC-H6-128] Use sysfs and ioctl in i2caccess

### DIFF
--- a/platform/aspeed/sonic-platform-modules-nokia/h6-128/modules/Makefile
+++ b/platform/aspeed/sonic-platform-modules-nokia/h6-128/modules/Makefile
@@ -1,0 +1,1 @@
+obj-m += cb_pld.o

--- a/platform/aspeed/sonic-platform-modules-nokia/h6-128/modules/cb_pld.c
+++ b/platform/aspeed/sonic-platform-modules-nokia/h6-128/modules/cb_pld.c
@@ -1,0 +1,417 @@
+//  * PLD driver for Nokia-7220-IXR-H6-128 Router
+//  *
+//  * Copyright (C) 2026 Nokia Corporation.
+//  *
+//  * This program is free software: you can redistribute it and/or modify
+//  * it under the terms of the GNU General Public License as published by
+//  * the Free Software Foundation, either version 3 of the License, or
+//  * any later version.
+//  *
+//  * This program is distributed in the hope that it will be useful,
+//  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  * GNU General Public License for more details.
+//  * see <http://www.gnu.org/licenses/>
+
+
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/i2c.h>
+#include <linux/kernel.h>
+#include <linux/err.h>
+#include <linux/hwmon.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/of_device.h>
+#include <linux/of.h>
+#include <linux/mutex.h>
+#include <linux/delay.h>
+
+#define DRIVER_NAME "cb_pld"
+
+// REGISTERS ADDRESS MAP
+#define HW_BOARD_VER_REG                 0x00
+#define VER_MAJOR_REG                    0x01
+#define VER_MINOR_REG                    0x02
+#define MISC_REG                         0x05
+#define PSU_PRESENT_REG                  0x07
+#define SSD_PRESENT_REG                  0x08
+#define MUX_SEL_REG                      0x0F
+#define RESET_SIGNAL_1_REG               0x20
+#define BIOS_RED_REG                     0x37
+#define RESET_REASON_REG                 0x3B
+#define PSU_POWERGOOD_REG                0x51
+#define CONSOLE_WDT_REG                  0x63
+
+static const unsigned short cpld_address_list[] = {0x60, I2C_CLIENT_END};
+
+struct cpld_data {
+    struct i2c_client *client;
+    struct mutex  update_lock;
+    int reset_cause;
+};
+
+static int cpld_i2c_read(struct cpld_data *data, u8 reg)
+{
+    int val = 0;
+    struct i2c_client *client = data->client;
+
+    val = i2c_smbus_read_byte_data(client, reg);
+    if (val < 0) {
+         dev_warn(&client->dev, "CB_PLD READ ERROR: reg(0x%02x) err %d\n", reg, val);
+    }
+
+    return val;
+}
+
+static void cpld_i2c_write(struct cpld_data *data, u8 reg, u8 value)
+{
+    int res = 0;
+    struct i2c_client *client = data->client;
+
+    mutex_lock(&data->update_lock);
+    res = i2c_smbus_write_byte_data(client, reg, value);
+    if (res < 0) {
+        dev_warn(&client->dev, "CB_PLD WRITE ERROR: reg(0x%02x) err %d\n", reg, res);
+    }
+    mutex_unlock(&data->update_lock);
+}
+
+static ssize_t show_hw_board_ver(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 val = 0;
+    val = cpld_i2c_read(data, HW_BOARD_VER_REG);
+    return sprintf(buf, "0x%x\n", val);
+}
+
+static ssize_t show_ver(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 reg_major = 0;
+    u8 reg_minor = 0;
+
+    reg_major = cpld_i2c_read(data, VER_MAJOR_REG);
+    reg_minor = cpld_i2c_read(data, VER_MINOR_REG);
+
+    return sprintf(buf, "%02x.%02x\n", reg_major, reg_minor);
+}
+
+static ssize_t show_misc(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 val = 0;
+    val = cpld_i2c_read(data, MISC_REG);
+    return sprintf(buf, "0x%x\n", val);
+}
+
+static ssize_t set_misc(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 reg_val = 0;
+    u8 usr_val = 0;
+    u8 mask;
+
+    int ret = kstrtou8(buf, 16, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val != 0x9 && usr_val != 0xb) {
+        return -EINVAL;
+    }
+
+    cpld_i2c_write(data, MISC_REG, usr_val);
+
+    return count;
+}
+
+static ssize_t show_psu_present(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+
+    val = cpld_i2c_read(data, PSU_PRESENT_REG);
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t show_psu_ok(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+
+    val = cpld_i2c_read(data, PSU_POWERGOOD_REG);
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t show_ssd_present(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+
+    val = cpld_i2c_read(data, SSD_PRESENT_REG);
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t show_mux_sel(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+    
+    val = cpld_i2c_read(data, MUX_SEL_REG);
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_mux_sel(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 usr_val = 0;
+    u8 mask;
+
+    int ret = kstrtou8(buf, 16, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val != 0x0 && usr_val != 0x1) {
+        return -EINVAL;
+    }
+
+    cpld_i2c_write(data, MUX_SEL_REG, usr_val);
+
+    return count;
+}
+
+static ssize_t show_reset_sig(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 val = 0;
+    val = cpld_i2c_read(data, RESET_SIGNAL_1_REG);
+    return sprintf(buf, "0x%x\n", val);
+}
+
+static ssize_t set_reset_sig(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 usr_val = 0;
+    u8 mask;
+
+    int ret = kstrtou8(buf, 16, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val != 0x7f && usr_val != 0xff) {
+        return -EINVAL;
+    }
+
+    cpld_i2c_write(data, RESET_SIGNAL_1_REG, usr_val);
+
+    return count;
+}
+
+static ssize_t show_bios_red(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 val = 0;
+    val = cpld_i2c_read(data, BIOS_RED_REG);
+    return sprintf(buf, "0x%x\n", val);
+}
+
+static ssize_t set_bios_red(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    u8 usr_val = 0;
+    u8 mask;
+
+    int ret = kstrtou8(buf, 16, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val != 0x0 && usr_val != 0x4) {
+        return -EINVAL;
+    }
+
+    cpld_i2c_write(data, BIOS_RED_REG, usr_val);
+
+    return count;
+}
+
+static ssize_t show_reset_cause(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    return sprintf(buf, "%02x\n", data->reset_cause);
+}
+
+static ssize_t show_console_wdt(struct device *dev, struct device_attribute *devattr, char *buf)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 val = 0;
+
+    val = cpld_i2c_read(data, CONSOLE_WDT_REG);
+
+    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+}
+
+static ssize_t set_console_wdt(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
+{
+    struct cpld_data *data = dev_get_drvdata(dev);
+    struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
+    u8 reg_val = 0;
+    u8 usr_val = 0;
+    u8 mask;
+
+    int ret = kstrtou8(buf, 10, &usr_val);
+    if (ret != 0) {
+        return ret;
+    }
+    if (usr_val > 1) {
+        return -EINVAL;
+    }
+
+    mask = (~(1 << sda->index)) & 0xFF;
+    reg_val = cpld_i2c_read(data, CONSOLE_WDT_REG);
+    reg_val = reg_val & mask;
+    usr_val = usr_val << sda->index;
+    cpld_i2c_write(data, CONSOLE_WDT_REG, (reg_val | usr_val));
+
+    return count;
+}
+
+// sysfs attributes
+static SENSOR_DEVICE_ATTR(hw_board_version, S_IRUGO, show_hw_board_ver, NULL, 0);
+static SENSOR_DEVICE_ATTR(version, S_IRUGO, show_ver, NULL, 0);
+static SENSOR_DEVICE_ATTR(misc, S_IRUGO | S_IWUSR, show_misc, set_misc, 0);
+static SENSOR_DEVICE_ATTR(psu1_ok, S_IRUGO, show_psu_ok, NULL, 4);
+static SENSOR_DEVICE_ATTR(psu2_ok, S_IRUGO, show_psu_ok, NULL, 5);
+static SENSOR_DEVICE_ATTR(psu3_ok, S_IRUGO, show_psu_ok, NULL, 6);
+static SENSOR_DEVICE_ATTR(psu4_ok, S_IRUGO, show_psu_ok, NULL, 7);
+static SENSOR_DEVICE_ATTR(psu1_pres, S_IRUGO, show_psu_present, NULL, 3);
+static SENSOR_DEVICE_ATTR(psu2_pres, S_IRUGO, show_psu_present, NULL, 2);
+static SENSOR_DEVICE_ATTR(psu3_pres, S_IRUGO, show_psu_present, NULL, 1);
+static SENSOR_DEVICE_ATTR(psu4_pres, S_IRUGO, show_psu_present, NULL, 0);
+static SENSOR_DEVICE_ATTR(ssd1_pres, S_IRUGO, show_ssd_present, NULL, 1);
+static SENSOR_DEVICE_ATTR(ssd2_pres, S_IRUGO, show_ssd_present, NULL, 0);
+static SENSOR_DEVICE_ATTR(mux_sel, S_IRUGO | S_IWUSR, show_mux_sel, set_mux_sel, 0);
+static SENSOR_DEVICE_ATTR(reset_sig, S_IRUGO | S_IWUSR, show_reset_sig, set_reset_sig, 0);
+static SENSOR_DEVICE_ATTR(bios_red, S_IRUGO | S_IWUSR, show_bios_red, set_bios_red, 0);
+static SENSOR_DEVICE_ATTR(reset_cause, S_IRUGO, show_reset_cause, NULL, 0);
+static SENSOR_DEVICE_ATTR(console_wdt, S_IRUGO | S_IWUSR, show_console_wdt, set_console_wdt, 0);
+
+static struct attribute *cb_pld_attributes[] = {
+    &sensor_dev_attr_hw_board_version.dev_attr.attr,
+    &sensor_dev_attr_version.dev_attr.attr,
+    &sensor_dev_attr_misc.dev_attr.attr,
+    &sensor_dev_attr_psu1_ok.dev_attr.attr,
+    &sensor_dev_attr_psu2_ok.dev_attr.attr,
+    &sensor_dev_attr_psu3_ok.dev_attr.attr,
+    &sensor_dev_attr_psu4_ok.dev_attr.attr,
+    &sensor_dev_attr_psu1_pres.dev_attr.attr,
+    &sensor_dev_attr_psu2_pres.dev_attr.attr,
+    &sensor_dev_attr_psu3_pres.dev_attr.attr,
+    &sensor_dev_attr_psu4_pres.dev_attr.attr,
+    &sensor_dev_attr_ssd1_pres.dev_attr.attr,
+    &sensor_dev_attr_ssd2_pres.dev_attr.attr,
+    &sensor_dev_attr_mux_sel.dev_attr.attr,
+    &sensor_dev_attr_reset_sig.dev_attr.attr,
+    &sensor_dev_attr_bios_red.dev_attr.attr,
+    &sensor_dev_attr_reset_cause.dev_attr.attr,
+    &sensor_dev_attr_console_wdt.dev_attr.attr,
+    NULL
+};
+
+static const struct attribute_group cb_pld_group = {
+    .attrs = cb_pld_attributes,
+};
+
+static int cb_pld_probe(struct i2c_client *client)
+{
+    int status;
+    struct cpld_data *data = NULL;
+
+    if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_BYTE_DATA)) {
+        dev_err(&client->dev, "CPLD PROBE ERROR: i2c_check_functionality failed (0x%x)\n", client->addr);
+        status = -EIO;
+        goto exit;
+    }
+
+    dev_info(&client->dev, "Nokia CB_PLD chip found.\n");
+    data = kzalloc(sizeof(struct cpld_data), GFP_KERNEL);
+
+    if (!data) {
+        dev_err(&client->dev, "CPLD PROBE ERROR: Can't allocate memory\n");
+        status = -ENOMEM;
+        goto exit;
+    }
+
+    data->client = client;
+    i2c_set_clientdata(client, data);
+    mutex_init(&data->update_lock);
+
+    status = sysfs_create_group(&client->dev.kobj, &cb_pld_group);
+    if (status) {
+        dev_err(&client->dev, "CPLD INIT ERROR: Cannot create sysfs\n");
+        goto exit_sysfs_create_group;
+    }
+
+   // data->reset_cause = cpld_i2c_read(data, RESET_REASON_REG);
+   // cpld_i2c_write(data, RESET_REASON_REG, 0xFF);
+
+    return 0;
+
+exit_sysfs_create_group:
+    kfree(data);
+exit:
+    return status;
+}
+
+static void cb_pld_remove(struct i2c_client *client)
+{
+    struct cpld_data *data = i2c_get_clientdata(client);
+    sysfs_remove_group(&client->dev.kobj, &cb_pld_group);
+    kfree(data);
+}
+
+static const struct of_device_id cb_pld_of_ids[] = {
+    {
+        .compatible = "cb_pld",
+        .data       = (void *) 0,
+    },
+    { },
+};
+MODULE_DEVICE_TABLE(of, cb_pld_of_ids);
+
+static const struct i2c_device_id cb_pld_ids[] = {
+    { DRIVER_NAME, 0 },
+    { }
+};
+MODULE_DEVICE_TABLE(i2c, cb_pld_ids);
+
+static struct i2c_driver cb_pld_driver = {
+    .driver = {
+        .name           = DRIVER_NAME,
+        .of_match_table = of_match_ptr(cb_pld_of_ids),
+    },
+    .probe        = cb_pld_probe,
+    .remove       = cb_pld_remove,
+    .id_table     = cb_pld_ids,
+    .address_list = cpld_address_list,
+};
+
+static int __init cb_pld_init(void)
+{
+    return i2c_add_driver(&cb_pld_driver);
+}
+
+static void __exit cb_pld_exit(void)
+{
+    i2c_del_driver(&cb_pld_driver);
+}
+
+MODULE_AUTHOR("Nokia");
+MODULE_DESCRIPTION("NOKIA H6-128 CB_PLD driver");
+MODULE_LICENSE("GPL");
+
+module_init(cb_pld_init);
+module_exit(cb_pld_exit);

--- a/platform/aspeed/sonic-platform-modules-nokia/h6-128/modules/cb_pld.c
+++ b/platform/aspeed/sonic-platform-modules-nokia/h6-128/modules/cb_pld.c
@@ -4,7 +4,7 @@
 //  *
 //  * This program is free software: you can redistribute it and/or modify
 //  * it under the terms of the GNU General Public License as published by
-//  * the Free Software Foundation, either version 3 of the License, or
+//  * the Free Software Foundation; either version 2 of the License, or
 //  * any later version.
 //  *
 //  * This program is distributed in the hope that it will be useful,
@@ -38,7 +38,6 @@
 #define MUX_SEL_REG                      0x0F
 #define RESET_SIGNAL_1_REG               0x20
 #define BIOS_RED_REG                     0x37
-#define RESET_REASON_REG                 0x3B
 #define PSU_POWERGOOD_REG                0x51
 #define CONSOLE_WDT_REG                  0x63
 
@@ -47,7 +46,6 @@ static const unsigned short cpld_address_list[] = {0x60, I2C_CLIENT_END};
 struct cpld_data {
     struct i2c_client *client;
     struct mutex  update_lock;
-    int reset_cause;
 };
 
 static int cpld_i2c_read(struct cpld_data *data, u8 reg)
@@ -76,22 +74,53 @@ static void cpld_i2c_write(struct cpld_data *data, u8 reg, u8 value)
     mutex_unlock(&data->update_lock);
 }
 
+static int cpld_i2c_update_bits(struct cpld_data *data, u8 reg, u8 mask, u8 value)
+{
+    int ret;
+    int val;
+    struct i2c_client *client = data->client;
+
+    mutex_lock(&data->update_lock);
+    val = i2c_smbus_read_byte_data(client, reg);
+    if (val < 0) {
+        dev_warn(&client->dev, "CB_PLD READ ERROR: reg(0x%02x) err %d\n", reg, val);
+        mutex_unlock(&data->update_lock);
+        return val;
+    }
+    val = (val & ~mask) | (value & mask);
+    ret = i2c_smbus_write_byte_data(client, reg, val);
+    if (ret < 0) {
+        dev_warn(&client->dev, "CB_PLD WRITE ERROR: reg(0x%02x) err %d\n", reg, ret);
+    }
+    mutex_unlock(&data->update_lock);
+
+    return ret;
+}
+
 static ssize_t show_hw_board_ver(struct device *dev, struct device_attribute *devattr, char *buf)
 {
     struct cpld_data *data = dev_get_drvdata(dev);
-    u8 val = 0;
+    int val;
+
     val = cpld_i2c_read(data, HW_BOARD_VER_REG);
+    if (val < 0)
+        return val;
+
     return sprintf(buf, "0x%x\n", val);
 }
 
 static ssize_t show_ver(struct device *dev, struct device_attribute *devattr, char *buf)
 {
     struct cpld_data *data = dev_get_drvdata(dev);
-    u8 reg_major = 0;
-    u8 reg_minor = 0;
+    int reg_major;
+    int reg_minor;
 
     reg_major = cpld_i2c_read(data, VER_MAJOR_REG);
+    if (reg_major < 0)
+        return reg_major;
     reg_minor = cpld_i2c_read(data, VER_MINOR_REG);
+    if (reg_minor < 0)
+        return reg_minor;
 
     return sprintf(buf, "%02x.%02x\n", reg_major, reg_minor);
 }
@@ -99,17 +128,19 @@ static ssize_t show_ver(struct device *dev, struct device_attribute *devattr, ch
 static ssize_t show_misc(struct device *dev, struct device_attribute *devattr, char *buf)
 {
     struct cpld_data *data = dev_get_drvdata(dev);
-    u8 val = 0;
+    int val;
+
     val = cpld_i2c_read(data, MISC_REG);
+    if (val < 0)
+        return val;
+
     return sprintf(buf, "0x%x\n", val);
 }
 
 static ssize_t set_misc(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
 {
     struct cpld_data *data = dev_get_drvdata(dev);
-    u8 reg_val = 0;
     u8 usr_val = 0;
-    u8 mask;
 
     int ret = kstrtou8(buf, 16, &usr_val);
     if (ret != 0) {
@@ -128,47 +159,58 @@ static ssize_t show_psu_present(struct device *dev, struct device_attribute *dev
 {
     struct cpld_data *data = dev_get_drvdata(dev);
     struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
-    u8 val = 0;
+    int val;
 
     val = cpld_i2c_read(data, PSU_PRESENT_REG);
-    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+    if (val < 0)
+        return val;
+
+    return sprintf(buf, "%d\n", (val >> sda->index) & 0x1 ? 1 : 0);
 }
 
 static ssize_t show_psu_ok(struct device *dev, struct device_attribute *devattr, char *buf)
 {
     struct cpld_data *data = dev_get_drvdata(dev);
     struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
-    u8 val = 0;
+    int val;
 
     val = cpld_i2c_read(data, PSU_POWERGOOD_REG);
-    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+    if (val < 0)
+        return val;
+
+    return sprintf(buf, "%d\n", (val >> sda->index) & 0x1 ? 1 : 0);
 }
 
 static ssize_t show_ssd_present(struct device *dev, struct device_attribute *devattr, char *buf)
 {
     struct cpld_data *data = dev_get_drvdata(dev);
     struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
-    u8 val = 0;
+    int val;
 
     val = cpld_i2c_read(data, SSD_PRESENT_REG);
-    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+    if (val < 0)
+        return val;
+
+    return sprintf(buf, "%d\n", (val >> sda->index) & 0x1 ? 1 : 0);
 }
 
 static ssize_t show_mux_sel(struct device *dev, struct device_attribute *devattr, char *buf)
 {
     struct cpld_data *data = dev_get_drvdata(dev);
     struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
-    u8 val = 0;
-    
+    int val;
+
     val = cpld_i2c_read(data, MUX_SEL_REG);
-    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+    if (val < 0)
+        return val;
+
+    return sprintf(buf, "%d\n", (val >> sda->index) & 0x1 ? 1 : 0);
 }
 
 static ssize_t set_mux_sel(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
 {
     struct cpld_data *data = dev_get_drvdata(dev);
     u8 usr_val = 0;
-    u8 mask;
 
     int ret = kstrtou8(buf, 16, &usr_val);
     if (ret != 0) {
@@ -186,8 +228,12 @@ static ssize_t set_mux_sel(struct device *dev, struct device_attribute *devattr,
 static ssize_t show_reset_sig(struct device *dev, struct device_attribute *devattr, char *buf)
 {
     struct cpld_data *data = dev_get_drvdata(dev);
-    u8 val = 0;
+    int val;
+
     val = cpld_i2c_read(data, RESET_SIGNAL_1_REG);
+    if (val < 0)
+        return val;
+
     return sprintf(buf, "0x%x\n", val);
 }
 
@@ -195,7 +241,6 @@ static ssize_t set_reset_sig(struct device *dev, struct device_attribute *devatt
 {
     struct cpld_data *data = dev_get_drvdata(dev);
     u8 usr_val = 0;
-    u8 mask;
 
     int ret = kstrtou8(buf, 16, &usr_val);
     if (ret != 0) {
@@ -213,8 +258,12 @@ static ssize_t set_reset_sig(struct device *dev, struct device_attribute *devatt
 static ssize_t show_bios_red(struct device *dev, struct device_attribute *devattr, char *buf)
 {
     struct cpld_data *data = dev_get_drvdata(dev);
-    u8 val = 0;
+    int val;
+
     val = cpld_i2c_read(data, BIOS_RED_REG);
+    if (val < 0)
+        return val;
+
     return sprintf(buf, "0x%x\n", val);
 }
 
@@ -222,7 +271,6 @@ static ssize_t set_bios_red(struct device *dev, struct device_attribute *devattr
 {
     struct cpld_data *data = dev_get_drvdata(dev);
     u8 usr_val = 0;
-    u8 mask;
 
     int ret = kstrtou8(buf, 16, &usr_val);
     if (ret != 0) {
@@ -237,28 +285,23 @@ static ssize_t set_bios_red(struct device *dev, struct device_attribute *devattr
     return count;
 }
 
-static ssize_t show_reset_cause(struct device *dev, struct device_attribute *devattr, char *buf)
-{
-    struct cpld_data *data = dev_get_drvdata(dev);
-    return sprintf(buf, "%02x\n", data->reset_cause);
-}
-
 static ssize_t show_console_wdt(struct device *dev, struct device_attribute *devattr, char *buf)
 {
     struct cpld_data *data = dev_get_drvdata(dev);
     struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
-    u8 val = 0;
+    int val;
 
     val = cpld_i2c_read(data, CONSOLE_WDT_REG);
+    if (val < 0)
+        return val;
 
-    return sprintf(buf, "%d\n", (val>>sda->index) & 0x1 ? 1:0);
+    return sprintf(buf, "%d\n", (val >> sda->index) & 0x1 ? 1 : 0);
 }
 
 static ssize_t set_console_wdt(struct device *dev, struct device_attribute *devattr, const char *buf, size_t count)
 {
     struct cpld_data *data = dev_get_drvdata(dev);
     struct sensor_device_attribute *sda = to_sensor_dev_attr(devattr);
-    u8 reg_val = 0;
     u8 usr_val = 0;
     u8 mask;
 
@@ -270,11 +313,10 @@ static ssize_t set_console_wdt(struct device *dev, struct device_attribute *deva
         return -EINVAL;
     }
 
-    mask = (~(1 << sda->index)) & 0xFF;
-    reg_val = cpld_i2c_read(data, CONSOLE_WDT_REG);
-    reg_val = reg_val & mask;
-    usr_val = usr_val << sda->index;
-    cpld_i2c_write(data, CONSOLE_WDT_REG, (reg_val | usr_val));
+    mask = 1 << sda->index;
+    ret = cpld_i2c_update_bits(data, CONSOLE_WDT_REG, mask, usr_val << sda->index);
+    if (ret < 0)
+        return ret;
 
     return count;
 }
@@ -296,7 +338,6 @@ static SENSOR_DEVICE_ATTR(ssd2_pres, S_IRUGO, show_ssd_present, NULL, 0);
 static SENSOR_DEVICE_ATTR(mux_sel, S_IRUGO | S_IWUSR, show_mux_sel, set_mux_sel, 0);
 static SENSOR_DEVICE_ATTR(reset_sig, S_IRUGO | S_IWUSR, show_reset_sig, set_reset_sig, 0);
 static SENSOR_DEVICE_ATTR(bios_red, S_IRUGO | S_IWUSR, show_bios_red, set_bios_red, 0);
-static SENSOR_DEVICE_ATTR(reset_cause, S_IRUGO, show_reset_cause, NULL, 0);
 static SENSOR_DEVICE_ATTR(console_wdt, S_IRUGO | S_IWUSR, show_console_wdt, set_console_wdt, 0);
 
 static struct attribute *cb_pld_attributes[] = {
@@ -316,7 +357,6 @@ static struct attribute *cb_pld_attributes[] = {
     &sensor_dev_attr_mux_sel.dev_attr.attr,
     &sensor_dev_attr_reset_sig.dev_attr.attr,
     &sensor_dev_attr_bios_red.dev_attr.attr,
-    &sensor_dev_attr_reset_cause.dev_attr.attr,
     &sensor_dev_attr_console_wdt.dev_attr.attr,
     NULL
 };
@@ -354,9 +394,6 @@ static int cb_pld_probe(struct i2c_client *client)
         dev_err(&client->dev, "CPLD INIT ERROR: Cannot create sysfs\n");
         goto exit_sysfs_create_group;
     }
-
-   // data->reset_cause = cpld_i2c_read(data, RESET_REASON_REG);
-   // cpld_i2c_write(data, RESET_REASON_REG, 0xFF);
 
     return 0;
 

--- a/platform/aspeed/sonic-platform-modules-nokia/h6-128/scripts/nokia-bmc-h6-128-init.sh
+++ b/platform/aspeed/sonic-platform-modules-nokia/h6-128/scripts/nokia-bmc-h6-128-init.sh
@@ -35,6 +35,8 @@ assign_mac_eth0()
 # Disable sysrq-trigger
 echo 0 > /proc/sys/kernel/sysrq
 
+echo cb_pld 0x60 > /sys/bus/i2c/devices/i2c-14/new_device
+
 assign_mac_eth0
 
 EEPROM_PATH="/sys/bus/i2c/devices/13-0056/eeprom"

--- a/platform/aspeed/sonic-platform-modules-nokia/h6-128/sonic_platform/chassis.py
+++ b/platform/aspeed/sonic-platform-modules-nokia/h6-128/sonic_platform/chassis.py
@@ -76,7 +76,7 @@ class Chassis(ChassisBase):
                 return int(value)
         except (IOError, OSError, ValueError):
             return 0
-    
+
     def get_reboot_cause(self):
         """
         Retrieves the cause of the previous reboot
@@ -100,7 +100,40 @@ class Chassis(ChassisBase):
             A list of Module objects representing all modules on the chassis
         """
         return self._module_list
-    
+
+    def get_num_modules(self):
+        """
+        Retrieves number of modules available on this chassis
+
+        Returns:
+            total number of modules
+        """
+        return len(self._module_list)
+
+    def get_module(self, index):
+        """
+        Retrieves ther numbered module available on this chassis
+
+        Returns:
+            the specified module object
+        """
+        if index >= len(self._module_list):
+            return None
+
+        return self._module_list[index]
+
+    def get_module_index(self, name):
+        """
+        given module name, retrieves zero based module index
+
+        Returns:
+            zero based index value
+        """
+        for index in range(0, len(self._module_list)):
+            if self._module_list[index].get_name() == name:
+                return index
+        return -1
+
     def get_name(self):
         """
         Retrieves the name of the chassis
@@ -109,7 +142,7 @@ class Chassis(ChassisBase):
             String containing the name of the chassis
         """
         return self._eeprom.modelstr()
-    
+
     def get_model(self):
         """
         Retrieves the model number (or part number) of the chassis
@@ -135,7 +168,7 @@ class Chassis(ChassisBase):
             string: BMC serial number from BMC EEPROM (i2c-4)
         """
         return self._eeprom.serial_number_str()
-    
+
     def get_serial(self):
         """
         Retrieves the serial number of the chassis
@@ -273,3 +306,21 @@ class Chassis(ChassisBase):
         """
         # For now, default to 'r0'
         return 'r0'
+
+    def is_liquid_cooled(self):
+        """
+        Retrieves whether this chassis is liquid cooled
+
+        Returns:
+            bool: True if this chassis is liquid cooled, False otherwise
+        """
+        return False
+
+    def get_liquid_cooling(self):
+        """
+        Lazily construct and return the platform's LiquidCooling object.
+
+        Returns:
+            LiquidCooling: the (cached) liquid cooling object for this chassis.
+        """
+        return None

--- a/platform/aspeed/sonic-platform-modules-nokia/h6-128/sonic_platform/chassis.py
+++ b/platform/aspeed/sonic-platform-modules-nokia/h6-128/sonic_platform/chassis.py
@@ -318,9 +318,9 @@ class Chassis(ChassisBase):
 
     def get_liquid_cooling(self):
         """
-        Lazily construct and return the platform's LiquidCooling object.
+        Liquid cooling is not present on the air-cooled H6-128 BMC platform.
 
         Returns:
-            LiquidCooling: the (cached) liquid cooling object for this chassis.
+            None: No liquid cooling object on this chassis.
         """
         return None

--- a/platform/aspeed/sonic-platform-modules-nokia/h6-128/sonic_platform/eeprom.py
+++ b/platform/aspeed/sonic-platform-modules-nokia/h6-128/sonic_platform/eeprom.py
@@ -33,8 +33,8 @@ class Eeprom(TlvInfoDecoder):
         self.part_number = ''
         self.model_str = ''
         self.service_tag = ''
-        self.manuf_date = 'NA'
-        self.revision = 'NA'
+        self.manuf_date = ''
+        self.revision = ''
 
     def _load_system_eeprom(self):
         """

--- a/platform/aspeed/sonic-platform-modules-nokia/h6-128/sonic_platform/eeprom.py
+++ b/platform/aspeed/sonic-platform-modules-nokia/h6-128/sonic_platform/eeprom.py
@@ -34,6 +34,7 @@ class Eeprom(TlvInfoDecoder):
         self.model_str = ''
         self.service_tag = ''
         self.manuf_date = 'NA'
+        self.revision = 'NA'
 
     def _load_system_eeprom(self):
         """
@@ -52,6 +53,7 @@ class Eeprom(TlvInfoDecoder):
             self.model_str = 'NA'
             self.service_tag = 'NA'
             self.manuf_date = 'NA'
+            self.revision = 'NA'
             self.eeprom_tlv_dict = dict()
         else:
             eeprom = self.eeprom_data
@@ -65,6 +67,7 @@ class Eeprom(TlvInfoDecoder):
                 self.model_str = 'NA'
                 self.service_tag = 'NA'
                 self.manuf_date = 'NA'
+                self.revision = 'NA'
                 return
 
             total_length = (eeprom[9] << 8) | eeprom[10]
@@ -99,7 +102,9 @@ class Eeprom(TlvInfoDecoder):
                 "0x%X" % (self._TLV_CODE_SERVICE_TAG), 'NA')
             self.manuf_date = self.eeprom_tlv_dict.get(
                 "0x%X" % (self._TLV_CODE_MANUF_DATE), 'NA')
-            
+            self.revision = self.eeprom_tlv_dict.get(
+                "0x%X" % (self._TLV_CODE_LABEL_REVISION), 'NA')
+
 
     def _get_eeprom_field(self, field_name):
         """
@@ -164,17 +169,26 @@ class Eeprom(TlvInfoDecoder):
         """
         if not self.service_tag:
             self._load_system_eeprom()
-            
+
         return self.service_tag
-    
+
     def manuf_date_str(self):
         """
         Returns the servicetag number.
         """
         if not self.manuf_date:
             self._load_system_eeprom()
-            
+
         return self.manuf_date
+
+    def label_revision_str(self):
+        """
+        Returns the revision string.
+        """
+        if not self.revision:
+            self._load_system_eeprom()
+
+        return self.revision
 
     def system_eeprom_info(self):
         """

--- a/platform/aspeed/sonic-platform-modules-nokia/h6-128/sonic_platform/switch_host_module.py
+++ b/platform/aspeed/sonic-platform-modules-nokia/h6-128/sonic_platform/switch_host_module.py
@@ -5,16 +5,48 @@ This module provides an abstraction for the BMC's interaction with the
 switch host CPU, including power management operations.
 """
 
+import ctypes
+import fcntl
+import os
 import subprocess
 import sys
 import time
 
 try:
     from sonic_platform_base.module_base import ModuleBase
+    from sonic_py_common import logger
     from sonic_platform.eeprom import Eeprom
+    from sonic_platform.sysfs import read_sysfs_file, write_sysfs_file
 except ImportError as e:
     raise ImportError(str(e) + " - required module not found")
 
+
+sonic_logger = logger.Logger('SwitchHostModule')
+
+CB_PLD_DIR = "/sys/bus/i2c/devices/i2c-14/14-0060/"
+
+I2C_SLAVE = 0x0703
+I2C_SMBUS = 0x0720
+I2C_SMBUS_READ = 1
+I2C_SMBUS_WRITE = 0
+I2C_SMBUS_BYTE = 1
+I2C_SMBUS_BYTE_DATA = 2
+
+class _I2cSmbusData(ctypes.Union):
+    _fields_ = [
+        ("byte", ctypes.c_uint8),
+        ("word", ctypes.c_uint16),
+        ("block", ctypes.c_uint8 * 34),
+    ]
+
+
+class _I2cSmbusIoctlData(ctypes.Structure):
+    _fields_ = [
+        ("read_write", ctypes.c_uint8),
+        ("command", ctypes.c_uint8),
+        ("size", ctypes.c_uint32),
+        ("data", ctypes.POINTER(_I2cSmbusData)),
+    ]
 
 class SwitchHostModule(ModuleBase):
     """
@@ -23,6 +55,9 @@ class SwitchHostModule(ModuleBase):
     This module provides an abstraction for the BMC's interaction with the
     switch host CPU, including power management and status reporting.
     """
+
+    NAME = "SWITCH-HOST"
+    DESCRIPTION = "Nokia Switch Host Module"
 
     def __init__(self, module_index=0):
         """
@@ -48,14 +83,34 @@ class SwitchHostModule(ModuleBase):
             bool: True if operation succeeded, False otherwise
         """
         try:
-            cmd = ["sudo", "i2cset", "-y", bus, addr, reg, value]
-            result = subprocess.run(cmd, capture_output=True, timeout=5)
-            if result.returncode != 0:
-                sys.stderr.write(f"i2c_set cmd={cmd} failed({result.stderr})\n")
-                return False
+            bus_int = int(bus, 0)
+            addr_int = int(addr, 0)
+            reg_int = int(reg, 0)
+            value_int = int(value, 0)
+            dev = "/dev/i2c-{}".format(bus_int)
+
+            data = _I2cSmbusData()
+            data.byte = value_int
+            args = _I2cSmbusIoctlData(
+                read_write=I2C_SMBUS_WRITE,
+                command=reg_int,
+                size=I2C_SMBUS_BYTE_DATA,
+                data=ctypes.pointer(data),
+            )
+
+            fd = os.open(dev, os.O_RDWR)
+            try:
+                fcntl.ioctl(fd, I2C_SLAVE, addr_int)
+                fcntl.ioctl(fd, I2C_SMBUS, args)
+            finally:
+                os.close(fd)
             return True
         except Exception as e:
-            sys.stderr.write(f"Failed to set i2c {cmd} {e}\n")
+            sonic_logger.log_error(
+                "i2c_set_reg failed (bus={}, addr={}, reg={}, value={}): {}".format(
+                    bus, addr, reg, value, e
+                )
+            )
             return False
 
     def _i2c_set_byte(self, addr, value, bus="14"):
@@ -70,14 +125,32 @@ class SwitchHostModule(ModuleBase):
             bool: True if operation succeeded, False otherwise
         """
         try:
-            cmd = ["sudo", "i2cset", "-y", bus, addr, value]
-            result = subprocess.run(cmd, capture_output=True, timeout=5)
-            if result.returncode != 0:
-                sys.stderr.write(f"i2c_set cmd={cmd} failed({result.stderr})\n")
-                return False
+            bus_int = int(bus, 0)
+            addr_int = int(addr, 0)
+            value_int = int(value, 0)
+            dev = "/dev/i2c-{}".format(bus_int)
+
+            # Match `i2cset -y <bus> <addr> <value>` short-write semantics.
+            args = _I2cSmbusIoctlData(
+                read_write=I2C_SMBUS_WRITE,
+                command=value_int,
+                size=I2C_SMBUS_BYTE,
+                data=ctypes.POINTER(_I2cSmbusData)(),
+            )
+
+            fd = os.open(dev, os.O_RDWR)
+            try:
+                fcntl.ioctl(fd, I2C_SLAVE, addr_int)
+                fcntl.ioctl(fd, I2C_SMBUS, args)
+            finally:
+                os.close(fd)
             return True
         except Exception as e:
-            sys.stderr.write(f"Failed to set i2c {cmd} {e}\n")
+            sonic_logger.log_error(
+                "i2c_set_byte failed (bus={}, addr={}, value={}): {}".format(
+                    bus, addr, value, e
+                )
+            )
             return False
 
     def _i2c_get_reg(self, addr, reg, bus="14"):
@@ -91,17 +164,36 @@ class SwitchHostModule(ModuleBase):
 
         Returns:
             int: value (read from i2c reg), -1 on error
+            bool: True if operation succeeded, False otherwise
         """
         try:
-            cmd = ["sudo", "i2cget", "-y", bus, addr, reg]
-            result = subprocess.run(cmd, capture_output=True, timeout=5)
-            if result.returncode == 0:
-                # Parse hex value (e.g., "0xff")
-                value = int(result.stdout.strip(), 16)
-                return value
+            bus_int = int(bus, 0)
+            addr_int = int(addr, 0)
+            reg_int = int(reg, 0)
+            dev = "/dev/i2c-{}".format(bus_int)
+
+            data = _I2cSmbusData()
+            args = _I2cSmbusIoctlData(
+                read_write=I2C_SMBUS_READ,
+                command=reg_int,
+                size=I2C_SMBUS_BYTE_DATA,
+                data=ctypes.pointer(data),
+            )
+
+            fd = os.open(dev, os.O_RDWR)
+            try:
+                fcntl.ioctl(fd, I2C_SLAVE, addr_int)
+                fcntl.ioctl(fd, I2C_SMBUS, args)
+            finally:
+                os.close(fd)
+            return int(data.byte)
         except Exception as e:
-            sys.stderr.write(f"Failed to get i2c {cmd} {e}\n")
-        return -1
+            sonic_logger.log_error(
+                "i2c_get_reg failed (bus={}, addr={}, reg={}): {}".format(
+                    bus, addr, reg, e
+                )
+            )
+            return -1
 
     def _do_power_off(self):
         """
@@ -111,10 +203,10 @@ class SwitchHostModule(ModuleBase):
             bool: True if SwitchCpu is powered off, False otherwise
         """
         try:
-            if not self._i2c_set_reg("0x60", "0x20", "0x7f"):
+            if write_sysfs_file(CB_PLD_DIR + "reset_sig", "0x7f") == 'ERR':
                 return False
             time.sleep(1)
-            if not self._i2c_set_reg("0x60", "0xf", "0x0"):
+            if write_sysfs_file(CB_PLD_DIR + "mux_sel", "0x0") == 'ERR':
                 return False
             time.sleep(1)
             if not self._i2c_set_reg("0x77", "0x0", "0x3"):
@@ -135,15 +227,15 @@ class SwitchHostModule(ModuleBase):
             if not self._i2c_set_byte("0x11", "0xdb"):
                 return False
             time.sleep(1)
-            if not self._i2c_set_reg("0x60", "0x37", "0x0"):
+            if write_sysfs_file(CB_PLD_DIR + "bios_red", "0x0") == 'ERR':
                 return False
             time.sleep(1)
-            if not self._i2c_set_reg("0x60", "0x5", "0x9"):
-                 return False
+            if write_sysfs_file(CB_PLD_DIR + "misc", "0x9") == 'ERR':
+                return False
             time.sleep(1)
             return True
         finally:
-            self._i2c_set_reg("0x60", "0xf", "0x1")
+            write_sysfs_file(CB_PLD_DIR + "mux_sel", "0x1")
 
     def _do_power_on(self):
         """
@@ -153,7 +245,7 @@ class SwitchHostModule(ModuleBase):
             bool: True if SwitchCpu is powered on, False otherwise
         """
         try:
-            if not self._i2c_set_reg("0x60", "0xf", "0x0"):
+            if write_sysfs_file(CB_PLD_DIR + "mux_sel", "0x0") == 'ERR':
                 return False
             time.sleep(1)
             if not self._i2c_set_reg("0x77", "0x0", "0x3"):
@@ -165,18 +257,18 @@ class SwitchHostModule(ModuleBase):
             if not self._i2c_set_reg("0x71", "0x19", "0x1f"):
                 return False
             time.sleep(1)
-            if not self._i2c_set_reg("0x60", "0x20", "0xff"):
+            if write_sysfs_file(CB_PLD_DIR + "reset_sig", "0xff") == 'ERR':
                 return False
             time.sleep(1)
-            if not self._i2c_set_reg("0x60", "0x5", "0xb"):
+            if write_sysfs_file(CB_PLD_DIR + "misc", "0xb") == 'ERR':
                 return False
             time.sleep(1)
-            if not self._i2c_set_reg("0x60", "0x37", "0x4"):
+            if write_sysfs_file(CB_PLD_DIR + "bios_red", "0x4") == 'ERR':
                 return False
             time.sleep(1)
             return True
         finally:
-            self._i2c_set_reg("0x60", "0xf", "0x1")
+            write_sysfs_file(CB_PLD_DIR + "mux_sel", "0x1")
 
     ##############################################
     # Core Power Management APIs
@@ -193,10 +285,10 @@ class SwitchHostModule(ModuleBase):
             bool: True if operation succeeded, False otherwise
         """
         if up:
-            sys.stderr.write("SwitchHost: Powering ON (out-of-reset)...\n")
+            sonic_logger.log_info("SwitchHost: Powering ON (out-of-reset)...\n")
             return self._do_power_on()
         else:
-            sys.stderr.write("SwitchHost: Powering OFF (put-in-reset)...\n")
+            sonic_logger.log_info("SwitchHost: Powering OFF (put-in-reset)...\n")
             return self._do_power_off()
 
     def do_power_cycle(self):
@@ -211,21 +303,21 @@ class SwitchHostModule(ModuleBase):
         Returns:
             bool: True if operation succeeded, False otherwise
         """
-        sys.stderr.write("SwitchHost: Starting power cycle...\n")
+        sonic_logger.log_info("SwitchHost: Starting power cycle...\n")
 
         if not self._do_power_off():
-            sys.stderr.write("SwitchHost: Failed to assert reset\n")
+            sonic_logger.log_warning("SwitchHost: Failed to assert reset\n")
             return False
 
-        sys.stderr.write("SwitchHost: Reset asserted, waiting 6 seconds...\n")
+        sonic_logger.log_info("SwitchHost: Reset asserted, waiting 6 seconds...\n")
 
         time.sleep(6)
 
         if not self._do_power_on():
-            sys.stderr.write("SwitchHost: Failed to deassert reset\n")
+            sonic_logger.log_warning("SwitchHost: Failed to deassert reset\n")
             return False
 
-        sys.stderr.write("SwitchHost: Power cycle complete\n")
+        sonic_logger.log_info("SwitchHost: Power cycle complete\n")
         return True
 
     def reboot(self, reboot_type=None):
@@ -252,11 +344,12 @@ class SwitchHostModule(ModuleBase):
         Returns:
             str: One of MODULE_STATUS_ONLINE, MODULE_STATUS_OFFLINE, MODULE_STATUS_FAULT
         """
-        reg_value = self._i2c_get_reg("0x60", "0x5")
+        result = read_sysfs_file(CB_PLD_DIR + "misc")
 
-        if reg_value == -1:
-            # Read error
+        if result == 'ERR':
             return self.MODULE_STATUS_FAULT
+
+        reg_value = int(result, 0)
 
         if reg_value & 0x2:
             # Bit 1 = 1: CPU is powered-on
@@ -271,12 +364,12 @@ class SwitchHostModule(ModuleBase):
 
     def get_name(self):
         """
-        Returns module name: SWITCH_HOST0
+        Returns module name: SWITCH-HOST
 
         Returns:
             str: Module name
         """
-        return f"{self.MODULE_TYPE_SWITCH_HOST}{self.module_index}"
+        return self.NAME
 
     def get_type(self):
         """
@@ -312,7 +405,7 @@ class SwitchHostModule(ModuleBase):
         Returns:
             str: Module description
         """
-        return "Main x86 Switch Host CPU managed by BMC"
+        return "Switch Host CPU"
 
     def get_maximum_consumed_power(self):
         """

--- a/platform/aspeed/sonic-platform-modules-nokia/h6-128/sonic_platform/switch_host_module.py
+++ b/platform/aspeed/sonic-platform-modules-nokia/h6-128/sonic_platform/switch_host_module.py
@@ -164,7 +164,6 @@ class SwitchHostModule(ModuleBase):
 
         Returns:
             int: value (read from i2c reg), -1 on error
-            bool: True if operation succeeded, False otherwise
         """
         try:
             bus_int = int(bus, 0)
@@ -349,7 +348,10 @@ class SwitchHostModule(ModuleBase):
         if result == 'ERR':
             return self.MODULE_STATUS_FAULT
 
-        reg_value = int(result, 0)
+        try:
+            reg_value = int(result, 0)
+        except (TypeError, ValueError):
+            return self.MODULE_STATUS_FAULT
 
         if reg_value & 0x2:
             # Bit 1 = 1: CPU is powered-on

--- a/platform/aspeed/sonic-platform-modules-nokia/h6-128/sonic_platform/sysfs.py
+++ b/platform/aspeed/sonic-platform-modules-nokia/h6-128/sonic_platform/sysfs.py
@@ -2,44 +2,55 @@
     Nokia H6-128 BMC sysfs functions
 """
 
+try:
+    from sonic_py_common import logger
+except ImportError as e:
+    raise ImportError(str(e) + " - required module not found")
+
+sonic_logger = logger.Logger('sysfs')
+
+
 def read_sysfs_file(sysfs_file):
     """
-    On successful read, returns the value read from given
-    reg_name and on failure returns ERR
+    Read a sysfs attribute file.
+
+    Returns:
+        str: The file contents on success, or 'ERR' on failure.
     """
     rv = 'ERR'
 
     try:
         with open(sysfs_file, 'r', encoding='utf-8') as fd:
             rv = fd.read()
-            fd.close()
     except FileNotFoundError:
-        print(f"Error: {sysfs_file} doesn't exist.")
+        sonic_logger.log_error("Error: {} doesn't exist.".format(sysfs_file))
     except PermissionError:
-        print(f"Error: Permission denied when reading file {sysfs_file}.")
+        sonic_logger.log_error("Error: Permission denied when reading file {}.".format(sysfs_file))
     except IOError:
-        print(f"IOError: An error occurred while reading file {sysfs_file}.")
+        sonic_logger.log_error("IOError: An error occurred while reading file {}.".format(sysfs_file))
     if rv != 'ERR':
         rv = rv.rstrip('\r\n')
         rv = rv.lstrip(" ")
     return rv
 
+
 def write_sysfs_file(sysfs_file, value):
     """
-    On successful write, the value read will be written on
-    reg_name and on failure returns ERR
+    Write a value to a sysfs attribute file.
+
+    Returns:
+        int or str: Number of bytes written on success, or 'ERR' on failure.
     """
     rv = 'ERR'
 
     try:
         with open(sysfs_file, 'w', encoding='utf-8') as fd:
             rv = fd.write(value)
-            fd.close()
     except FileNotFoundError:
-        print(f"Error: {sysfs_file} doesn't exist.")
+        sonic_logger.log_error("Error: {} doesn't exist.".format(sysfs_file))
     except PermissionError:
-        print(f"Error: Permission denied when writing file {sysfs_file}.")
+        sonic_logger.log_error("Error: Permission denied when writing file {}.".format(sysfs_file))
     except IOError:
-        print(f"IOError: An error occurred while writing file {sysfs_file}.")
+        sonic_logger.log_error("IOError: An error occurred while writing file {}.".format(sysfs_file))
 
     return rv

--- a/platform/aspeed/sonic-platform-modules-nokia/h6-128/sonic_platform/sysfs.py
+++ b/platform/aspeed/sonic-platform-modules-nokia/h6-128/sonic_platform/sysfs.py
@@ -1,0 +1,45 @@
+"""
+    Nokia H6-128 BMC sysfs functions
+"""
+
+def read_sysfs_file(sysfs_file):
+    """
+    On successful read, returns the value read from given
+    reg_name and on failure returns ERR
+    """
+    rv = 'ERR'
+
+    try:
+        with open(sysfs_file, 'r', encoding='utf-8') as fd:
+            rv = fd.read()
+            fd.close()
+    except FileNotFoundError:
+        print(f"Error: {sysfs_file} doesn't exist.")
+    except PermissionError:
+        print(f"Error: Permission denied when reading file {sysfs_file}.")
+    except IOError:
+        print(f"IOError: An error occurred while reading file {sysfs_file}.")
+    if rv != 'ERR':
+        rv = rv.rstrip('\r\n')
+        rv = rv.lstrip(" ")
+    return rv
+
+def write_sysfs_file(sysfs_file, value):
+    """
+    On successful write, the value read will be written on
+    reg_name and on failure returns ERR
+    """
+    rv = 'ERR'
+
+    try:
+        with open(sysfs_file, 'w', encoding='utf-8') as fd:
+            rv = fd.write(value)
+            fd.close()
+    except FileNotFoundError:
+        print(f"Error: {sysfs_file} doesn't exist.")
+    except PermissionError:
+        print(f"Error: Permission denied when writing file {sysfs_file}.")
+    except IOError:
+        print(f"IOError: An error occurred while writing file {sysfs_file}.")
+
+    return rv


### PR DESCRIPTION
1)Added cb_fpga driver which provides sysfs access.
 Replaced i2cget and i2set with ioctl calls.
2)Added platform APIs in chassis.py and eeprom.py

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [x] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

