### PR TITLE
[system-health]: Honor 'psu' and 'pdb' device ignore independently in hardware checker

### DIFF
--- a/src/system-health/health_checker/hardware_checker.py
+++ b/src/system-health/health_checker/hardware_checker.py
@@ -171,12 +171,17 @@ class HardwareChecker(HealthChecker):
         :param config: Health checker configuration
         :return:
         """
-        if config.ignore_devices and 'psu' in config.ignore_devices and 'pdb' in config.ignore_devices:
+        ignore_psu = bool(config.ignore_devices) and 'psu' in config.ignore_devices
+        ignore_pdb = bool(config.ignore_devices) and 'pdb' in config.ignore_devices
+        if ignore_psu and ignore_pdb:
             return
 
         keys = self._db.keys(self._db.STATE_DB, HardwareChecker.PSU_TABLE_NAME + '*')
         if not keys:
-            self.set_object_not_ok('PSU', 'PSU', 'Failed to get PSU information')
+            # An empty PSU_INFO table is only a failure when PSU monitoring is expected.
+            # Platforms without PSUs (e.g. DPUs) ignore 'psu' to suppress this alarm.
+            if not ignore_psu:
+                self.set_object_not_ok('PSU', 'PSU', 'Failed to get PSU information')
             return
 
         for key in natsorted(keys):
@@ -187,6 +192,12 @@ class HardwareChecker(HealthChecker):
 
             name = key_list[1]
             if config.ignore_devices and name in config.ignore_devices:
+                continue
+
+            # PSU and PDB rows share PSU_INFO (PDB keys look like "PDB 1"); honor each
+            # category-level ignore independently so ignoring one does not check the other.
+            is_pdb = name.upper().startswith('PDB')
+            if (is_pdb and ignore_pdb) or (not is_pdb and ignore_psu):
                 continue
 
             data_dict = self._db.get_all(self._db.STATE_DB, key)

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -905,6 +905,38 @@ def test_hardware_checker_psu_pdb_ignore_both_skips_psu_check():
     assert 'PSU 1' not in checker._info
 
 
+def test_hardware_checker_psu_ignore_no_psu_info():
+    """Ignoring 'psu' on a platform with no PSU_INFO (e.g. a DPU) must not report a PSU failure."""
+    MockConnector.data.clear()
+    config = Config()
+    config.ignore_devices = ['psu', 'fan']
+    checker = HardwareChecker()
+    checker.check(config)
+    assert 'PSU' not in checker._info
+
+
+def test_hardware_checker_psu_ignore_skips_psu_but_checks_pdb():
+    """Ignoring only 'psu' skips PSU rows but still evaluates PDB rows."""
+    MockConnector.data.clear()
+    MockConnector.data.update({
+        'PSU_INFO|PSU 1': {
+            'presence': 'False',
+            'status': 'True',
+        },
+        'PSU_INFO|PDB 1': {
+            'presence': 'True',
+            'status': 'False',
+        },
+    })
+    config = Config()
+    config.ignore_devices = ['psu']
+    checker = HardwareChecker()
+    checker.check(config)
+    assert 'PSU 1' not in checker._info
+    assert 'PDB 1' in checker._info
+    assert checker._info['PDB 1'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_NOT_OK
+
+
 def test_config():
     config = Config()
     config._config_file = os.path.join(test_path, Config.CONFIG_FILE)


### PR DESCRIPTION
#### Why I did it

`show system-health detail` reports **Hardware: Not OK** with reason **"Failed to get PSU information"** on platforms that have no PSUs and whose `system_health_monitoring_config.json` lists `psu` in `devices_to_ignore` **but not** `pdb` — even though `psu` is shown as ignored.

This is a regression from #26829 ("Add PDB support for system-health"), which changed the `_check_psu_status` early-return guard to require **both** `psu` and `pdb` to be ignored. When only `psu` is ignored, the checker proceeds, finds an empty `PSU_INFO`, and reports the failure. The same change also silently re-enabled per-PSU checks on switches that ignore the `psu` category but not `pdb`.

fixes #28414

##### Work item tracking
- Microsoft ADO **(number only)**: 38803669

#### How I did it

In `src/system-health/health_checker/hardware_checker.py`, `_check_psu_status` now honors `psu` and `pdb` independently:
- Skip the whole check only when **both** `psu` and `pdb` are ignored.
- Report the empty-`PSU_INFO` "Failed to get PSU information" failure only when `psu` is **not** ignored (so a genuinely broken `psud` on a real switch is still detected).
- Per row, skip PSU rows when `psu` is ignored and PDB rows (keyed `PDB N`) when `pdb` is ignored.

Added regression unit tests in `src/system-health/tests/test_system_health.py`.

#### How to verify it

1. Unit tests:
   ```
   cd src/system-health && python3 -m pytest tests/test_system_health.py -k "hardware or psu or pdb or config"
   ```
2. Manual: on a platform with no `PSU_INFO` in STATE_DB, set `devices_to_ignore` to include `psu` (and `fan`) but **not** `pdb`, restart the `system-health` service, and confirm `show system-health detail` reports **Hardware: OK** (previously **Not OK — Failed to get PSU information**).
3. Confirm a platform that exposes PSUs still reports PSU failures when `psu` is not ignored, and that PDB rows are still evaluated when only `psu` is ignored.

Verified with both 202605 and master image. PSU is correctly ignored on a DPU, while it is correctly checked on the NPU.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Reason: the regression (#26829) is present on `master` and `202605`; the fix should follow it wherever `#26829` is merged.

#### Tested branch (Please provide the tested image version)

- [x] Validated via the unit tests above on `master`; the regression was originally observed on `20260510`.

#### Description for the changelog

[system-health] Fix false "Failed to get PSU information" when only 'psu' (not 'pdb') is in devices_to_ignore

#### Link to config_db schema for YANG module changes

N/A — no YANG/config_db schema changes.

#### A picture of a cute animal (not mandatory but encouraged)

🐾🐱
