### PR TITLE
[yang-mgmt] Treat empty CONFIG DB leaf-list (['']) as empty so libyang3 accepts empty pattern-constrained leaf-lists

### DIFF
--- a/src/sonic-yang-mgmt/sonic_yang_ext.py
+++ b/src/sonic-yang-mgmt/sonic_yang_ext.py
@@ -248,7 +248,21 @@ class SonicYangExtMixin(SonicYangPathMixin):
                 # port.adv_speeds in CONFIG DB has value "100,1000,10000", it shall be transferred to [100,1000,10000] as YANG value here to
                 # be compliant with yang model.
                 value = [x.strip() for x in value.split(LEAF_LIST_WITH_STRING_VALUE_DICT[(self.elementPath[0], self.elementPath[-1])])]
+            # An empty leaf-list is stored in CONFIG DB as `field@ = ""`, which
+            # the Python ConfigDBConnector deserialises to a single empty-string
+            # element (`['']`). This is the CONFIG DB representation of "no
+            # elements", not a real element. libyang1 tolerated it; libyang3
+            # validates the '' against the element's type (e.g. the ip-prefix
+            # pattern of BGP_ALLOWED_PREFIXES) and rejects the whole config,
+            # breaking `config apply-patch` / `config rollback`. Drop the
+            # sentinel so an empty leaf-list is represented as an empty list
+            # (which libyang3 accepts). Only do this for leaf-lists without a
+            # schema default, so the empty-with-default handling below (which
+            # deliberately rejects the empty representation) is left untouched.
+            drop_empty_sentinel = not list(leaf.defaults())
             for v in value:
+                if v == '' and drop_empty_sentinel:
+                    continue
                 vValue.append(_yangConvert(v))
             # SONiC YANG models that allow "logically empty" leaf-lists declare
             # `default ""` (e.g. ACL_TABLE.ports) so libyang accepts the empty

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/test_sonic_yang.py
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/test_sonic_yang.py
@@ -512,6 +512,46 @@ class Test_SonicYang(object):
 
         return
 
+    def test_empty_leaflist_collapses_to_empty(self, sonic_yang_data):
+        # Regression test for empty leaf-list handling in _findYangTypedValue.
+        # CONFIG DB stores an empty leaf-list as `field@ = ""`, which the Python
+        # ConfigDBConnector deserialises to a single empty-string element
+        # (['']). This is the CONFIG DB representation of "no elements", not a
+        # real element. libyang1 tolerated it; libyang3 validates the '' against
+        # the element's type pattern (e.g. the ip-prefix pattern of
+        # BGP_ALLOWED_PREFIXES) and rejects the whole config, breaking
+        # `config apply-patch` / `config rollback`. The translation must treat
+        # [''] as an empty leaf-list ([]), which libyang3 accepts.
+        syc = sonic_yang_data['syc']
+        config = {
+            "BGP_ALLOWED_PREFIXES": {
+                "DEPLOYMENT_ID|0": {
+                    "prefixes_v4": [""],
+                    "prefixes_v6": ["fc00:f0::/64"],
+                }
+            }
+        }
+
+        # Must not raise during load (parse) or validation.
+        syc.loadData(config)
+        syc.validate_data_tree()
+
+        # The empty-string sentinel must not survive into the data tree: the
+        # empty leaf-list becomes [] while the populated one is preserved.
+        entry = None
+        for top in syc.xlateJson.values():
+            for cont in top.values():
+                for lst in cont.values():
+                    if isinstance(lst, list):
+                        for e in lst:
+                            if isinstance(e, dict) and e.get("deployment") == "DEPLOYMENT_ID":
+                                entry = e
+        assert entry is not None, "BGP_ALLOWED_PREFIXES entry not found in xlated data"
+        assert entry.get("prefixes_v4", []) == []
+        assert entry["prefixes_v6"] == ["fc00:f0::/64"]
+
+        return
+
     def test_loaddata_quiet_suppresses_syslog_on_success(self, sonic_yang_data, monkeypatch):
         # With quiet=True, the informational "Try to load Data" sysLog
         # call must not be emitted. Exception path is covered below.


### PR DESCRIPTION
#### Why I did it

`config apply-patch`, `config replace` and `config rollback` fail on master for any configuration that contains an empty pattern-constrained leaf-list. `BGP_ALLOWED_PREFIXES` is the common trigger, because a deployment often populates only `prefixes_v4` or only `prefixes_v6`, leaving the other leaf-list empty.

