### PR TITLE
move /var/log to tmpfs for arista_7060x6 platforms

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -684,16 +684,20 @@ write_platform_specific_cmdline() {
     fi
     if in_array "$sid" "Shearwater4Mk2" "Shearwater4Mk2N" "Shearwater4Mk2QuicksilverDD" "Shearwater4Mk2NQuicksilverDD"; then
         aboot_machine=arista_7060x6_64de
+        cmdline_add logs_inram=on
     fi
     if in_array "$sid" "Shearwater4Mk2QuicksilverP" "Shearwater4Mk2NQuicksilverP"; then
         aboot_machine=arista_7060x6_64pe
+        cmdline_add logs_inram=on
     fi
     if in_array "$sid" "Redstart8Mk2QuicksilverP512" "Redstart8Mk2NQuicksilverP512" \
                 "Redstart832Mk2QuicksilverP512" "Redstart832Mk2NQuicksilverP512"; then
         aboot_machine=arista_7060x6_64pe_b
+        cmdline_add logs_inram=on
     fi
     if in_array "$sid" "MorandaP"; then
         aboot_machine=arista_7060x6_32pe
+        cmdline_add logs_inram=on
     fi
 
     # disable cpu c-state other than C1
@@ -753,6 +757,7 @@ write_platform_specific_cmdline() {
     fi
     if in_array "$sid" "Moby" "RedstartFixed8CNMoby"; then
         aboot_machine=arista_7060x6_16pe_384c_b
+        cmdline_add logs_inram=on
 
         local hw_api="$(get_eeprom_value HwApi)"
         info "HwApi for Moby: $hw_api"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
As part of reducing disk wear and prevent disk RO issues, moving `/var/log/` to be on a RAM based file system like `tmpfs` for `arista_7060x6 ` platforms

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Adding `logs_inram=on` to append to the kernel cmdline parameters to enable mounting tmpfs

#### How to verify it
Verified on Arista-7060x6 platforms by passing it to the kernel cmdline parameters

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

