### PR TITLE
Add optional platform metadata to ONIE installer header

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -90,6 +90,13 @@ generate_onie_installer_image()
     if [ ! -f $platform_conf_file ]; then
         platform_conf_file="platform/$TARGET_MACHINE/platform.conf"
     fi
+
+    # Optional platform metadata header for installer images.
+    if [ -z "${INSTALLER_PLATFORM_METADATA:-}" ] && [ -n "$TARGET_MACHINE" ] && [ -f "platform/${TARGET_MACHINE}/platform_metadata" ]; then
+        INSTALLER_PLATFORM_METADATA="$(pwd)/platform/${TARGET_MACHINE}/platform_metadata"
+    fi
+    export INSTALLER_PLATFORM_METADATA
+
     ## Generate an ONIE installer image
     ## Note: Don't leave blank between lines. It is single line command.
     ./onie-mk-demo.sh $CONFIGURED_ARCH $TARGET_MACHINE $TARGET_PLATFORM-$TARGET_MACHINE-$ONIEIMAGE_VERSION \

--- a/installer/sharch_body.sh
+++ b/installer/sharch_body.sh
@@ -8,7 +8,11 @@
 ## Shell archive template
 ##
 ## Strings of the form %%VAR%% are replaced during construction.
+## %%PLATFORM_METADATA%% is replaced with optional platform metadata lines from
+## platform/${TARGET_MACHINE}/platform_metadata (or removed) by onie-mk-demo.sh.
 ##
+
+%%PLATFORM_METADATA%%
 
 echo -n "Verifying image checksum ..."
 payload_image_size=%%PAYLOAD_IMAGE_SIZE%%

--- a/onie-mk-demo.sh
+++ b/onie-mk-demo.sh
@@ -136,6 +136,22 @@ sed -i -e "s/%%IMAGE_SHA1%%/$sha1/" $output_file
 echo -n "."
 tar_size="$(wc -c < "${sharch}")"
 sed -i -e "s|%%PAYLOAD_IMAGE_SIZE%%|${tar_size}|" ${output_file}
+
+# Optional installer header from INSTALLER_PLATFORM_METADATA.
+if [ -n "$INSTALLER_PLATFORM_METADATA" ] && [ -f "$INSTALLER_PLATFORM_METADATA" ]; then
+    awk -v metafile="$INSTALLER_PLATFORM_METADATA" '
+/^%%PLATFORM_METADATA%%$/ {
+  while ((getline line < metafile) > 0) print line
+  close(metafile)
+  print ""
+  next
+}
+{ print }
+' "$output_file" > "${output_file}.tmp" && mv -f "${output_file}.tmp" "$output_file"
+else
+    sed -i -e '/^%%PLATFORM_METADATA%%$/d' "$output_file"
+fi
+
 cat $sharch >> $output_file
 echo "secure upgrade flags: SECURE_UPGRADE_MODE = $SECURE_UPGRADE_MODE, \
 SECURE_UPGRADE_DEV_SIGNING_KEY = $SECURE_UPGRADE_DEV_SIGNING_KEY, SECURE_UPGRADE_SIGNING_CERT = $SECURE_UPGRADE_SIGNING_CERT"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Some platforms may need image-header-visible metadata for some system bringup or install flows, such as artifact (like SDK) versions etc. This adds an optional `platform_metadata` hook for ONIE installer images.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- `build_image.sh` exports `INSTALLER_PLATFORM_METADATA`; when unset, it defaults to `platform/${TARGET_MACHINE}/platform_metadata` if that file exists.
- `installer/sharch_body.sh` adds a `%%PLATFORM_METADATA%%` placeholder near the top of the generated installer shell header.
- `onie-mk-demo.sh` replaces the placeholder with the metadata file contents when present, or removes the placeholder line when no metadata file is provided.

#### How to verify it

build image with required metadat in platform/${TARGET_MACHINE}/platform_metadata file
e.g.:
```
cat platform/cisco-8000/platform_metadata
## SDK XYZ: 26.x.y.z
##
```

- Verified the shell-header substitution logic with a local fixture:
  - metadata present: generated header contains `## artifact foo: 1.2.3` and `## setting bar: enabled`
  - metadata absent: standalone `%%PLATFORM_METADATA%%` placeholder line is removed
e.g.:
```
cat sonic-cisco-8000.bin | head -15
#!/bin/sh

#  Copyright (C) 2013 Curt Brune <curt@cumulusnetworks.com>
#
#  SPDX-License-Identifier:     GPL-2.0

##
## Shell archive template
##
## Strings of the form %%VAR%% are replaced during construction.
##

## SDK XYZ: 26.x.y.z
## 

```

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

No backport requested; this is a feature.

#### Tested branch (Please provide the tested image version)

- [ ] Not tested with a full image build; local script/template validation only
- [ ] <!-- image version 2 -->

#### Description for the changelog

Add optional platform metadata injection to ONIE installer image headers.

#### Link to config_db schema for YANG module changes

N/A - no YANG or config_db schema changes.

#### A picture of a cute animal (not mandatory but encouraged)