### PR TITLE
[Mellanox] Remove redundant hwsku interfaces for SN6600-LD

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/ACS-SN6600_LD/hwsku.json
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/ACS-SN6600_LD/hwsku.json
@@ -3,391 +3,196 @@
         "Ethernet0": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet4": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet8": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet12": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet16": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet20": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet24": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet28": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet32": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet36": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet40": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet44": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet48": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet52": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet56": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet60": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet64": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet68": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet72": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet76": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet80": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet84": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet88": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet92": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet96": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet100": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet104": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet108": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet112": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet116": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet120": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet124": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet128": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet132": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet136": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet140": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet144": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet148": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet152": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet156": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet160": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet164": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet168": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet172": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet176": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet180": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet184": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet188": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet192": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet196": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet200": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet204": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet208": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet212": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet216": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet220": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet224": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet228": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet232": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet236": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet240": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet244": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet248": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet252": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet256": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet260": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet264": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet268": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet272": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet276": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet280": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet284": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet288": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet292": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet296": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet300": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet304": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet308": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet312": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet316": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet320": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet324": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet328": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet332": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet336": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet340": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet344": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet348": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet352": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet356": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet360": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet364": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet368": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet372": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet376": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet380": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet384": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet388": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet392": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet396": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet400": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet404": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet408": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet412": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet416": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet420": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet424": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet428": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet432": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet436": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet440": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet444": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet448": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet452": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet456": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet460": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet464": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet468": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet472": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet476": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet480": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet484": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet488": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet492": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet496": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet500": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet504": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet508": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet512": {
-            "default_brkout_mode": "2x100G"
-        },
-        "Ethernet513": {
             "default_brkout_mode": "2x100G"
         }
     }

--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P128C2/hwsku.json
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P128C2/hwsku.json
@@ -3,391 +3,196 @@
         "Ethernet0": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet4": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet8": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet12": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet16": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet20": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet24": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet28": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet32": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet36": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet40": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet44": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet48": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet52": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet56": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet60": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet64": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet68": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet72": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet76": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet80": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet84": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet88": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet92": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet96": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet100": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet104": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet108": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet112": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet116": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet120": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet124": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet128": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet132": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet136": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet140": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet144": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet148": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet152": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet156": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet160": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet164": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet168": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet172": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet176": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet180": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet184": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet188": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet192": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet196": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet200": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet204": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet208": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet212": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet216": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet220": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet224": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet228": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet232": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet236": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet240": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet244": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet248": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet252": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet256": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet260": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet264": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet268": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet272": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet276": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet280": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet284": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet288": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet292": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet296": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet300": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet304": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet308": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet312": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet316": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet320": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet324": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet328": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet332": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet336": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet340": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet344": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet348": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet352": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet356": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet360": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet364": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet368": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet372": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet376": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet380": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet384": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet388": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet392": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet396": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet400": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet404": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet408": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet412": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet416": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet420": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet424": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet428": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet432": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet436": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet440": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet444": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet448": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet452": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet456": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet460": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet464": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet468": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet472": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet476": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet480": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet484": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet488": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
-        "Ethernet492": {
             "default_brkout_mode": "2x800G[400G]"
         },
         "Ethernet496": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet500": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet504": {
             "default_brkout_mode": "2x800G[400G]"
         },
-        "Ethernet508": {
-            "default_brkout_mode": "2x800G[400G]"
-        },
         "Ethernet512": {
-            "default_brkout_mode": "2x100G"
-        },
-        "Ethernet513": {
             "default_brkout_mode": "2x100G"
         }
     }

