### PR TITLE
[ci]: Add daily Bazel build pipeline

### DIFF
--- a/.azure-pipelines/azure-pipelines-bazel-daily.yml
+++ b/.azure-pipelines/azure-pipelines-bazel-daily.yml
@@ -1,0 +1,101 @@
+pr: none
+trigger: none
+
+schedules:
+- cron: "0 0 * * *"
+  displayName: Daily Bazel Build
+  branches:
+    include:
+    - master
+  always: true
+
+
+name: $(TeamProject)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
+
+resources:
+  repositories:
+  - repository: buildimage
+    type: github
+    name: sonic-net/sonic-buildimage
+    endpoint: sonic-net
+    ref: master
+
+
+variables:
+- template: .azure-pipelines/azure-pipelines-repd-build-variables.yml@buildimage
+- template: .azure-pipelines/template-variables.yml@buildimage
+- name: CACHE_MODE
+  value: rcache
+- name: ENABLE_FIPS
+  value: y
+- name: BUILD_BRANCH
+  ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+    value: $(System.PullRequest.TargetBranch)
+  ${{ else }}:
+    value: $(Build.SourceBranchName)
+
+
+stages:
+- stage: BuildVS
+  pool: sonicso1ES-amd64
+  jobs:
+  - template: azure-pipelines-build.yml
+    parameters:
+      buildOptions: 'USERNAME=admin SONIC_BUILD_JOBS=$(nproc) BUILD_WITH_BAZEL_WHEN_AVAILABLE=y BUILD_MULTIASIC_KVM=y INCLUDE_DHCP_SERVER=y ${{ variables.VERSION_CONTROL_OPTIONS }}'
+      jobGroups:
+      - name: vs
+  - template: azure-pipelines-build.yml
+    parameters:
+      buildOptions: 'USERNAME=admin SONIC_BUILD_JOBS=$(nproc) BUILD_WITH_BAZEL_WHEN_AVAILABLE=y ${{ variables.VERSION_CONTROL_OPTIONS }}'
+      jobGroups:
+      - name: vpp
+        continueOnError: true
+  - template: azure-pipelines-build.yml
+    parameters:
+      buildOptions: 'USERNAME=admin SONIC_BUILD_JOBS=2 BUILD_WITH_BAZEL_WHEN_AVAILABLE=y ${{ variables.VERSION_CONTROL_OPTIONS }}'
+      jobGroups:
+      - name: alpinevs
+        continueOnError: true
+
+- stage: Build
+  pool: sonicso1ES-amd64
+  dependsOn: []
+  jobs:
+  - template: azure-pipelines-build.yml
+    parameters:
+      buildOptions: 'USERNAME=admin SONIC_BUILD_JOBS=$(nproc) BUILD_WITH_BAZEL_WHEN_AVAILABLE=y ${{ variables.VERSION_CONTROL_OPTIONS }}'
+      jobGroups:
+      - name: broadcom
+        variables:
+          swi_image: yes
+          docker_syncd_rpc_image: yes
+          dbg_image: yes
+          platform_rpc: brcm
+          INCLUDE_RESTAPI: y
+      - name: mellanox
+        variables:
+          dbg_image: yes
+          docker_syncd_rpc_image: yes
+          session_monitor: yes
+          platform_rpc: mlnx
+      - name: marvell-prestera-arm64
+        pool: sonicso1ES-arm64
+        variables:
+          PLATFORM_NAME: marvell-prestera
+          PLATFORM_ARCH: arm64
+      - name: marvell-prestera-armhf
+        pool: sonicso1ES-armhf
+        timeoutInMinutes: 1200
+        variables:
+          PLATFORM_NAME: marvell-prestera
+          PLATFORM_ARCH: armhf
+          INCLUDE_RESTAPI: y
+      - name: nvidia-bluefield
+        pool: sonicso1ES-arm64
+        variables:
+          PLATFORM_ARCH: arm64
+      - name: aspeed-arm64
+        pool: sonicso1ES-arm64
+        variables:
+          PLATFORM_NAME: aspeed
+          PLATFORM_ARCH: arm64

--- a/rules/config
+++ b/rules/config
@@ -213,6 +213,12 @@ INCLUDE_DHCP_SERVER ?= n
 # INCLUDE_P4RT - build docker-p4rt for P4RT support
 INCLUDE_P4RT = n
 
+# BUILD_WITH_BAZEL_WHEN_AVAILABLE - build components that support a Bazel
+# build via Bazel instead of the traditional path. Kept at n as a
+# temporary phase-1 default while the Bazel build path is being
+# introduced incrementally; expected to change as the migration proceeds.
+BUILD_WITH_BAZEL_WHEN_AVAILABLE ?= n
+
 # INCLUDE_PTF - build docker-ptf and docker-ptf-sai test containers.
 # These are only needed for PTF (Packet Test Framework) testing and are
 # not included in the final switch image. Disabling saves ~28 minutes


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Introduce a daily Bazel build pipeline to exercise the Bazel build path as it is
rolled out incrementally. It is gated behind `BUILD_WITH_BAZEL_WHEN_AVAILABLE`,
which defaults to `n` (phase 1), so all existing pipelines are unaffected.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- `rules/config`: add `BUILD_WITH_BAZEL_WHEN_AVAILABLE ?= n` (temporary phase-1 default).
- `.azure-pipelines/azure-pipelines-bazel-daily.yml`: new pipeline — schedule-triggered
  (daily on `master`, `always: true`) + manual only (`trigger/pr: none`), each leg built
  with `BUILD_WITH_BAZEL_WHEN_AVAILABLE=y`. It covers the same platform set as the main
  `azure-pipelines.yml` build stages: `vs`, `vpp`, `alpinevs`, `broadcom`, `mellanox`,
  `marvell-prestera-arm64`, `marvell-prestera-armhf`, `nvidia-bluefield`, `aspeed-arm64`
  (not every platform in `azure-pipelines-build.yml`'s default jobGroups — e.g.
  `barefoot`, `marvell-teralynx`, `nephos`, `pensando` are not included).

#### How to verify it
- Run the `azure-pipelines-bazel-daily` pipeline manually (or wait for the daily
  schedule) and confirm every platform leg builds.
- Existing pipelines are unchanged: they don't pass the flag and inherit the `?= n`
  default.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

