### PR TITLE
[202511][Broadcom] Upgrade Broadcom xgs SAI version to 14.3.0.0.0.0.27.0

### DIFF
--- a/platform/broadcom/sai-xgs.mk
+++ b/platform/broadcom/sai-xgs.mk
@@ -1,5 +1,5 @@
 # Broadcom XGS SAI definitions
-LIBSAIBCM_XGS_VERSION = 14.3.0.0.0.0.21.0
+LIBSAIBCM_XGS_VERSION = 14.3.0.0.0.0.27.0
 LIBSAIBCM_XGS_BRANCH_NAME = SAI_14.3.0_GA
 
 LIBSAIBCM_XGS_URL_PREFIX = "https://packages.trafficmanager.net/public/sai/sai-broadcom/$(LIBSAIBCM_XGS_BRANCH_NAME)/$(LIBSAIBCM_XGS_VERSION)/xgs"


### PR DESCRIPTION
#### Why I did it
Upgrade the xgs SAI version on 202511 to 14.3.0.0.0.0.27.0 to include the following changes (22.0/23.0 are folded into 24.0; 26.0 is folded into 27.0):
- 14.3.0.0.0.0.24.0: Use TH6 dedicated FP counter tables for VFP ACL counters; merge 22.0/23.0 updates including TH5 Accton config updates, SONIC-119405 test validation enhancements, DLB offset KVP support, and Google SAI API performance tests.
- 14.3.0.0.0.0.25.0: Uplift SONIC-120399 (TH5-512 front-panel queue stats to count CPU-injected packets).
- 14.3.0.0.0.0.27.0: Uplift SDK-460299 fix for `_brcm_sai_read_fec_stat_err_counters_acc` ERR logs when peer interface is shutdown; includes 26.0 updates (TH5T 200G config files and SONIC-124262 policing flex counter test enhancements).

##### Work item tracking
- Microsoft ADO **(number only)**: 38698800

#### How I did it
Bump `LIBSAIBCM_XGS_VERSION` in `platform/broadcom/sai-xgs.mk` from 14.3.0.0.0.0.21.0 to 14.3.0.0.0.0.27.0.

#### How to verify it
Build a 202511 `sonic-aboot-broadcom.swi` from this PR, install on a TD3X2 DUT, and run the canonical 12-script SAI upgrade test set via Elastictest.

#### Which release branch to backport (provide reason below if selected)
N/A - this PR targets 202511 directly (master is on 15.2).