### PR TITLE
Revert "[Aspeed BMC] Exclude ztp.service to fix systemd-sonic-generator boot errors (#27838)"

### DIFF
--- a/files/build_scripts/aspeed_bmc_filter_services.py
+++ b/files/build_scripts/aspeed_bmc_filter_services.py
@@ -30,9 +30,6 @@ BMC_EXCLUDED_SERVICES = {
     'dhcp_dos_logger.service',       # DHCP DoS detection - no switch ports on BMC
     'warmboot-finalizer.service',    # Warm boot reconciliation - no SWSS/BGP on BMC
 
-    # ZTP - not needed for BMC
-    'ztp.service',
-
     # UUID daemon - not needed
     'uuidd.service',                 # UUID daemon - kernel provides UUID generation
     'uuidd.socket',                  # UUID daemon socket activation
@@ -60,6 +57,9 @@ BMC_REQUIRED_SERVICES = {
 
     # Time synchronization
     'chrony.service',                 # Chrony time synchronization
+
+    # Zero Touch Provisioning
+    'ztp.service',                    # ZTP for automated device provisioning
 
     # System health monitoring
     'system-health.service',          # SONiC system health monitor


### PR DESCRIPTION
This reverts #27838.

We have decided to enable ZTP (Zero Touch Provisioning) on the BMC, so `ztp.service` should no longer be excluded from BMC images. This restores `ztp.service` to `BMC_REQUIRED_SERVICES`.