### PR TITLE
Adding id support in sonic-port YANG model

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -255,6 +255,10 @@ module sonic-port{
 					description "Enable or disable fast link-up on the port";
 				}
 
+				leaf id {
+					description "Numeric identifier (SDN Port) used by the controller to address the interface";
+					type uint32;
+				}
 
 			} /* end of list PORT_LIST */
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Added support for id leaf in sonic-port YANG 

#### How I did it
Changes to sonic-port.yang to include the id field 

#### How to verify it
build
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
