### PR TITLE
[bgpcfgd]: Support deployment-specific managers without patching main

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/main.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/main.py
@@ -131,6 +131,19 @@ def do_work():
 
     managers.append(PrefixListMgr(common_objs, "CONFIG_DB", "PREFIX_LIST"))
 
+    # Optional deployment-specific managers. A derived image may add a
+    # `managers_custom.py` module next to this file exposing
+    # `get_managers(common_objs) -> list` to register extra managers without
+    # patching this file. The module is absent upstream, so this is a no-op.
+    try:
+        from .managers_custom import get_managers as get_custom_managers
+    except ImportError:
+        get_custom_managers = None
+    if get_custom_managers is not None:
+        custom_managers = get_custom_managers(common_objs)
+        managers.extend(custom_managers)
+        log_notice("Loaded %d custom manager(s) from managers_custom" % len(custom_managers))
+
     runner = Runner(common_objs['cfg_mgr'])
     for mgr in managers:
         runner.add_manager(mgr)

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
@@ -86,17 +86,30 @@ class BGPPeerGroupMgr(object):
 
 class BGPPeerMgrBase(Manager):
     """ Manager of BGP peers """
-    def __init__(self, common_objs, db_name, table_name, peer_type, check_neig_meta):
+    def __init__(
+        self,
+        common_objs,
+        db_name,
+        table_name,
+        peer_type,
+        check_neig_meta,
+        require_loopback=True,
+        include_mgmt_interface=False,
+    ):
         """
         Initialize the object
         :param common_objs: common objects
         :param table_name: name of the table with peers
         :param peer_type: type of the peers. It is used to find right templates
+        :param require_loopback: wait for configured loopbacks before adding peers
+        :param include_mgmt_interface: expose management interfaces to templates
         """
         self.common_objs = common_objs
         self.constants = self.common_objs["constants"]
         self.fabric = common_objs['tf']
         self.peer_type = peer_type
+        self.require_loopback = require_loopback
+        self.include_mgmt_interface = include_mgmt_interface
         self.loopbacks = ["Loopback0"]
         self.post_dependencies_init_complete = False
 
