### PR TITLE
[aspeed] net-install: honor static ip= boot arg instead of always using DHCP

### DIFF
--- a/platform/aspeed/installer/create_tftp_image.sh
+++ b/platform/aspeed/installer/create_tftp_image.sh
@@ -400,9 +400,10 @@ bootm \$loadaddr#conf-\$bootconf
 #
 #    Auto-reboot after a successful install is enabled by default.
 #    To stay in the installer shell after success, add: sonic_install.reboot=n
-#    Static IP instead of DHCP: add e.g. ip=192.168.1.50::192.168.1.1:255.255.255.0::eth0:off
-#    Static IP has no DHCP, so hostname URLs won't resolve — use an IP-literal URL.
-#    (network is always eth0)
+#    Static IP instead of DHCP (applied once eth0 is up; autoconf field must be off or none):
+#      ip=192.168.1.50::192.168.1.1:255.255.255.0::eth0:off
+#    Hostname image URLs need DNS fields appended, e.g. ...:eth0:off:8.8.8.8:8.8.4.4;
+#    IP-literal URLs need none. (network is always eth0)
 #
 # 3. Manual install (no sonic_install.bmc_image in bootargs): shell then
 #      /sbin/install-to-emmc.sh /tmp/$TFTP_IMAGE_NAME

--- a/platform/aspeed/tftp-installer-init/init
+++ b/platform/aspeed/tftp-installer-init/init
@@ -1,7 +1,8 @@
 #!/bin/sh
 # Net-install initramfs: minimal bring-up, then same driver load path as stock SONiC initramfs
 # (init-top + /conf/modules + init-premount/udev) so MDIO/I2C/GPIO/PHY deps match full initramfs.
-# If cmdline has sonic_install.bmc_image=, DHCP (or existing ip=) + fetch + /sbin/install-to-emmc.sh;
+# If cmdline has sonic_install.bmc_image=, static ip= (via klibc ipconfig) or DHCP + fetch +
+# /sbin/install-to-emmc.sh;
 # else interactive shell. Optional: sonic_install.reboot=n (network: always eth0)
 # (auto-reboot is the default on successful auto-install; reboot=n keeps the shell open).
 #
@@ -164,6 +165,17 @@ iface_has_ipv4() {
     ifconfig "$1" 2>/dev/null | grep -q 'inet '
 }
 
+# Echo the first ip= token's value (without the ip= prefix) from the kernel cmdline.
+# Deterministic: first match wins. Returns non-zero (and echoes nothing) when ip= is absent.
+get_cmdline_ip_arg() {
+    for x in $(cat /proc/cmdline); do
+        case "$x" in
+        ip=*) printf '%s\n' "${x#ip=}"; return 0 ;;
+        esac
+    done
+    return 1
+}
+
 bringup_network() {
     IFACE=eth0
     case "$onie_platform" in
@@ -191,6 +203,31 @@ bringup_network() {
         echo "Interface $IFACE already has an IPv4 address (kernel/ip=)."
         return 0
     fi
+
+    # The kernel's ip= autoconfig can't configure eth0 here — ftgmac100 is a module loaded above,
+    # after the kernel's late_initcall ipconfig — so apply a static ip= with klibc ipconfig.
+    # autoconf off/none = static (no DHCP); anything else uses the DHCP path below.
+    ip_arg=$(get_cmdline_ip_arg || true)
+    case "$ip_arg" in
+    *:*)
+        case "$(printf '%s' "$ip_arg" | cut -d: -f7)" in
+        off | none)
+            echo "Applying static ip= on $IFACE ($ip_arg)..."
+            if ipconfig -t 20 "$ip_arg" && iface_has_ipv4 "$IFACE"; then
+                # honor dns0/dns1 (ip= fields 8-9) so a hostname image URL can resolve
+                for _f in 8 9; do
+                    _ns=$(printf '%s' "$ip_arg" | cut -d: -f"$_f")
+                    [ -n "$_ns" ] && [ "$_ns" != "0.0.0.0" ] && echo "nameserver $_ns"
+                done > /etc/resolv.conf
+                return 0
+            fi
+            echo "Error: static ip= failed to configure $IFACE (check the ip= string)."
+            return 1
+            ;;
+        esac
+        ;;
+    esac
+
     if [ ! -x /sbin/udhcpc.script ]; then
         echo "Error: /sbin/udhcpc.script missing (net-install initrd must ship udhcpc.script next to install-to-emmc.sh)."
         return 1


### PR DESCRIPTION
#### Why I did it

The Aspeed AST2700 BMC TFTP/FIT net-installer ignored a static `ip=...:eth0:off` kernel boot argument and always ran DHCP (`udhcpc`) on `eth0`. `bringup_network()` only checked whether `eth0` already had an IPv4 address — which it assumed the kernel's in-kernel `ip=` autoconfiguration had applied — and otherwise fell back to DHCP. That in-kernel autoconfiguration cannot run in this initramfs because `ftgmac100` is a loadable module that the initramfs loads itself, after the kernel's one-shot `late_initcall(ip_auto_config)` has already run with no NIC present. So the static configuration was never applied and DHCP always won, even when the operator explicitly requested a static address.

##### Work item tracking

#### How I did it

In `bringup_network()`, after the interface is brought up, the `ip=` token is parsed from `/proc/cmdline`. When its autoconf field is `off` or `none`, the static configuration is applied in userspace with klibc `ipconfig` (already shipped in the initrd) — the same mechanism Debian `initramfs-tools` `configure_networking()` uses when the NIC driver is a module. Nameservers from the `ip=` `dns0`/`dns1` fields are written to `/etc/resolv.conf` so a hostname image URL can still resolve. Every other `ip=` form (`dhcp`/`on`/`any`/`bootp`) and the no-`ip=` case keep the existing `udhcpc` path unchanged. `create_tftp_image.sh` gains updated comments in the generated U-Boot instructions describing the static `ip=` usage and the optional DNS fields.

#### How to verify it

1. Build the bundle: `make target/sonic-aspeed-arm64.bin`, then `./platform/aspeed/installer/create_tftp_image.sh target/aspeed-tftp`.
2. In U-Boot, boot the FIT with a static address and an IP-literal image URL, e.g. `root=/dev/ram0 rw ip=<ip>::<gw>:<mask>::eth0:off sonic_install.bmc_image=http://<server-ip>/sonic-aspeed-arm64-emmc.img.gz`. Confirm the console prints `Applying static ip= on eth0 ...`, that no `Running DHCP on eth0` / `udhcpc` line appears, and that the eMMC fetch proceeds over the static address.
3. Regression: boot with no `ip=` and confirm DHCP still runs as before; boot with `ip=dhcp` and confirm it also uses the existing DHCP path.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

- master

#### Description for the changelog

Aspeed BMC net-installer: honor a static `ip=` kernel boot argument (applied via klibc `ipconfig`) instead of always falling back to DHCP.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)
