### PR TITLE
[device]: Remove hardcoded ZMQ fields from DNX context_config.json

### DIFF
--- a/device/arista/x86_64-arista_7280cr3mk_32p4/Arista-7280CR3-C40/context_config.json
+++ b/device/arista/x86_64-arista_7280cr3mk_32p4/Arista-7280CR3-C40/context_config.json
@@ -7,9 +7,6 @@
             "dbCounters" : "COUNTERS_DB",
             "dbFlex": "FLEX_COUNTER_DB",
             "dbState" : "STATE_DB",
-            "zmq_enable" : false,
-            "zmq_endpoint": "tcp://127.0.0.1:5555",
-            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
             "switches": [
                 {
                     "index" : 0,

--- a/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/0/context_config.json
+++ b/device/arista/x86_64-arista_7280dr3a_36/Arista-7280DR3A-36/0/context_config.json
@@ -7,9 +7,6 @@
             "dbCounters" : "COUNTERS_DB",
             "dbFlex": "FLEX_COUNTER_DB",
             "dbState" : "STATE_DB",
-            "zmq_enable": false,
-            "zmq_endpoint": "tcp://127.0.0.1:5555",
-            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
             "switches": [
                 {
                     "index" : 0,

--- a/device/arista/x86_64-arista_7280r4_32qf_32df/Arista-7280R4-32QF-32DF-64O/context_config.json
+++ b/device/arista/x86_64-arista_7280r4_32qf_32df/Arista-7280R4-32QF-32DF-64O/context_config.json
@@ -7,9 +7,6 @@
             "dbCounters" : "COUNTERS_DB",
             "dbFlex": "FLEX_COUNTER_DB",
             "dbState" : "STATE_DB",
-            "zmq_enable" : false,
-            "zmq_endpoint": "tcp://127.0.0.1:5555",
-            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
             "switches": [
                 {
                     "index" : 0,

--- a/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/context_config.json
+++ b/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/context_config.json
@@ -7,9 +7,6 @@
             "dbCounters" : "COUNTERS_DB",
             "dbFlex": "FLEX_COUNTER_DB",
             "dbState" : "STATE_DB",
-            "zmq_enable" : false,
-            "zmq_endpoint": "tcp://127.0.0.1:5555",
-            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
             "switches": [
                 {
                     "index" : 0,

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/context_config.json
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/context_config.json
@@ -7,9 +7,6 @@
             "dbCounters" : "COUNTERS_DB",
             "dbFlex": "FLEX_COUNTER_DB",
             "dbState" : "STATE_DB",
-            "zmq_enable": false,
-            "zmq_endpoint": "tcp://127.0.0.1:5555",
-            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
             "switches": [
                 {
                     "index" : 0,

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/context_config.json
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/context_config.json
@@ -7,9 +7,6 @@
             "dbCounters" : "COUNTERS_DB",
             "dbFlex": "FLEX_COUNTER_DB",
             "dbState" : "STATE_DB",
-            "zmq_enable": false,
-            "zmq_endpoint": "tcp://127.0.0.1:5555",
-            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
             "switches": [
                 {
                     "index" : 0,

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/context_config.json
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/context_config.json
@@ -7,9 +7,6 @@
             "dbCounters" : "COUNTERS_DB",
             "dbFlex": "FLEX_COUNTER_DB",
             "dbState" : "STATE_DB",
-            "zmq_enable": false,
-            "zmq_endpoint": "tcp://127.0.0.1:5555",
-            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
             "switches": [
                 {
                     "index" : 0,

--- a/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O32-C32/context_config.json
+++ b/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O32-C32/context_config.json
@@ -7,9 +7,6 @@
             "dbCounters": "COUNTERS_DB",
             "dbFlex": "FLEX_COUNTER_DB",
             "dbState": "STATE_DB",
-            "zmq_enable": false,
-            "zmq_endpoint": "tcp://127.0.0.1:5555",
-            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
             "switches": [
                 {
                     "index": 0,

--- a/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/context_config.json
+++ b/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O64/context_config.json
@@ -7,9 +7,6 @@
             "dbCounters": "COUNTERS_DB",
             "dbFlex": "FLEX_COUNTER_DB",
             "dbState": "STATE_DB",
-            "zmq_enable": false,
-            "zmq_endpoint": "tcp://127.0.0.1:5555",
-            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
             "switches": [
                 {
                     "index": 0,

--- a/device/nokia/x86_64-nokia_ixr7250_x1b-r0/Nokia-IXR7250-X1b/context_config.json
+++ b/device/nokia/x86_64-nokia_ixr7250_x1b-r0/Nokia-IXR7250-X1b/context_config.json
@@ -7,9 +7,6 @@
             "dbCounters" : "COUNTERS_DB",
             "dbFlex": "FLEX_COUNTER_DB",
             "dbState" : "STATE_DB",
-            "zmq_enable" : false,
-            "zmq_endpoint": "tcp://127.0.0.1:5555",
-            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
             "switches": [
                 {
                     "index" : 0,

--- a/device/nokia/x86_64-nokia_ixr7250_x3b-r0/Nokia-IXR7250-X3B/0/context_config.json
+++ b/device/nokia/x86_64-nokia_ixr7250_x3b-r0/Nokia-IXR7250-X3B/0/context_config.json
@@ -7,9 +7,6 @@
             "dbCounters" : "COUNTERS_DB",
             "dbFlex": "FLEX_COUNTER_DB",
             "dbState" : "STATE_DB",
-            "zmq_enable": false,
-            "zmq_endpoint": "tcp://127.0.0.1:5555",
-            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
             "switches": [
                 {
                     "index" : 0,

--- a/device/nokia/x86_64-nokia_ixr7250_x3b-r0/Nokia-IXR7250-X3B/1/context_config.json
+++ b/device/nokia/x86_64-nokia_ixr7250_x3b-r0/Nokia-IXR7250-X3B/1/context_config.json
@@ -7,9 +7,6 @@
             "dbCounters" : "COUNTERS_DB",
             "dbFlex": "FLEX_COUNTER_DB",
             "dbState" : "STATE_DB",
-            "zmq_enable": false,
-            "zmq_endpoint": "tcp://127.0.0.1:5555",
-            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
             "switches": [
                 {
                     "index" : 1,

--- a/device/nokia/x86_64-nokia_ixr7250_x4-r0/Nokia-IXR7250-X4/context_config.json
+++ b/device/nokia/x86_64-nokia_ixr7250_x4-r0/Nokia-IXR7250-X4/context_config.json
@@ -7,9 +7,6 @@
             "dbCounters" : "COUNTERS_DB",
             "dbFlex": "FLEX_COUNTER_DB",
             "dbState" : "STATE_DB",
-            "zmq_enable": false,
-            "zmq_endpoint": "tcp://127.0.0.1:5555",
-            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
             "switches": [
                 {
                     "index" : 0,

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/context_config.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/context_config.json
@@ -7,9 +7,6 @@
             "dbCounters" : "COUNTERS_DB",
             "dbFlex": "FLEX_COUNTER_DB",
             "dbState" : "STATE_DB",
-            "zmq_enable": false,
-            "zmq_endpoint": "tcp://127.0.0.1:5555",
-            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
             "switches": [
                 {
                     "index" : 0,

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/context_config.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/context_config.json
@@ -7,9 +7,6 @@
             "dbCounters" : "COUNTERS_DB",
             "dbFlex": "FLEX_COUNTER_DB",
             "dbState" : "STATE_DB",
-            "zmq_enable": false,
-            "zmq_endpoint": "tcp://127.0.0.1:5555",
-            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
             "switches": [
                 {
                     "index" : 1,

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/context_config.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/context_config.json
@@ -7,9 +7,6 @@
             "dbCounters" : "COUNTERS_DB",
             "dbFlex": "FLEX_COUNTER_DB",
             "dbState" : "STATE_DB",
-            "zmq_enable": false,
-            "zmq_endpoint": "tcp://127.0.0.1:5555",
-            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
             "switches": [
                 {
                     "index" : 0,

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/context_config.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/context_config.json
@@ -7,9 +7,6 @@
             "dbCounters" : "COUNTERS_DB",
             "dbFlex": "FLEX_COUNTER_DB",
             "dbState" : "STATE_DB",
-            "zmq_enable": false,
-            "zmq_endpoint": "tcp://127.0.0.1:5555",
-            "zmq_ntf_endpoint": "tcp://127.0.0.1:5556",
             "switches": [
                 {
                     "index" : 1,


### PR DESCRIPTION
#### Why I did it

The three ZMQ fields in `context_config.json` (`zmq_enable`, `zmq_endpoint`, `zmq_ntf_endpoint`) hardcode the syncd ZMQ transport per platform. sonic-sairedis [PR #1919](https://github.com/sonic-net/sonic-sairedis/pull/1919) (merged, already in the current master submodule pin) made these fields optional via a three‑state parse (`EMPTY`/`ENABLED`/`DISABLED`): when a field is absent the value defaults to `EMPTY` and defers to the syncd command line.

By removing the hardcoded fields from the **DNX‑family** platforms, the ZMQ transport for those platforms becomes governed centrally by the CONFIG_DB toggle (`SYSTEM_DEFAULTS|swss_zmq` → `syncd_init_common.sh` → `-z zmq_sync`) instead of being pinned in each platform file.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Removed `zmq_enable`/`zmq_endpoint`/`zmq_ntf_endpoint` from the **ASIC_DB** (main NPU) context of the `context_config.json` files of DNX‑family platforms (Broadcom Jericho/Qumran/Ramon, Nokia J2 chassis, Nexthop 5010). 17 real files changed (symlinked HWSKUs follow automatically).

Scope decisions:
- **Gearbox** (`GB_ASIC_DB`) contexts are left unchanged (`zmq_enable: false`).
- **Supervisors** (fabric‑only: Arista 7800 SUP, Nokia IXR7250E SUP‑10) are out of scope.
- **Non‑DNX** platforms (XGS/Trident/Tomahawk) and **DPUs** are out of scope.

#### How to verify it

This is a behavior‑preserving change today:
- In‑scope platforms are all non‑DPU, and `syncd_init_common.sh` only appends `-z zmq_sync` for `switch_type == dpu`. So syncd is never launched with `-z` on these platforms.
- Previous state: `zmq_enable: false` → `DISABLED` → syncd resolves to Redis transport.
- New state: field absent → `EMPTY` → defers to command line (no `-z`) → syncd resolves to the same Redis transport.

Checks performed:
1. Every `context_config.json` in `device/` parses as valid JSON.
2. All required parser fields (`guid`, `name`, `dbAsic`, `dbCounters`, `dbFlex`, `dbState`, `switches`) remain present; only the optional ZMQ fields were removed.
3. `GB_ASIC_DB` contexts retain `zmq_enable: false`; only `ASIC_DB` contexts were stripped.
4. Excluded platforms (supervisors,  non‑DNX) are unchanged.
5. The merged sonic-sairedis [PR #1919](https://github.com/sonic-net/sonic-sairedis/pull/1919) parser guards each field with `item.contains(...)`, so an absent field yields `CONTEXT_CONFIG_ZMQ_EMPTY` with no parse error.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

- [ ] master (config‑only change; validated by JSON schema/parse checks and transport‑resolution analysis above)

#### Description for the changelog

Remove hardcoded ZMQ fields from DNX‑family context_config.json so ZMQ transport is controlled by the SYSTEM_DEFAULTS|swss_zmq toggle.

#### Link to config_db schema for YANG module changes

N/A — no YANG module changes.
