### PR TITLE
ci: force PTF_MODIFIED to False to pause in-PR docker-ptf testing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -135,10 +135,11 @@ stages:
   - name: testbed_file
     value: vtestbed.csv
   - name: PTF_MODIFIED
-    # Enable in-PR docker-ptf testing only when the PR modifies docker-ptf; the coalesce
-    # falls back to False otherwise (including non-PR builds), so the pull-once/reuse path
-    # is taken only when needed.
-    value: $[ coalesce(stageDependencies.BuildVS.vs.outputs['PublishAndSetPtfTag.PTF_MODIFIED'], stageDependencies.BuildVS.vs.outputs['script.PTF_MODIFIED'], stageDependencies.BuildVS.vs.outputs['script1.PTF_MODIFIED'], 'False') ]
+    # Force-disable in-PR docker-ptf testing while the docker-ptf image is not in a good
+    # state, to avoid bleeding unstable PTF code into every PR's test run. Re-enable the
+    # dynamic detection below (only tests when the PR modifies docker-ptf) once PTF is stable:
+    # value: $[ coalesce(stageDependencies.BuildVS.vs.outputs['PublishAndSetPtfTag.PTF_MODIFIED'], stageDependencies.BuildVS.vs.outputs['script.PTF_MODIFIED'], stageDependencies.BuildVS.vs.outputs['script1.PTF_MODIFIED'], 'False') ]
+    value: 'False'
   - name: PTF_IMAGE_TAG
     # Branch-aligned docker-ptf image tag used for PR test. PR builds only.
     ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:


### PR DESCRIPTION
The dynamic coalesce enabled in-PR docker-ptf testing whenever a PR touches docker-ptf. The docker-ptf image is not yet in a good state, so this bleeds unstable PTF code into those PRs' test runs. Hard-set PTF_MODIFIED to False to stop that; keep the dynamic-detection expression commented for easy re-enable once PTF is stable.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