@@ -118,7 +131,6 @@ class BGPPeerMgrBase(Manager):
         deps = [
             ("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost/bgp_asn"),
             ("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost/type"),
-            ("CONFIG_DB", swsscommon.CFG_LOOPBACK_INTERFACE_TABLE_NAME, "Loopback0"),
             ("CONFIG_DB", swsscommon.CFG_BGP_DEVICE_GLOBAL_TABLE_NAME, "tsa_enabled"),
             ("CONFIG_DB", swsscommon.CFG_BGP_DEVICE_GLOBAL_TABLE_NAME, "idf_isolation_state"),
             ("LOCAL", "local_addresses", ""),
@@ -142,8 +154,14 @@ class BGPPeerMgrBase(Manager):
         if self.check_deployment_id:
             deps.append(("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME, "localhost/deployment_id"))
 
-        if self.peer_type == 'internal':
+        if self.require_loopback:
+            deps.append(("CONFIG_DB", swsscommon.CFG_LOOPBACK_INTERFACE_TABLE_NAME, "Loopback0"))
+
+        if self.peer_type == 'internal' and self.require_loopback:
             deps.append(("CONFIG_DB", swsscommon.CFG_LOOPBACK_INTERFACE_TABLE_NAME, "Loopback4096"))
+
+        if self.include_mgmt_interface:
+            deps.append(("CONFIG_DB", swsscommon.CFG_MGMT_INTERFACE_TABLE_NAME, ""))
 
         super(BGPPeerMgrBase, self).__init__(
             common_objs,
@@ -183,7 +201,7 @@ class BGPPeerMgrBase(Manager):
 
         for loopback in self.loopbacks:
             lo_ipv4 = self.get_lo_ipv4(loopback + "|")
-            if (lo_ipv4 is None and "bgp_router_id"
+            if (lo_ipv4 is None and self.require_loopback and "bgp_router_id"
                 not in self.directory.get_slot("CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)["localhost"]):
                 log_warn(loopback + " ipv4 address is not presented yet and bgp_router_id not configured")
                 return False
@@ -222,6 +240,15 @@ class BGPPeerMgrBase(Manager):
                 log_info("DEVICE_NEIGHBOR_METADATA is not ready for neighbor '%s' - '%s'" % (nbr, data['name']))
                 return False
             kwargs['CONFIG_DB__DEVICE_NEIGHBOR_METADATA'] = neigmeta
+
+        if self.include_mgmt_interface:
+            kwargs['CONFIG_DB__MGMT_INTERFACE'] = {
+                tuple(key.split('|')): {}
+                for key in self.directory.get_slot(
+                    "CONFIG_DB", swsscommon.CFG_MGMT_INTERFACE_TABLE_NAME
+                )
+                if '|' in key
+            }
 
         tag = data['name'] if 'name' in data else nbr
         self.peer_group_mgr.update(tag, **kwargs)

--- a/src/sonic-bgpcfgd/tests/test_bgp.py
+++ b/src/sonic-bgpcfgd/tests/test_bgp.py
@@ -22,7 +22,16 @@ def load_constant_files():
     return constant_files
 
 
-def constructor(constants_path, bgp_router_id="", peer_type="general", with_lo0_ipv4=True, with_lo4096_ipv4=False, vrf=None):
+def constructor(
+    constants_path,
+    bgp_router_id="",
+    peer_type="general",
+    with_lo0_ipv4=True,
+    with_lo4096_ipv4=False,
+    vrf=None,
+    require_loopback=True,
+    include_mgmt_interface=False,
+):
     cfg_mgr = MagicMock()
     constants = load_constants(constants_path)['constants']
     common_objs = {
@@ -40,9 +49,19 @@ def constructor(constants_path, bgp_router_id="", peer_type="general", with_lo0_
     }
 
     bgpcfgd.managers_bgp.run_command = lambda cmd: return_value_map[str(cmd)]
-    m = bgpcfgd.managers_bgp.BGPPeerMgrBase(common_objs, "CONFIG_DB", swsscommon.CFG_BGP_NEIGHBOR_TABLE_NAME, peer_type, True)
+    m = bgpcfgd.managers_bgp.BGPPeerMgrBase(
+        common_objs,
+        "CONFIG_DB",
+        swsscommon.CFG_BGP_NEIGHBOR_TABLE_NAME,
+        peer_type,
+        True,
+        require_loopback=require_loopback,
+        include_mgmt_interface=include_mgmt_interface,
+    )
     assert m.peer_type == peer_type
     assert m.check_neig_meta == ('bgp' in constants and 'use_neighbors_meta' in constants['bgp'] and constants['bgp']['use_neighbors_meta'])
+    assert m.require_loopback is require_loopback
+    assert m.include_mgmt_interface is include_mgmt_interface
 
     localhost_obj = {"bgp_asn": "65100"}
     if len(bgp_router_id) != 0:
@@ -65,6 +84,8 @@ def constructor(constants_path, bgp_router_id="", peer_type="general", with_lo0_
     m.directory.put("LOCAL", "interfaces", "Ethernet4", intf_meta_v4)
     m.directory.put("LOCAL", "interfaces", "Ethernet8", intf_meta_v6)
     m.directory.put("CONFIG_DB", swsscommon.CFG_BGP_NEIGHBOR_TABLE_NAME, "default|10.10.10.1", {"ip_range": None})
+    if include_mgmt_interface:
+        m.directory.put("CONFIG_DB", swsscommon.CFG_MGMT_INTERFACE_TABLE_NAME, "eth0|10.0.0.1/24", {})
 
     if m.check_neig_meta:
         m.directory.put("CONFIG_DB", swsscommon.CFG_DEVICE_NEIGHBOR_METADATA_TABLE_NAME, "TOR", {})
@@ -162,6 +183,28 @@ def test_add_peer_without_lo_ipv4_router_id():
         m = constructor(constant, bgp_router_id="8.8.8.8", with_lo0_ipv4=False)
         res = m.set_handler("30.30.30.1", {'asn': '65200', 'holdtime': '180', 'keepalive': '60', 'local_addr': '30.30.30.30', 'name': 'TOR', 'nhopself': '0', 'rrclient': '0'})
         assert res, "Expect True return value"
+
+def test_add_peer_without_required_loopback_with_mgmt_interface():
+    for constant in load_constant_files():
+        m = constructor(
+            constant,
+            with_lo0_ipv4=False,
+            require_loopback=False,
+            include_mgmt_interface=True,
+        )
+        m.peer_group_mgr.update = MagicMock(return_value=True)
+        m.templates["add"].render = MagicMock(return_value="")
+
+        res = m.set_handler("30.30.30.1", {'asn': '65200', 'holdtime': '180', 'keepalive': '60', 'local_addr': '30.30.30.30', 'name': 'TOR', 'nhopself': '0', 'rrclient': '0'})
+
+        assert res, "Expect True return value"
+        assert ("CONFIG_DB", swsscommon.CFG_LOOPBACK_INTERFACE_TABLE_NAME, "Loopback0") not in m.deps
+        assert ("CONFIG_DB", swsscommon.CFG_MGMT_INTERFACE_TABLE_NAME, "") in m.deps
+        render_args = m.templates["add"].render.call_args.kwargs
+        assert render_args["CONFIG_DB__MGMT_INTERFACE"] == {
+            ("eth0", "10.0.0.1/24"): {},
+        }
+        assert "loopback0_ipv4" not in render_args
 
 def test_add_peer_ipv6():
     for constant in load_constant_files():

--- a/src/sonic-bgpcfgd/tests/test_bgp.py
+++ b/src/sonic-bgpcfgd/tests/test_bgp.py
@@ -22,16 +22,7 @@ def load_constant_files():
     return constant_files
 
 
-def constructor(
-    constants_path,
-    bgp_router_id="",
-    peer_type="general",
-    with_lo0_ipv4=True,
-    with_lo4096_ipv4=False,
-    vrf=None,
-    require_loopback=True,
-    include_mgmt_interface=False,
-):
+def constructor(constants_path, bgp_router_id="", peer_type="general", with_lo0_ipv4=True, with_lo4096_ipv4=False, vrf=None):
     cfg_mgr = MagicMock()
     constants = load_constants(constants_path)['constants']
     common_objs = {
@@ -49,19 +40,9 @@ def constructor(
     }
 
     bgpcfgd.managers_bgp.run_command = lambda cmd: return_value_map[str(cmd)]
-    m = bgpcfgd.managers_bgp.BGPPeerMgrBase(
-        common_objs,
-        "CONFIG_DB",
-        swsscommon.CFG_BGP_NEIGHBOR_TABLE_NAME,
-        peer_type,
-        True,
-        require_loopback=require_loopback,
-        include_mgmt_interface=include_mgmt_interface,
-    )
+    m = bgpcfgd.managers_bgp.BGPPeerMgrBase(common_objs, "CONFIG_DB", swsscommon.CFG_BGP_NEIGHBOR_TABLE_NAME, peer_type, True)
     assert m.peer_type == peer_type
     assert m.check_neig_meta == ('bgp' in constants and 'use_neighbors_meta' in constants['bgp'] and constants['bgp']['use_neighbors_meta'])
-    assert m.require_loopback is require_loopback
-    assert m.include_mgmt_interface is include_mgmt_interface
 
     localhost_obj = {"bgp_asn": "65100"}
     if len(bgp_router_id) != 0:
@@ -84,8 +65,6 @@ def constructor(
     m.directory.put("LOCAL", "interfaces", "Ethernet4", intf_meta_v4)
     m.directory.put("LOCAL", "interfaces", "Ethernet8", intf_meta_v6)
     m.directory.put("CONFIG_DB", swsscommon.CFG_BGP_NEIGHBOR_TABLE_NAME, "default|10.10.10.1", {"ip_range": None})
-    if include_mgmt_interface:
-        m.directory.put("CONFIG_DB", swsscommon.CFG_MGMT_INTERFACE_TABLE_NAME, "eth0|10.0.0.1/24", {})
 
     if m.check_neig_meta:
         m.directory.put("CONFIG_DB", swsscommon.CFG_DEVICE_NEIGHBOR_METADATA_TABLE_NAME, "TOR", {})
@@ -183,28 +162,6 @@ def test_add_peer_without_lo_ipv4_router_id():
         m = constructor(constant, bgp_router_id="8.8.8.8", with_lo0_ipv4=False)
         res = m.set_handler("30.30.30.1", {'asn': '65200', 'holdtime': '180', 'keepalive': '60', 'local_addr': '30.30.30.30', 'name': 'TOR', 'nhopself': '0', 'rrclient': '0'})
         assert res, "Expect True return value"
-
-def test_add_peer_without_required_loopback_with_mgmt_interface():
-    for constant in load_constant_files():
-        m = constructor(
-            constant,
-            with_lo0_ipv4=False,
-            require_loopback=False,
-            include_mgmt_interface=True,
-        )
-        m.peer_group_mgr.update = MagicMock(return_value=True)
-        m.templates["add"].render = MagicMock(return_value="")
-
-        res = m.set_handler("30.30.30.1", {'asn': '65200', 'holdtime': '180', 'keepalive': '60', 'local_addr': '30.30.30.30', 'name': 'TOR', 'nhopself': '0', 'rrclient': '0'})
-
-        assert res, "Expect True return value"
-        assert ("CONFIG_DB", swsscommon.CFG_LOOPBACK_INTERFACE_TABLE_NAME, "Loopback0") not in m.deps
-        assert ("CONFIG_DB", swsscommon.CFG_MGMT_INTERFACE_TABLE_NAME, "") in m.deps
-        render_args = m.templates["add"].render.call_args.kwargs
-        assert render_args["CONFIG_DB__MGMT_INTERFACE"] == {
-            ("eth0", "10.0.0.1/24"): {},
-        }
-        assert "loopback0_ipv4" not in render_args
 
 def test_add_peer_ipv6():
     for constant in load_constant_files():

--- a/src/sonic-bgpcfgd/tests/test_bgp_options.py
+++ b/src/sonic-bgpcfgd/tests/test_bgp_options.py
@@ -1,0 +1,133 @@
+from unittest.mock import MagicMock
+
+import os
+
+import bgpcfgd.managers_bgp
+from bgpcfgd.directory import Directory
+from bgpcfgd.template import TemplateFabric
+from swsscommon import swsscommon
+
+from . import swsscommon_test
+from .util import load_constants
+
+
+TEMPLATE_PATH = os.path.abspath('../../dockers/docker-fpm-frr/frr')
+
+
+def constructor(require_loopback=True, include_mgmt_interface=False):
+    common_objs = {
+        'directory': Directory(),
+        'cfg_mgr': MagicMock(),
+        'tf': TemplateFabric(TEMPLATE_PATH),
+        'constants': load_constants()['constants'],
+    }
+    return_value_map = {
+        "['vtysh', '-H', '/dev/null', '-c', 'show bgp vrfs json']": (
+            0,
+            '{"vrfs": {"default": {}}}',
+            '',
+        ),
+        "['vtysh', '-c', 'show bgp vrf default neighbors json']": (
+            0,
+            '{}',
+            '',
+        ),
+    }
+    bgpcfgd.managers_bgp.run_command = lambda cmd: return_value_map[str(cmd)]
+
+    manager = bgpcfgd.managers_bgp.BGPPeerMgrBase(
+        common_objs,
+        'CONFIG_DB',
+        swsscommon.CFG_BGP_NEIGHBOR_TABLE_NAME,
+        'general',
+        True,
+        require_loopback=require_loopback,
+        include_mgmt_interface=include_mgmt_interface,
+    )
+    manager.directory.put(
+        'CONFIG_DB',
+        swsscommon.CFG_DEVICE_METADATA_TABLE_NAME,
+        'localhost',
+        {'bgp_asn': '65100'},
+    )
+    manager.directory.put(
+        'CONFIG_DB',
+        swsscommon.CFG_DEVICE_NEIGHBOR_METADATA_TABLE_NAME,
+        'TOR',
+        {},
+    )
+    manager.directory.put(
+        'LOCAL',
+        'local_addresses',
+        'Ethernet4|30.30.30.30',
+        {'interface': 'Ethernet4', 'prefixlen': '24'},
+    )
+    manager.directory.put(
+        'LOCAL',
+        'interfaces',
+        'Ethernet4',
+        {'admin_status': 'up'},
+    )
+    return manager
+
+
+def test_default_peer_manager_options():
+    manager = constructor()
+
+    assert manager.require_loopback is True
+    assert manager.include_mgmt_interface is False
+    assert (
+        'CONFIG_DB',
+        swsscommon.CFG_LOOPBACK_INTERFACE_TABLE_NAME,
+        'Loopback0',
+    ) in manager.deps
+    assert (
+        'CONFIG_DB',
+        swsscommon.CFG_MGMT_INTERFACE_TABLE_NAME,
+        '',
+    ) not in manager.deps
+
+
+def test_optional_mgmt_interface_without_loopback():
+    manager = constructor(
+        require_loopback=False,
+        include_mgmt_interface=True,
+    )
+    manager.directory.put(
+        'CONFIG_DB',
+        swsscommon.CFG_MGMT_INTERFACE_TABLE_NAME,
+        'eth0|10.0.0.1/24',
+        {},
+    )
+    manager.peer_group_mgr.update = MagicMock(return_value=True)
+    manager.templates['add'].render = MagicMock(return_value='')
+
+    result = manager.set_handler(
+        '30.30.30.1',
+        {
+            'asn': '65200',
+            'holdtime': '180',
+            'keepalive': '60',
+            'local_addr': '30.30.30.30',
+            'name': 'TOR',
+            'nhopself': '0',
+            'rrclient': '0',
+        },
+    )
+
+    assert result
+    assert (
+        'CONFIG_DB',
+        swsscommon.CFG_LOOPBACK_INTERFACE_TABLE_NAME,
+        'Loopback0',
+    ) not in manager.deps
+    assert (
+        'CONFIG_DB',
+        swsscommon.CFG_MGMT_INTERFACE_TABLE_NAME,
+        '',
+    ) in manager.deps
+    render_args = manager.templates['add'].render.call_args.kwargs
+    assert render_args['CONFIG_DB__MGMT_INTERFACE'] == {
+        ('eth0', '10.0.0.1/24'): {},
+    }
+    assert 'loopback0_ipv4' not in render_args


### PR DESCRIPTION
#### Why I did it

Derived images sometimes need additional `bgpcfgd` managers or peer-manager behavior. Today this requires patching `main.py` and `BGPPeerMgrBase`, creating recurring conflicts when synchronizing.

This change adds small, backward-compatible extension points so deployment-specific code can live in a separate module instead of modifying upstream-owned manager registration and peer logic.

#### Work item tracking

- Microsoft ADO: N/A

#### How I did it

1. Added an optional `managers_custom.py` hook in `main.do_work()`. When present, its `get_managers(common_objs)` function returns additional managers to register. The module is absent upstream, so normal upstream behavior is unchanged.
2. Added two optional `BGPPeerMgrBase` constructor arguments:
   - `require_loopback=True` controls whether Loopback0/Loopback4096 are dependencies and required before adding peers.
   - `include_mgmt_interface=False` subscribes to `MGMT_INTERFACE` and exposes it to peer templates as `CONFIG_DB__MGMT_INTERFACE`.
3. Kept defaults equivalent to existing behavior for every upstream manager.
4. Added unit coverage for the default behavior and the opt-in no-loopback/management-interface path.


#### How to verify it

```bash
cd src/sonic-bgpcfgd
python3 -m pytest -q tests/test_bgp.py tests/test_bgp_options.py
```

Result: 35 tests passed.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

- master

#### Description for the changelog

bgpcfgd: support deployment-specific managers and configurable peer-manager dependencies

#### Link to config_db schema for YANG module changes

N/A — no schema/YANG changes.