### PR TITLE
[github]: Add tested branch checklist to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -49,18 +49,34 @@ If you request a backport/cherry-pick, provide both:
 Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
 Failure type: <!-- day-one issue / regression / other -->
 
-#### Tested branch (Please provide the tested image version)
+#### Tested branch
 
 <!--
-- Please provide tested image version.
-- If you request a backport/cherry-pick, include test evidence from the target
-  branch(es), not only from master.
-- e.g.
-- [x] 20201231.100
+- Select each branch where the change was tested.
+- If you request a backport/cherry-pick, select the base branch and the tested
+  target release branch(es).
 -->
 
-- [ ] <!-- image version 1 -->
-- [ ] <!-- image version 2 -->
+- [ ] master
+- [ ] 202305
+- [ ] 202311
+- [ ] 202405
+- [ ] 202411
+- [ ] 202505
+- [ ] 202511
+- [ ] 202512
+- [ ] 202605
+- [ ] 202608
+- [ ] N/A
+
+#### Test result
+
+<!--
+- Provide the tested image version and test evidence for each selected branch.
+- e.g.
+- master: 20260716.01 - <test result or link>
+- 202605: 20260531.42 - <test result or link>
+-->
 
 #### Description for the changelog
 <!--


### PR DESCRIPTION
#### Why I did it
Follow up on #28355 and @yijingyan2's suggestion to make target-branch test coverage machine-readable. A structured tested-branch list will allow automation to add `Tested for <branch>` labels and identify backport requests that do not include target-branch test results.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it
- Replaced the free-form tested image checkboxes with explicit branch checkboxes matching the current backport branches, plus `master` and `N/A`.
- Added a separate `Test result` section for image versions and evidence associated with each selected branch.

#### How to verify it
Template-only change. Verified the Markdown diff and ran `git diff --check`.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

#### Tested branch

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [x] N/A

#### Test result
Template-only change; `git diff --check` passes.

#### Description for the changelog
Add machine-readable tested-branch options and a separate test-result section to the PR template.

#### Link to config_db schema for YANG module changes
N/A

#### A picture of a cute animal (not mandatory but encouraged)
🐣
