### PR TITLE
Ecn acl marking

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -274,6 +274,25 @@ and migration plan
 }
 ```
 
+***ECN marking action (ECN_ACTION)***
+
+An ingress ACL rule can mark the ECN field of matching traffic in hardware using the
+`ECN_ACTION` field (uint8, range `0..3` per RFC 3168: 0=Non-ECT, 1=ECT(1), 2=ECT(0),
+3=CE). It sets the low two bits of the IPv4 TOS / IPv6 Traffic-Class byte, independently
+of any packet action.
+
+```
+{
+"ACL_RULE": {
+        "DATAACL|mark_ecn": {
+        "PRIORITY": "9990",
+        "L4_SRC_PORT": "5000",
+        "ECN_ACTION": "3"
+        }
+   }
+}
+```
+
 ***Below ACL table added by comparig minigraph.xml & config_db.json***
 
 ```

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
@@ -210,5 +210,12 @@
     },
     "ACL_INNERSRCMACREWRITE_NO_INNERSRCIP": {
         "desc": "Configure INNERSRCMACREWRITE ACL with no inner src IP"
+    },
+    "ACL_RULE_WITH_VALID_ECN_ACTION": {
+        "desc": "Configure ACL_RULE with valid ECN_ACTION (0..3)."
+    },
+    "ACL_RULE_WITH_OUT_OF_RANGE_ECN_ACTION": {
+        "desc": "Configure ACL_RULE with out-of-range ECN_ACTION (> 3).",
+        "eStrKey": "Range"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
@@ -2283,5 +2283,61 @@
                 ]
             }
         }
+    },
+    "ACL_RULE_WITH_VALID_ECN_ACTION": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "DATAACL",
+                        "ECN_ACTION": 3,
+                        "PRIORITY": 9990,
+                        "RULE_NAME": "Rule_ECN",
+                        "SRC_IP": "1.2.3.4/32"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "DATAACL",
+                        "policy_desc": "ECN",
+                        "ports": [
+                            ""
+                        ],
+                        "stage": "INGRESS",
+                        "type": "L3"
+                    }
+                ]
+            }
+        }
+    },
+    "ACL_RULE_WITH_OUT_OF_RANGE_ECN_ACTION": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "DATAACL",
+                        "ECN_ACTION": 4,
+                        "PRIORITY": 9990,
+                        "RULE_NAME": "Rule_ECN",
+                        "SRC_IP": "1.2.3.4/32"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "DATAACL",
+                        "policy_desc": "ECN",
+                        "ports": [
+                            ""
+                        ],
+                        "stage": "INGRESS",
+                        "type": "L3"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
@@ -69,6 +69,13 @@ module sonic-acl {
 					}
 				}
 
+				leaf ECN_ACTION {
+					type uint8 {
+						range "0..3";
+					}
+					description "ECN marking action. 0=Non-ECT, 1=ECT(1), 2=ECT(0), 3=CE";
+				}
+
 				leaf PACKET_ACTION {
 					description "Action to take on matching packets (forward, drop, redirect, or mirror)";
 					type stypes:packet_action;


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Add the management-plane schema for the new  ECN_ACTION  ACL action so SONiC's YANG validation recognizes it as a valid  ACL_RULE  field. Without this leaf,  sonic-yang  validation — used by  config reload  and the Generic Config Updater ( config apply-patch ) — rejects any ACL rule containing  ECN_ACTION . This is the schema half of the ECN-marking-via-ACL feature; the orchagent support that maps  ECN_ACTION  to the SAI action  SAI_ACL_ENTRY_ATTR_ACTION_SET_ECN  is in the companion  sonic-swss  PR.

##### Work item tracking
- Microsoft ADO **(number only)**: 38245401

#### How I did it
Added an  ECN_ACTION  leaf to  ACL_RULE_LIST  in  src/sonic-yang-models/yang-templates/sonic-acl.yang.j2 , typed  uint8  with  range "0..3"  (RFC 3168 ECN codepoints:  0 =Non-ECT,  1 =ECT(1),  2 =ECT(0),  3 =CE):
```
leaf ECN_ACTION {
    type uint8 {
        range "0..3";
    }
    description "ECN marking action. 0=Non-ECT, 1=ECT(1), 2=ECT(0), 3=CE";
}
```

#### How to verify it
• YANG model tests / build: build  sonic-yang-models  (the package compiles the templates to  .yang  and runs its model test suite) — it builds cleanly with the new leaf.
• Functional (on a device): apply an ACL rule that includes  ECN_ACTION  and confirm YANG validation accepts it (with  0..3  accepted and out-of-range rejected):
```
cat > /tmp/ecn.json <<'EOF'
[ { "op": "add", "path": "/ACL_RULE/DATAACL|ECN",
    "value": { "PRIORITY": "9990", "L4_SRC_PORT": "5000", "ECN_ACTION": "3" } } ]
EOF
sudo config apply-patch /tmp/ecn.json      # accepted with this change; rejected without it
``` Before this change the patch fails YANG validation with `ECN_ACTION` reported as an unparsed key.
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
Below https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#acl-and-mirroring
Added in this PR

#### A picture of a cute animal (not mandatory but encouraged)

