### PR TITLE
[Mellanox] lazily import redis in module to reduce psud memory

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
@@ -16,7 +16,6 @@
 # limitations under the License.
 #
 
-import redis
 import threading
 from sonic_platform_base.module_base import ModuleBase
 from sonic_platform_base.chassis_base import ChassisBase
@@ -42,7 +41,7 @@ class Module(ModuleBase):
     STATE_DB = 6
     STATE_MODULAR_CHASSIS_SLOT_TABLE = 'MODULAR_CHASSIS_SLOT|{}'
     FIELD_SEQ_NO = 'seq_no'
-    redis_client = redis.Redis(db = STATE_DB)
+    redis_client = None
 
     def __init__(self, slot_id):
         super(Module, self).__init__()
@@ -125,9 +124,18 @@ class Module(ModuleBase):
         self.current_state = state
         self.seq_no = seq_no
 
+    @classmethod
+    def _get_redis_client(cls):
+        # Lazily create the STATE_DB client so that importing this module does not
+        # pull in the redis package (saves ~20MB RSS in psud).
+        if cls.redis_client is None:
+            import redis
+            cls.redis_client = redis.Redis(db=cls.STATE_DB)
+        return cls.redis_client
+
     def _get_seq_no(self):
         try:
-            seq_no = Module.redis_client.hget(Module.STATE_MODULAR_CHASSIS_SLOT_TABLE.format(self.slot_id), Module.FIELD_SEQ_NO)
+            seq_no = Module._get_redis_client().hget(Module.STATE_MODULAR_CHASSIS_SLOT_TABLE.format(self.slot_id), Module.FIELD_SEQ_NO)
             seq_no = seq_no.decode().strip()
         except Exception as e:
             seq_no = 0


### PR DESCRIPTION
### Description
On SmartSwitch platforms (e.g. SN4280) `psud` builds DPU `Module` objects via `get_chassis()`, which imports `sonic_platform/module.py`. That module did an unconditional top-level `import redis` and instantiated a `redis.Redis` client at class-definition time. Importing `redis-py` costs ~20MB RSS, pushing `psud` over the memory threshold checked by the RAM-usage test (25MB * 1.05 = 26.25MB).

`redis` is only used in `Module._get_seq_no()` (modular-chassis slot seq_no), which never runs on SmartSwitch DPU modules. This change defers the import and client creation into a lazy getter, so `psud` no longer pulls in `redis` at all.

No functional change to `_get_seq_no` behaviour.

### Motivation
The `psud` process memory usage exceeds the threshold defined in the `test_ram_usage` test on SmartSwitch platforms.

### Measured impact (live, before/after reboot)
| Platform | psud Pss before | psud Pss after |
| --- | --- | --- |
| SN4280 (SmartSwitch, 4 DPUs) | 36.83 MB | 19.20 MB |
| SN4700 (non-SmartSwitch, 0 DPUs) | 19.90 MB | 18.51 MB |

`redis` is no longer mapped into the `psud` process; the SmartSwitch platform drops ~17.6MB, back under the 26.25MB threshold. Non-SmartSwitch platforms are unaffected.

### How to verify
```
sudo cat /proc/$(pgrep -f /usr/local/bin/psud | head -1)/smaps | grep Pss | grep -v Pss_Dirty | awk '{T+=$2} END {print T/1024}'
```
