### PR TITLE
[Mellanox] add a new reset cause to the platform API

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -1204,6 +1204,7 @@ class Chassis(ChassisBase):
             'reset_comex_pwr_fail'      :   self.REBOOT_CAUSE_POWER_LOSS,
             'reset_main_51v'            :   self.REBOOT_CAUSE_POWER_LOSS,
             'reset_mgmt_pwr_fail'       :   self.REBOOT_CAUSE_POWER_LOSS,
+            'reset_sw_pwr_off'          :   self.REBOOT_CAUSE_POWER_LOSS,
             'reset_asic_thermal'        :   self.REBOOT_CAUSE_THERMAL_OVERLOAD_ASIC,
             'reset_cpu_thermal'         :   self.REBOOT_CAUSE_THERMAL_OVERLOAD_CPU,
             'reset_comex_thermal'       :   self.REBOOT_CAUSE_THERMAL_OVERLOAD_CPU,


### PR DESCRIPTION
#### Why I did it
The Mellanox platform API maps hardware reset-cause files under /var/run/hwmanagement/system to SONiC reboot-cause categories. A new hardware reset cause, reset_sw_pwr_off (software-triggered power off), was not recognized by the platform API. As a result, when a system rebooted due to this cause, the reboot reason would be reported as unknown/generic instead of being properly categorized.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added the reset_sw_pwr_off entry to the _reboot_major_cause_dict_ in _Chassis.initialize_reboot_cause()_

#### How to verify it
1. On a Mellanox platform, trigger (or simulate) the reset_sw_pwr_off condition so that the corresponding file under /var/run/hwmanagement/system/reset_sw_pwr_off is set to 1.
2. Run show reboot-cause (or call the platform API get_reboot_cause()).
3. Verify the reported reboot cause is Power Loss (REBOOT_CAUSE_POWER_LOSS) rather than an unknown/generic cause.

Tested via BMC test _test_switch_host_do_power_cycle_ with 202605 SwitchHost image. 

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202605 
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

