### PR TITLE
Revert "Build an VS image that uses UEFI alongside existing BIOS image"

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -32,7 +32,6 @@ IMAGE_VERSION="${SONIC_IMAGE_VERSION}"
 generate_kvm_image()
 {
     NUM_ASIC=$1
-    BOOT_FIRMWARE=${2:-BIOS}
     if [ $NUM_ASIC == 4 ]; then 
          KVM_IMAGE=$OUTPUT_KVM_4ASIC_IMAGE
          RECOVERY_ISO=$onie_recovery_kvm_4asic_image
@@ -45,15 +44,11 @@ generate_kvm_image()
          NUM_ASIC=1
     fi
 
-    echo "Build $NUM_ASIC-asic ${BOOT_FIRMWARE} KVM image"
-    if [[ "$BOOT_FIRMWARE" == "UEFI" ]]; then
-        KVM_IMAGE_DISK=${KVM_IMAGE%.img.gz}-uefi.img
-    else
-        KVM_IMAGE_DISK=${KVM_IMAGE%.gz}
-    fi
+    echo "Build $NUM_ASIC-asic KVM image"
+    KVM_IMAGE_DISK=${KVM_IMAGE%.gz}
     sudo rm -f $KVM_IMAGE_DISK $KVM_IMAGE_DISK.gz
 
-    SONIC_USERNAME=$USERNAME PASSWD=$PASSWORD sudo -E ./scripts/build_kvm_image.sh $KVM_IMAGE_DISK $RECOVERY_ISO $OUTPUT_ONIE_IMAGE $KVM_IMAGE_DISK_SIZE ${BOOT_FIRMWARE}
+    SONIC_USERNAME=$USERNAME PASSWD=$PASSWORD sudo -E ./scripts/build_kvm_image.sh $KVM_IMAGE_DISK $RECOVERY_ISO $OUTPUT_ONIE_IMAGE $KVM_IMAGE_DISK_SIZE
 
     if [ $? -ne 0 ]; then
         echo "Error : build kvm image failed"
@@ -177,8 +172,7 @@ elif [ "$IMAGE_TYPE" = "kvm" ]; then
 
     generate_onie_installer_image
     # Generate single asic KVM image
-    generate_kvm_image 1
-    generate_kvm_image 1 UEFI
+    generate_kvm_image
     if [ "$BUILD_MULTIASIC_KVM" == "y" ]; then
         # Generate 4-asic KVM image
         generate_kvm_image 4

--- a/install_sonic.py
+++ b/install_sonic.py
@@ -34,8 +34,7 @@ def main():
 
     # select ONIE embed
     p.expect(grub_selection)
-    p.send(KEY_DOWN)
-    p.sendline()
+    p.sendline(KEY_DOWN)
 
     # select ONIE install
     p.expect(['ONIE: Install OS'])

--- a/platform/vs/onie.mk
+++ b/platform/vs/onie.mk
@@ -1,5 +1,5 @@
 ONIE_RECOVERY_IMAGE = onie-recovery-x86_64-kvm_x86_64-r0.iso
-$(ONIE_RECOVERY_IMAGE)_URL = "$(BUILD_PUBLIC_URL)/onie/efi/onie-recovery-x86_64-kvm_x86_64-r0.iso"
+$(ONIE_RECOVERY_IMAGE)_URL = "$(BUILD_PUBLIC_URL)/onie/onie-recovery-x86_64-kvm_x86_64-r0.iso"
 
 ONIE_RECOVERY_KVM_4ASIC_IMAGE = onie-recovery-x86_64-kvm_x86_64_4_asic-r0.iso
 $(ONIE_RECOVERY_KVM_4ASIC_IMAGE)_URL = "$(BUILD_PUBLIC_URL)/onie/onie-recovery-x86_64-kvm_x86_64_4_asic-r0.iso"

--- a/scripts/build_kvm_image.sh
+++ b/scripts/build_kvm_image.sh
@@ -9,7 +9,6 @@ DISK=$1
 ONIE_RECOVERY_ISO=$2
 INSTALLER=$3
 DISK_SIZE=$4
-BOOT_FIRMWARE=$5
 
 INSTALLER_DISK="./sonic-installer.img"
 
@@ -87,21 +86,13 @@ trap on_error ERR
 
 echo "Installing SONiC"
 
-
-if [[ "$BOOT_FIRMWARE" == "UEFI" ]]; then
-    efi_vars=${DISK%.img}_vars.fd
-    cp /usr/share/OVMF/OVMF_VARS_4M.fd $efi_vars
-    uefi_options="-drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE_4M.secboot.fd -drive if=pflash,format=raw,file=$efi_vars"
-fi
-
 /usr/bin/kvm -m $MEM \
-    -machine "q35,smm=on" \
     -name "onie" \
     -boot "order=cd,once=d" -cdrom "$ONIE_RECOVERY_ISO" \
-    ${uefi_options} \
-    -device virtio-net,netdev=onienet \
-    -netdev user,id=onienet \
-    -nographic \
+    -device e1000,netdev=onienet \
+    -netdev user,id=onienet,hostfwd=:0.0.0.0:3041-:22 \
+    -vnc 0.0.0.0:0 \
+    -vga std \
     -drive file=$DISK,media=disk,if=virtio,index=0 \
     -drive file=$INSTALLER_DISK,if=virtio,index=1 \
     -serial telnet:127.0.0.1:$KVM_PORT,server > $kvm_log 2>&1 &
@@ -125,12 +116,11 @@ kill $kvm_pid
 echo "Booting up SONiC"
 
 /usr/bin/kvm -m $MEM \
-    -machine "q35,smm=on" \
     -name "onie" \
-    ${uefi_options} \
-    -device virtio-net,netdev=onienet \
+    -device e1000,netdev=onienet \
     -netdev user,id=onienet,hostfwd=:0.0.0.0:3041-:22 \
-    -nographic \
+    -vnc 0.0.0.0:0 \
+    -vga std \
     -snapshot \
     -drive file=$DISK,media=disk,if=virtio,index=0 \
     -serial telnet:127.0.0.1:$KVM_PORT,server > $kvm_log 2>&1 &


### PR DESCRIPTION
Reverts sonic-net/sonic-buildimage#27080

`generate_kvm_image 1 UEFI` failed
```
============= kvm_log ==============
++ cat /tmp/tmp.z1Fzfxv44Z
QEMU 10.0.8 monitor - type 'help' for more information
kvm: -serial telnet:127.0.0.1:9000,server: info: QEMU waiting for connection on: disconnected:telnet:127.0.0.1:9000,server=on
(qemu) + on_exit
+ rm -f /tmp/tmp.z1Fzfxv44Z
```
This causes `generate_kvm_image 4` never gets run and `sonic-4asic-vs.img` is no longer being published, which failing the prepare testbed step in multi-asic-t1 test

revert the commit as a temp fix to unblock the PR checkers for other PRs
