### PR TITLE
ci: disable KVM PR tests on 202505, keep build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,7 +98,8 @@ stages:
 
 - stage: Test
   dependsOn: BuildVS
-  condition: and(succeeded(), and(ne(stageDependencies.BuildVS.outputs['vs.SetVar.SKIP_VSTEST'], 'YES'), in(dependencies.BuildVS.result, 'Succeeded', 'SucceededWithIssues')))
+  # KVM/Elastictest PR tests disabled on 202505 (ADO 38681685); BuildVS/Build still run.
+  condition: false
   variables:
   - group: SONiC-Elastictest
   - name: inventory


### PR DESCRIPTION
Disables the Elastictest KVM `Test` stage (sets `condition: false`) so PRs targeting 202505 no longer run the impacted-area KVM tests, while the `BuildVS` and `Build` stages keep building the image.

This replaces the earlier `pr: none` approach so PR image builds are preserved.

Internal tracking: ADO 38681685.
