### PR TITLE
[docker-sonic-vs] Restore CHASSIS_APP_DB for SpineRouter containers

### DIFF
--- a/platform/vs/docker-sonic-vs/start.sh
+++ b/platform/vs/docker-sonic-vs/start.sh
@@ -122,6 +122,29 @@ if [ "$start_chassis_db" != "1" ] && [ "$conn_chassis_db" != "1" ]; then
    cp $db_cfg_file $db_cfg_file_tmp
    update_chassisdb_config -j $db_cfg_file_tmp -d
    cp $db_cfg_file_tmp $db_cfg_file
+
+   # Some non-chassis containers still get device_info.is_chassis()==True -- e.g.
+   # cSONiC neighbors configured with DEVICE_METADATA.localhost.type=SpineRouter
+   # to emulate T2 in vms-kvm-t1 / vms-kvm-t2 topologies. bgpcfgd then instantiates
+   # ChassisAppDbMgr, which calls swsscommon.SonicDBConfig.getDbId("CHASSIS_APP_DB")
+   # and crash-loops because we just stripped CHASSIS_APP_DB from database_config.json.
+   # Restore CHASSIS_APP_DB pointing at the local "redis" instance so ChassisAppDbMgr
+   # connects locally instead of aborting bgpcfgd. This does not surface on T0 cSONiC
+   # (the documented example) because T0 has no SpineRouter neighbors.
+   dev_type=$(sonic-cfggen -j /etc/sonic/init_cfg.json -j /etc/sonic/config_db.json -v "DEVICE_METADATA['localhost']['type']" 2>/dev/null || true)
+   if [ "$dev_type" = "SpineRouter" ]; then
+      python3 - "$db_cfg_file" <<'PYEOF'
+import json, sys
+p = sys.argv[1]
+with open(p) as f:
+    d = json.load(f)
+dbs = d.setdefault("DATABASES", {})
+if "CHASSIS_APP_DB" not in dbs:
+    dbs["CHASSIS_APP_DB"] = {"id": 12, "separator": "|", "instance": "redis"}
+    with open(p, "w") as f:
+        json.dump(d, f, indent=4, separators=(",", ": "))
+PYEOF
+   fi
 fi
 
 if [ "$conn_chassis_db" == "1" ]; then


### PR DESCRIPTION
#### Why I did it

cSONiC neighbors that emulate a `SpineRouter` (e.g. the T2 nodes in the T1/T2 topologies exercised by the `vms-kvm-t1-csonic` / `vms-kvm-t2-csonic` testbeds) render `DEVICE_METADATA.localhost.type=SpineRouter` in their `CONFIG_DB`. `sonic-py-common` `device_info.is_chassis()` returns `True` for that type, so `bgpcfgd` instantiates `ChassisAppDbMgr`, which calls `swsscommon.SonicDBConfig.getDbId('CHASSIS_APP_DB')`.

A cSONiC neighbor, however, is a single container — not a real chassis — so `docker-sonic-vs`'s `start.sh` runs `update_chassisdb_config -d` and strips `CHASSIS_APP_DB` (and the `redis_chassis` instance) from `database_config.json`. `bgpcfgd` then crash-loops with:

```
CRIT #bgpcfgd: Got an exception Failed to find CHASSIS_APP_DB database
IndexError: Failed to find CHASSIS_APP_DB database in : key
```

and never emits a `router bgp` stanza, so those neighbors never establish BGP with the DUT.

This does not surface on T0 cSONiC (the documented example) because T0 has no `SpineRouter` neighbors — it only appears once a topology (T1/T2) includes `SpineRouter` neighbors.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

After `update_chassisdb_config -d` strips the chassis-DB config on a non-chassis container, `start.sh` now detects the `DEVICE_METADATA.localhost.type=SpineRouter` false-positive case and re-adds a `CHASSIS_APP_DB` entry (id `12`, separator `"|"`) pointing at the local `redis` instance. `ChassisAppDbMgr` then connects locally instead of aborting `bgpcfgd`.

- The block only runs when `type=SpineRouter`, so non-SpineRouter neighbors (T0 ToR, real DUT, etc.) are completely unaffected.
- The device type is resolved from **both** `/etc/sonic/init_cfg.json` **and** `/etc/sonic/config_db.json` (the latter is what `deploy-mg` writes), so the fix works both at initial container start and after minigraph deployment.
- The Python snippet uses `setdefault`-style insertion, making the change idempotent across container restarts.

#### How to verify it

Built `docker-sonic-vs` with this change and brought up the `vms-kvm-t1-csonic` testbed via `sonic-mgmt` `add-topo` + `deploy-mg`:

- 24 cSONiC neighbors: 8 `SpineRouter` (T2) + 16 `ToRRouter` (T0).

**Before the fix** — the 8 `SpineRouter` neighbors' `bgpcfgd` crash-looped with `IndexError: Failed to find CHASSIS_APP_DB database` and produced no `router bgp`; their BGP sessions stayed down.

**After the fix** on all 24 cSONiC neighbors:
- `bgpcfgd` supervisorctl status: `RUNNING` (stable, no restarts)
- `CHASSIS_APP_DB` present in `/var/run/redis/sonic-db/database_config.json` on all 4 `SpineRouter` containers
- All 24/24 BGP sessions `Established`
- All 8/8 PortChannels `LACP(A)(Up)`
- `bgp/test_bgp_fact.py::test_bgp_facts[vlab-03-None]` **PASSED** via `run_tests.sh -n vms-kvm-t1-csonic -d vlab-03 -t t1,any -f vtestbed.yaml -i veos_vtb -u -e --disable_loganalyzer -c bgp/test_bgp_fact.py`

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

- [x] master

#### Description for the changelog

[docker-sonic-vs] Restore CHASSIS_APP_DB for SpineRouter cSONiC containers so `bgpcfgd` does not crash-loop on T1/T2 topologies.

#### Link to config_db schema for YANG module changes

N/A — no schema changes.
