### PR TITLE
[YANG] Enhance PREFIX_LIST Yang model with optional fields

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -3288,11 +3288,38 @@ An example is as follows:
 ### Prefix List
 Prefix list table stores a list of prefixes with type and prefix separated by `|`. The specific configuration for the prefix type are then rendered by the PrefixListMgr. Currently ANCHOR_PREFIX is supported to add RADIAN configuration.
 
-An example is as follows:
+The following optional fields are supported for dynamic prefix list configuration:
+
+| Field   | Type   | Description                                                                 |
+|---------|--------|-----------------------------------------------------------------------------|
+| action  | string | Permit or deny action for this prefix entry (`permit` or `deny`)            |
+| seq     | uint32 | Sequence number (1–4294967295) for ordering prefix list entries             |
+| ge      | uint8  | Minimum prefix length to match, greater-than-or-equal (0–128)              |
+| le      | uint8  | Maximum prefix length to match, less-than-or-equal (0–128)                 |
+
+Note: `seq`, `ge`, and `le` are modeled as numeric YANG types, but in CONFIG_DB JSON they are stored as strings, as shown in the examples below.
+
+Examples:
 ```json
 {
     "PREFIX_LIST": {
-        "ANCHOR_PREFIX|fc00::/48": {}
+        "ANCHOR_PREFIX|fc00::/48": {},
+        "BGP_ALLOWED_IPV4|172.16.0.0/12": {
+            "action": "permit",
+            "seq": "200",
+            "ge": "16",
+            "le": "24"
+        },
+        "BGP_ALLOWED_IPV6|2001:db8::/32": {
+            "action": "permit",
+            "seq": "30",
+            "ge": "48",
+            "le": "64"
+        },
+        "BGP_DENIED_IPV4|10.255.0.0/16": {
+            "action": "deny",
+            "seq": "30"
+        }
     }
 }
 ```

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -3172,7 +3172,23 @@
         },
         "PREFIX_LIST": {
             "ANCHOR_PREFIX|10.0.0.0/8" : {},
-            "ANCHOR_PREFIX|FC00::/48" : {}
+            "ANCHOR_PREFIX|FC00::/48" : {},
+            "BGP_ALLOWED_IPV4|172.16.0.0/12": {
+                "action": "permit",
+                "seq": "200",
+                "ge": "16",
+                "le": "24"
+            },
+            "BGP_ALLOWED_IPV6|2001:db8::/32": {
+                "action": "permit",
+                "seq": "30",
+                "ge": "48",
+                "le": "64"
+            },
+            "BGP_DENIED_IPV4|10.255.0.0/16": {
+                "action": "deny",
+                "seq": "30"
+            }
         },
         "DEBUG_COUNTER": {
             "DEBUG_4": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_prefix_list.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_prefix_list.json
@@ -9,5 +9,73 @@
         "desc": "Load BGP prefix list table with an invalid prefix",
         "eStrKey": "InvalidValue",
         "eStr": ["prefix"]
+    },
+    "BGP_PREFIX_LIST_WITH_ALL_OPTIONAL_FIELDS": {
+        "desc": "Load BGP prefix list with action, seq, ge and le fields"
+    },
+    "BGP_PREFIX_LIST_WITH_PERMIT_ACTION": {
+        "desc": "Load BGP prefix list with permit action only"
+    },
+    "BGP_PREFIX_LIST_WITH_DENY_ACTION": {
+        "desc": "Load BGP prefix list with deny action only"
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_ACTION": {
+        "desc": "Load BGP prefix list with invalid action value",
+        "eStrKey": "InvalidValue",
+        "eStr": ["action"]
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_SEQ_ZERO": {
+        "desc": "Load BGP prefix list with seq value 0 (out of range)",
+        "eStrKey": "Range"
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_GE": {
+        "desc": "Load BGP prefix list with ge value 129 (out of range)",
+        "eStrKey": "Range"
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_LE": {
+        "desc": "Load BGP prefix list with le value 129 (out of range)",
+        "eStrKey": "Range"
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_IPV4_GE_LENGTH": {
+        "desc": "Load BGP prefix list with IPv4 prefix and ge=33 (must fail)",
+        "eStr": ["ge value must be <= 32 for IPv4 or <= 128 for IPv6"]
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_IPV4_LE_LENGTH": {
+        "desc": "Load BGP prefix list with IPv4 prefix and le=33 (must fail)",
+        "eStr": ["le value must be <= 32 for IPv4 or <= 128 for IPv6"]
+    },
+    "BGP_PREFIX_LIST_WITH_IPV6_VALID_GE_LE": {
+        "desc": "Load BGP prefix list with IPv6 prefix and ge=64 le=128 (valid)"
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_GE_GREATER_THAN_LE": {
+        "desc": "Load BGP prefix list with ge=24 and le=16 (ge > le must fail)",
+        "eStr": ["le value must be >= ge value"]
+    },
+    "BGP_PREFIX_LIST_WITH_GE_LESS_THAN_PREFIX_LENGTH": {
+        "desc": "Load BGP prefix list with 10.0.0.0/24 and ge=16 (ge < prefix length must fail)",
+        "eStr": ["ge value must be >= prefix length"]
+    },
+    "BGP_PREFIX_LIST_WITH_LE_LESS_THAN_PREFIX_LENGTH": {
+        "desc": "Load BGP prefix list with 10.0.0.0/24 and le=8 (le < prefix length must fail)",
+        "eStr": ["le value must be >= prefix length"]
+    },
+    "BGP_PREFIX_LIST_WITH_EMBEDDED_IPV4_IN_IPV6_VALID_GE_LE": {
+        "desc": "Load BGP prefix list with IPv6 embedded IPv4 prefix 2001:db8::192.0.2.0/120 and ge=120 le=128 (valid, proves not misclassified as IPv4)"
+    },
+    "BGP_PREFIX_LIST_WITH_EMBEDDED_IPV4_IN_IPV6_GE_LESS_THAN_PREFIX": {
+        "desc": "Load BGP prefix list with IPv6 embedded IPv4 prefix 2001:db8::192.0.2.0/120 and ge=64 (ge < prefix length must fail)",
+        "eStr": ["ge value must be >= prefix length"]
+    },
+    "BGP_PREFIX_LIST_WITH_SEQ_WITHOUT_ACTION": {
+        "desc": "Load BGP prefix list with seq but no action (must fail, seq requires action)",
+        "eStrKey": "When"
+    },
+    "BGP_PREFIX_LIST_WITH_GE_WITHOUT_ACTION": {
+        "desc": "Load BGP prefix list with ge but no action (must fail, ge requires action)",
+        "eStrKey": "When"
+    },
+    "BGP_PREFIX_LIST_WITH_LE_WITHOUT_ACTION": {
+        "desc": "Load BGP prefix list with le but no action (must fail, le requires action)",
+        "eStrKey": "When"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_prefix_list.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_prefix_list.json
@@ -36,5 +36,256 @@
         },
         "eStrKey": "InvalidValue",
         "eStr": ["prefix"]
