### PR TITLE
[pddf] Add MSI and i2c-xiic config for Nexthop platforms

### DIFF
--- a/device/nexthop/x86_64-nexthop_4010-r0/pddf/pddf-device.json.j2
+++ b/device/nexthop/x86_64-nexthop_4010-r0/pddf/pddf-device.json.j2
@@ -34,12 +34,14 @@
     "std_kos": [
       "at24",
       "i2c-dev",
+      "i2c-xiic",
       "spi-xilinx",
       "optoe"
     ],
     "pddf_kos": [
       "pddf_spi_module",
       "pddf_multifpgapci_i2c_module",
+      "pddf_multifpgapci_i2c_xiic_module",
       "pddf_multifpgapci_gpio_module",
       "pddf_multifpgapci_spi_module",
       "pddf_client_module",
@@ -232,7 +234,22 @@
     },
     "dev_attr": {
       "pwr_cycle_reg_offset": "0x8",
-      "pwr_cycle_enable_word": "0xdeadbeef"
+      "pwr_cycle_enable_word": "0xdeadbeef",
+      "check_fpga_version_cmd": "fpga read32 {{cpu_card_fpga_bdf}} --bits=0:7 0x0",
+      "reg_width": 32
+    },
+    "use_msi": {
+      "min_fpga_version": "0x86",
+      "num_msi_vectors": 1,
+      "msi_domains": [
+        {
+          "msi_vector_num": 0,
+          "irq_chip_name": "ko-msi-0",
+          "irq_line_mask": "00007f73",
+          "interrupt_enable_reg": "20",
+          "interrupt_status_reg": "24"
+        }
+      ]
     },
     "i2c": {
       "dev_attr": {
@@ -258,6 +275,15 @@
           "chn": "6",
           "dev": "TMP464"
         }
+      ],
+      "channel_irq": [
+        {"msi_domain": 0, "hw_irq": 8},
+        {"msi_domain": 0, "hw_irq": 9},
+        {"msi_domain": 0, "hw_irq": 10},
+        {"msi_domain": 0, "hw_irq": 11},
+        {"msi_domain": 0, "hw_irq": 12},
+        {"msi_domain": 0, "hw_irq": 13},
+        {"msi_domain": 0, "hw_irq": 14}
       ]
     },
 {%- if platform == 'x86_64-nexthop_4010-r1' %}
@@ -1398,11 +1424,40 @@
     },
     "dev_attr": {
       "pwr_cycle_reg_offset": "0x4",
-      "pwr_cycle_enable_word": "0xdeadbeef"
+      "pwr_cycle_enable_word": "0xdeadbeef",
+      "check_fpga_version_cmd": "fpga read32 {{switchcard_fpga_bdf}} --bits=0:7 0x0",
+      "reg_width": 32
     },
 {%- if platform == 'x86_64-nexthop_4010-r1' %}
     "spi_controllers": ["SWITCHCARD_SPI_CONTROLLER"],
 {%- endif %}
