### PR TITLE
[QoS] Add SpineRouter support to shared QoS templates

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/qos.json.j2
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/qos.json.j2
@@ -211,6 +211,9 @@
     {%- elif 'LeafRouter' in router_type %}
         {# Leaf Router thresholds - only override if different from defaults #}
         {%- set max_threshold = "239616" %}
+    {%- elif 'SpineRouter' in router_type %}
+        {# Spine Router thresholds. Defaulting to the LeafRouter value #}
+        {%- set max_threshold = "239616" %}
     {%- endif %}
 
     "WRED_PROFILE": {

--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -118,6 +118,8 @@
                     {%- else %}
                         {%- if PORT_DOWNLINK.append(port) %}{%- endif %}
                     {%- endif %}
+                {%- elif 'SpineRouter' in local_router_type %}
+                    {%- if PORT_DOWNLINK.append(port) %}{%- endif %}
                 {%- endif %}
             {%- else %}
                 {%- if PORT_DOWNLINK.append(port) %}{%- endif %}

--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -119,7 +119,9 @@
                         {%- if PORT_DOWNLINK.append(port) %}{%- endif %}
                     {%- endif %}
                 {%- elif 'SpineRouter' in local_router_type %}
-                    {%- if PORT_DOWNLINK.append(port) %}{%- endif %}
+                    {%- if 'LeafRouter' in neighbor_info.type %}
+                        {%- if PORT_DOWNLINK.append(port) %}{%- endif %}
+                    {%- endif %}
                 {%- endif %}
             {%- else %}
                 {%- if PORT_DOWNLINK.append(port) %}{%- endif %}


### PR DESCRIPTION
#### Why I did it

Two shared QoS templates only handle `ToRRouter` and `LeafRouter` values of
`DEVICE_METADATA.localhost.type`. When a Mellanox SN5600 / SN5640 SKU is
deployed as `SpineRouter`, `config_db.json` fails sonic-yang-models
validation on two independent points:

1. **WRED_PROFILE** — `device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/qos.json.j2`
   `generate_wred_profiles()` falls through the ToRRouter/LeafRouter if/elif
   chain without setting `max_threshold`, producing empty thresholds and
   `Invalid value "" in "green_max_threshold" element`.

2. **QUEUE / SCHEDULER** — `files/build_templates/qos_config.j2`
   The port-classification helper introduced in #22869 has no `SpineRouter`
   branch, so `PORT_UPLINK` / `PORT_DOWNLINK` stay empty and
   `generate_direction_based_queue_per_sku()` is never called. The QUEUE
   block then falls back to hardcoded `scheduler.0` / `scheduler.1` while
   SCHEDULER is rendered with the per-SKU macro (`scheduler.port.0` /
   `scheduler.port.1`), producing orphan leafrefs:
   `Invalid leafref value "scheduler.0" - no target instance
   "/sch:sonic-scheduler/sch:SCHEDULER/sch:SCHEDULER_LIST/sch:name"`.

Both bugs were discovered while validating `Mellanox-SN5640-O128X2` (BT2)
deployed as `SpineRouter`.

#### How I did it

- `Mellanox-SN5600-C256S1/qos.json.j2`: added
  `elif 'SpineRouter' in router_type` with `max_threshold = "239616"`
  (same as `LeafRouter`; on the deployments where these SKUs face this
  role all ports are downlinks and reuse the LeafRouter thresholds).
- `files/build_templates/qos_config.j2`: added
  `elif 'SpineRouter' in local_router_type` that classifies every
  neighbored port as `PORT_DOWNLINK`, so the direction-based QUEUE macro
  runs and matches the SCHEDULER names.

Both are additive `elif` branches; behavior for `ToRRouter` / `LeafRouter`
is unchanged.

#### How to verify it

- Render `config_db.json` on `Mellanox-SN5640-O128X2` with
  `DEVICE_METADATA.localhost.type = "SpineRouter"`.
- Before: sonic-yang validation fails with the two errors above.
- After: `WRED_PROFILE` thresholds are populated and `QUEUE` entries
  reference the SKU's `scheduler.port.*` names; validation passes.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Both fixed files exist unchanged on `202605`; the same failures reproduce
there. Mellanox-SN5640-O128X2 SKU which is defined as BackEndSpineRouter is requested for 202605, therefore these supporting changes need to be there also.

#### Tested branch (Please provide the test result in the following table)
| Branch  | Test result |
|---------|-------------|
| 202605  | pass        |


#### Description for the changelog

Add `SpineRouter` handling to the shared WRED and port-classification QoS
templates.