### PR TITLE
[installer] Enroll and prune UEFI Secure Boot db certificate during SONiC installation

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -423,6 +423,10 @@ endif
 ifneq ($(SECURE_UPGRADE_KERNEL_CAFILE),)
     DOCKER_RUN += -v $(SECURE_UPGRADE_KERNEL_CAFILE):$(SECURE_UPGRADE_KERNEL_CAFILE):ro
 endif
+# Mount the Secure Boot db certificate (DB.auth) file into the slave container
+ifneq ($(SECURE_BOOT_DB_CERT),)
+    DOCKER_RUN += -v $(abspath $(SECURE_BOOT_DB_CERT)):$(abspath $(SECURE_BOOT_DB_CERT)):ro
+endif
 # Mount the Signing prod tool in the slave container
 $(info "SECURE_UPGRADE_PROD_SIGNING_TOOL": "$(SECURE_UPGRADE_PROD_SIGNING_TOOL)")
 ifneq ($(SECURE_UPGRADE_PROD_SIGNING_TOOL),)
@@ -679,6 +683,7 @@ SONIC_BUILD_INSTRUCTION :=  $(MAKE) \
                            SECURE_UPGRADE_SIGNING_CERT=$(SECURE_UPGRADE_SIGNING_CERT) \
                            SECURE_UPGRADE_KERNEL_CAFILE=$(SECURE_UPGRADE_KERNEL_CAFILE) \
                            SECURE_UPGRADE_PROD_SIGNING_TOOL=$(SECURE_UPGRADE_PROD_SIGNING_TOOL) \
+                           SECURE_BOOT_DB_CERT=$(SECURE_BOOT_DB_CERT) \
                            SONIC_DEFAULT_CONTAINER_REGISTRY=$(DEFAULT_CONTAINER_REGISTRY) \
                            ENABLE_HOST_SERVICE_ON_START=$(ENABLE_HOST_SERVICE_ON_START) \
                            SLAVE_DIR=$(SLAVE_DIR) \

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -767,6 +767,18 @@ if [[ $SECURE_UPGRADE_MODE == 'dev' || $SECURE_UPGRADE_MODE == "prod" ]]; then
         sudo ./scripts/secure_boot_signature_verification.sh -e $FILESYSTEM_ROOT/boot/vmlinuz-${LINUX_KERNEL_VERSION}-sonic-${CONFIGURED_ARCH} \
                                                              -c $SECURE_UPGRADE_SIGNING_CERT
     fi
+
+    # Embed the UEFI Secure Boot db certificate (DB.auth) into the image so the installer can
+    # enroll it into the DUT firmware. The file is placed under /boot so it ships at
+    # image-<version>/boot/ alongside the signed shim/grub.
+    if [ -n "$SECURE_BOOT_DB_CERT" ]; then
+        echo "Secure Boot support build stage: embedding Secure Boot db certificate from $SECURE_BOOT_DB_CERT"
+        if [ ! -f "$SECURE_BOOT_DB_CERT" ]; then
+            echo "Error: SECURE_BOOT_DB_CERT=$SECURE_BOOT_DB_CERT is set but the file is missing"
+            exit 1
+        fi
+        sudo cp "$SECURE_BOOT_DB_CERT" "$FILESYSTEM_ROOT/boot/DB.auth"
+    fi
     echo "Secure Boot support build stage: END."
 fi
 

--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -595,6 +595,50 @@ demo_enroll_secure_boot_keys()
     fi
 }
 
