### PR TITLE
[snmpd]: Add optional local patch hook to net-snmp build

### DIFF
--- a/src/snmpd/Makefile
+++ b/src/snmpd/Makefile
@@ -29,6 +29,14 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 
 	pushd net-snmp-$(SNMPD_VERSION)
 	git init
+
+	# Apply optional local patches (e.g. downstream/vendor fixes) dropped into
+	# ../patches/ before recording the baseline commit. No-op when the series
+	# file is absent, so upstream builds are unaffected.
+	if [ -f ../patches/series ]; then
+		while read -r file; do echo $$file; patch -p1 < ../patches/$$file; done < ../patches/series
+	fi
+
 	git add -f *
 	git commit -m "unmodified snmpd source"
 


### PR DESCRIPTION
#### Why I did it

The net-snmp build recipe (`src/snmpd/Makefile`) is a recurring merge-conflict
point for us. We carry a small local net-snmp fix and need a place to apply it
during the build, but the only way to do that today is to edit this Makefile
directly — which then collides on every rebase against upstream.

Rather than keep diverging on the Makefile, I'd like to add a tiny, dormant
extension point upstream so downstreams/vendors can drop local net-snmp patches
in without touching the build rule at all.

#### How I did it

Before the baseline `git commit -m "unmodified snmpd source"`, apply any patches
listed in `src/snmpd/patches/series` with plain `patch -p1`:

```make
	git init

	# Apply optional local patches (e.g. downstream/vendor fixes) dropped into
	# ../patches/ before recording the baseline commit. No-op when the series
	# file is absent, so upstream builds are unaffected.
	if [ -f ../patches/series ]; then
		while read -r file; do echo $$file; patch -p1 < ../patches/$$file; done < ../patches/series
	fi

	git add -f *
```

The whole thing is guarded by `[ -f ../patches/series ]`, so:

- Upstream ships **no** `src/snmpd/patches/` directory, so the block is a
  complete no-op — the build behaves exactly as before.
- The existing `stg import -s ../patch-$(SNMPD_VERSION)/series` flow is
  untouched and still runs afterward; this hook only lets you seed extra local
  patches into the pristine tree first.

#### How to verify it

1. Build snmpd as usual on a clean tree — behavior is identical (no `patches/`
   dir present, guard is false):
   ```
   make target/debs/bookworm/libsnmp-base_5.9.3+dfsg-1_all.deb
   ```
2. `make -n` on `src/snmpd/Makefile` shows the guarded block rendered in the
   recipe with no other changes.
3. To exercise the hook, add `src/snmpd/patches/series` listing a patch file in
   `src/snmpd/patches/`; it is applied to the source before the baseline commit.

Confirmed the guard is a no-op when the series file is absent and that the file
still parses (`make -n`).

#### Which release branch to backport (provide reason below if selected)

<!-- - [ ] 202xxx -->

#### Description for the changelog

[snmpd]: Add an optional, no-op local patch hook (`src/snmpd/patches/series`) to the net-snmp build.
