### PR TITLE
[aspeed][nvidia-bmc] Set bootconf to select the correct BMC DTB

### DIFF
--- a/device/aspeed/arm64-aspeed_nvidia_ast2700_bmc-r0/installer.conf
+++ b/device/aspeed/arm64-aspeed_nvidia_ast2700_bmc-r0/installer.conf
@@ -9,3 +9,5 @@ VAR_LOG_SIZE=512
 
 # Additional kernel command line arguments
 ONIE_PLATFORM_EXTRA_CMDLINE_LINUX=""
+
+bootconf="sonic-ast2700-nvidia-spc6-bmc"


### PR DESCRIPTION
#### Why I did it

The NVIDIA AST2700 BMC `installer.conf` did not set `bootconf`. When `bootconf` is empty, `platform_arm64.conf`'s `prepare_boot_menu` skips the `fw_setenv bootconf` call entirely, leaving the pre-existing factory EVB value in U-Boot. The board then boots the generic AST2700 EVB DTB, which enables the FMC SPI-NOR flash and triggers a NULL-pointer kernel panic in `spi-aspeed-smc`, leaving the BMC in an endless reboot loop.

##### Work item tracking

#### How I did it

Set `bootconf` in `device/aspeed/arm64-aspeed_nvidia_ast2700_bmc-r0/installer.conf` to `sonic-ast2700-nvidia-spc6-bmc` so the installer writes the hardware-correct FIT boot configuration to the U-Boot env instead of leaving the pre-existing EVB factory value.

#### How to verify it

After `sudo sonic-installer install <bmc.bin>`, run `sudo fw_printenv bootconf` and confirm it retains the value `sonic-ast2700-nvidia-spc6-bmc` (previously it was reset to `ast2700-evb`). After reboot, `cat /proc/device-tree/model` should show the correct BMC platform string with no `spi-aspeed-smc` kernel panic or reboot loop.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

- master

#### Description for the changelog

Set `bootconf` for the NVIDIA AST2700 BMC so `sonic-installer` selects the correct BMC FIT boot configuration instead of the EVB default, fixing a kernel-panic reboot loop after install.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)
