### PR TITLE
[ci] correctly treat nvidia-bluefield as arm64 when freezing the versions

### DIFF
--- a/.azure-pipelines/azure-pipelines-UpgrateVersion.yml
+++ b/.azure-pipelines/azure-pipelines-UpgrateVersion.yml
@@ -115,13 +115,13 @@ stages:
         cp -r $(Pipeline.Workspace)/sonic-buildimage.${default_platform}/target/versions target/
         make freeze FREEZE_VERSION_OPTIONS=-r
         find -L files/build/versions
-        ordered_artifacts=$(echo "$artifacts" | grep -v -E "arm64|armhf" && echo "$artifacts" | grep -E "arm64|armhf")
+        ordered_artifacts=$(echo "$artifacts" | grep -v -E "arm64|armhf|nvidia-bluefield" && echo "$artifacts" | grep -E "arm64|armhf|nvidia-bluefield")
         for artifact in $ordered_artifacts
         do
           rm -rf target/versions
           cp -r $artifact/target/versions target/
           OPTIONS="-a -d"
-          [[ "$artifact" == *arm64* || "$artifact" == *armhf* ]] && OPTIONS="-d"
+          [[ "$artifact" == *arm64* || "$artifact" == *armhf* || "$artifact" == *nvidia-bluefield* ]] && OPTIONS="-d"
           make freeze FREEZE_VERSION_OPTIONS="$OPTIONS"
         done
         git diff files/build/versions-public


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The version-upgrade pipeline classifies a build artifact as arm (and thus freezes its package versions into arch-specific files via `-d` flag) by matching `arm64|armhf` in the artifact name. Nvidia-bluefield is an arm64 platform, but its artifact name carries no arch token, so it fell into the amd64 group and was frozen with `-a` flag (for_all_arch), putting its arm-resolved pip versions
into the arch-independent common version files. This is how `pyroute2==0.9.6` leaked into `files/build/versions-public/build/build-sonic-slave-trixie/versions-py3`. The arm slaves have no Debian python3-pyroute2 and pip pulls the unpinned latest (0.9.6)

when installing the sonic-utilities wheel, the pip installs the `pyroute2==0.9.6` based on the constraint in the versions-py3 file, but the RECORD-less Debian package cannot be uninstalled to satisfy the constraint.
```
Installing collected packages: www-authenticate, toposort, ipaddress, colorful, xmltodict, semantic-version, pyroute2, prettyprinter, lazy-object-proxy, jsonpatch, filelock, docker-image-py, click-log, docker, scp, sonic-utilities
  Attempting uninstall: pyroute2
    Found existing installation: pyroute2 0.7.7
error: uninstall-no-record-file

× Cannot uninstall pyroute2 0.7.7
╰─> The package's contents are unknown: no RECORD file was found for pyroute2.

hint: The package was installed by debian. You should check if it can uninstall the package.

Failed to run the command with constraint, try to install with the original command
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Match nvidia-bluefield alongside arm64/armhf so it is frozen with `-d` and its versions stay in the arch-specific files instead of the common ones.
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

