### PR TITLE
fix(docker-ptf): backport Go 1.25.12 to 202511

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -135,18 +135,18 @@ RUN WIRESHARK_VERSION=4.6.6 \
 {% endif %}
 
 # Install Go toolchain for building grpcurl and gnmic from source
-# to ensure they use a patched Go stdlib (GO-2026-5039: net/textproto)
+# to ensure they use a patched Go stdlib (GO-2026-4970, GO-2026-5856)
 {% if CONFIGURED_ARCH == "armhf" %}
 RUN GO_ARCH=armv6l \
-    && GO_SHA256=492d69badee59cae12e9a36282dfce94041bd4aac88fdddea575a7d99a2bd05d \
+    && GO_SHA256=6cd7311c02c73ba0b482a1cf8c885268edf23519261bf4b5cef3353ad934d1f1 \
 {% elif CONFIGURED_ARCH == "arm64" %}
 RUN GO_ARCH=arm64 \
-    && GO_SHA256=c30bf9e156a54ea4e31fbbbf31a712b32734b58cc9a22426fa5ee632d0885124 \
+    && GO_SHA256=8b5884aef89600aef5b0b051fb971f11f49bb996521e911f30f02a66884f7bd2 \
 {% else %}
 RUN GO_ARCH=amd64 \
-    && GO_SHA256=34f14304e856893f4ba30c2cacfe93906e9de7915c5f6aaaf3a81cdccd7ba30b \
+    && GO_SHA256=234828b7a89e0e303d2556310ee549fbcf253d28de937bac3da13d6294262ac1 \
 {% endif %}
-    && GO_VERSION=1.25.11 \
+    && GO_VERSION=1.25.12 \
     && curl -L "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz" -o /tmp/go.tar.gz \
     && echo "${GO_SHA256}  /tmp/go.tar.gz" | sha256sum -c - \
     && tar -C /usr/local -xzf /tmp/go.tar.gz \


### PR DESCRIPTION
#### Why I did it

This is the 202511 backport of #28424. S360 and Trivy scanning flag the Go standard library embedded in `/usr/local/bin/grpcurl` and `/usr/local/bin/gnmic`, which are built with the pinned Go 1.25.11 toolchain, for **GO-2026-4970 / CVE-2026-39822** and **GO-2026-5856 / CVE-2026-42505**. Both vulnerabilities are fixed in Go 1.25.12.

##### Work item tracking
- Microsoft ADO **(number only)**: 38808442

#### How I did it

Updated the pinned Go toolchain in `dockers/docker-ptf/Dockerfile.j2` from 1.25.11 to 1.25.12 and replaced the amd64, arm64, and armv6l archive checksums with the official values from the Go release feed.

#### How to verify it

1. Build docker-ptf with `make configure PLATFORM=vs && make target/docker-ptf.gz`.
2. Run `trivy image --scanners vuln docker-ptf:latest`.
3. Confirm Trivy no longer reports CVE-2026-39822 or CVE-2026-42505 against `usr/local/bin/grpcurl` or `usr/local/bin/gnmic`.

The baseline Go 1.25.11 image reported both CVEs against both binaries. The patched master image `sha256:4d8f558989d3cc85f326f3133314589e08ba8ed7489d93588d8dd1dedb105b80` reports zero matching findings, and Trivy identifies stdlib v1.25.12 in both binaries. This backport applies the identical pinned version and architecture checksums and passes `git diff --check`.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

This PR directly targets 202511. No additional release backport is requested from this PR.

#### Tested branch (Please provide the tested image version)

- [x] master - local docker-ptf image `sha256:4d8f558989d3cc85f326f3133314589e08ba8ed7489d93588d8dd1dedb105b80`
- [ ] 202511 - PR CI pending

#### Description for the changelog

[docker-ptf] Update Go to 1.25.12 to remediate GO-2026-4970 and GO-2026-5856 in grpcurl and gnmic

#### Link to config_db schema for YANG module changes

N/A. No YANG or config_db schema changes.

#### A picture of a cute animal (not mandatory but encouraged)

N/A.