+# Prune UEFI Secure Boot "db" certificates that no longer sign any installed SONiC image.
+# This runs at the END of an in-place upgrade (install_env = sonic), AFTER the old images were
+# removed and the new image was installed and added to the boot menu, so the db is trimmed to
+# just the certificates that still verify a binary of a remaining image (the running image and
+# the freshly installed one). It reclaims the db entries left behind by images deleted during
+# this installation.
+#
+# It delegates to /usr/local/bin/remove_stale_db_certs.sh (shipped by sonic-utilities), which
+# re-derives the "still used" set exactly and applies a signed db update. --allow-essential-missing
+# is deliberately NOT passed: if pruning would leave a boot-critical (shim/grub/MokManager) binary
+# without a db signer, that tool refuses and leaves db unchanged, so an automated install can
+# never strip the certificate the system needs to boot. Every step is best-effort: failures are
+# logged but never abort the installation.
+demo_prune_stale_db_certs()
+{
+    local prune_script="/usr/local/bin/remove_stale_db_certs.sh"
+
+    # Only meaningful when installing from a running SONiC: the tool inspects the live /host
+    # images, the ESP and the UEFI db of the running system.
+    if [ "$install_env" != "sonic" ]; then
+        return 0
+    fi
+
+    if [ ! -x "$prune_script" ]; then
+        echo "demo_prune_stale_db_certs(): $prune_script not present, skipping db certificate prune"
+        return 0
+    fi
+
+    if [ ! -d /sys/firmware/efi/efivars ]; then
+        echo "demo_prune_stale_db_certs(): efivars not available, skipping db certificate prune"
+        return 0
+    fi
+    if ! mountpoint -q /sys/firmware/efi/efivars 2>/dev/null; then
+        mount -t efivarfs efivarfs /sys/firmware/efi/efivars 2>/dev/null || true
+    fi
+
+    echo "demo_prune_stale_db_certs(): pruning stale UEFI db certificates"
+    if "$prune_script" --commit --yes; then
+        echo "demo_prune_stale_db_certs(): db certificate prune completed"
+    else
+        echo "WARNING: demo_prune_stale_db_certs(): db certificate prune did not complete (db left unchanged)"
+    fi
+}
+
 bootloader_menu_config()
 {
 

--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -472,7 +472,127 @@ demo_install_uefi_shim()
         echo "ERROR: efibootmgr failed to create new boot variable on: $blk_dev"
         exit 1
     }
+
     echo "demo_install_uefi_shim(): Secure Boot components installed successfully"
