### PR TITLE
Install pyipmi in sonic-buildimage

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -201,6 +201,9 @@ fi
 # Install Python module for smbus2
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install smbus2
 
+# Install Python module for IPMI FRU decoding
+sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install python-ipmi
+
 # Install Python module for telnetlib3
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install telnetlib3
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Many instances of the PSU EEPROMs are encoded in IPMI FRU format. This PR installs `python-ipmi` into `sonic-buildimage` for ease of decoding these structures.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Install pyipmi in SONiC via `files/build_templates/sonic_debian_extension.j2`

#### How to verify it

Before:

```
admin@abcd156:~$ python3
Python 3.13.5 (tags/v3.13.5-dirty:6cb20a219a8, Jun 26 2025, 18:55:22) [GCC 14.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pyipmi.fru
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    import pyipmi.fru
ModuleNotFoundError: No module named 'pyipmi'
>>>
admin@abcd156:~$
admin@abcd201:~$ find /usr/local/lib/python3.13/dist-packages/ -name "*ipmi*"                                             │
```

After:

```
admin@abcd201:~$

After:
admin@abcd156:~$ python3 -c 'import pyipmi; import pyipmi.fru; print(pyipmi.__file__)'
/usr/local/lib/python3.13/dist-packages/pyipmi/__init__.py
admin@abcd156:~$ python3
Python 3.13.5 (tags/v3.13.5-dirty:6cb20a219a8, Jun 26 2025, 18:55:22) [GCC 14.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pyipmi
>>> import pyipmi.fru
>>>

admin@abcd156:~$ find /usr/local/lib/python3.13/dist-packages/ -name "*ipmi*"
/usr/local/lib/python3.13/dist-packages/pyipmi
/usr/local/lib/python3.13/dist-packages/pyipmi/interfaces/ipmitool.py
/usr/local/lib/python3.13/dist-packages/pyipmi/ipmitool.py
/usr/local/lib/python3.13/dist-packages/python_ipmi-0.5.8.dist-info
```


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