+    },
+    "BGP_PREFIX_LIST_WITH_ALL_OPTIONAL_FIELDS": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/8",
+                        "action": "permit",
+                        "seq": "100",
+                        "ge": "16",
+                        "le": "24"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_PERMIT_ACTION": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.1.0.0/16",
+                        "action": "permit"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_DENY_ACTION": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "192.168.0.0/16",
+                        "action": "deny"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_ACTION": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/8",
+                        "action": "reject"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_SEQ_ZERO": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/8",
+                        "action": "permit",
+                        "seq": "0"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_GE": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/8",
+                        "action": "permit",
+                        "ge": "129"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_LE": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/8",
+                        "action": "permit",
+                        "le": "129"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_IPV4_GE_LENGTH": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/8",
+                        "action": "permit",
+                        "ge": "33"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_IPV4_LE_LENGTH": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/8",
+                        "action": "permit",
+                        "le": "33"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_IPV6_VALID_GE_LE": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "fc00::/48",
+                        "action": "permit",
+                        "ge": "64",
+                        "le": "128"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_INVALID_GE_GREATER_THAN_LE": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/8",
+                        "action": "permit",
+                        "ge": "24",
+                        "le": "16"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_GE_LESS_THAN_PREFIX_LENGTH": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/24",
+                        "action": "permit",
+                        "ge": "16"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_LE_LESS_THAN_PREFIX_LENGTH": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/24",
+                        "action": "permit",
+                        "le": "8"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_EMBEDDED_IPV4_IN_IPV6_VALID_GE_LE": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "2001:db8::192.0.2.0/120",
+                        "action": "permit",
+                        "ge": "120",
+                        "le": "128"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_EMBEDDED_IPV4_IN_IPV6_GE_LESS_THAN_PREFIX": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "2001:db8::192.0.2.0/120",
+                        "action": "permit",
+                        "ge": "64"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_SEQ_WITHOUT_ACTION": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/8",
+                        "seq": "100"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_GE_WITHOUT_ACTION": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/8",
+                        "ge": "16"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PREFIX_LIST_WITH_LE_WITHOUT_ACTION": {
+        "sonic-bgp-prefix-list:sonic-bgp-prefix-list": {
+            "sonic-bgp-prefix-list:PREFIX_LIST": {
+                "PREFIX_LIST_LIST": [
+                    {
+                        "prefix_type": "DOWNSTREAM_PREFIX",
+                        "ip-prefix": "10.0.0.0/8",
+                        "le": "16"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-bgp-prefix-list.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-prefix-list.yang
@@ -10,10 +10,18 @@ module sonic-bgp-prefix-list {
         prefix stypes;
     }
 
+    import sonic-routing-policy-sets {
+        prefix rpolsets;
+    }
+
     description "SONIC Device-specfifc BGP prefix lists data";
 
+    revision 2026-05-18 {
+        description "Add optional action, seq, ge and le leaves; require action for seq, ge, and le";
+    }
+
     revision 2025-02-17 {
-        description "Updated description and leafs for PREFIX_LIST_LIST";
+        description "Updated description and leaves for PREFIX_LIST_LIST";
     }
 
     revision 2025-02-05 {
@@ -55,6 +63,54 @@ module sonic-bgp-prefix-list {
                     must "(contains(../ip-prefix, ':') and current()='IPv6') or
                         (contains(../ip-prefix, '.') and current()='IPv4')";
                     type stypes:ip-family;
+                }
+
+                leaf action {
+                    type rpolsets:routing-policy-action-type;
+                    description "Permit or deny action for this prefix entry";
+                }
+
+                leaf seq {
+                    when "../action";
+                    type uint32 {
+                        range "1..4294967295";
+                    }
+                    description "Sequence number for ordering prefix list entries. Optional, but should be provided when a specific execution order is needed";
+                }
+
+                leaf ge {
+                    when "../action";
+                    must "(contains(../ip-prefix, '.') and . <= 32) or
+                        (contains(../ip-prefix, ':') and . <= 128)" {
+                        error-message "ge value must be <= 32 for IPv4 or <= 128 for IPv6";
+                    }
+                    must ". >= number(substring-after(../ip-prefix, '/'))" {
+                        error-message "ge value must be >= prefix length";
+                    }
+                    type uint8 {
+                        range "0..128";
+                    }
+                    description "Minimum prefix length to match (greater-than-or-equal)";
+                }
+
+                leaf le {
+                    when "../action";
+                    must "(contains(../ip-prefix, '.') and . <= 32) or
+                        (contains(../ip-prefix, ':') and . <= 128)" {
+                        error-message "le value must be <= 32 for IPv4 or <= 128 for IPv6";
+                    }
+                    must ". >= number(substring-after(../ip-prefix, '/'))" {
+                        error-message "le value must be >= prefix length";
+                    }
+                    /* If ge is not set, skip this check.
+                       If ge is set, enforce le >= ge. */
+                    must "not(../ge) or current() >= ../ge" {
+                        error-message "le value must be >= ge value";
+                    }
+                    type uint8 {
+                        range "0..128";
+                    }
+                    description "Maximum prefix length to match (less-than-or-equal)";
                 }
             }
         }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This PR enhances the existing `PREFIX_LIST` Yang model by adding optional fields for `action`, `seq`, `ge` and `le`.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Added 4 optional leaves to `PREFIX_LIST_LIST` in `sonic-bgp-prefix-list.yang`:
- Added `must` constraints.
- Added 11 new Yang model test cases.
- Updated `Configuration.md` with examples
- Updated `sample_config_db.json` with a new example entry.
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