--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P64O128C2/hwsku.json
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P64O128C2/hwsku.json
@@ -5,29 +5,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet2": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet4": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet8": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet10": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet12": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet16": {
@@ -35,29 +15,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet18": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet20": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet24": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet26": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet28": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet32": {
@@ -65,29 +25,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet34": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet36": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet40": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet42": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet44": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet48": {
@@ -95,29 +35,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet50": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet52": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet56": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet58": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet60": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet64": {
@@ -125,29 +45,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet66": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet68": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet72": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet74": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet76": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet80": {
@@ -155,29 +55,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet82": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet84": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet88": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet90": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet92": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet96": {
@@ -185,29 +65,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet98": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet100": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet104": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet106": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet108": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet112": {
@@ -215,29 +75,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet114": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet116": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet120": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet122": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet124": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet128": {
@@ -245,29 +85,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet130": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet132": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet136": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet138": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet140": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet144": {
@@ -275,29 +95,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet146": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet148": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet152": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet154": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet156": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet160": {
@@ -305,29 +105,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet162": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet164": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet168": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet170": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet172": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet176": {
@@ -335,29 +115,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet178": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet180": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet184": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet186": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet188": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet192": {
@@ -365,29 +125,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet194": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet196": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet200": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet202": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet204": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet208": {
@@ -395,29 +135,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet210": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet212": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet216": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet218": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet220": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet224": {
@@ -425,29 +145,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet226": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet228": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet232": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet234": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet236": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet240": {
@@ -455,29 +155,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet242": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet244": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet248": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet250": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet252": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet256": {
@@ -485,29 +165,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet258": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet260": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet264": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet266": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet268": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet272": {
@@ -515,29 +175,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet274": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet276": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet280": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet282": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet284": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet288": {
@@ -545,29 +185,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet290": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet292": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet296": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet298": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet300": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet304": {
@@ -575,29 +195,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet306": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet308": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet312": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet314": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet316": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet320": {
@@ -605,29 +205,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet322": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet324": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet328": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet330": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet332": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet336": {
@@ -635,29 +215,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet338": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet340": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet344": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet346": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet348": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet352": {
@@ -665,29 +225,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet354": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet356": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet360": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet362": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet364": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet368": {
@@ -695,29 +235,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet370": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet372": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet376": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet378": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet380": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet384": {
@@ -725,29 +245,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet386": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet388": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet392": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet394": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet396": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet400": {
@@ -755,29 +255,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet402": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet404": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet408": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet410": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet412": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet416": {
@@ -785,29 +265,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet418": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet420": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet424": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet426": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet428": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet432": {
@@ -815,29 +275,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet434": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet436": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet440": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet442": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet444": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet448": {
@@ -845,29 +285,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet450": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet452": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet456": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet458": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet460": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet464": {
@@ -875,29 +295,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet466": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet468": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet472": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet474": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet476": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet480": {
@@ -905,29 +305,9 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet482": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet484": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet488": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
-            "autoneg": "off"
-        },
-        "Ethernet490": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet492": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
             "autoneg": "off"
         },
         "Ethernet496": {
@@ -935,36 +315,12 @@
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet498": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet500": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet504": {
             "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
             "subport": "1",
             "autoneg": "off"
         },
-        "Ethernet506": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "2",
-            "autoneg": "off"
-        },
-        "Ethernet508": {
-            "default_brkout_mode": "2x400G[200G](4)+1x800G[400G](4)",
-            "subport": "3",
-            "autoneg": "off"
-        },
         "Ethernet512": {
-            "default_brkout_mode": "2x100G",
-            "autoneg": "off"
-        },
-        "Ethernet513": {
             "default_brkout_mode": "2x100G",
             "autoneg": "off"
         }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
#### Why I did it

The SN6600-LD `hwsku.json` files contained redundant entries for non-leading breakout interfaces. Breakout configuration should be defined only on the leading interface of each physical port.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Removed redundant non-leading interface entries from the following SN6600-LD SKUs while preserving their existing breakout modes and SKU-specific attributes:

- `ACS-SN6600_LD`
- `Mellanox-SN6600_LD-P128C2`
- `Mellanox-SN6600_LD-P64O128C2`

#### How to verify it

- Confirm that all three modified `hwsku.json` files are valid JSON.
- Confirm that each file contains 65 leading physical-port interfaces.
- Confirm that breakout modes and SKU-specific attributes on the retained interfaces remain unchanged.
- Confirm that `git diff --check` reports no errors.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

