### PR TITLE
[broadcom][dnx] Point saibcm-modules-dnx submodule at new sdk-6.5.35-dnx

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -82,8 +82,8 @@
 	url = https://github.com/sonic-net/sonic-wpa-supplicant.git
 [submodule "platform/broadcom/saibcm-modules-dnx"]
 	path = platform/broadcom/saibcm-modules-dnx
-	url = https://github.com/nexthop-ai/saibcm-modules.git
-	branch = sdk-6.5.35-dnx_venu
+	url = https://github.com/sonic-net/saibcm-modules.git
+	branch = sdk-6.5.35-dnx
 [submodule "platform/broadcom/sonic-platform-modules-nokia"]
 	path = platform/broadcom/sonic-platform-modules-nokia
 	url = https://github.com/nokia/sonic-platform.git


### PR DESCRIPTION
Follow-up to #28152. That PR temporarily pointed the `platform/broadcom/saibcm-modules-dnx` submodule at the nexthop-ai fork's PR branch (`sdk-6.5.35-dnx_venu` @ bfca8dd) while https://github.com/sonic-net/saibcm-modules/pull/41 was in review. That PR is now merged, so this points the submodule back at the upstream `sonic-net/saibcm-modules` repo on branch `sdk-6.5.35-dnx` (matching how the XGS `saibcm-modules` submodule is set up) and bumps the pointer to the branch head 7ef751f.

No content change: 7ef751f is the merge commit of saibcm-modules PR https://github.com/sonic-net/saibcm-modules/pull/41, whose second parent bfca8dd is exactly the commit the submodule points to today.

#### Why I did it

The saibcm-modules-dnx submodule should track the upstream sonic-net/saibcm-modules repo, not a fork's PR branch. The fork branch was only needed while sonic-net/saibcm-modules#41 was pending; it has since merged.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- `.gitmodules`: url `nexthop-ai/saibcm-modules.git` → `sonic-net/saibcm-modules.git`, branch `sdk-6.5.35-dnx_venu` → `sdk-6.5.35-dnx`.
- Bumped the submodule pointer from bfca8dd to 7ef751f (the sdk-6.5.35-dnx branch head, i.e. the merge commit of sonic-net/saibcm-modules#41).

#### How to verify it

The submodule tree content is identical to what #28152 shipped (7ef751f is the merge of bfca8dd into sdk-6.5.35-dnx). Verified the DNX image built from this configuration on a Broadcom Q3D platform: image loads, no agent crashes, interfaces, port channels and BGP sessions come up.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
- Point the saibcm-modules-dnx submodule at upstream sonic-net/saibcm-modules branch sdk-6.5.35-dnx and bump it to the head of that branch (merge of saibcm-modules PR #41).

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