+}
+
+# Clear the immutable (i) attribute on an efivarfs file so the variable can be updated. The
+# kernel marks existing Secure Boot variables (db/dbx/KEK/PK) immutable; a write fails while
+# the i flag is set. Returns 0 only when the file does not exist yet or is no longer immutable.
+clear_efivar_immutable()
+{
+    local efivar_path="$1"
+
+    [ -e "$efivar_path" ] || return 0
+    if command -v chattr >/dev/null 2>&1; then
+        chattr -i "$efivar_path" 2>/dev/null || true
+    fi
+    if command -v lsattr >/dev/null 2>&1; then
+        case "$(lsattr "$efivar_path" 2>/dev/null)" in
+            *i*) return 1 ;;
+        esac
+    fi
+    return 0
+}
+
+# Write a signed authenticated variable update ($3 = .auth) to UEFI variable $1 (GUID $2)
+# using efi-updatevar (efitools). $4 selects "append" (coexist with existing entries) or
+# "replace". efitools is installed in the SONiC image; enrollment is skipped if it is absent.
+write_efi_auth_var()
+{
+    local var_name="$1"
+    local var_guid="$2"
+    local auth_file="$3"
+    local mode="$4"
+    local efivar_path="/sys/firmware/efi/efivars/${var_name}-${var_guid}"
+
+    if ! command -v efi-updatevar >/dev/null 2>&1; then
+        echo "write_efi_auth_var(): efi-updatevar not found, cannot enroll $var_name"
+        return 1
+    fi
+
+    # The variable can only be written once the immutable flag is cleared. Bail out if a
+    # previous entry remains immutable, since efi-updatevar cannot update it in that state.
+    if ! clear_efivar_immutable "$efivar_path"; then
+        echo "write_efi_auth_var(): $efivar_path is immutable, cannot enroll $var_name"
+        return 1
+    fi
+
+    if [ "$mode" = "append" ]; then
+        efi-updatevar -a -f "$auth_file" "$var_name" && return 0
+    else
+        efi-updatevar -f "$auth_file" "$var_name" && return 0
+    fi
+    echo "write_efi_auth_var(): efi-updatevar failed for $var_name"
+    return 1
+}
+
+# Enroll the UEFI Secure Boot db certificate bundled in the installed image (image-<ver>/boot/)
+# into firmware NVRAM. This must run BEFORE the SONiC image filesystem is installed, so the
+# signed image is trusted by firmware on first boot. The certificate is appended so it coexists
+# with any pre-existing keys; firmware ignores a duplicate append of an already-enrolled cert.
+# Every step is best-effort: failures are logged but never abort the installation.
+demo_enroll_secure_boot_keys()
+{
+    local demo_mnt="$1"
+    local keys_dir="$demo_mnt/$image_dir/boot"
+    local db_guid="d719b2cb-3d3a-4596-a3bc-dad00e67656f"
+
+    # Only proceed if the image bundled Secure Boot key material.
+    if [ ! -f "$keys_dir/DB.auth" ]; then
+        echo "demo_enroll_secure_boot_keys(): no Secure Boot keys bundled in image, skipping key enrollment"
+        return 0
+    fi
+
+    # Persist the db certificate shipped with the image under /host/db-auth using a unique,
+    # content-based name, so certificates from successive installations accumulate instead of
+    # overwriting each other. If a byte-identical DB.auth is already stored (e.g. re-installing
+    # an image that ships the same certificate), it is not copied again. demo_mnt is the host
+    # partition, mounted at /host on the booted system. Best-effort.
+    local db_auth_dir="$demo_mnt/db-auth"
+    local existing_auth found_auth db_hash db_dest
+    if mkdir -p "$db_auth_dir" 2>/dev/null; then
+        found_auth=""
+        for existing_auth in "$db_auth_dir"/*.auth; do
+            [ -e "$existing_auth" ] || continue
+            if cmp -s "$keys_dir/DB.auth" "$existing_auth"; then
+                found_auth="$existing_auth"
+                break
+            fi
+        done
+        if [ -n "$found_auth" ]; then
+            echo "demo_enroll_secure_boot_keys(): DB.auth already present at $found_auth, not copying"
+        else
+            db_hash=$(sha256sum "$keys_dir/DB.auth" 2>/dev/null | cut -d' ' -f1)
+            if [ -n "$db_hash" ]; then
+                db_dest="$db_auth_dir/DB-${db_hash}.auth"
+            else
+                db_dest="$db_auth_dir/DB-$(date -u +%Y%m%d%H%M%S).auth"
+            fi
+            if cp "$keys_dir/DB.auth" "$db_dest" 2>/dev/null; then
+                echo "demo_enroll_secure_boot_keys(): copied DB.auth to $db_dest"
+            else
+                echo "WARNING: demo_enroll_secure_boot_keys(): failed to copy DB.auth to $db_dest"
+            fi
+        fi
+    else
+        echo "WARNING: demo_enroll_secure_boot_keys(): failed to create $db_auth_dir"
+    fi
+
+    if [ ! -d /sys/firmware/efi/efivars ]; then
+        echo "demo_enroll_secure_boot_keys(): efivars not available, skipping key enrollment"
+        return 0
+    fi
+    if ! mountpoint -q /sys/firmware/efi/efivars 2>/dev/null; then
+        mount -t efivarfs efivarfs /sys/firmware/efi/efivars 2>/dev/null || true
+    fi
+
+    echo "demo_enroll_secure_boot_keys(): enrolling db from $keys_dir"
+    if write_efi_auth_var "db" "$db_guid" "$keys_dir/DB.auth" "append"; then
+        echo "demo_enroll_secure_boot_keys(): db enrolled"
+    else
+        echo "WARNING: demo_enroll_secure_boot_keys(): failed to enroll db"
+    fi
 }
 
 bootloader_menu_config()

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -269,6 +269,14 @@ echo "EXTRA_CMDLINE_LINUX=$extra_cmdline_linux"
 # Update Bootloader Menu with installed image
 bootloader_menu_config
 
+# For an in-place upgrade on a running SONiC with Secure Boot, the old-image cleanup above may
+# have left UEFI db certificates that no longer sign any installed image. Now that the new image
+# is installed and the boot menu is updated, prune db down to the certificates still in use.
+# Best-effort; never aborts the installation.
+if [ "$install_env" = "sonic" ]; then
+    demo_prune_stale_db_certs || true
+fi
+
 # Set NOS mode if available.  For manufacturing diag installers, you
 # probably want to skip this step so that the system remains in ONIE
 # "installer" mode for installing a true NOS later.

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -217,6 +217,14 @@ else
     }
 fi
 
+# Enroll the UEFI Secure Boot db certificate BEFORE installing the SONiC image, so the signed
+# image is trusted by firmware on first boot. Extract only boot/DB.auth from the payload up
+# front; the full image extraction below repopulates boot/ with the rest. Best-effort.
+if [ "$install_env" != "build" ]; then
+    unzip -o $INSTALLER_PAYLOAD "boot/DB.auth" -d $demo_mnt/$image_dir > /dev/null 2>&1 || true
+    demo_enroll_secure_boot_keys "$demo_mnt" || true
+fi
+
 # Decompress the file for the file system directly to the partition
 if [ x"$docker_inram" = x"on" ]; then
     # when disk is small, keep dockerfs.tar.gz in disk, expand it into ramfs during initrd

--- a/rules/config
+++ b/rules/config
@@ -299,12 +299,17 @@ SONIC_ENABLE_IMAGE_SIGNATURE ?= n
 # SECURE_UPGRADE_MODE - enum value for secure upgrade mode, valid options are "dev", "prod" and "no_sign"
 # SECURE_UPGRADE_PROD_SIGNING_TOOL - path to a vendor signing tool for production flow.
 # SECURE_UPGRADE_PROD_TOOL_ARGS - Extra arguments options for vendor to use to run his specific prod signing script
+# SECURE_BOOT_DB_CERT - path to the UEFI Secure Boot db certificate file (DB.auth). When set,
+#                       this file is embedded into the image (under image-<version>/boot/) and
+#                       enrolled into the DUT's UEFI firmware during installation. Leave empty to
+#                       disable key embedding/enrollment.
 SECURE_UPGRADE_DEV_SIGNING_KEY ?=
 SECURE_UPGRADE_SIGNING_CERT ?=
 SECURE_UPGRADE_MODE ?= "no_sign"
 SECURE_UPGRADE_KERNEL_CAFILE ?= $(SECURE_UPGRADE_SIGNING_CERT)
 SECURE_UPGRADE_PROD_SIGNING_TOOL ?=
 SECURE_UPGRADE_PROD_TOOL_ARGS ?=
+SECURE_BOOT_DB_CERT ?=
 
 # BUILD_SNAPSHOT_URL - Default debian snapshot mirror url
 # Mirror of https://snapshot.debian.org/archive


### PR DESCRIPTION
#### Why I did it
Embed the UEFI Secure Boot db certificate in the image and manage it during installation so a
signed image is trusted on first boot, enable KEK-authorized db key rotation, and reclaim db
space from certificates of removed images.

##### Work item tracking
- Microsoft ADO (number only): 38692567

#### How I did it
- Build: SECURE_BOOT_DB_CERT embeds DB.auth at image-<ver>/boot/ (Makefile.work, rules/config,
  build_debian.sh).
- Install (installer/default_platform.conf, installer/install.sh):
  - Enroll the image's db cert into UEFI db before the filesystem is written; persist each shipped
    DB.auth to /host/db-auth under a content-unique name (DB-<sha256>.auth).
  - At the end of an in-place (sonic-env) upgrade, prune stale db certs via
    /usr/local/bin/remove_stale_db_certs.sh (never drops a boot-critical binary's only signer).
- Submodule: bump sonic-utilities to the matching commits. Depends on sonic-utilities PR sonic-net/sonic-utilities#4690.
- All enrollment/prune steps are best-effort and never abort an install.

#### How to verify it
Build a signed image with SECURE_BOOT_DB_CERT set; install on a UEFI switch; confirm the db cert
is enrolled and verification passes; re-install the same image to see /host/db-auth dedup; perform
an in-place upgrade to see stale db certs pruned.

#### Which release branch to backport
None (feature).

#### Description for the changelog
Enroll and prune the UEFI Secure Boot db certificate during SONiC installation.