+    "use_msi": {
+      "min_fpga_version": "0x8e",
+      "num_msi_vectors": 3,
+      "msi_domains": [
+        {
+          "msi_vector_num": 0,
+          "irq_chip_name": "ge-msi-0",
+          "irq_line_mask": "00000f11",
+          "interrupt_enable_reg": "170",
+          "interrupt_status_reg": "174"
+        },
+        {
+          "msi_vector_num": 1,
+          "irq_chip_name": "ge-msi-1",
+          "irq_line_mask": "ffffffff",
+          "interrupt_enable_reg": "178",
+          "interrupt_status_reg": "17C"
+        },
+        {
+          "msi_vector_num": 2,
+          "irq_chip_name": "ge-msi-2",
+          "irq_line_mask": "ffffffff",
+          "interrupt_enable_reg": "180",
+          "interrupt_status_reg": "184"
+        }
+      ]
+    },
     "i2c": {
       "dev_attr": {
         "virt_bus": "0x13",
@@ -1479,6 +1534,76 @@
         { "chn": "65", "dev": "PORT62" },
         { "chn": "66", "dev": "PORT63" },
         { "chn": "67", "dev": "PORT64" }
+      ],
+      "channel_irq": [
+        {"msi_domain": 0, "hw_irq": 8},
+        {"msi_domain": 0, "hw_irq": 9},
+        {"msi_domain": 0, "hw_irq": 10},
+        {"msi_domain": 0, "hw_irq": 11},
+        {"msi_domain": 1, "hw_irq": 0},
+        {"msi_domain": 1, "hw_irq": 1},
+        {"msi_domain": 1, "hw_irq": 2},
+        {"msi_domain": 1, "hw_irq": 3},
+        {"msi_domain": 1, "hw_irq": 4},
+        {"msi_domain": 1, "hw_irq": 5},
+        {"msi_domain": 1, "hw_irq": 6},
+        {"msi_domain": 1, "hw_irq": 7},
+        {"msi_domain": 1, "hw_irq": 8},
+        {"msi_domain": 1, "hw_irq": 9},
+        {"msi_domain": 1, "hw_irq": 10},
+        {"msi_domain": 1, "hw_irq": 11},
+        {"msi_domain": 1, "hw_irq": 12},
+        {"msi_domain": 1, "hw_irq": 13},
+        {"msi_domain": 1, "hw_irq": 14},
+        {"msi_domain": 1, "hw_irq": 15},
+        {"msi_domain": 1, "hw_irq": 16},
+        {"msi_domain": 1, "hw_irq": 17},
+        {"msi_domain": 1, "hw_irq": 18},
+        {"msi_domain": 1, "hw_irq": 19},
+        {"msi_domain": 1, "hw_irq": 20},
+        {"msi_domain": 1, "hw_irq": 21},
+        {"msi_domain": 1, "hw_irq": 22},
+        {"msi_domain": 1, "hw_irq": 23},
+        {"msi_domain": 1, "hw_irq": 24},
+        {"msi_domain": 1, "hw_irq": 25},
+        {"msi_domain": 1, "hw_irq": 26},
+        {"msi_domain": 1, "hw_irq": 27},
+        {"msi_domain": 1, "hw_irq": 28},
+        {"msi_domain": 1, "hw_irq": 29},
+        {"msi_domain": 1, "hw_irq": 30},
+        {"msi_domain": 1, "hw_irq": 31},
+        {"msi_domain": 2, "hw_irq": 0},
+        {"msi_domain": 2, "hw_irq": 1},
+        {"msi_domain": 2, "hw_irq": 2},
+        {"msi_domain": 2, "hw_irq": 3},
+        {"msi_domain": 2, "hw_irq": 4},
+        {"msi_domain": 2, "hw_irq": 5},
+        {"msi_domain": 2, "hw_irq": 6},
+        {"msi_domain": 2, "hw_irq": 7},
+        {"msi_domain": 2, "hw_irq": 8},
+        {"msi_domain": 2, "hw_irq": 9},
+        {"msi_domain": 2, "hw_irq": 10},
+        {"msi_domain": 2, "hw_irq": 11},
+        {"msi_domain": 2, "hw_irq": 12},
+        {"msi_domain": 2, "hw_irq": 13},
+        {"msi_domain": 2, "hw_irq": 14},
+        {"msi_domain": 2, "hw_irq": 15},
+        {"msi_domain": 2, "hw_irq": 16},
+        {"msi_domain": 2, "hw_irq": 17},
+        {"msi_domain": 2, "hw_irq": 18},
+        {"msi_domain": 2, "hw_irq": 19},
+        {"msi_domain": 2, "hw_irq": 20},
+        {"msi_domain": 2, "hw_irq": 21},
+        {"msi_domain": 2, "hw_irq": 22},
+        {"msi_domain": 2, "hw_irq": 23},
+        {"msi_domain": 2, "hw_irq": 24},
+        {"msi_domain": 2, "hw_irq": 25},
+        {"msi_domain": 2, "hw_irq": 26},
+        {"msi_domain": 2, "hw_irq": 27},
+        {"msi_domain": 2, "hw_irq": 28},
+        {"msi_domain": 2, "hw_irq": 29},
+        {"msi_domain": 2, "hw_irq": 30},
+        {"msi_domain": 2, "hw_irq": 31}
       ]
     }
   },

