### PR TITLE
Add a systemd service to run post-upgrade actions after the OS is up

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -459,6 +459,14 @@ sudo cp -f $IMAGE_CONFIGS/systemd/set-epoch.timer $FILESYSTEM_ROOT_USR_LIB_SYSTE
 sudo cp -f $IMAGE_CONFIGS/systemd/set-epoch.sh $FILESYSTEM_ROOT/usr/local/sbin/
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable set-epoch.timer
 
+# Copy post-upgrade actions systemd units (script execution hook).
+# The service runs /tmp/anpscripts/postupgrade_actions directly, ~20 min after
+# syncd/the OS is up. No scripts are baked into the image -- the upgrade flow
+# stages the script into /tmp/anpscripts.
+sudo cp $IMAGE_CONFIGS/script-execution-hooks/postupgrade-actions.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
+sudo cp $IMAGE_CONFIGS/script-execution-hooks/postupgrade-actions.timer $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
+sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable postupgrade-actions.timer
+
 # Copy DNS templates
 sudo cp $BUILD_TEMPLATES/dns.j2 $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/
 

--- a/files/image_config/script-execution-hooks/postupgrade-actions.service
+++ b/files/image_config/script-execution-hooks/postupgrade-actions.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=SONiC post-upgrade actions runner
+# Order after the core SONiC services so the system is up before we run.
+After=syncd.service swss.service bgp.service
+# Skip cleanly (not fail) on normal boots when the upgrade flow did not stage a
+# script -- avoids noisy failures every boot when nothing is present.
+# ConditionPathExists=
+
+[Service]
+Type=oneshot
+# Run the script the upgrade flow staged at /tmp/anpscripts, directly.
+# ExecStart=
+# Give it room to finish (patches can take a while).
+TimeoutStartSec=1h

--- a/files/image_config/script-execution-hooks/postupgrade-actions.timer
+++ b/files/image_config/script-execution-hooks/postupgrade-actions.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run SONiC post-upgrade actions after the OS is up
+
+[Timer]
+# Arm when syncd starts (every boot); fire once, 20 minutes later, to give the
+# OS/control plane time to fully come up before we run the script.
+OnActiveSec=20min
+
+[Install]
+WantedBy=syncd.service


### PR DESCRIPTION
Add a oneshot systemd service, triggered by a timer, that runs the post-upgrade actions script staged by the upgrade flow at /tmp/anpscripts/postupgrade_actions. The timer is armed when syncd starts and fires 20 minutes later, giving the OS and control plane time to reach a steady state before the script runs. No scripts are baked into the image; only the service and timer units are installed and the timer enabled.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**: 36560113

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

