### PR TITLE
[.azure-pipelines]: remove python3-pip from docker-sonic-mgmt

### DIFF
--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -112,7 +112,7 @@ stages:
       displayName: "Download docker-sonic-mgmt artifact (includes SBOM)"
     - script: |
         set -ex
-        sudo apt-get install -y python3-pip jq
+        sudo apt-get install -y jq
       displayName: "Install dependencies"
     - script: |
         set -x


### PR DESCRIPTION
#### Why I did it

`python3-pip` is installed in the "Install dependencies" step of the docker-sonic-mgmt pipeline, but it is not used anywhere in the pipeline. It also triggers S360 security alerts and would require upgrading to a version only available in Ubuntu Pro. Python dependencies are being moved to `uv` (see sonic-net/sonic-pipelines#181), so pip is no longer needed here.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Removed `python3-pip` from the `apt-get install` line in the "Install dependencies" step of `.azure-pipelines/docker-sonic-mgmt.yml`, keeping `jq`.

#### How to verify it

Run the docker-sonic-mgmt pipeline and confirm the "Install dependencies" step succeeds without installing `python3-pip`, and that the subsequent steps still pass (no step in this pipeline uses pip).

#### Which release branch to backport (provide reason below if selected)


- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Description for the changelog

Remove the unused `python3-pip` install from the docker-sonic-mgmt pipeline's "Install dependencies" step.

#### Link to config_db schema for YANG module changes


#### A picture of a cute animal (not mandatory but encouraged)