--- a/device/nexthop/x86_64-nexthop_4220-r0/pddf/pddf-device.json.j2
+++ b/device/nexthop/x86_64-nexthop_4220-r0/pddf/pddf-device.json.j2
@@ -31,12 +31,14 @@
     "std_kos": [
       "at24",
       "i2c-dev",
+      "i2c-xiic",
       "spi-xilinx",
       "optoe"
     ],
     "pddf_kos": [
       "pddf_spi_module",
       "pddf_multifpgapci_i2c_module",
+      "pddf_multifpgapci_i2c_xiic_module",
       "pddf_multifpgapci_gpio_module",
       "pddf_multifpgapci_spi_module",
       "pddf_client_module",
@@ -157,7 +159,14 @@
   },
   "MULTIFPGAPCIE0": {
     "dev_info": {"device_type": "MULTIFPGAPCIE", "device_name": "CPUCARD_FPGA", "device_parent": "PCIE0", "device_bdf": "{{cpu_card_fpga_bdf}}", "dev_attr": {}},
-    "dev_attr": {"pwr_cycle_reg_offset": "0x8", "pwr_cycle_enable_word": "0xdeadbeef"},
+    "dev_attr": {"pwr_cycle_reg_offset": "0x8", "pwr_cycle_enable_word": "0xdeadbeef", "check_fpga_version_cmd": "fpga read32 {{cpu_card_fpga_bdf}} 0x0 --bits=0:7", "reg_width": 32},
+    "use_msi": {
+      "min_fpga_version": "0x86",
+      "num_msi_vectors": 1,
+      "msi_domains": [
+        {"msi_vector_num": 0, "irq_chip_name": "ko-msi-0", "irq_line_mask": "00007f73", "interrupt_enable_reg": "20", "interrupt_status_reg": "24"}
+      ]
+    },
     "i2c": {
       "dev_attr": {"virt_bus": "0x4", "ch_base_offset": "0x40000", "ch_size": "0x200", "num_virt_ch": "0x8"},
       "channel": [
@@ -166,6 +175,15 @@
         {"chn": "5", "dev": "DPM3"},
         {"chn": "6", "dev": "EEPROM1"},
         {"chn": "6", "dev": "TMP464"}
+      ],
+      "channel_irq": [
+        {"msi_domain": 0, "hw_irq": 8},
+        {"msi_domain": 0, "hw_irq": 9},
+        {"msi_domain": 0, "hw_irq": 10},
+        {"msi_domain": 0, "hw_irq": 11},
+        {"msi_domain": 0, "hw_irq": 12},
+        {"msi_domain": 0, "hw_irq": 13},
+        {"msi_domain": 0, "hw_irq": 14}
       ]
     },
     "gpio": {
@@ -1113,7 +1131,16 @@
 
   "MULTIFPGAPCIE1": {
     "dev_info": {"device_type": "MULTIFPGAPCIE", "device_name": "SWITCHCARD_FPGA", "device_parent": "PCIE0", "device_bdf": "{{switchcard_fpga_bdf}}", "dev_attr": {}},
-    "dev_attr": {"pwr_cycle_reg_offset": "0x4", "pwr_cycle_enable_word": "0xdeadbeef"},
+    "dev_attr": {"pwr_cycle_reg_offset": "0x4", "pwr_cycle_enable_word": "0xdeadbeef", "check_fpga_version_cmd": "fpga read32 {{switchcard_fpga_bdf}} 0x0 --bits=0:7", "reg_width": 32},
+    "use_msi": {
+      "min_fpga_version": "0x7",
+      "num_msi_vectors": 3,
+      "msi_domains": [
+        {"msi_vector_num": 0, "irq_chip_name": "blkt-msi-0", "irq_line_mask": "00001f11", "interrupt_enable_reg": "170", "interrupt_status_reg": "174"},
+        {"msi_vector_num": 1, "irq_chip_name": "blkt-msi-1", "irq_line_mask": "ffffffff", "interrupt_enable_reg": "178", "interrupt_status_reg": "17C"},
+        {"msi_vector_num": 2, "irq_chip_name": "blkt-msi-2", "irq_line_mask": "ffffffff", "interrupt_enable_reg": "180", "interrupt_status_reg": "184"}
+      ]
+    },
     "i2c": {
       "dev_attr": {"virt_bus": "0x13", "ch_base_offset": "0x40000", "ch_size": "0x200", "num_virt_ch": "0x45"},
       "channel": [
@@ -1186,6 +1213,77 @@
         {"chn": "66", "dev": "PORT62"},
         {"chn": "67", "dev": "PORT63"},
         {"chn": "68", "dev": "PORT64"}
+      ],
+      "channel_irq": [
+        {"msi_domain": 0, "hw_irq": 8},
+        {"msi_domain": 0, "hw_irq": 9},
+        {"msi_domain": 0, "hw_irq": 10},
+        {"msi_domain": 0, "hw_irq": 11},
+        {"msi_domain": 0, "hw_irq": 12},
+        {"msi_domain": 1, "hw_irq": 0},
+        {"msi_domain": 1, "hw_irq": 1},
+        {"msi_domain": 1, "hw_irq": 2},
+        {"msi_domain": 1, "hw_irq": 3},
+        {"msi_domain": 1, "hw_irq": 4},
+        {"msi_domain": 1, "hw_irq": 5},
+        {"msi_domain": 1, "hw_irq": 6},
+        {"msi_domain": 1, "hw_irq": 7},
+        {"msi_domain": 1, "hw_irq": 8},
+        {"msi_domain": 1, "hw_irq": 9},
+        {"msi_domain": 1, "hw_irq": 10},
+        {"msi_domain": 1, "hw_irq": 11},
+        {"msi_domain": 1, "hw_irq": 12},
+        {"msi_domain": 1, "hw_irq": 13},
+        {"msi_domain": 1, "hw_irq": 14},
+        {"msi_domain": 1, "hw_irq": 15},
+        {"msi_domain": 1, "hw_irq": 16},
+        {"msi_domain": 1, "hw_irq": 17},
+        {"msi_domain": 1, "hw_irq": 18},
+        {"msi_domain": 1, "hw_irq": 19},
+        {"msi_domain": 1, "hw_irq": 20},
+        {"msi_domain": 1, "hw_irq": 21},
+        {"msi_domain": 1, "hw_irq": 22},
+        {"msi_domain": 1, "hw_irq": 23},
+        {"msi_domain": 1, "hw_irq": 24},
+        {"msi_domain": 1, "hw_irq": 25},
+        {"msi_domain": 1, "hw_irq": 26},
+        {"msi_domain": 1, "hw_irq": 27},
+        {"msi_domain": 1, "hw_irq": 28},
+        {"msi_domain": 1, "hw_irq": 29},
+        {"msi_domain": 1, "hw_irq": 30},
+        {"msi_domain": 1, "hw_irq": 31},
+        {"msi_domain": 2, "hw_irq": 0},
+        {"msi_domain": 2, "hw_irq": 1},
+        {"msi_domain": 2, "hw_irq": 2},
+        {"msi_domain": 2, "hw_irq": 3},
+        {"msi_domain": 2, "hw_irq": 4},
+        {"msi_domain": 2, "hw_irq": 5},
+        {"msi_domain": 2, "hw_irq": 6},
+        {"msi_domain": 2, "hw_irq": 7},
+        {"msi_domain": 2, "hw_irq": 8},
+        {"msi_domain": 2, "hw_irq": 9},
+        {"msi_domain": 2, "hw_irq": 10},
+        {"msi_domain": 2, "hw_irq": 11},
+        {"msi_domain": 2, "hw_irq": 12},
+        {"msi_domain": 2, "hw_irq": 13},
+        {"msi_domain": 2, "hw_irq": 14},
+        {"msi_domain": 2, "hw_irq": 15},
+        {"msi_domain": 2, "hw_irq": 16},
+        {"msi_domain": 2, "hw_irq": 17},
+        {"msi_domain": 2, "hw_irq": 18},
+        {"msi_domain": 2, "hw_irq": 19},
+        {"msi_domain": 2, "hw_irq": 20},
+        {"msi_domain": 2, "hw_irq": 21},
+        {"msi_domain": 2, "hw_irq": 22},
+        {"msi_domain": 2, "hw_irq": 23},
+        {"msi_domain": 2, "hw_irq": 24},
+        {"msi_domain": 2, "hw_irq": 25},
+        {"msi_domain": 2, "hw_irq": 26},
+        {"msi_domain": 2, "hw_irq": 27},
+        {"msi_domain": 2, "hw_irq": 28},
+        {"msi_domain": 2, "hw_irq": 29},
+        {"msi_domain": 2, "hw_irq": 30},
+        {"msi_domain": 2, "hw_irq": 31}
       ]
     },
     "spi_controllers": [

--- a/device/nexthop/x86_64-nexthop_5010-r0/pddf/pddf-device.json.j2
+++ b/device/nexthop/x86_64-nexthop_5010-r0/pddf/pddf-device.json.j2
@@ -33,12 +33,14 @@
     "std_kos": [
       "at24",
       "i2c-dev",
+      "i2c-xiic",
       "spi-xilinx",
       "optoe"
     ],
     "pddf_kos": [
       "pddf_spi_module",
       "pddf_multifpgapci_i2c_module",
+      "pddf_multifpgapci_i2c_xiic_module",
       "pddf_multifpgapci_gpio_module",
       "pddf_multifpgapci_mdio_module",
       "pddf_multifpgapci_spi_module",
@@ -1234,7 +1236,22 @@
     },
     "dev_attr": {
       "pwr_cycle_reg_offset": "0x8",
-      "pwr_cycle_enable_word": "0xdeadbeef"
+      "pwr_cycle_enable_word": "0xdeadbeef",
+      "check_fpga_version_cmd": "fpga read32 {{cpu_card_fpga_bdf}} --bits=0:7 0x0",
+      "reg_width": 32
+    },
+    "use_msi": {
+      "min_fpga_version": "0x86",
+      "num_msi_vectors": 1,
+      "msi_domains": [
+        {
+          "msi_vector_num": 0,
+          "irq_chip_name": "ko-msi-0",
+          "irq_line_mask": "00007f73",
+          "interrupt_enable_reg": "20",
+          "interrupt_status_reg": "24"
+        }
+      ]
     },
     "i2c": {
       "dev_attr": {
@@ -1280,6 +1297,15 @@
           "chn": "6",
           "dev": "TMP464"
         }
+      ],
+      "channel_irq": [
+        {"msi_domain": 0, "hw_irq": 8},
+        {"msi_domain": 0, "hw_irq": 9},
+        {"msi_domain": 0, "hw_irq": 10},
+        {"msi_domain": 0, "hw_irq": 11},
+        {"msi_domain": 0, "hw_irq": 12},
+        {"msi_domain": 0, "hw_irq": 13},
+        {"msi_domain": 0, "hw_irq": 14}
       ]
     },
     "spi_controllers": ["CPUCARD_SPI_CONTROLLER"],
@@ -2642,7 +2668,36 @@
     },
     "dev_attr": {
       "pwr_cycle_reg_offset": "0x4",
-      "pwr_cycle_enable_word": "0xdeadbeef"
+      "pwr_cycle_enable_word": "0xdeadbeef",
+      "check_fpga_version_cmd": "fpga read32 {{switchcard_fpga_bdf}} --bits=0:7 0x0",
+      "reg_width": 32
+    },
+    "use_msi": {
+      "min_fpga_version": "0x1f",
+      "num_msi_vectors": 3,
+      "msi_domains": [
+        {
+          "msi_vector_num": 0,
+          "irq_chip_name": "humm-msi-0",
+          "irq_line_mask": "0001ff00",
+          "interrupt_enable_reg": "170",
+          "interrupt_status_reg": "174"
+        },
+        {
+          "msi_vector_num": 1,
+          "irq_chip_name": "humm-msi-1",
+          "irq_line_mask": "ffffffff",
+          "interrupt_enable_reg": "178",
+          "interrupt_status_reg": "17C"
+        },
+        {
+          "msi_vector_num": 2,
+          "irq_chip_name": "humm-msi-2",
+          "irq_line_mask": "ffffffff",
+          "interrupt_enable_reg": "180",
+          "interrupt_status_reg": "184"
+        }
+      ]
     },
     "i2c": {
       "dev_attr": {
@@ -2932,6 +2987,81 @@
           "chn": "72",
           "dev": "PORT32"
         }
+      ],
+      "channel_irq": [
+        {"msi_domain": 0, "hw_irq": 8},
+        {"msi_domain": 0, "hw_irq": 9},
+        {"msi_domain": 0, "hw_irq": 10},
+        {"msi_domain": 0, "hw_irq": 11},
+        {"msi_domain": 0, "hw_irq": 12},
+        {"msi_domain": 0, "hw_irq": 13},
+        {"msi_domain": 1, "hw_irq": 0},
+        {"msi_domain": 1, "hw_irq": 1},
+        {"msi_domain": 1, "hw_irq": 2},
+        {"msi_domain": 1, "hw_irq": 3},
+        {"msi_domain": 1, "hw_irq": 4},
+        {"msi_domain": 1, "hw_irq": 5},
+        {"msi_domain": 1, "hw_irq": 6},
+        {"msi_domain": 1, "hw_irq": 7},
+        {"msi_domain": 1, "hw_irq": 8},
+        {"msi_domain": 1, "hw_irq": 9},
+        {"msi_domain": 1, "hw_irq": 10},
+        {"msi_domain": 1, "hw_irq": 11},
+        {"msi_domain": 1, "hw_irq": 12},
+        {"msi_domain": 1, "hw_irq": 13},
+        {"msi_domain": 1, "hw_irq": 14},
+        {"msi_domain": 1, "hw_irq": 15},
+        {"msi_domain": 1, "hw_irq": 16},
+        {"msi_domain": 1, "hw_irq": 17},
+        {"msi_domain": 1, "hw_irq": 18},
+        {"msi_domain": 1, "hw_irq": 19},
+        {"msi_domain": 1, "hw_irq": 20},
+        {"msi_domain": 1, "hw_irq": 21},
+        {"msi_domain": 1, "hw_irq": 22},
+        {"msi_domain": 1, "hw_irq": 23},
+        {"msi_domain": 1, "hw_irq": 24},
+        {"msi_domain": 1, "hw_irq": 25},
+        {"msi_domain": 1, "hw_irq": 26},
+        {"msi_domain": 1, "hw_irq": 27},
+        {"msi_domain": 1, "hw_irq": 28},
+        {"msi_domain": 1, "hw_irq": 29},
+        {"msi_domain": 1, "hw_irq": 30},
+        {"msi_domain": 1, "hw_irq": 31},
+        {"msi_domain": 0, "hw_irq": 14},
+        {"msi_domain": 0, "hw_irq": 15},
+        {"msi_domain": 0, "hw_irq": 16},
+        {"msi_domain": 2, "hw_irq": 0},
+        {"msi_domain": 2, "hw_irq": 1},
+        {"msi_domain": 2, "hw_irq": 2},
+        {"msi_domain": 2, "hw_irq": 3},
+        {"msi_domain": 2, "hw_irq": 4},
+        {"msi_domain": 2, "hw_irq": 5},
+        {"msi_domain": 2, "hw_irq": 6},
+        {"msi_domain": 2, "hw_irq": 7},
+        {"msi_domain": 2, "hw_irq": 8},
+        {"msi_domain": 2, "hw_irq": 9},
+        {"msi_domain": 2, "hw_irq": 10},
+        {"msi_domain": 2, "hw_irq": 11},
+        {"msi_domain": 2, "hw_irq": 12},
+        {"msi_domain": 2, "hw_irq": 13},
+        {"msi_domain": 2, "hw_irq": 14},
+        {"msi_domain": 2, "hw_irq": 15},
+        {"msi_domain": 2, "hw_irq": 16},
+        {"msi_domain": 2, "hw_irq": 17},
+        {"msi_domain": 2, "hw_irq": 18},
+        {"msi_domain": 2, "hw_irq": 19},
+        {"msi_domain": 2, "hw_irq": 20},
+        {"msi_domain": 2, "hw_irq": 21},
+        {"msi_domain": 2, "hw_irq": 22},
+        {"msi_domain": 2, "hw_irq": 23},
+        {"msi_domain": 2, "hw_irq": 24},
+        {"msi_domain": 2, "hw_irq": 25},
+        {"msi_domain": 2, "hw_irq": 26},
+        {"msi_domain": 2, "hw_irq": 27},
+        {"msi_domain": 2, "hw_irq": 28},
+        {"msi_domain": 2, "hw_irq": 29},
+        {"msi_domain": 2, "hw_irq": 30},
+        {"msi_domain": 2, "hw_irq": 31}
       ]
     },
     "spi_controllers": [


### PR DESCRIPTION
#### Why I did it

Instantiate i2c adapters using the i2c-xiic driver (instead of the polling `pddf_custom_fpga_algo`) via PDDF. i2c-xiic has been enabled in https://github.com/sonic-net/sonic-linux-kernel/pull/564 via PDDF. The feature is gated on the underlying FPGA version which needs to support MSI. 

Continuation of https://github.com/sonic-net/sonic-buildimage/pull/27437

Resolves #28380

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Add the relevant config to enable MSI (gated by FPGA version) and config for i2c channels.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

```
cat /proc/interrupts
show platform firm status
show platform psu
show platform curr
show platform vol
i2cdetect -l | grep -c xiic
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

