### PR TITLE
Enable PFC watchdog by default on start

### DIFF
--- a/rules/config
+++ b/rules/config
@@ -97,7 +97,7 @@ BMC_ROOT_ACCOUNT_DEFAULT_PASSWORD ?=
 
 # ENABLE_PFCWD_ON_START - if set to y PFC Watchdog (PFCWD) will be enabled all server-facing ports
 # by default for TOR switch
-# ENABLE_PFCWD_ON_START = y
+ENABLE_PFCWD_ON_START = y
 
 # INSTALL_DEBUG_TOOLS - installs debugging tools in baseline docker
 # Uncomment next line to enable:


### PR DESCRIPTION
Change-Id: Ib66bc8486af2a1968fba855d0ab0833cffed237a

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The test case`generic_config_updater/test_pfcwd_status.py::test_start_pfcwd` expects PFC watchdog to be enabled by default on start. Previously it was disabled, causing the test to fail. Enabling by default satisfies the test's preconditions.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Uncommented `ENABLE_PFCWD_ON_START` in `rules/config` and set it to `y`.
#### How to verify it
Build the image with the updated config, boot it on, then query the Config DB: 
sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" default_pfcwd_status 
Expected output `"enable"`.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Enable PFC watchdog by default on start
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

