### PR TITLE
[docker-base-trixie] Fix armhf base mislabeled as arm/v8 instead of arm/v7

### DIFF
--- a/dockers/docker-base-trixie/Dockerfile.j2
+++ b/dockers/docker-base-trixie/Dockerfile.j2
@@ -1,6 +1,6 @@
 {% set prefix = DEFAULT_CONTAINER_REGISTRY %}
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-{% if CONFIGURED_ARCH == "armhf" and (MULTIARCH_QEMU_ENVIRON == "y" or CROSS_BUILD_ENVIRON == "y") %}
+{% if CONFIGURED_ARCH == "armhf" %}
 ARG BASE=--platform=linux/arm/v7 {{ prefix }}debian:trixie
 {% elif CONFIGURED_ARCH == "arm64" and (MULTIARCH_QEMU_ENVIRON == "y" or CROSS_BUILD_ENVIRON == "y") %}
 ARG BASE=--platform=linux/arm64 {{ prefix }}debian:trixie

--- a/dockers/docker-base-trixie/Dockerfile.j2
+++ b/dockers/docker-base-trixie/Dockerfile.j2
@@ -1,12 +1,6 @@
 {% set prefix = DEFAULT_CONTAINER_REGISTRY %}
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-{% if CONFIGURED_ARCH == "armhf" %}
-ARG BASE=--platform=linux/arm/v7 {{ prefix }}debian:trixie
-{% elif CONFIGURED_ARCH == "arm64" and (MULTIARCH_QEMU_ENVIRON == "y" or CROSS_BUILD_ENVIRON == "y") %}
-ARG BASE=--platform=linux/arm64 {{ prefix }}debian:trixie
-{% else %}
 ARG BASE={{ prefix }}debian:trixie
-{% endif %}
 
 FROM $BASE AS base
 

--- a/slave.mk
+++ b/slave.mk
@@ -66,9 +66,13 @@ endif
 DOCKER_BASE_ARCH := $(CONFIGURED_ARCH)
 ifeq ($(CONFIGURED_ARCH),armhf)
 	override DOCKER_BASE_ARCH = arm32v7
+	override DOCKER_DEFAULT_PLATFORM = linux/arm/v7
 else
 ifeq ($(CONFIGURED_ARCH),arm64)
 	override DOCKER_BASE_ARCH = arm64v8
+ifneq ($(filter y,$(MULTIARCH_QEMU_ENVIRON) $(CROSS_BUILD_ENVIRON)),)
+	override DOCKER_DEFAULT_PLATFORM = linux/arm64
+endif
 endif
 endif
 
@@ -97,6 +101,7 @@ export IMAGE_DISTRO
 export IMAGE_DISTRO_DEBS_PATH
 export MULTIARCH_QEMU_ENVIRON
 export DOCKER_BASE_ARCH
+export DOCKER_DEFAULT_PLATFORM
 export CROSS_BUILD_ENVIRON
 export BLDENV
 export BUILD_WORKDIR


### PR DESCRIPTION
### Problem

The armhf `docker-base-trixie` image can be stamped `architecture: arm, variant: v8` even though its root filesystem is 32-bit `arm/v7`. Downstream armhf images can likewise be stamped `architecture: arm, variant: v8`, so ARMv7 devices reject the manifest with:

```
no matching manifest for linux/arm/v7 in the manifest list entries
```

### Root cause

The native armhf CI worker reports Docker daemon architecture `armv8l`. Without an explicit build target, Docker can stamp the final image with the host platform.

`BASE` must remain an image reference. `FROM $BASE` parses the expanded value as the stage image. Including `--platform=...` in `$BASE` makes Docker parse the option as the image reference and report `invalid reference format`. Applying `--platform` only to the first `FROM` is also insufficient because `docker-base-trixie` ends with a `FROM scratch` stage and downstream builds can use the host target again.

### Fix

- Keep `ARG BASE={{ prefix }}debian:trixie` as an image-only reference to the mirrored multi-architecture tag.
- Export `DOCKER_DEFAULT_PLATFORM=linux/arm/v7` from `slave.mk` for armhf builds. This target applies to the base image, final `scratch` stage, version-cache rebuild, debug image, and downstream Docker builds.
- Preserve the existing `linux/arm64` target for ARM64 QEMU/cross builds. Native amd64 and ARM64 builds retain Docker's default target.

The CI mirror contains `debian:trixie` for `linux/arm/v7`; it does not contain `arm32v7/debian:trixie`.

### Validation

- Azure build `1178477` passed for commit `1f5d7150734736f242bc773f8f08f552de97f7ec`.
- `Build marvell_prestera_armhf` passed on the native ARM worker.
- All required GitHub checks and reported Elastictest jobs passed.
- Minimal legacy Docker and BuildKit builds verified that both the multi-stage base image and a downstream image report `linux/arm/v7`.
