### PR TITLE
[sonic-yang-models]: Add Linux VRF Route Lookup Fallback Control schema

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -92,6 +92,7 @@
   * [VOQ Inband Interface](#voq-inband-interface)
   * [VXLAN](#vxlan)
   * [Virtual router](#virtual-router)
+  * [Kernel VRF fallback](#kernel-vrf-fallback)
   * [LOGGER](#logger)
   * [WRED_PROFILE](#wred_profile)
   * [XCVRD_LOG](#xcvrd_log)
@@ -3077,6 +3078,92 @@ The packet action could be:
 	'vni': '100'
 }
 ```
+
+### Kernel VRF fallback
+
+`KERNEL_VRF_FALLBACK` is a temporary, global compatibility control for
+Linux kernel route lookup after a lookup misses in a non-default VRF. It
+affects both IPv4 and IPv6 in the kernel forwarding path only. It does not
+create routes in APP_DB or ASIC_DB and does not program SAI or hardware.
+
+Supply the setting through the standard persistent CONFIG_DB workflow, such
+as a persistent configuration patch or `config_db.json`. A direct in-memory
+Redis write alone is not persistent configuration.
+
+On a multi-ASIC system, each `vrfmgrd` consumes its namespace-local CONFIG_DB;
+the `GLOBAL` key does not replicate data between namespaces. Treat this as one
+logical device-wide setting by persisting the same row and value in every
+applicable data-ASIC namespace. A row written only under the host or
+`localhost` scope does not control the per-ASIC VRFs. If an ASIC namespace
+omits the row, that namespace uses the default `disabled` state. Multi-ASIC
+configuration patches and save/reload workflows must therefore include and
+preserve an identical scoped copy for every applicable ASIC.
+
+The table has one valid key, `GLOBAL`, and the `status` field is required
+when that row is present:
+
+```json
+{
+    "KERNEL_VRF_FALLBACK": {
+        "GLOBAL": {
+            "status": "disabled"
+        }
+    }
+}
+```
+
+| Field | Required | Values | Description |
+|-------|----------|--------|-------------|
+| `status` | Yes | `enabled`, `disabled` | `enabled` permits legacy kernel fallback; `disabled` blocks fallback. |
+
+The default effective state is `disabled`. When the table, `GLOBAL` row, or
+`status` field is absent, `vrfmgrd` installs an unreachable default route for
+both IPv4 and IPv6 in each applicable non-default VRF. The YANG schema rejects
+a configured `GLOBAL` row without `status`; `vrfmgrd` also treats such
+unvalidated input defensively as `disabled`.
+
+Setting `status` to `enabled` removes only the exact unreachable default
+routes managed by `vrfmgrd` and restores the legacy Linux kernel fallback
+behavior. Deleting the entry restores the default `disabled` state.
+
+This control is global. The deprecated `fallback` field on a `VRF|<name>` row
+is retained only for configuration-schema compatibility and does not override
+`KERNEL_VRF_FALLBACK|GLOBAL`. No CLI is provided for this setting.
+
+Upgrading from vanilla Linux behavior, a fallback-allowed SONiC deployment,
+or an inactive or absent prior downstream disable-fallback control changes the
+effective behavior when the new entry is absent: `vrfmgrd` installs the
+sentinels and blocks fallback. This intentional default change affects only
+kernel routing; ASIC programming is unchanged. There is no automatic
+conversion of a prior downstream control. If uninterrupted legacy fallback is
+required, persist `status=enabled` before the new `vrfmgrd` starts
+reconciliation. Migration must map effective behavior rather than copy the old
+boolean literally: an inactive or absent prior disable control maps to
+`status=enabled` only when fallback must be preserved, while an active prior
+disable control maps to the new absent or `status=disabled` state.
+
+The compatibility control itself is deprecated and is expected to be removed
+in a future release. Before a warm or in-service rollback to software that does
+not manage these routes:
+
+1. Persist `status=enabled`, allow the current `vrfmgrd` to reconcile every
+   applicable VRF, and verify that both sentinels are absent.
+2. Stop or quiesce the current `vrfmgrd` so it cannot consume another CONFIG_DB
+   update, then remove the persisted `KERNEL_VRF_FALLBACK|GLOBAL` entry.
+3. Verify that the exact managed routes remain absent, clean them up manually
+   if necessary, and only then start the older software.
+
+Manual route cleanup must occur while the current daemon is quiesced. Use the
+exact VRF table IDs:
+
+```bash
+ip route del table <TABLE_ID> unreachable default metric 4278198272
+ip -6 route del table <TABLE_ID> unreachable default metric 4278198272
+```
+
+A cold rollback that deletes and recreates the VRF devices naturally removes
+their old routing tables, but the persisted entry must still be removed or
+migrated.
 
 
 ### WRED_PROFILE

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -5,6 +5,11 @@
                     "vni" : "100"
                 }
         },
+        "KERNEL_VRF_FALLBACK": {
+            "GLOBAL": {
+                "status": "disabled"
+            }
+        },
         "SUBNET_DECAP": {
             "AZURE": {
                 "status": "enable",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vrf.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vrf.json
@@ -19,5 +19,35 @@
     "VRF_TEST_WITH_VNI_OOR": {
         "desc": "Configure VRF with out of range VNI in VRF table.",
         "eStrKey": "Range"
+    },
+    "KERNEL_VRF_FALLBACK_ENABLED_TEST": {
+        "desc": "Enable global Linux kernel VRF fallback.",
+        "eStrKey": "Verify",
+        "verify": {
+            "xpath": "/sonic-vrf:sonic-vrf/KERNEL_VRF_FALLBACK/GLOBAL/status",
+            "key": "sonic-vrf:status",
+            "value": "enabled"
+        }
+    },
+    "KERNEL_VRF_FALLBACK_DISABLED_TEST": {
+        "desc": "Disable global Linux kernel VRF fallback.",
+        "eStrKey": "Verify",
+        "verify": {
+            "xpath": "/sonic-vrf:sonic-vrf/KERNEL_VRF_FALLBACK/GLOBAL/status",
+            "key": "sonic-vrf:status",
+            "value": "disabled"
+        }
+    },
+    "KERNEL_VRF_FALLBACK_MISSING_STATUS_TEST": {
+        "desc": "Reject a kernel VRF fallback entry without status.",
+        "eStrKey": "Mandatory"
+    },
+    "KERNEL_VRF_FALLBACK_INVALID_STATUS_TEST": {
+        "desc": "Reject an invalid kernel VRF fallback status.",
+        "eStrKey": "InvalidValue"
+    },
+    "KERNEL_VRF_FALLBACK_INVALID_KEY_TEST": {
+        "desc": "Reject a kernel VRF fallback entry whose key is not GLOBAL.",
+        "eStrKey": "UnknownElement"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vrf.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vrf.json
@@ -60,5 +60,53 @@
                 }]
             }
         }
+    },
+
+    "KERNEL_VRF_FALLBACK_ENABLED_TEST": {
+        "sonic-vrf:sonic-vrf": {
+            "sonic-vrf:KERNEL_VRF_FALLBACK": {
+                "GLOBAL": {
+                    "status": "enabled"
+                }
+            }
+        }
+    },
+
+    "KERNEL_VRF_FALLBACK_DISABLED_TEST": {
+        "sonic-vrf:sonic-vrf": {
+            "sonic-vrf:KERNEL_VRF_FALLBACK": {
+                "GLOBAL": {
+                    "status": "disabled"
+                }
+            }
+        }
+    },
+
+    "KERNEL_VRF_FALLBACK_MISSING_STATUS_TEST": {
+        "sonic-vrf:sonic-vrf": {
+            "sonic-vrf:KERNEL_VRF_FALLBACK": {
+                "GLOBAL": {}
+            }
+        }
+    },
+
+    "KERNEL_VRF_FALLBACK_INVALID_STATUS_TEST": {
+        "sonic-vrf:sonic-vrf": {
+            "sonic-vrf:KERNEL_VRF_FALLBACK": {
+                "GLOBAL": {
+                    "status": "invalid"
+                }
+            }
+        }
+    },
+
+    "KERNEL_VRF_FALLBACK_INVALID_KEY_TEST": {
+        "sonic-vrf:sonic-vrf": {
+            "sonic-vrf:KERNEL_VRF_FALLBACK": {
+                "DEFAULT": {
+                    "status": "enabled"
+                }
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-vrf.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vrf.yang
@@ -68,6 +68,8 @@ module sonic-vrf {
                 "Global, dual-stack Linux kernel VRF route fallback compatibility configuration. This setting affects only the kernel forwarding path.";
 
             container GLOBAL {
+                presence
+                    "Configure the singleton KERNEL_VRF_FALLBACK|GLOBAL row.";
                 description
                     "Singleton global kernel VRF fallback configuration.";
 

--- a/src/sonic-yang-models/yang-models/sonic-vrf.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vrf.yang
@@ -15,6 +15,11 @@ module sonic-vrf {
     description
         "Virtual Routing and Forwarding (VRF) instance configuration for L3 traffic isolation";
 
+    revision 2026-07-02 {
+        description
+            "Added the global Linux kernel VRF fallback compatibility control and deprecated the legacy per-VRF control.";
+    }
+
     revision 2021-03-30 {
         description
             "Initial revision.";
@@ -42,8 +47,9 @@ module sonic-vrf {
                 leaf fallback {
                     type  boolean;
                     default false;
+                    status deprecated;
                     description
-                        "Enable/disable fallback feature which is useful for specified VRF user to access internet through global/main route.";
+                        "Deprecated legacy per-VRF fallback setting. This leaf is retained only for schema compatibility and does not override the global KERNEL_VRF_FALLBACK setting.";
                 }
 
                 leaf vni {
@@ -56,5 +62,23 @@ module sonic-vrf {
                 }
             } /* end of list VRF_LISt */
         } /* end of container VRf */
+
+        container KERNEL_VRF_FALLBACK {
+            description
+                "Global, dual-stack Linux kernel VRF route fallback compatibility configuration. This setting affects only the kernel forwarding path.";
+
+            container GLOBAL {
+                description
+                    "Singleton global kernel VRF fallback configuration.";
+
+                leaf status {
+                    type stypes:admin_mode;
+                    mandatory true;
+                    status deprecated;
+                    description
+                        "Enable or disable legacy Linux kernel VRF fallback. Enabled permits fallback after a VRF route lookup miss. Disabled blocks fallback and is also the effective state when the table, key, or field is absent at runtime.";
+                }
+            } /* end of container GLOBAL */
+        } /* end of container KERNEL_VRF_FALLBACK */
     } /* end of container sonic-vrf */
 }/* end of module sonic-vrf */


### PR DESCRIPTION
#### Why I did it

The related [Linux VRF Route Lookup Fallback Control HLD](https://github.com/sonic-net/SONiC/pull/2067) proposes a validated CONFIG_DB contract for a temporary global compatibility state. The upstream default is intentionally `disabled`: an absent entry or `status=disabled` causes `vrfmgrd` to block legacy Linux RPDB fall-through, while explicit `status=enabled` permits the legacy behavior.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

- Extended `sonic-vrf.yang` with the optional fixed singleton `KERNEL_VRF_FALLBACK|GLOBAL` row and mandatory `enabled`/`disabled` status when the row is present.
- Marked both the temporary compatibility status and the pre-existing per-VRF `fallback` leaf deprecated; the legacy per-VRF leaf is retained only for schema compatibility and is not an override.
- Added valid enabled/disabled fixtures and negative coverage for a missing status, invalid value, and non-`GLOBAL` key.
- Added sample configuration and documentation for the default, kernel-only scope, multi-ASIC namespace placement, upgrade mapping, persistence, and safe rollback order.

#### How to verify it

Static validation:

```text
python3 -m json.tool <each changed JSON file>
fixture manifest/config key-parity assertion
Configuration.md CRLF consistency assertion
git -c core.whitespace=cr-at-eol diff HEAD^ --check
```

Linux build and test validation was completed on `vxr-slurm-577`:

- Focused Trixie `sonic_yang_models` wheel build completed with `930 passed`.
- The Bookworm YANG model wheel built successfully as part of the VS image dependency graph.
- Bookworm `docker-sonic-vs.gz` built successfully.
- Combined validation with companion SWSS head `5662a703` completed the two focused VRF fallback DVS tests: `2 passed` in 46.51 seconds.

Reproduction commands from a configured `sonic-buildimage` workspace:

```bash
make BLDENV=trixie -f Makefile.work \
  target/python-wheels/trixie/sonic_yang_models-1.0-py3-none-any.whl

make NOTRIXIE=1 SONIC_BUILD_JOBS=32 \
  SONIC_BUILD_VARS='INCLUDE_VS_DASH_SAI=n' \
  target/docker-sonic-vs.gz
```

#### Which release branch to backport (provide reason below if selected)

None. This is a new feature.

#### Tested branch (Please provide the tested image version)

Locally built `docker-sonic-vs:latest` from this PR head `3d199e399` with companion sonic-swss head `5662a703` on 2026-07-02.

#### Description for the changelog

Add the global CONFIG_DB schema for Linux VRF Route Lookup Fallback Control.

#### Link to config_db schema for YANG module changes

[KERNEL_VRF_FALLBACK configuration](https://github.com/sudharr86/sonic-buildimage/blob/sudharr/kernel-vrf-fallback-yang/src/sonic-yang-models/doc/Configuration.md#kernel-vrf-fallback)

#### Related changes

- HLD: https://github.com/sonic-net/SONiC/pull/2067
- SWSS implementation: https://github.com/sonic-net/sonic-swss/pull/4730
- Prior non-normative IPv4 prototype: https://github.com/sonic-net/sonic-swss/pull/2943

Merge/build order: this schema should merge and make its generated CONFIG_DB artifacts available before the companion SWSS implementation merges. Both PRs can be reviewed concurrently.

Maintainer action requested: apply the `YANG` and `Enhancement :heavy_plus_sign:` labels. The author account does not have upstream label permissions.
