### PR TITLE
[Mellanox] Start MST around SPC1 chassis CPLD firmware install

### DIFF
--- a/platform/mellanox/asic_detect/asic_detect.sh
+++ b/platform/mellanox/asic_detect/asic_detect.sh
@@ -20,25 +20,63 @@
 SUCCESS_CODE=0
 RC=-1
 RETURN_PCI_ID=false
+RETURN_MST_DEV=false
 
 # Parse command line arguments
-while getopts "p" opt; do
+#   -p : print the ASIC PCI id (e.g. 03:00.0)
+#   -m : print the MST cr-space device node (e.g. /dev/mst/mt52100_pci_cr0)
+while getopts "pm" opt; do
     case $opt in
         p)
             RETURN_PCI_ID=true
+            ;;
+        m)
+            RETURN_MST_DEV=true
             ;;
         *)
             ;;
     esac
 done
 
+# Resolve the MST cr-space device node for a given PCI id. The *_pci_cr0 node uses
+# fast memory-mapped ("PCI direct access") register access; the bare PCI id or the
+# *_pciconf0 node use slow PCI config cycles, which make a CPLD burn ~10x slower.
+# Requires `mst start` to have created the device nodes. Prints the node, returns
+# 0 on success and non-zero if no matching cr-space node is found.
+get_mst_device() {
+    local pci_id="$1"
+    local node=""
+
+    # Match the *_pci_cr0 node whose PCI address matches ours (mst status -v prints
+    # the node on one line and "domain:bus:dev.fn=<pci>" on the following line).
+    if [[ -n "$pci_id" ]]; then
+        node=$(mst status -v 2>/dev/null | awk -v pci="$pci_id" '
+            /\/dev\/mst\// { dev=$1 }
+            index($0, pci) { if (dev ~ /_pci_cr0$/) { print dev; exit } }')
+    fi
+
+    # Fallback: a single cr-space node is present.
+    if [[ -z "$node" ]]; then
+        node=$(ls /dev/mst/*_pci_cr0 2>/dev/null)
+        if [[ $(echo "$node" | grep -c .) -ne 1 ]]; then
+            node=""
+        fi
+    fi
+
+    [[ -n "$node" ]] || return 1
+    echo "$node"
+    return $SUCCESS_CODE
+}
+
 if [[ -f "/usr/bin/asic_detect/asic_type" ]] && [[ -f "/usr/bin/asic_detect/asic_pci_id" ]]; then
-    if [[ "$RETURN_PCI_ID" == true ]]; then
+    if [[ "$RETURN_MST_DEV" == true ]]; then
+        get_mst_device "$(cat /usr/bin/asic_detect/asic_pci_id)"
+    elif [[ "$RETURN_PCI_ID" == true ]]; then
         cat /usr/bin/asic_detect/asic_pci_id
     else
         cat /usr/bin/asic_detect/asic_type
     fi
-    exit $SUCCESS_CODE
+    exit $?
 fi
 
 # make sure that DEVICE_DICT keys are the same as values in DEVICE_ORDER
@@ -70,14 +108,17 @@ if [[ -n "$lspci_output" ]]; then
         fi
     done
     if [[ -n "$DEVICE_TYPE" ]]; then
-        if [[ "$RETURN_PCI_ID" == true ]]; then
-            echo "$DEVICE_PCI_ID"
-        else
-            echo "$DEVICE_TYPE"
-        fi
         if [[ "$DEVICE_TYPE" != "$TYPE_UNKNOWN" ]] && [[ -n "$DEVICE_PCI_ID" ]]; then
             echo "$DEVICE_TYPE" > /usr/bin/asic_detect/asic_type
             echo "$DEVICE_PCI_ID" > /usr/bin/asic_detect/asic_pci_id
+        fi
+        if [[ "$RETURN_MST_DEV" == true ]]; then
+            get_mst_device "$DEVICE_PCI_ID"
+            RC=$?
+        elif [[ "$RETURN_PCI_ID" == true ]]; then
+            echo "$DEVICE_PCI_ID"
+        else
+            echo "$DEVICE_TYPE"
         fi
     fi
     exit $RC

--- a/platform/mellanox/asic_detect/asic_detect.sh
+++ b/platform/mellanox/asic_detect/asic_detect.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -772,12 +772,37 @@ class ComponentCPLD(Component):
         self.description = self.COMPONENT_DESCRIPTION
         self.image_ext_name = self.COMPONENT_FIRMWARE_EXTENSION
 
-    def __get_mst_device(self):
-        output = None
+    @contextlib.contextmanager
+    def _mst_context(self):
         try:
-            output = subprocess.check_output(['/usr/bin/asic_detect/asic_detect.sh', '-p']).decode('utf-8').strip()
+            logger.log_notice("{}: mst start begin".format(self.name), also_print_to_console=True)
+            subprocess.check_call(['/usr/bin/mst', 'start'], universal_newlines=True)
+        except subprocess.CalledProcessError as e:
+            logger.log_error("Failed to manage {} mst: {}".format(self.name, str(e)))
+            raise
+
+        # Keep the body outside the mst-start try so a cpldupdate failure in the
+        # caller is not mislabeled as an mst management error.
+        try:
+            yield
+        finally:
+            try:
+                logger.log_notice("{}: mst stop begin".format(self.name), also_print_to_console=True)
+                subprocess.check_call(['/usr/bin/mst', 'stop'], universal_newlines=True)
+            except subprocess.CalledProcessError as e:
+                logger.log_error("Failed to stop {} mst: {}".format(self.name, str(e)))
+
+    def __get_mst_device(self):
+        # Ask asic_detect for the MST cr-space node (e.g. /dev/mst/mt52100_pci_cr0), not the
+        # raw PCI id. cpldupdate --dev over the mst node uses fast memory-mapped register
+        # access; a bare PCI id falls back to slow PCI config cycles and makes the CPLD burn
+        # ~10x slower. The node exists because _mst_context() runs `mst start` first.
+        try:
+            output = subprocess.check_output([self.ASIC_DETECT_SCRIPT, '-m']).decode('utf-8').strip()
         except subprocess.CalledProcessError as e:
             raise RuntimeError("Failed to get {} mst device: {}".format(self.name, str(e)))
+        if not output:
+            raise RuntimeError("Failed to get {} mst device: empty device node".format(self.name))
         return output
 
     @classmethod
@@ -807,16 +832,26 @@ class ComponentCPLD(Component):
 
         if self._is_spc1_asic():
             try:
-                mst_dev = self.__get_mst_device()
+                with self._mst_context():
+                    mst_dev = self.__get_mst_device()
+                    logger.log_notice("{}: mst device = {}".format(self.name, mst_dev), also_print_to_console=True)
+                    cmd = list(self.CPLD_FIRMWARE_UPDATE_COMMAND_SPC1)
+                    cmd[2] = mst_dev
+                    cmd[4] = image_path
+                    print("INFO: Installing {} firmware update: path={}".format(self.name, image_path))
+                    logger.log_notice("{}: cpldupdate begin: {}".format(self.name, ' '.join(cmd)), also_print_to_console=True)
+                    subprocess.check_call(cmd, universal_newlines=True)
+                    logger.log_notice("{}: cpldupdate done".format(self.name), also_print_to_console=True)
             except RuntimeError as e:
                 print("ERROR: {}".format(e))
                 return False
-            cmd = list(self.CPLD_FIRMWARE_UPDATE_COMMAND_SPC1)
-            cmd[2] = mst_dev
-            cmd[4] = image_path
-        else:
-            cmd = list(self.CPLD_FIRMWARE_UPDATE_COMMAND)
-            cmd[3] = image_path
+            except subprocess.CalledProcessError as e:
+                print("ERROR: Failed to update {} firmware: {}".format(self.name, str(e)))
+                return False
+            return True
+
+        cmd = list(self.CPLD_FIRMWARE_UPDATE_COMMAND)
+        cmd[3] = image_path
 
         try:
             print("INFO: Installing {} firmware update: path={}".format(self.name, image_path))
@@ -1080,20 +1115,6 @@ class ComponenetFPGADPU(ComponentCPLD):
     CPLD_FIRMWARE_UPDATE_COMMAND = ['cpldupdate', '--cpld_chain', '2', '--gpio', '--print-progress', '']
 
     POST_REFRESH_REBOOT_CMD = ['/usr/local/bin/reboot']
-
-    @contextlib.contextmanager
-    def _mst_context(self):
-        try:
-            subprocess.check_call(['/usr/bin/mst', 'start'], universal_newlines=True)
-            yield
-        except subprocess.CalledProcessError as e:
-            logger.log_error("Failed to manage {} mst: {}".format(self.name, str(e)))
-            raise
-        finally:
-            try:
-                subprocess.check_call(['/usr/bin/mst', 'stop'], universal_newlines=True)
-            except subprocess.CalledProcessError as e:
-                logger.log_error("Failed to stop {} mst: {}".format(self.name, str(e)))
 
     def _install_firmware(self, image_path):
         self.CPLD_FIRMWARE_UPDATE_COMMAND[5] = image_path

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -28,7 +28,6 @@ try:
     import io
     import re
     import sys
-    import glob
     import tempfile
     import subprocess
     import traceback
@@ -739,8 +738,6 @@ class ComponentCPLD(Component):
     COMPONENT_DESCRIPTION = 'CPLD - Complex Programmable Logic Device'
     COMPONENT_FIRMWARE_EXTENSION = ['.vme']
 
-    MST_DEVICE_PATH = '/dev/mst'
-    MST_DEVICE_PATTERN = 'mt[0-9]*_pci_cr0'
     FW_VERSION_FORMAT = 'CPLD{}_REV{}{}'
 
     CPLD_NUMBER_FILE = '/var/run/hw-management/config/cpld_num'

--- a/platform/mellanox/mlnx-platform-api/tests/test_component.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_component.py
@@ -210,6 +210,7 @@ class TestComponent:
             c.get_firmware_version()
 
     @mock.patch('sonic_platform.component.ComponentCPLD._is_spc1_asic')
+    @mock.patch('sonic_platform.component.ComponentCPLD._mst_context')
     @mock.patch('sonic_platform.component.MPFAManager.cleanup', mock.MagicMock())
     @mock.patch('sonic_platform.component.MPFAManager.extract', mock.MagicMock())
     @mock.patch('sonic_platform.component.subprocess.check_call')
@@ -218,7 +219,11 @@ class TestComponent:
     @mock.patch('sonic_platform.device_data.DeviceDataManager.is_platform_with_bmc',
                 mock.MagicMock(return_value=False))
     @mock.patch('sonic_platform.component.os.path.exists')
-    def test_cpld_component(self, mock_exists, mock_get_meta_data, mock_get_path, mock_check_call, mock_is_spc1):
+    def test_cpld_component(self, mock_exists, mock_get_meta_data, mock_get_path, mock_check_call, mock_mst_context, mock_is_spc1):
+        mock_mst_cm = mock.MagicMock()
+        mock_mst_cm.__enter__ = mock.MagicMock(return_value=None)
+        mock_mst_cm.__exit__ = mock.MagicMock(return_value=False)
+        mock_mst_context.return_value = mock_mst_cm
         c = ComponentCPLD(1)
         mock_is_spc1.return_value = True
         c._read_generic_file = mock.MagicMock(side_effect=[None, '1', None])
@@ -243,13 +248,19 @@ class TestComponent:
         c._check_file_validity = mock.MagicMock(return_value=True)
         c._ComponentCPLD__get_mst_device = mock.MagicMock(side_effect=RuntimeError('no device'))
         assert not c._install_firmware('')
+        # SPC1 install must run inside the mst context
+        assert mock_mst_context.call_count == 1
+        mock_mst_context.reset_mock()
         c._ComponentCPLD__get_mst_device = mock.MagicMock(return_value='some dev')
         assert c._install_firmware('')
+        mock_mst_context.assert_called_once_with()
         mock_check_call.assert_called_once_with(
             ['cpldupdate', '--dev', 'some dev', '--print-progress', ''],
             universal_newlines=True)
+        # cpldupdate failure -> install fails
         mock_check_call.side_effect = subprocess.CalledProcessError(1, None)
         assert not c._install_firmware('')
+        mock_check_call.side_effect = None
 
         c._install_firmware = mock.MagicMock()
         mock_meta_data.has_option = mock.MagicMock(return_value=False)
@@ -370,17 +381,19 @@ class TestComponent:
 
     @mock.patch('sonic_platform.component.subprocess.check_output')
     def test_cpld_get_mst_device(self, mock_check_output):
-        ComponentCPLD.MST_DEVICE_PATH = '/tmp/mst'
-        os.system('rm -rf /tmp/mst')
         c = ComponentCPLD(1)
+        # empty output (asic_detect could not resolve the mst node) -> error
         mock_check_output.return_value = b''
-        assert c._ComponentCPLD__get_mst_device() == ''
-        os.makedirs(ComponentCPLD.MST_DEVICE_PATH)
-        assert c._ComponentCPLD__get_mst_device() == ''
-        with open('/tmp/mst/mt0_pci_cr0', 'w+') as f:
-            f.write('dummy')
-        mock_check_output.return_value = b'/tmp/mst/mt0_pci_cr0'
-        assert c._ComponentCPLD__get_mst_device() == '/tmp/mst/mt0_pci_cr0'
+        with pytest.raises(RuntimeError):
+            c._ComponentCPLD__get_mst_device()
+        # asic_detect -m returns the mst cr-space node
+        mock_check_output.return_value = b'/dev/mst/mt52100_pci_cr0'
+        assert c._ComponentCPLD__get_mst_device() == '/dev/mst/mt52100_pci_cr0'
+        mock_check_output.assert_called_with([ComponentCPLD.ASIC_DETECT_SCRIPT, '-m'])
+        # asic_detect exiting non-zero -> error
+        mock_check_output.side_effect = subprocess.CalledProcessError(1, None)
+        with pytest.raises(RuntimeError):
+            c._ComponentCPLD__get_mst_device()
 
     @mock.patch('sonic_platform.component.subprocess.check_call')
     def test_cpld_2201_component(self, mock_check_call):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Chassis CPLD firmware updates were failing on Spectrum-1 (SPC1) systems via fwutil install ... CPLD. This is a regression from #26549, which made two changes to the SPC1 CPLD path at once:

1. It removed the global MST startup. SPC1 programs the CPLD with cpldupdate --dev <device>, which needs MST loaded, so with no MST running cpldupdate failed immediately with:
-E- JTAG REG sending failed. Timed out trying to take the ICMD semaphore
2. It switched the device lookup from the MST cr-space node to the raw PCI id. Even after MST is started, passing the bare PCI id (03:00.0) makes cpldupdate reach the ASIC over slow PCI config cycles instead of the MST driver's memory-mapped access — making the burn ~10x slower (it only reached ~80% in 900s in testing, so it never completed inside the test/reboot window).

Both had to be fixed for the CPLD update to succeed in a reasonable time.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- asic_detect.sh: added a -m option that resolves and prints the MST cr-space device node (/dev/mst/mt*_pci_cr0) for the detected ASIC, mapping it from the PCI id via mst status -v, with a single-node glob fallback. Both the cached and detection paths handle it.
- ComponentCPLD (component.py):
  - Wrapped the SPC1 CPLD install in a _mst_context() that runs mst start before cpldupdate and mst stop afterwards (hoisted to ComponentCPLD so the DPU FPGA path reuses it).
  - __get_mst_device() now returns the MST cr-space node via asic_detect.sh -m (using the ASIC_DETECT_SCRIPT constant) instead of the raw PCI id, so cpldupdate uses the fast memory-mapped path.
  - Added notice-level log markers around mst start/stop and cpldupdate so the flow is visible in syslog even if an install stalls.
- Updated the unit tests in tests/test_component.py accordingly.


#### How to verify it
1. Unit tests:
cd platform/mellanox/mlnx-platform-api && pytest tests/test_component.py
2. On an SPC1 switch (e.g. MSN2700), install a chassis CPLD firmware:
fwutil install chassis component CPLD1 fw <FUI000076.mpfa> -y
  - It completes successfully (no JTAG REG sending failed / ICMD semaphore error) within the normal window, and the CPLD version updates after the required power cycle.
  - grep CPLD1 /var/log/syslog shows the new markers, e.g. mst start done, mst device = /dev/mst/mt52100_pci_cr0, cpldupdate begin, cpldupdate done.
3. Or run the platform test:
platform_tests/fwutil/test_fwutil.py::test_fwutil_install_url  (CPLD)

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

