### PR TITLE
fix(docker-ptf): pin grpcio-tools to match protobuf so gNMI stubs load

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -306,14 +306,14 @@ RUN python3 -m pip install --upgrade --ignore-installed pip
 # setuptools on Python 3.9. The packages downgrade setuptools
 # to 40.x causing further installations to fail
 {% if PTF_ENV_PY_VER == "py3" %}
-{% set offending_packages = ["supervisor", "ipython", "exabgp==4.2.25", "grpcio-tools", "pybrctl", "pyrasite", "scapy", "thrift"] %}
+{% set offending_packages = ["supervisor", "ipython", "exabgp==4.2.25", "grpcio-tools==1.82.0", "pybrctl", "pyrasite", "scapy", "thrift"] %}
 {{ install_offending_packages(offending_packages) }}
 {% else %}
 RUN pip3 install setuptools \
         && pip3 install supervisor \
         && pip3 install ipython \
         && pip3 install exabgp==4.2.25 \
-        && pip3 install grpcio-tools \
+        && pip3 install grpcio-tools==1.82.0 \
         && pip3 install pybrctl \
         && pip3 install pyrasite \
         && pip3 install scapy \
@@ -338,18 +338,19 @@ RUN pip3 install Flask   \
     && pip3 install pyro4 rpyc \
     && pip3 install unittest-xml-reporting \
     && pip3 install python-libpcap \
-    && pip3 install grpcio \
+    && pip3 install grpcio==1.82.0 \
     && pip3 install six \
     && pip3 install itsdangerous \
     && pip3 install retrying \
     && pip3 install jinja2
 
-# gnxi/gnmi_cli_py ships pre-generated _pb2.py stubs; they are
-# Pin to 6.33.5 to match grpcio-tools keep a known-good version.
+# gnxi/gnmi_cli_py regenerates its _pb2.py stubs below with grpcio-tools'
+# protoc, so pin protobuf and grpcio-tools together: the generated gencode
+# must never outrun the runtime (protobuf requires runtime >= gencode).
 RUN set -e; \
     . /etc/os-release; \
     if [ "$VERSION_CODENAME" = "bookworm" ]; then \
-        pip install protobuf==6.33.5; \
+        pip install protobuf==7.35.1; \
     else \
         pip install protobuf; \
     fi


### PR DESCRIPTION
#### Why I did it

`docker-ptf` regenerates the `gnmi_cli_py` `*_pb2.py` stubs with `grpc_tools.protoc` from an **unpinned** `grpcio-tools`, while the protobuf runtime was pinned to `6.33.5`. Once `grpcio-tools` drifted to `1.82.0` on PyPI, its `protoc` emitted gencode `7.35.0`, which the older pinned runtime rejects at import:

```
google.protobuf.runtime_version.VersionError: Detected incompatible Protobuf
Gencode/Runtime versions when loading gnmi.proto: gencode 7.35.0 runtime 6.33.5.
Runtime version cannot be older than the linked gencode version.
```

`py_gnmicli.py` then crashes on import, so every telemetry/gNMI PTF test that shells it fails at the first `get` - e.g. `telemetry/test_telemetry.py::test_telemetry_ouput`, `telemetry/test_telemetry_cert_rotation.py::test_telemetry_post_cert_del`, `gnmi_e2e/test_telemetry_auth.py`. The generic assert text ("Telemetry server request should complete with certs", "'get' command failed to execute") makes it look like a cert/TLS problem, but the client dies before it ever connects.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

In `dockers/docker-ptf/Dockerfile.j2`, pin `grpcio-tools` and `protobuf` together so the generated gencode and the runtime can never drift apart:

- `grpcio-tools` -> `grpcio-tools==1.82.0` (both the `py3` `offending_packages` list and the non-`py3` branch)
- bookworm runtime `protobuf==6.33.5` -> `protobuf==7.35.1` (>= the `7.35.0` gencode that `grpcio-tools==1.82.0` emits, and picks up the newer protobuf fixes)

`grpcio-tools==1.82.0` requires `protobuf>=6.33.5,<8`, so `7.35.1` satisfies it with no resolver conflict. The `mixed` PTF env (which uses the shipped stubs, not regenerated ones) and the non-bookworm branch are left unchanged - they do not hit the gencode/runtime skew.

> Note: this moves the PTF protobuf runtime across the 6 -> 7 major line. It only touches the `docker-ptf` image; CI should validate the other protobuf consumers in that image.

#### How to verify it

Build the `docker-ptf` image and confirm the regenerated gNMI stubs import:

```
python3 -c "import sys; sys.path.insert(0,'/root/gnxi/gnmi_cli_py'); import gnmi_pb2; print('gnmi_pb2 ok')"
```

Then run a telemetry test against a VS testbed, e.g. `telemetry/test_telemetry.py::test_telemetry_ouput` - it should no longer fail with `VersionError`.

#### Which release branch to backport (provide reason below if selected)

N/A - raising direct PRs per affected branch (master, 202511, 202605), each carrying the same unpinned-`grpcio-tools` + pinned-`protobuf` pattern. Companion PRs are cross-linked below once opened. Backport checkboxes intentionally left unchecked to avoid duplicate auto-cherry-picks.

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

- [ ] <!-- pending CI PTF image build -->

#### Description for the changelog

[docker-ptf] Pin grpcio-tools==1.82.0 and protobuf==7.35.1 so regenerated gNMI stubs load

---
**Companion PRs (same fix, per branch):** master #28270 &middot; 202605 #28271 &middot; 202511 #28272