### PR TITLE
[sbom] Emit container distro in per-container SBOM so grype scans deb/OS packages

### DIFF
--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -19,6 +19,7 @@ pr:
   paths:
     include:
     - dockers/docker-sonic-mgmt
+    - .azure-pipelines/docker-sonic-mgmt.yml
 
 resources:
   repositories:
@@ -94,12 +95,9 @@ stages:
   jobs:
   - job: sbom_vuln_scan
     displayName: "[OPTIONAL] SBOM-based vulnerability scan (docker-sonic-mgmt)"
-    # Disabled for now; remove this `condition: false` (or change to
-    # `and(succeeded(), in(dependencies.Build.result, 'Succeeded'))`)
-    # to re-enable the docker-sonic-mgmt SBOM vulnerability scan.
-    # The SBOM itself is still produced by the Build stage above
-    # when ENABLE_SBOM=y; only the post-build scan is gated.
-    condition: false
+    # The SBOM is produced by the Build stage (ENABLE_SBOM=y); this job
+    # scans it with grype and reports CVEs. Informational only
+    # (continueOnError: true) so findings do not block the pipeline.
     pool: sonic-ubuntu-1c
     continueOnError: true
     timeoutInMinutes: 30

--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -110,7 +110,7 @@ stages:
       displayName: "Download docker-sonic-mgmt artifact (includes SBOM)"
     - script: |
         set -ex
-        sudo apt-get install -y python3-pip jq
+        sudo apt-get install -y jq
       displayName: "Install dependencies"
     - script: |
         set -x

--- a/scripts/build_sbom.py
+++ b/scripts/build_sbom.py
@@ -506,10 +506,26 @@ def apply_licenses(components: list, license_map: dict) -> tuple:
 
 def observation_components_for_scope(
     target_path: str, scope: str, arch: str, supplier: str,
+    distro: Optional[tuple] = None,
 ) -> list:
-    """Emit observation-only components for everything in post-versions/."""
+    """Emit observation-only components for everything in post-versions/.
+
+    When ``distro`` is a ``(id, version_id)`` tuple (e.g. ``("ubuntu",
+    "24.04")``), deb PURLs are namespaced to that distro and carry a
+    ``distro=`` qualifier so grype selects the right OS advisory feed.
+    When ``None`` the legacy ``pkg:deb/debian/`` form is preserved.
+    """
     components = []
     seen: set = set()
+
+    if distro and distro[0]:
+        deb_ns = distro[0]
+        deb_qual = f"&distro={distro[0]}-{distro[1]}" if distro[1] else ""
+        deb_supplier = distro[0].capitalize()
+    else:
+        deb_ns = "debian"
+        deb_qual = ""
+        deb_supplier = supplier
 
     for vfile in find_post_versions(target_path, scope, "deb", arch):
         for name, ver in parse_versions_file(vfile):