An empty leaf-list is stored in CONFIG DB as `field@ = ""`. The Python `ConfigDBConnector` deserialises that empty string into a single empty-string element (`['']`), which is the CONFIG DB representation of "no elements", not a real element. Before the libyang1 to libyang3 port ([#26584](https://github.com/sonic-net/sonic-buildimage/pull/26584)) the `''` sentinel was tolerated by the validation library. libyang3 validates the `''` element against the leaf type's pattern (for example the ipv4-prefix pattern of `BGP_ALLOWED_PREFIXES.prefixes_v4`) and rejects the whole config:

    Unsatisfied pattern - "" does not conform to "(([0-9]| ... )/(([0-9])|([1-2][0-9])|(3[0-2]))( (le|ge) ...)?"
    Data path: .../BGP_ALLOWED_PREFIXES_LIST[deployment='DEPLOYMENT_ID'][id='0']/prefixes_v4

This is a read-side (config-to-YANG validation) regression. [#26584](https://github.com/sonic-net/sonic-buildimage/pull/26584) did add a guard for the sibling case of an empty leaf-list that has a schema `default ""`, but missed the pattern-typed, no-default leaf-list case (`['']`), which is exactly `BGP_ALLOWED_PREFIXES`.

This fixes the read-side regression behind sonic-mgmt test `generic_config_updater/test_bgp_prefix.py` (tracked by [sonic-mgmt issue 25549](https://github.com/sonic-net/sonic-mgmt/issues/25549)). It is complementary to, and does not replace, the separate write-side effort that avoids writing `prefixes_v4@ = ""` into CONFIG DB in the first place ([sonic-buildimage issue 27818](https://github.com/sonic-net/sonic-buildimage/issues/27818), [sonic-utilities PR 4478](https://github.com/sonic-net/sonic-utilities/pull/4478)). Even with that write-side fix, existing configs and other tables can still present an empty leaf-list, so the validation layer should accept it.

##### Work item tracking
- Microsoft ADO **(number only)**: 38183186

#### How I did it

In the CONFIG DB to YANG translation in `src/sonic-yang-mgmt/sonic_yang_ext.py` (the leaf-list branch of `_findYangTypedValue`), drop the empty-string sentinel so an empty leaf-list is represented as an empty list `[]`, which libyang3 accepts. The drop is gated on the leaf-list having no schema default (`not list(leaf.defaults())`), so the existing empty-with-default handling introduced by [#26584](https://github.com/sonic-net/sonic-buildimage/pull/26584) is left byte-for-byte unchanged.

Added a regression unit test (`test_empty_leaflist_collapses_to_empty`) that loads `BGP_ALLOWED_PREFIXES` with an empty `prefixes_v4` leaf-list and asserts the config validates and the leaf-list collapses to `[]`.

#### How to verify it

Unit test (sonic-yang-mgmt suite): with the fix the new test passes and the full suite is green; reverting only the two changed lines makes just `test_empty_leaflist_collapses_to_empty` fail with the `Unsatisfied pattern - ""` error above.

End-to-end on a KVM t1 testbed (`vms-kvm-t1-lag`), baseline master image built after [#26584](https://github.com/sonic-net/sonic-buildimage/pull/26584) (so it carries the regression), matched before/after with only `sonic_yang_ext.py` swapped:

| DUT state | `generic_config_updater/test_bgp_prefix.py::test_bgp_prefix_tc1_suite` |
|---|---|
| before (unpatched baseline) | 2 failed, 2 errors — `config apply-patch` returns non-zero, teardown `config rollback failed` |
| after (fix applied) | 2 passed |

Also verified the mechanism directly: with `BGP_ALLOWED_PREFIXES|DEPLOYMENT_ID|0` holding `prefixes_v4@ = ""`, a subsequent valid `config apply-patch` fails with the `Unsatisfied pattern - ""` error before the fix and succeeds after it.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

- [x] master — `SONiC.master.1145536-931dbfb70` (build 2026-06-22)

#### Description for the changelog

[yang-mgmt] Treat an empty CONFIG DB leaf-list (`['']`) as empty so libyang3 does not reject empty pattern-constrained leaf-lists such as BGP_ALLOWED_PREFIXES.

#### Link to config_db schema for YANG module changes

No YANG model change. `BGP_ALLOWED_PREFIXES` schema: https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#bgp_allowed_prefixes

#### A picture of a cute animal (not mandatory but encouraged)

🦔
