### PR TITLE
[202511][Broadcom] Upgrade Broadcom xgs SAI version to 14.3.0.0.0.0.30.0

### DIFF
--- a/platform/broadcom/sai-xgs.mk
+++ b/platform/broadcom/sai-xgs.mk
@@ -1,5 +1,5 @@
 # Broadcom XGS SAI definitions
-LIBSAIBCM_XGS_VERSION = 14.3.0.0.0.0.27.0
+LIBSAIBCM_XGS_VERSION = 14.3.0.0.0.0.30.0
 LIBSAIBCM_XGS_BRANCH_NAME = SAI_14.3.0_GA
 
 LIBSAIBCM_XGS_URL_PREFIX = "https://packages.trafficmanager.net/public/sai/sai-broadcom/$(LIBSAIBCM_XGS_BRANCH_NAME)/$(LIBSAIBCM_XGS_VERSION)/xgs"


### PR DESCRIPTION
#### Why I did it
Bump the Broadcom XGS SAI on the 202511 branch from `14.3.0.0.0.0.27.0` to `14.3.0.0.0.0.30.0`. Changes since `14.3.0.0.0.0.27.0`:

- `14.3.0.0.0.0.28.0`: Add 128x800G config files for TH6P.
- `14.3.0.0.0.0.29.0`: Uplift SONIC-124273 - fix `_brcm_sai_inif_discard_wa` counter underflow and clear-order race. On TH5 with `sai_stats_support_mask: 0x800`, PFCWD tests could log `PORT_IF_INDISCARDS ... is less than PFC/PAUSE drop` because PORT_IF_INDISCARDS and the PFC/PAUSE counters were not polled atomically, producing an underflowed (~UINT64_MAX) value. The fix clamps the result to 0, downgrades the log from ERROR to WARN, and reorders the counter clears so the underflow is no longer reported to SONiC.
- `14.3.0.0.0.0.30.0`: Uplift SONIC-123559 - duplicate mirror session support.

##### Work item tracking
- Microsoft ADO **(number only)**: 38846195

#### How I did it
Bump `LIBSAIBCM_XGS_VERSION` from `14.3.0.0.0.0.27.0` to `14.3.0.0.0.0.30.0` in `platform/broadcom/sai-xgs.mk`. The corresponding `libsaibcm` and `libsaibcm-dev` 14.3.0.0.0.0.30.0 packages are already published under `SAI_14.3.0_GA/14.3.0.0.0.0.30.0/xgs`.

#### How to verify it
- Build the 202511 Broadcom SWI and install it on a Broadcom XGS DUT.
- Run the SAI qualification set (12 scripts) via Elastictest and confirm no regressions.

#### Which release branch to backport (provide reason below if selected)
N/A - this PR targets 202511 directly (master is on SAI 15.2).