### PR TITLE
[dplane_fpm_sonic]: Fix incorrect callback argument in fpm_enqueue_l3vni_table

### DIFF
--- a/src/sonic-frr/dplane_fpm_sonic/dplane_fpm_sonic.c
+++ b/src/sonic-frr/dplane_fpm_sonic/dplane_fpm_sonic.c
@@ -2991,7 +2991,7 @@ static void fpm_enqueue_l3vni_table(struct hash_bucket *bucket, void *arg)
 	struct zebra_l3vni *zl3vni = bucket->data;
 
 	fra->zl3vni = zl3vni;
-	hash_iterate(zl3vni->rmac_table, fpm_enqueue_rmac_table, zl3vni);
+	hash_iterate(zl3vni->rmac_table, fpm_enqueue_rmac_table, fra);
 }
 
 static void fpm_rmac_send(struct event *t)


### PR DESCRIPTION
#### Why I did it

Fix https://github.com/sonic-net/sonic-buildimage/issues/27779

This is a port of upstream FRR fix [`a3877e444`](https://github.com/FRRouting/frr/commit/a3877e444) ("zebra: Fix crash during reconnect" by Igor Zhukov, Oct 4 2024) to SONiC's `dplane_fpm_sonic` module. The fix is still there in the upstream [FRR head](https://github.com/FRRouting/frr/blob/b055aead2f21cac182442d1f140e6f2098c77a6d/zebra/dplane_fpm_nl.c#L1401) as of July 10th, 2026.

`fpm_enqueue_l3vni_table()` passes `zl3vni` (a `struct zebra_l3vni *`) as the callback argument to `hash_iterate()`, but the callback `fpm_enqueue_rmac_table()` casts it to `struct fpm_rmac_arg *` and dereferences fields like `fra->ctx`, `fra->fnc`, `fra->zl3vni`, and `fra->complete`. This type mismatch causes a **SIGSEGV** when zebra reconnects to fpmsyncd and triggers a full RMAC table walk.

The bug was introduced when SONiC forked `dplane_fpm_nl.c` into `dplane_fpm_sonic.c`. FRR fixed the bug later, but the fix was never ported to SONiC.

**Impact:** Any deployment using EVPN symmetric IRB with L3VNI + remote RMACs will crash on fpmsyncd restart or FPM TCP reconnect. The bug is latent because this specific code path requires all three conditions simultaneously.

#### How I did it

* Pass `fra` instead of `zl3vni` as the third argument to `hash_iterate()` in `fpm_enqueue_l3vni_table()`

#### How to verify it

1. Confirm `fpm_enqueue_rmac_table()` casts `arg` to `struct fpm_rmac_arg *` and accesses `fra->zl3vni`, `fra->ctx`, `fra->fnc`, `fra->complete`, and only `fra` provides the correct layout
  - [fpm_rmac_arg](https://github.com/sonic-net/sonic-buildimage/blob/d3a7f642187828cdfc454f4a6d5fe5b14835ad53/src/sonic-frr/dplane_fpm_sonic/dplane_fpm_sonic.c#L3146-L3151) starts with a 8 bytes pointer.
  - [zebra_l3vni](https://github.com/sonic-net/sonic-frr/blob/de0e358b877ac9b595e7fb387a302c960a4c02d1/zebra/zebra_vxlan_private.h#L42-L62) starts with a 4 byte uint32.
2. Reading a pointer from offset 0 of `zebra_l3vni` produces a garbage address that segfaults immediately

#### References

- Upstream FRR fix: [`FRRouting/frr@a3877e444`](https://github.com/FRRouting/frr/commit/a3877e444)
- Upstream FRR PR that introduced the bug: [FRRouting/frr#16220](https://github.com/FRRouting/frr/pull/16220)
- SONiC PR that forked the buggy code: [sonic-net/sonic-buildimage#18715](https://github.com/sonic-net/sonic-buildimage/pull/18715)

#### Description for the changelog

Fix crash (SIGSEGV) in dplane_fpm_sonic RMAC sync path during FPM reconnect, port of upstream FRR fix FRRouting/frr@a3877e444