### PR TITLE
[202605] fix(docker-ptf): replace end-of-life Wireshark with source-built 4.6.6 CLI tools

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -96,12 +96,43 @@ RUN apt-get update          \
         automake            \
         iproute2            \
         iptables            \
-{% if PTF_ENV_PY_VER != "mixed" %}
-        wireshark-common    \
-{% endif %}
         freeradius          \
         quilt               \
     && rm -rf /var/lib/apt/lists/*
+
+{% if PTF_ENV_PY_VER != "mixed" %}
+# Build the Wireshark capture CLI tools (dumpcap/editcap/mergecap) used by PTF
+# tests from a maintained Wireshark release. Debian bookworm only ships the
+# end-of-life Wireshark 4.0.x (libwireshark16), flagged EOL by security scans,
+# so the wireshark-common package is no longer installed. These tools link only
+# libwiretap/libwsutil, so the dissection engine (libwireshark/epan), tshark and
+# the Qt GUI are disabled to keep the build minimal.
+RUN WIRESHARK_VERSION=4.6.6 \
+    && WIRESHARK_SHA256=27e7ff780cd68a7466082be82ca26c06a002e74a71646ef3a6e4683e444c1a86 \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libglib2.0-dev libgcrypt20-dev libpcre2-dev libc-ares-dev libxml2-dev \
+        zlib1g-dev libnl-3-dev libnl-genl-3-dev libnl-route-3-dev xz-utils \
+    && curl -fL "https://www.wireshark.org/download/src/all-versions/wireshark-${WIRESHARK_VERSION}.tar.xz" -o /tmp/wireshark.tar.xz \
+    && echo "${WIRESHARK_SHA256}  /tmp/wireshark.tar.xz" | sha256sum -c - \
+    && tar -C /tmp -xJf /tmp/wireshark.tar.xz \
+    && cmake -S "/tmp/wireshark-${WIRESHARK_VERSION}" -B /tmp/wireshark-build \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_wireshark=OFF -DBUILD_logray=OFF \
+        -DBUILD_tshark=OFF -DBUILD_tfshark=OFF -DBUILD_rawshark=OFF -DBUILD_sharkd=OFF \
+        -DBUILD_dftest=OFF -DBUILD_randpkt=OFF -DBUILD_fuzzshark=OFF \
+        -DBUILD_capinfos=OFF -DBUILD_captype=OFF -DBUILD_reordercap=OFF -DBUILD_text2pcap=OFF \
+        -DBUILD_dumpcap=ON -DBUILD_editcap=ON -DBUILD_mergecap=ON \
+        -DBUILD_androiddump=OFF -DBUILD_sshdump=OFF -DBUILD_ciscodump=OFF -DBUILD_wifidump=OFF \
+        -DBUILD_dpauxmon=OFF -DBUILD_udpdump=OFF -DBUILD_sdjournal=OFF -DBUILD_randpktdump=OFF \
+        -DBUILD_mmdbresolve=OFF -DENABLE_PCAP=ON -DENABLE_PLUGINS=OFF \
+    && cmake --build /tmp/wireshark-build -j"$(nproc)" --target dumpcap editcap mergecap \
+    && install -m 0755 /tmp/wireshark-build/run/dumpcap /tmp/wireshark-build/run/editcap /tmp/wireshark-build/run/mergecap /usr/local/bin/ \
+    && cp -a /tmp/wireshark-build/run/libwiretap.so* /tmp/wireshark-build/run/libwsutil.so* /usr/local/lib/ \
+    && echo /usr/local/lib > /etc/ld.so.conf.d/wireshark-tools.conf \
+    && ldconfig \
+    && rm -rf /tmp/wireshark.tar.xz "/tmp/wireshark-${WIRESHARK_VERSION}" /tmp/wireshark-build /var/lib/apt/lists/*
+{% endif %}
 
 # Install Go toolchain for building grpcurl and gnmic from source
 # to ensure they use a patched Go stdlib (GO-2026-4337: crypto/tls)


### PR DESCRIPTION
#### Why I did it

Debian bookworm only ships Wireshark 4.0.x (`libwireshark16` 4.0.17). The Wireshark 4.0 branch reached end of life on 2024-08-28, so security scans flag it as EOL. The `docker-ptf` image installs `wireshark-common`, and via apt recommends that package also pulls in the full `wireshark` / `wireshark-qt` GUI, the Qt5 stack and the `libwireshark16` dissection engine - none of which a headless PTF container needs.

PTF tests only use the capture CLI tools `dumpcap`, `editcap` and `mergecap` (`advanced-reboot.py`, `tests/common/helpers/tcpdump_sniff_helper.py` and the `erspan_mirror` plugin in sonic-mgmt). Those tools link `libwiretap`/`libwsutil` and do not need the dissection engine, so there is no need to ship any Wireshark 4.0.x package.

##### Work item tracking
- Microsoft ADO **(number only)**: 38420321

#### How I did it

In `dockers/docker-ptf/Dockerfile.j2`:

- Removed the `wireshark-common` apt package (which was dragging in the EOL Wireshark 4.0.x GUI + dissection engine).
- Added a source build of `dumpcap`, `editcap` and `mergecap` from the maintained Wireshark 4.6.6 release (SHA256-pinned tarball), configured with the Qt GUI, `tshark`, `rawshark`, `sharkd` and the `libwireshark`/epan dissection engine all disabled. Only the three targets PTF needs are compiled, so the large dissector library is never built.
- Installed the three binaries into `/usr/local/bin` and their `libwiretap`/`libwsutil` support libraries into `/usr/local/lib` (+ `ldconfig`).

The result is an image with zero Wireshark 4.0.x packages, while `dumpcap`/`editcap`/`mergecap` remain available for the tests that rely on them.

#### How to verify it

1. Build the `docker-ptf` image and confirm no end-of-life Wireshark packages remain: `dpkg -l | grep -iE 'wireshark|libwireshark'` returns nothing.
2. Confirm the tools are present and maintained: `dumpcap --version`, `editcap --version`, `mergecap --version` all report `4.6.6`, and `ldd $(command -v editcap)` shows `libwiretap`/`libwsutil` only (no `libwireshark`).
3. Run PTF tests that exercise these tools (advanced-reboot capture, the tcpdump/mergecap sniff helper, and the erspan_mirror `editcap -C` path) and confirm they still work.

This was validated by reproducing the exact build block in a clean `debian:bookworm` container: all three binaries build, install to `/usr/local`, and run correctly from there with no `libwireshark` linkage after the build tree is removed.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

The other affected bookworm branches are handled by companion PRs rather than an automated backport: master (#28288) and 202511 (#28287).

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

[docker-ptf]: Replace end-of-life Wireshark 4.0.x with source-built 4.6.6 dumpcap/editcap/mergecap (GUI and dissection engine disabled).

#### Link to config_db schema for YANG module changes

N/A - no YANG/config_db changes.
