### PR TITLE
[build_debian.sh]: Remove mft bash-completion scripts to fix login latency

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -868,6 +868,11 @@ sudo LANG=C chroot $FILESYSTEM_ROOT bash -c 'rm -rf /usr/share/doc/* /usr/share/
 ## Clean up pip cache
 sudo LANG=C chroot $FILESYSTEM_ROOT pip3 cache purge
 
+## Remove /etc/bash_completion.d/ scripts installed by mft-*-x86_64.deb
+## These scripts will run 100+ commands after user login and cause user login latency
+sudo LANG=C chroot $FILESYSTEM_ROOT bash -c 'rm -rf /etc/bash_completion.d/mft/ /etc/bash_completion.d/mlx* /etc/bash_completion.d/mst_complete \
+ /etc/bash_completion.d/devmon_complete /etc/bash_completion.d/flint_complete /etc/bash_completion.d/mget_temp_complete'
+
 ## Umount all
 echo '[INFO] Umount all'
 ## Display all process details access /proc


### PR DESCRIPTION
#### Why I did it

The Mellanox Firmware Tools package (`mft-*-x86_64.deb`) installs a set of
bash-completion scripts under `/etc/bash_completion.d/` (`mft/`, `mlx*`,
`mst_complete`, `devmon_complete`, `flint_complete`, `mget_temp_complete`).
These completion scripts probe the system by running 100+ commands the first
time completion is triggered after an interactive login, which introduces a
noticeable user-login latency on images that ship `mft`.

#### Work item tracking
- Microsoft ADO: N/A

#### How I did it

At the end of the rootfs build in `build_debian.sh` (right after the pip cache
cleanup, before the final umount), remove the `mft`-installed
bash-completion scripts from the target filesystem.

This is a no-op on images that do not install `mft` (the paths simply do not
exist, and `rm -rf` on a missing path is harmless).

#### How to verify it

- Build an image that includes the `mft` package and confirm
  `/etc/bash_completion.d/mft*` / `mlx*` / `mst_complete` etc. are absent in
  the resulting rootfs.
- Log in interactively and confirm the previous multi-second first-completion
  delay is gone.
- Build an image without `mft` and confirm the build still succeeds (the
  removal is a no-op).

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

- master

#### Description for the changelog

build_debian.sh: remove mft-installed bash-completion scripts that cause interactive-login latency

#### Link to config_db schema for YANG module changes

N/A — no schema/YANG changes.
