### PR TITLE
[build] fix ijson source build failure by bumping setuptools to 78.1.1 and adding libyajl-dev

### DIFF
--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -108,6 +108,7 @@ RUN apt-get update && apt-get install -y eatmydata && eatmydata apt-get install 
         dh-exec \
         kmod \
         libtinyxml2-dev \
+        libyajl-dev \
         python3 \
         python3-pip \
         python3-setuptools \
@@ -632,7 +633,9 @@ RUN pip3 install mmh3==2.5.1
 
 # PEP 517 wheels (e.g. src/ptf-py3): slave.mk runs "python -m build -n" without isolation, so [build-system]
 # requires must be present on the host interpreter (pip install . alone uses an isolated build env).
-RUN pip3 install setuptools==75.8.0 setuptools-scm==8.2.1 setuptools-scm-git-archive==1.4.1 wheel
+# setuptools >= 77 is required to parse PEP 639 SPDX license expressions (e.g. ijson's
+# license = "BSD-3-Clause AND ISC"); older releases fail from-source builds of such sdists.
+RUN pip3 install setuptools==78.1.1 setuptools-scm==8.2.1 setuptools-scm-git-archive==1.4.1 wheel
 
 RUN eatmydata apt-get install -y xsltproc
 


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Building the trixie sonic-utilities wheels fails while preparing metadata for the `ijson` sdist:
```
error: subprocess-exited-with-error
Preparing metadata (pyproject.toml) did not run successfully.
ValueError: invalid pyproject.toml config: `project.license`.
configuration error: `project.license` must be valid exactly by one definition
GIVEN VALUE: "BSD-3-Clause AND ISC
```
when pip installs `ijson` from source in the trixie slave, the host interpreter's setuptools was pinned to `75.8.0`, which predates PEP 639 support (added in setuptools 77.0.0). It therefore rejects ijson's SPDX license expression `license = "BSD-3-Clause AND ISC"`, so any from-source ijson build fails.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
In `sonic-slave-trixie/Dockerfile.j2`:
- upgrade `setuptools` from `75.8.0` to `78.1.1`
- Added `libyajl-dev` to the apt install list so ijson's C backend finds `yajl/yajl_version.h` and compiles cleanly.
#### How to verify it
Without this change, in `sonic_yang_models` log, installing `ijson` failed:
```
Collecting ijson>=3.2.3 (from sonic-yang-mgmt==1.0)
  Using cached ijson-3.5.0.tar.gz (68 kB)
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'error'
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
```
log in `sonic_yang_models` from this PR checker build:
```
Collecting ijson>=3.2.3 (from sonic-yang-models==1.0)
  Downloading ijson-3.5.0.tar.gz (68 kB)
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

