### PR TITLE
Fix UEFI boot entry not created for images installed from ONIE (regression from #27928)

### DIFF
--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -369,7 +369,11 @@ demo_install_uefi_grub()
     }
     rm -f $grub_install_log
 
-    if [ "$install_env" = "sonic" ]; then
+    # Create the boot entry for both the SONiC and ONIE install environments;
+    # only "build" (chroot, no EFI NVRAM) must be skipped. Restricting this to
+    # "sonic" left non-secure-boot images installed from ONIE with no UEFI boot
+    # entry, so the firmware falls back to booting ONIE instead of SONiC.
+    if [ "$install_env" = "sonic" ] || [ "$install_env" = "onie" ]; then
         # Configure EFI NVRAM Boot variables.  --create also sets the
         # new boot number as active.
         grub=$(find /boot/efi/EFI/$demo_volume_label/ -name grub*.efi -exec basename {} \;)


### PR DESCRIPTION
#### Why I did it

Fixes #28382.

After #27928, installing an **unsigned** (`SECURE_UPGRADE_MODE=no_sign`) SONiC image in **UEFI** mode **from ONIE** no longer creates an EFI NVRAM boot entry for SONiC, so the firmware falls back to booting ONIE and never boots the freshly installed SONiC. For the UEFI VS image added in #27080 this makes the build's UEFI boot verification (`check_install.py`) time out.

Root cause: in `installer/default_platform.conf`, `demo_install_uefi_grub()` runs `grub-install --no-nvram` (no NVRAM entry, and no `--removable` fallback), and #27928 (commit `e57ada5e3`) wrapped the previously **unconditional** `efibootmgr --create` — the only code that registers the SONiC UEFI boot entry — in `if [ "$install_env" = "sonic" ]`. When installing from ONIE (`install_env=onie`) that block is skipped and nothing else creates an entry, so the only remaining entry (ONIE's `\EFI\onie\shimx64.efi`) is booted. Signed images are unaffected because they use `demo_install_uefi_shim()`, which still creates the entry unconditionally.

#### How I did it

Allow the `efibootmgr --create` boot entry to be created for the `onie` install environment as well. Only `build` (a chroot with no EFI NVRAM) must be excluded, so the guard becomes `if [ "$install_env" = "sonic" ] || [ "$install_env" = "onie" ]`.

#### How to verify it

Build the default (unsigned) UEFI VS image, which runs `generate_kvm_image 1 UEFI`:

```
make configure PLATFORM=vs
make target/sonic-vs.img.gz
```

- **Before:** the UEFI verify boot loads `Boot0004 "ONIE" … \EFI\onie\shimx64.efi` and `check_install.py` times out.
- **After:** the install creates `Boot0005 "SONiC-OS" … \EFI\SONiC-OS\grubx64.efi`, the verify boot reaches `sonic login:`, and the build succeeds.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### A picture of a cute animal (not mandatory but encouraged)
