### PR TITLE
[Mellanox] Update SN6810_LD pcie.yaml GPP bridge function number

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn6810_ld-r0/pcie.yaml
+++ b/device/mellanox/x86_64-nvidia_sn6810_ld-r0/pcie.yaml
@@ -46,7 +46,7 @@
     Host Bridge (rev 01)'
 - bus: '00'
   dev: '02'
-  fn: '2'
+  fn: '3'
   id: 14ba
   name: 'PCI bridge: Advanced Micro Devices, Inc. [AMD] Family 17h-19h PCIe GPP Bridge'
 - bus: '00'

--- a/device/mellanox/x86_64-nvidia_sn6810_ld_simx-r0/pcie.yaml
+++ b/device/mellanox/x86_64-nvidia_sn6810_ld_simx-r0/pcie.yaml
@@ -46,7 +46,7 @@
     Host Bridge (rev 01)'
 - bus: '00'
   dev: '02'
-  fn: '2'
+  fn: '3'
   id: 14ba
   name: 'PCI bridge: Advanced Micro Devices, Inc. [AMD] Family 17h-19h PCIe GPP Bridge'
 - bus: '00'


### PR DESCRIPTION
## Why I did
On SN6810_LD, the expected PCIe topology in `pcie.yaml` did not match the
actual hardware: the AMD Family 17h-19h PCIe GPP Bridge (`id: 14ba`) is on
function `3`, not function `2`. This mismatch can cause PCIe device check
failures / false alarms.

## How I did
- Updated `bus 00 / dev 02` GPP bridge function from `2` to `3` in:
  - `device/mellanox/x86_64-nvidia_sn6810_ld-r0/pcie.yaml`
  - `device/mellanox/x86_64-nvidia_sn6810_ld_simx-r0/pcie.yaml`
- Kept remaining PCIe device entries unchanged.

## How to verify
1. On SN6810_LD, run:
   ```bash
   sudo pcieutil check
   ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