@@ -517,13 +533,16 @@ def observation_components_for_scope(
             if key in seen:
                 continue
             seen.add(key)
+            deb_purl = (
+                f"pkg:deb/{deb_ns}/{name}@{ver}?arch={arch}{deb_qual}"
+            )
             comp: dict[str, Any] = {
-                "bom-ref": f"pkg:deb/debian/{name}@{ver}?arch={arch}",
+                "bom-ref": deb_purl,
                 "type": "library",
                 "name": name,
                 "version": ver,
-                "purl": f"pkg:deb/debian/{name}@{ver}?arch={arch}",
-                "supplier": {"name": supplier},
+                "purl": deb_purl,
+                "supplier": {"name": deb_supplier},
                 "properties": [
                     {"name": "sonic:fragment_kind", "value": "observation"},
                     {"name": "sonic:scope", "value": scope},
@@ -1016,6 +1035,154 @@ def _promote_cpe(winner: dict, loser: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Container distro detection (needed for deb/OS-package vuln matching)
+# ---------------------------------------------------------------------------
+
+
+def _parse_os_release(text: str) -> Optional[tuple]:
+    """Parse /etc/os-release content into ``(ID, VERSION_ID)``.
+
+    Returns None when no ``ID`` field is present.
+    """
+    kv: dict = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        kv[k] = v.strip().strip('"').strip("'")
+    did = kv.get("ID")
+    if not did:
+        return None
+    return (did, kv.get("VERSION_ID", ""))
+
+
+def detect_container_distro(gz_path: str) -> Optional[tuple]:
+    """Return the container's ``(distro_id, version_id)`` by reading
+    ``/etc/os-release`` from the image archive, e.g. ``("ubuntu", "24.04")``.
+
+    The env var ``SBOM_CONTAINER_DISTRO`` (``id-version``, e.g.
+    ``ubuntu-24.04``) overrides detection. Returns None when the distro
+    can't be determined; callers then skip emitting distro metadata and
+    the SBOM keeps its legacy (distro-less) shape.
+    """
+    override = os.environ.get("SBOM_CONTAINER_DISTRO", "").strip()
+    if override:
+        # Accept "id" or "id-version"; split on the LAST '-' so distro
+        # ids that themselves contain hyphens (e.g. "cbl-mariner-2.0")
+        # keep their id intact. Ignore a value with an empty id.
+        if "-" in override:
+            oid, over = override.rsplit("-", 1)
+        else:
+            oid, over = override, ""
+        if oid:
+            return (oid, over)
+        warn(f"ignoring malformed SBOM_CONTAINER_DISTRO={override!r}")
+
+    import shutil
+    import tarfile
+    import tempfile
+
+    def _search(tf) -> Optional[tuple]:
+        for member in tf:
+            # /etc/os-release is commonly a symlink to /usr/lib/os-release,
+            # so don't require a regular file (symlinks report isfile()==
+            # False) and match both paths. extractfile() follows in-tar
+            # symlinks and returns the target content.
+            nm = member.name.lstrip("./").rstrip("/")
+            if nm.endswith("etc/os-release") or nm.endswith("usr/lib/os-release"):
+                ex = tf.extractfile(member)
+                if ex is not None:
+                    got = _parse_os_release(
+                        ex.read().decode("utf-8", "replace")
+                    )
+                    if got:
+                        return got
+        return None
+
+    try:
+        with tarfile.open(gz_path, "r:*") as outer:
+            for m in outer:
+                nm = m.name.lstrip("./").rstrip("/")
+                # os-release directly present in a flattened rootfs archive
+                # (may be a symlink to usr/lib/os-release)
+                if nm.endswith("etc/os-release") or nm.endswith(
+                    "usr/lib/os-release"
+                ):
+                    ex = outer.extractfile(m)
+                    if ex is not None:
+                        got = _parse_os_release(
+                            ex.read().decode("utf-8", "replace")
+                        )
+                        if got:
+                            return got
+                    continue
+                if not m.isfile():
+                    continue
+                # nested image layers (docker-archive: */layer.tar or
+                # *.tar; OCI: blobs/sha256/*) — peek inside for os-release
+                looks_like_layer = (
+                    nm.endswith(".tar")
+                    or nm.endswith("layer.tar")
+                    or "blobs/sha256" in nm
+                    or nm.endswith(".tar.gz")
+                )
+                if not looks_like_layer:
+                    continue
+                ex = outer.extractfile(m)
+                if ex is None:
+                    continue
+                # Spill the layer to a temp file, then parse with random
+                # access. Opening a nested tar directly off the gzip outer
+                # stream (mode="r|*") silently finds no members, and
+                # buffering whole layers in memory risks OOM on large
+                # images, so stream to disk (bounded memory) and seek.
+                tmp = tempfile.NamedTemporaryFile(
+                    prefix="sbom-distro-", suffix=".tar",
+                    dir=os.path.dirname(os.path.abspath(gz_path)) or None,
+                    delete=False,
+                )
+                try:
+                    shutil.copyfileobj(ex, tmp, 1024 * 1024)
+                    tmp.close()
+                    with tarfile.open(tmp.name, "r:*") as inner:
+                        got = _search(inner)
+                except tarfile.TarError:
+                    got = None
+                finally:
+                    try:
+                        os.unlink(tmp.name)
+                    except OSError:
+                        pass
+                if got:
+                    return got
+    except Exception as e:  # defensive: never fail the build on this
+        warn(f"container distro detection failed for {gz_path}: {e}")
+    return None
+
+
+def operating_system_component(distro_id: str, version_id: str) -> dict:
+    """Build a CycloneDX ``operating-system`` component carrying the
+    distro. grype keys OS-package (deb/rpm/apk) matching off the
+    ``syft:distro:*`` properties, so without such a component every deb
+    package is silently skipped.
+    """
+    ver = version_id or "unknown"
+    props = [{"name": "syft:distro:id", "value": distro_id}]
+    if version_id:
+        props.append(
+            {"name": "syft:distro:versionID", "value": version_id}
+        )
+    return {
+        "bom-ref": f"os:{distro_id}-{ver}",
+        "type": "operating-system",
+        "name": distro_id,
+        "version": ver,
+        "properties": props,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Top-level orchestration
 # ---------------------------------------------------------------------------
 
@@ -1083,10 +1250,21 @@ def _container_main(container_filename: str) -> int:
                 {"alg": "SHA-256", "content": sha}
             ]
 
+    # Detect the container's OS/distro so grype can vuln-match deb/OS
+    # packages. Without a distro the SBOM carries no OS context and
+    # grype silently skips every deb component, scanning only language
+    # packages. See README.sbom.md "Vulnerability scanning".
+    distro = detect_container_distro(gz_path)
+    if distro:
+        info(f"Container distro: {distro[0]} {distro[1]}")
+    else:
+        warn("container distro undetected; deb/OS packages will not be "
+             "vuln-matched by grype for this container SBOM")
+
     # Observation: only this container's scope.
     scope = f"dockers/{cname}"
     obs = observation_components_for_scope(
-        target_path, scope, arch, "Debian",
+        target_path, scope, arch, "Debian", distro=distro,
     )
     info(f"Container observation: {len(obs)} components")
 
@@ -1117,6 +1295,13 @@ def _container_main(container_filename: str) -> int:
         lockfile_components,
         scanner_components,
     )
+
+    # Emit an operating-system component so grype can identify the
+    # distro and match deb/OS packages against the right advisory feed.
+    if distro:
+        all_components.append(
+            operating_system_component(distro[0], distro[1])
+        )
     info(f"Final merged: {len(all_components)} unique components")
 
     # License resolution (per-scope copyrights tarball + fallback to


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The `docker-sonic-mgmt` SBOM-based vulnerability scan (added opt-in in #27455)
only ever reported npm CVEs — grype silently skipped **every** Debian/Ubuntu
(`deb`) and OS package.

Root cause: the per-container SBOM (`target/<container>.gz.sbom.cdx.json`)
carried no OS/distro context. `metadata.component` was `type: container`, there
was no `operating-system` component, and every deb component used a bare
`pkg:deb/debian/<name>@<ver>` PURL with no `distro=` qualifier. grype needs the
distro to select an OS advisory feed, so it dropped all deb/OS packages and
matched only language (npm/py/…) packages.

For `docker-sonic-mgmt` (an `ubuntu:24.04` image) this meant the scan reported
~22 npm findings and **0 deb**, hiding exactly the Debian/Ubuntu CVEs that
image-based scanners (S360, trivy) surface — defeating the purpose of the scan.

##### Work item tracking
- Microsoft ADO: 38823175

#### How I did it
**`scripts/build_sbom.py`** — per-container SBOM path (`_container_main`):
- Detect the container distro by reading `/etc/os-release` from the image
  archive (`detect_container_distro`). Handles both docker-archive
  (`<hash>/layer.tar`) and OCI (`blobs/sha256/*`) layouts, and the common case
  where `/etc/os-release` is a symlink to `/usr/lib/os-release`. Overridable via
  `SBOM_CONTAINER_DISTRO=<id>-<version>`. Detection failure degrades gracefully
  (warns, keeps the legacy shape) and never fails the build.
- Emit a CycloneDX `operating-system` component carrying `syft:distro:id` /
  `syft:distro:versionID`, which grype reads to identify the distro.
- Namespace deb PURLs to the detected distro with a `distro=` qualifier, e.g.
  `pkg:deb/ubuntu/adduser@3.137ubuntu1?arch=amd64&distro=ubuntu-24.04`.
- The aggregate `.bin` SBOM path is **unchanged** (`distro` defaults to `None`
  → legacy `pkg:deb/debian/…`), so this only affects the standalone
  per-container test SBOMs (docker-ptf, docker-sonic-mgmt).

**`.azure-pipelines/docker-sonic-mgmt.yml`**:
- Enable the `sbom_vuln_scan` job (previously gated with `condition: false`).
- Add `.azure-pipelines/docker-sonic-mgmt.yml` to the PR `paths` filter so
  changes to this pipeline definition actually trigger it (mirroring
  `docker-ptf.yml`).

#### How to verify it
1. Build the SBOM:
   ```
   make ENABLE_SBOM=y ... target/docker-sonic-mgmt.gz
   ```
   The build log prints `[build_sbom.py] Container distro: ubuntu 24.04`, and
   `target/docker-sonic-mgmt.gz.sbom.cdx.json` now contains an
   `operating-system` component plus `pkg:deb/ubuntu/…&distro=ubuntu-24.04` deb
   PURLs.
2. Scan it:
   ```
   grype sbom:target/docker-sonic-mgmt.gz.sbom.cdx.json
   ```
   deb CVEs are now reported.

Measured on the real docker-sonic-mgmt SBOM, grype findings went from **23 (all
npm, 0 deb)** to **114 (23 npm + 91 deb)**. The `sbom_vuln_scan` CI job
(mssonic build 1166089) confirmed **62 deb CVEs** (medium+) in addition to the
npm findings, where before it reported npm only.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

