### PR TITLE
sonic-yang-models: clean up YANG description and error-message text

### DIFF
--- a/src/sonic-yang-mgmt/tests/test_cfghelp.py
+++ b/src/sonic-yang-mgmt/tests/test_cfghelp.py
@@ -18,13 +18,13 @@ key - GLOBAL
 |                         | techsupport invocations. Configure 0 to explicitly |             |           |             |
 |                         | disable                                            |             |           |             |
 +-------------------------+----------------------------------------------------+-------------+-----------+-------------+
-| max_techsupport_limit   | Max Limit in percentage for the cummulative size   |             |           |             |
-|                         | of ts dumps. No cleanup is performed if the value  |             |           |             |
+| max_techsupport_limit   | Max Limit in percentage for the cumulative size of |             |           |             |
+|                         | ts dumps. No cleanup is performed if the value     |             |           |             |
 |                         | isn't configured or is 0.0                         |             |           |             |
 +-------------------------+----------------------------------------------------+-------------+-----------+-------------+
-| max_core_limit          | Max Limit in percentage for the cummulative size   |             |           |             |
-|                         | of core dumps. No cleanup is performed if the      |             |           |             |
-|                         | value isn't congiured or is 0.0                    |             |           |             |
+| max_core_limit          | Max Limit in percentage for the cumulative size of |             |           |             |
+|                         | core dumps. No cleanup is performed if the value   |             |           |             |
+|                         | isn't configured or is 0.0                         |             |           |             |
 +-------------------------+----------------------------------------------------+-------------+-----------+-------------+
 | available_mem_threshold | Memory threshold; 0 to disable techsupport         |             | 10.0      |             |
 |                         | invocation on memory usage threshold crossing      |             |           |             |

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -1089,7 +1089,7 @@ This table stores the default lossless buffer parameters for dynamic buffer calc
 
 The **DEVICE_METADATA** table contains only one object named
 *localhost*. In this table the device metadata such as hostname, hwsku,
-deployment envionment id and deployment type are specified. BGP local AS
+deployment environment id and deployment type are specified. BGP local AS
 number is also specified in this table as current only single BGP
 instance is supported in SONiC.
 
@@ -2078,7 +2078,7 @@ attributes in those objects.
 }
 ```
 * `association_type` - is used to control the type of the server. It can be `server` or `pool`.
-* `iburst` - agressive server polling `{on, off}`.
+* `iburst` - aggressive server polling `{on, off}`.
 * `version` - NTP protool version to use `[3..4]`.
 * `key` - authentication key id `[1..65535]` to use to auth the server.
 * `admin_state` - enable or disable specific server.
@@ -2107,7 +2107,7 @@ attributes in those objects.
 
 ### Peer Switch
 
-Below is an exmaple of the peer switch table configuration.
+Below is an example of the peer switch table configuration.
 ```
 {
     "PEER_SWITCH": {
@@ -2805,7 +2805,7 @@ Asymmetric DSCP and dynamic queue:
 
 ### Versions
 
-This table is where the curret version of the software is recorded.
+This table is where the current version of the software is recorded.
 ```
 {
     "VERSIONS": {
@@ -3188,7 +3188,7 @@ In this table, we allow configuring ssh server global settings. This will featur
 
 -   authentication_retries - number of login attepmts 1-100
 -   login_timeout - Timeout in seconds for login session for user to connect 1-600
--   ports - Ssh port numbers - string of port numbers seperated by ','
+-   ports - Ssh port numbers - string of port numbers separated by ','
 -   inactivity_timeout - Inactivity timeout for SSH session, allowed values: 0-35000 (min), default value: 15 (min)
 -   max_sessions - Max number of concurrent logins, allowed values: 0-100 (where 0 means no limit), default value: 0
 -   permit_root_login - Whether or not to allow root login. Default value: "prohibit-password"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/aaa.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/aaa.json
@@ -20,7 +20,7 @@
     },
     "AAA_AUTHENTICATION_TEST_TACACS_WITHOUT_TACPLUS": {
         "desc": "Configure tacacs in authentication type in AAA table without TACPLUS table.",
-        "eStr": ["Authentication with 'tacacs+' is not allowed when passkey not exists."]
+        "eStr": ["Authentication with 'tacacs+' is not allowed when no passkey exists."]
     },
     "AAA_ACCOUNTING_TEST": {
         "desc": "Configure an accounting type in AAA table."

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
@@ -168,7 +168,7 @@
         "eStr" : "Too many route_map_out elements"
     },
     "BGP_NEIGHBOR_NEG_INVALID_HOPS": {
-        "desc": "Invalid TTL hops for unnumbered interface neigbhor.",
+        "desc": "Invalid TTL hops for unnumbered interface neighbor.",
         "eStrKey" : "Range"
     },
     "BGP_MONITORS_ALL_VALID": {
@@ -201,7 +201,7 @@
         "eStrKey" : "InvalidValue"
     },
     "BGP_ALLOWED_PREFIXES_ALL_VALID": {
-        "desc": "Configue BGP allowed prefix list."
+        "desc": "Configure BGP allowed prefix list."
     },
     "BGP_ALLOWED_PREFIXES_INVALID_DEPLOYMENT": {
         "desc": "Invalid deployment.",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_internal.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_internal.json
@@ -8,7 +8,7 @@
     },
     "BGP_INVALID_LOCAL_ADDRESS_FAMILY_TEST": {
         "desc":  "Load bgp internal ipv4 neighboripv6 local address.",
-        "eStr": ["local address and neighbor address family doesnt match"]
+        "eStr": ["local address and neighbor address family does not match"]
     },
     "BGP_LOCAL_ADDRESS_ABSENT_TEST": {
         "desc":"Load bgp internal neighbor table no local address.",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_voq_chassis_neighbor.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_voq_chassis_neighbor.json
@@ -8,7 +8,7 @@
     },
     "BGP_VOQ_CHASSIS_INVALID_LOCAL_ADDRESS_ADDRESS_FAMILY_TEST": {
         "desc": "Load ipv6 bgp voq chassis with ipv4 local address",
-        "eStr": ["local address and neighbor address family doesnt match"]
+        "eStr": ["local address and neighbor address family does not match"]
     },
     "BGP_VOQ_CHASSIS_INVALID_ASN_TEST": {
         "desc" :"Load bgp voq chassis neighbor with asn number different than local asn",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/lossless_traffic_pattern.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/lossless_traffic_pattern.json
@@ -12,11 +12,11 @@
     },
     "LOSSLESS_TRAFFIC_PATTERN_TOO_SMALL_MTU_TEST": {
         "desc": "Configure LOSSLESS_TRAFFIC_PATTERN table with an MTU exceeding the lowerbound.",
-        "eStr": "Invaild MTU which should be in [1, 9216]."
+        "eStr": "Invalid MTU which should be in [1, 9216]."
     },
     "LOSSLESS_TRAFFIC_PATTERN_TOO_LARGE_MTU_TEST": {
         "desc": "Configure LOSSLESS_TRAFFIC_PATTERN table with an MTU exceeding the upperbound.",
-        "eStr": "Invaild MTU which should be in [1, 9216]."
+        "eStr": "Invalid MTU which should be in [1, 9216]."
     },
     "LOSSLESS_TRAFFIC_PATTERN_INVALID_FORMAT_MTU_TEST": {
         "desc": "Configure LOSSLESS_TRAFFIC_PATTERN table with an invalid MTU",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/qos.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/qos.json
@@ -15,7 +15,7 @@
     },
 
     "SCHEDULER_INVALID_METER_TYPE": {
-        "desc": "Configure unsuported meter type in SCHEDULER table.",
+        "desc": "Configure unsupported meter type in SCHEDULER table.",
         "eStrKey": "InvalidValue",
         "eStr": ["meter_type"]
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/route_filter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/route_filter.json
@@ -79,7 +79,7 @@
         "eStrKey": "InvalidValue"
     },
     "ROUTE_PREFIX_INVALID_SEQ_NO": {
-        "desc": "Out of range seqence number",
+        "desc": "Out of range sequence number",
         "eStrKey": "Range"
     },
     "ROUTE_PREFIX_DUPLICATE_SEQ_NO": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
@@ -22,7 +22,7 @@
         "eStrKey": "Length"
     },
     "SNMP_COMMUNITY_MAX_NEG_TEST": {
-        "desc": "Load SNMP community string of lenth > 32.",
+        "desc": "Load SNMP community string of length > 32.",
         "eStrKey": "Length"
     },
     "SNMP_COMMUNITY_WRONG_TYPE_TEST": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vlan_sub_interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vlan_sub_interface.json
@@ -71,7 +71,7 @@
         "desc": "Configure PortChannel VLAN sub interface with VNET reference."
     },
     "VLAN_SUB_INTERFACE_WITH_MISSING_VNET": {
-        "desc": "Configure VLAN sub interface with VNET reference but no VNET exsiting.",
+        "desc": "Configure VLAN sub interface with VNET reference but no VNET existing.",
         "eStrKey": "LeafRef"
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-alarm.yang
+++ b/src/sonic-yang-models/yang-models/sonic-alarm.yang
@@ -16,7 +16,7 @@
     "SONiC";
 
     description
-    "This module defines operational state data for SONiC alarms.";
+    "This module defines operational state data for alarms.";
 
     revision "2024-01-30" {
       description

--- a/src/sonic-yang-models/yang-models/sonic-asic-sensors.yang
+++ b/src/sonic-yang-models/yang-models/sonic-asic-sensors.yang
@@ -7,7 +7,7 @@ module sonic-asic-sensors {
     prefix stypes;
   }
 
-  description "ASIC SENSORs config yang Module for SONiC OS";
+  description "ASIC sensors configuration";
 
   revision 2024-11-19 {
     description "First Revision";

--- a/src/sonic-yang-models/yang-models/sonic-auto_techsupport.yang
+++ b/src/sonic-yang-models/yang-models/sonic-auto_techsupport.yang
@@ -9,7 +9,7 @@ module sonic-auto_techsupport {
         prefix stypes;
     }
 
-    description "Event Driven Techsupport & CoreDump Mgmt Capability in SONiC OS";
+    description "Event Driven Techsupport & CoreDump Mgmt Capability";
 
     revision 2021-08-09 {
         description "First Revision";
@@ -46,7 +46,7 @@ module sonic-auto_techsupport {
                         The actual value in bytes is calculate based on the available space in the filesystem hosting /var/dump
                         When the limit is crossed, the older dump files are incrementally deleted
                         */
-                        description "Max Limit in percentage for the cummulative size of ts dumps. No cleanup is performed if the value isn't configured or is 0.0";
+                        description "Max Limit in percentage for the cumulative size of ts dumps. No cleanup is performed if the value isn't configured or is 0.0";
                         type decimal-repr;
                     }
 
@@ -56,7 +56,7 @@ module sonic-auto_techsupport {
                         The actual value in bytes is calculated based on the available space in the filesystem hosting /var/core
                         When the limit is crossed, the older core files are incrementally deleted
                         */
-                        description "Max Limit in percentage for the cummulative size of core dumps. No cleanup is performed if the value isn't congiured or is 0.0";
+                        description "Max Limit in percentage for the cumulative size of core dumps. No cleanup is performed if the value isn't configured or is 0.0";
                         type decimal-repr;
                     }
 

--- a/src/sonic-yang-models/yang-models/sonic-banner.yang
+++ b/src/sonic-yang-models/yang-models/sonic-banner.yang
@@ -7,7 +7,7 @@ module sonic-banner {
         prefix stypes;
     }
 
-    description "Login, MOTD, and logout banner message YANG module for SONiC OS.";
+    description "Login, MOTD, and logout banner message configuration";
     revision 2023-05-18 {
         description "First Revision";
     }

--- a/src/sonic-yang-models/yang-models/sonic-bgp-aggregate-address.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-aggregate-address.yang
@@ -17,7 +17,7 @@ module sonic-bgp-aggregate-address {
         "SONiC";
 
     description
-        "SONIC BGP aggregate address configuration module.";
+        "BGP aggregate address configuration module.";
 
     revision 2024-07-10 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-bgp-allowed-prefix.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-allowed-prefix.yang
@@ -18,7 +18,7 @@ module sonic-bgp-allowed-prefix {
         "SONiC";
 
     description
-        "SONIC BGP Allowed Prefix";
+        "BGP Allowed Prefix configuration";
 
     revision 2022-02-26 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-bgp-bbr.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-bbr.yang
@@ -14,7 +14,7 @@ module sonic-bgp-bbr {
         "SONiC";
 
     description
-        "SONIC BGP BBR";
+        "BGP BBR configuration";
 
     revision 2023-12-25 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
@@ -47,7 +47,7 @@ module sonic-bgp-common {
         "SONiC";
 
     description
-        "SONIC BGP common YANG attributes for Neighbors and Peer group";
+        "BGP common attributes for neighbors and peer groups";
 
     revision 2021-02-26 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
@@ -10,7 +10,7 @@ module sonic-bgp-device-global {
         "SONiC";
 
     description
-        "SONIC Device-specific BGP global data";
+        "Device-specific BGP global data";
 
     revision 2024-01-28 {
         description "Add Weighted ECMP using BGP link bandwidth";

--- a/src/sonic-yang-models/yang-models/sonic-bgp-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-global.yang
@@ -26,7 +26,7 @@ module sonic-bgp-global {
         "SONiC";
 
     description
-        "SONIC BGP Global YANG";
+        "BGP Global configuration";
 
     revision 2021-02-26 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-bgp-internal-neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-internal-neighbor.yang
@@ -22,7 +22,7 @@ module sonic-bgp-internal-neighbor {
         "SONiC";
 
     description
-        "SONIC BGP Internal Neighbor for multi asic platforms";
+        "BGP Internal Neighbor for multi asic platforms";
 
     revision 2021-04-10 {
         description
@@ -51,7 +51,7 @@ module sonic-bgp-internal-neighbor {
                         mandatory true;
                         must "((contains(../neighbor, '.') and contains(current(), '.')) or
                                 (contains(../neighbor, ':') and contains(current(), ':')))" {
-                            error-message "local address and neighbor address family doesnt match";
+                            error-message "local address and neighbor address family does not match";
                         }
                     }
                 }

--- a/src/sonic-yang-models/yang-models/sonic-bgp-monitor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-monitor.yang
@@ -18,7 +18,7 @@ module sonic-bgp-monitor {
         "SONiC";
 
     description
-        "SONIC BGP Monitor";
+        "BGP Monitor configuration";
 
     revision 2022-01-11 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
@@ -39,7 +39,7 @@ module sonic-bgp-neighbor {
         "SONiC";
 
     description
-        "SONIC BGP Neighbor";
+        "BGP Neighbor configuration";
 
     revision 2021-02-26 {
         description
@@ -68,7 +68,7 @@ module sonic-bgp-neighbor {
 
             list BGP_NEIGHBOR_LIST {
                 description "This list is to support generic BGP neighbor configuration handled by frrcfgd and
-                frr_mgmt_framework_config field should be set to true in DEVICE_METADATA talbe for accepting the generic BGP table configurations.";
+                frr_mgmt_framework_config field should be set to true in DEVICE_METADATA table for accepting the generic BGP table configurations.";
                 key "vrf_name neighbor";
 
                 leaf vrf_name {

--- a/src/sonic-yang-models/yang-models/sonic-bgp-peergroup.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-peergroup.yang
@@ -22,7 +22,7 @@ module sonic-bgp-peergroup {
         "SONiC";
 
     description
-        "SONIC BGP Peer Group YANG";
+        "BGP Peer Group configuration";
 
     revision 2021-02-26 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-bgp-peerrange.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-peerrange.yang
@@ -26,7 +26,7 @@ module sonic-bgp-peerrange {
         "SONiC";
 
     description
-        "SONIC BGP Peer Range YANG";
+        "BGP Peer Range configuration";
 
     revision 2022-02-24 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-bgp-prefix-list.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-prefix-list.yang
@@ -10,7 +10,7 @@ module sonic-bgp-prefix-list {
         prefix stypes;
     }
 
-    description "SONIC Device-specfifc BGP prefix lists data";
+    description "Device-specific BGP prefix lists data";
 
     revision 2025-02-17 {
         description "Updated description and leafs for PREFIX_LIST_LIST";

--- a/src/sonic-yang-models/yang-models/sonic-bgp-sentinel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-sentinel.yang
@@ -18,7 +18,7 @@ module sonic-bgp-sentinel {
         "SONiC";
 
     description
-        "SONIC BGP Sentinel YANG";
+        "BGP Sentinel configuration";
 
     revision 2023-06-06 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-bgp-voq-chassis-neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-voq-chassis-neighbor.yang
@@ -21,7 +21,7 @@ module sonic-bgp-voq-chassis-neighbor {
         "SONiC";
 
     description
-        "SONIC BGP Internal Neighbor for voq chassis platforms";
+        "BGP Internal Neighbor for voq chassis platforms";
 
     revision 2021-04-10 {
         description
@@ -53,7 +53,7 @@ module sonic-bgp-voq-chassis-neighbor {
                         mandatory true;
                         must "((contains(../neighbor, '.') and contains(current(), '.')) or
                                 (contains(../neighbor, ':') and contains(current(), ':')))" {
-                            error-message "local address and neighbor address family doesnt match";
+                            error-message "local address and neighbor address family does not match";
                         }
                     }
                 }

--- a/src/sonic-yang-models/yang-models/sonic-bmp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bmp.yang
@@ -15,7 +15,7 @@ module sonic-bmp {
     contact
         "SONiC";
 
-    description "BMP YANG Module for SONiC OS";
+    description "BMP configuration";
 
     revision 2024-03-20 {
         description "First Revision";

--- a/src/sonic-yang-models/yang-models/sonic-breakout_cfg.yang
+++ b/src/sonic-yang-models/yang-models/sonic-breakout_cfg.yang
@@ -5,7 +5,7 @@ module sonic-breakout_cfg {
     namespace "http://github.com/sonic-net/sonic-breakout_cfg";
     prefix breakout_cfg;
 
-    description "BREAKOUT_CFG YANG Module for SONiC OS";
+    description "BREAKOUT_CFG configuration";
 
     revision 2020-04-10 {
         description "First Revision";
@@ -36,7 +36,7 @@ module sonic-breakout_cfg {
                 }
 
                 leaf brkout_mode {
-                    description "break_mode for port, it is verifed using platform.json";
+                    description "break_mode for port, it is verified using platform.json";
                     type string {
                         length 1..64;
                     }

--- a/src/sonic-yang-models/yang-models/sonic-buffer-pg.yang
+++ b/src/sonic-yang-models/yang-models/sonic-buffer-pg.yang
@@ -19,7 +19,7 @@ module sonic-buffer-pg {
         "SONiC";
 
     description
-        "Ingress buffer priority group configuration for SONiC ports.";
+        "Ingress buffer priority group configuration for ports.";
 
     revision 2021-07-01 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-cable-length.yang
+++ b/src/sonic-yang-models/yang-models/sonic-cable-length.yang
@@ -10,7 +10,7 @@ module sonic-cable-length {
         prefix port;
     }
 
-    description "CABLE_LENGTH YANG module for SONiC OS";
+    description "CABLE_LENGTH configuration";
 
     revision 2021-11-11 {
         description "Initial version";

--- a/src/sonic-yang-models/yang-models/sonic-chassis-module.yang
+++ b/src/sonic-yang-models/yang-models/sonic-chassis-module.yang
@@ -7,7 +7,7 @@ module sonic-chassis-module {
     import sonic-types {
         prefix stypes;
     }
-    description "CHASSIS_MODULE YANG to administratively set SONIC modules state";
+    description "CHASSIS_MODULE configuration to administratively set module state";
 
     revision 2026-04-17 {
         description "Add SWITCH-HOST to name pattern; add power_on_delay and graceful_shutdown_timeout leaves for BMC support";

--- a/src/sonic-yang-models/yang-models/sonic-console.yang
+++ b/src/sonic-yang-models/yang-models/sonic-console.yang
@@ -7,7 +7,7 @@ module sonic-console {
         prefix stypes;
     }
 
-    description "Console port switch and management YANG module for SONiC OS.";
+    description "Console port switch and management configuration";
 
     revision 2026-02-12 {
         description "Add escape_char config";
@@ -32,7 +32,7 @@ module sonic-console {
     }
 
     typedef console-flow-control {
-        description "Configuration to set if enable flow control on a console port";
+        description "Whether to enable flow control on a console port";
         type string {
             pattern "0|1";
         }
@@ -94,7 +94,7 @@ module sonic-console {
 
             container controlled_device {
                 leaf enabled {
-                    description "This configuration indicate if enable controlled device feature on SONiC";
+                    description "Whether to enable the controlled device feature";
                     type console-mgmt-enabled;
                     default "no";
                 }

--- a/src/sonic-yang-models/yang-models/sonic-copp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-copp.yang
@@ -9,7 +9,7 @@ module sonic-copp {
 		prefix stypes;
 	}
 
-	description "CoPP YANG Module for SONiC OS";
+	description "CoPP configuration";
 
 	revision 2021-03-31 {
 		description

--- a/src/sonic-yang-models/yang-models/sonic-crm.yang
+++ b/src/sonic-yang-models/yang-models/sonic-crm.yang
@@ -13,7 +13,7 @@ module sonic-crm {
         prefix dm;
     }
 
-    description "CRM YANG Module for SONiC OS";
+    description "CRM configuration";
 
     revision 2020-04-10 {
         description "First Revision";

--- a/src/sonic-yang-models/yang-models/sonic-dash.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dash.yang
@@ -24,7 +24,7 @@ module sonic-dash {
         "SONiC";
 
     description
-        "Disaggregated API for SONiC Hosts (DASH) SmartNIC/DPU overlay configuration.";
+        "Disaggregated API for Hosts (DASH) SmartNIC/DPU overlay configuration.";
 
     revision 2022-12-07 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-debug-counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-debug-counter.yang
@@ -14,7 +14,7 @@ module sonic-debug-counter {
         "SONiC";
 
     description
-        "SONiC Debug Counter Yang Model";
+        "Debug Counter configuration";
 
     revision 2024-03-07 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-default-lossless-buffer-parameter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-default-lossless-buffer-parameter.yang
@@ -6,7 +6,7 @@ module sonic-default-lossless-buffer-parameter {
 
     prefix default-lossless-buffer-parameter;
 
-    description "DEFAULT_LOSSLESS_BUFFER_PARAMETER YANG module for SONiC OS";
+    description "DEFAULT_LOSSLESS_BUFFER_PARAMETER configuration";
 
     revision 2022-05-31 {
         description "Initial version";

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -17,7 +17,7 @@ module sonic-device_metadata {
         prefix stypes;
     }
 
-    description "DEVICE_METADATA YANG Module for SONiC OS";
+    description "DEVICE_METADATA configuration";
 
     revision 2026-06-05 {
         description "Added dpu_auto_recovery to enable/disable automatic DPU recovery on SmartSwitch.";
@@ -254,7 +254,7 @@ module sonic-device_metadata {
                 leaf bgp_adv_lo_prefix_as_128 {
                     type boolean;
                     description "Advertise Loopback0 interface IPv6 /128 subnet address as it is with set to true.
-                                 By default SONiC advertises /128 subnet prefix in Loopback0 as /64 subnet route";
+                                 By default advertises /128 subnet prefix in Loopback0 as /64 subnet route";
                 }
 
                 leaf suppress-fib-pending {

--- a/src/sonic-yang-models/yang-models/sonic-device_neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_neighbor.yang
@@ -14,7 +14,7 @@ module sonic-device_neighbor {
         revision-date 2019-07-01;
     }
 
-    description "DEVICE_NEIGHBOR YANG Module for SONiC OS";
+    description "DEVICE_NEIGHBOR configuration";
 
     revision 2020-04-10 {
         description "First Revision";

--- a/src/sonic-yang-models/yang-models/sonic-device_neighbor_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_neighbor_metadata.yang
@@ -13,7 +13,7 @@ module sonic-device_neighbor_metadata {
         prefix stypes;
     }
 
-    description "DEVICE_NEIGHBOR_METADATA YANG Module for SONiC OS";
+    description "DEVICE_NEIGHBOR_METADATA configuration";
 
     revision 2022-08-25 {
         description "First Revision";

--- a/src/sonic-yang-models/yang-models/sonic-dhcp-server-ipv4.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dhcp-server-ipv4.yang
@@ -31,7 +31,7 @@ module sonic-dhcp-server-ipv4 {
         prefix smartswitch;
     }
 
-    description "DHCP_SERVER_IPV4 YANG module for SONiC OS";
+    description "DHCP_SERVER_IPV4 configuration";
 
     revision 2023-07-19 {
         description "Initial version";

--- a/src/sonic-yang-models/yang-models/sonic-dhcp-server.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dhcp-server.yang
@@ -16,7 +16,7 @@ module sonic-dhcp-server {
     contact
         "SONiC";
 
-    description "DHCP SERVER YANG module for SONiC OS";
+    description "DHCP SERVER configuration";
 
     revision 2022-09-23 {
         description "Initial version";

--- a/src/sonic-yang-models/yang-models/sonic-dhcpv4-relay.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dhcpv4-relay.yang
@@ -30,7 +30,7 @@ module sonic-dhcpv4-relay {
 
     organization "SONiC";
     contact "SONiC";
-    description "DHCPv4 Relay yang Module for SONiC OS";
+    description "DHCPv4 Relay configuration";
 
     revision 2024-12-30 {
         description "First Revision";

--- a/src/sonic-yang-models/yang-models/sonic-dhcpv6-relay.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dhcpv6-relay.yang
@@ -14,7 +14,7 @@ module sonic-dhcpv6-relay {
 
 	contact "SONiC";
 
-	description "DHCPv6 Relay yang Module for SONiC OS";
+	description "DHCPv6 Relay configuration";
 
 	revision 2021-10-30 {
 		description "First Revision";

--- a/src/sonic-yang-models/yang-models/sonic-dns.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dns.yang
@@ -14,7 +14,7 @@ module sonic-dns {
     contact
         "SONiC";
 
-    description "Domain Name System (DNS) resolver configuration YANG module for SONiC OS.";
+    description "Domain Name System (DNS) resolver configuration";
 
     revision 2023-02-14 {
         description "Initial version";

--- a/src/sonic-yang-models/yang-models/sonic-dot1p-tc-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dot1p-tc-map.yang
@@ -17,7 +17,7 @@ module sonic-dot1p-tc-map {
         "SONiC";
 
     description
-        "DOT1P_TO_TC_MAP yang Module for SONiC OS";
+        "DOT1P_TO_TC_MAP configuration";
 
     revision 2021-04-15 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-dscp-fc-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dscp-fc-map.yang
@@ -13,7 +13,7 @@ module sonic-dscp-fc-map {
         "SONiC";
 
     description
-        "DSCP_TO_FC_MAP yang Module for SONiC OS";
+        "DSCP_TO_FC_MAP configuration";
 
     revision 2021-10-29 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-dscp-tc-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dscp-tc-map.yang
@@ -17,7 +17,7 @@ module sonic-dscp-tc-map {
         "SONiC";
 
     description
-        "DSCP_TO_TC_MAP yang Module for SONiC OS";
+        "DSCP_TO_TC_MAP configuration";
 
     revision 2021-04-15 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-event.yang
+++ b/src/sonic-yang-models/yang-models/sonic-event.yang
@@ -10,7 +10,7 @@
     "SONiC";
 
     description
-    "This module defines operational state data for SONiC events.";
+    "This module defines operational state data for events.";
 
     revision "2024-01-30" {
       description

--- a/src/sonic-yang-models/yang-models/sonic-events-bgp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-events-bgp.yang
@@ -23,7 +23,7 @@ module sonic-events-bgp {
         "SONiC";
 
     description
-        "SONIC BGP events";
+        "BGP events";
 
     revision 2022-12-01 {
         description "BGP alert events.";
@@ -53,7 +53,7 @@ module sonic-events-bgp {
             evtcmn:ALARM_SEVERITY_MAJOR;
 
             description "
-                Reports an notification.
+                Reports a notification.
                 The error codes as per IANA.
                 The other params are as in the message";
 

--- a/src/sonic-yang-models/yang-models/sonic-events-common.yang
+++ b/src/sonic-yang-models/yang-models/sonic-events-common.yang
@@ -14,7 +14,7 @@ module sonic-events-common {
         "SONiC";
 
     description
-        "SONIC Events common definition";
+        "Events common definition";
 
     revision 2022-12-01 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-events-dhcp-relay.yang
+++ b/src/sonic-yang-models/yang-models/sonic-events-dhcp-relay.yang
@@ -15,7 +15,7 @@ module sonic-events-dhcp-relay {
         "SONiC";
 
     description
-        "SONIC dhcp-relay events";
+        "DHCP-relay events";
 
     revision 2022-12-01 {
         description "dhcp-relay alert events.";

--- a/src/sonic-yang-models/yang-models/sonic-events-host.yang
+++ b/src/sonic-yang-models/yang-models/sonic-events-host.yang
@@ -125,7 +125,7 @@ module sonic-events-host {
             evtcmn:EVENT_SEVERITY_2;
 
             description "
-                Declares an container that is expected to be up is down.
+                Declares a container that is expected to be up but is down.
                 Reported by monit periodically.";
 
             leaf ctr_name {

--- a/src/sonic-yang-models/yang-models/sonic-events-swss.yang
+++ b/src/sonic-yang-models/yang-models/sonic-events-swss.yang
@@ -19,7 +19,7 @@ module sonic-events-swss {
         "SONiC";
 
     description
-        "SONIC SWSS events";
+        "SWSS events";
 
     revision 2022-12-01 {
         description "SWSS alert events.";

--- a/src/sonic-yang-models/yang-models/sonic-events-syncd.yang
+++ b/src/sonic-yang-models/yang-models/sonic-events-syncd.yang
@@ -19,7 +19,7 @@ module sonic-events-syncd {
         "SONiC";
 
     description
-        "SONIC syncd events";
+        "syncd events";
 
     revision 2022-12-01 {
         description "syncd alert events.";

--- a/src/sonic-yang-models/yang-models/sonic-evpn.yang
+++ b/src/sonic-yang-models/yang-models/sonic-evpn.yang
@@ -19,7 +19,7 @@ module sonic-evpn {
         "SONiC";
 
     description
-        "SONIC EVPN";
+        "EVPN configuration";
 
     revision 2026-05-27 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-exp-fc-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-exp-fc-map.yang
@@ -13,7 +13,7 @@ module sonic-exp-fc-map {
         "SONiC";
 
     description
-        "EXP_TO_FC_MAP yang Module for SONiC OS";
+        "EXP_TO_FC_MAP configuration";
 
     revision 2021-10-29 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-fabric-monitor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-fabric-monitor.yang
@@ -9,7 +9,7 @@ module sonic-fabric-monitor{
         prefix stypes;
     }
 
-    description "FABRIC_MONITOR yang Module for SONiC OS";
+    description "FABRIC_MONITOR configuration";
 
     revision 2023-03-14 {
         description "First Revision";

--- a/src/sonic-yang-models/yang-models/sonic-fabric-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-fabric-port.yang
@@ -9,7 +9,7 @@ module sonic-fabric-port{
        prefix stypes;
     }
 
-    description "FABRIC_PORT yang Module for SONiC OS";
+    description "FABRIC_PORT configuration";
 
     revision 2023-03-14 {
         description "First Revision";

--- a/src/sonic-yang-models/yang-models/sonic-fast-linkup.yang
+++ b/src/sonic-yang-models/yang-models/sonic-fast-linkup.yang
@@ -6,7 +6,7 @@ module sonic-fast-linkup {
   organization "SONiC";
   contact "SONiC";
   description
-    "YANG model for SWITCH_FAST_LINKUP global configuration.";
+    "SWITCH_FAST_LINKUP global configuration.";
 
   revision 2025-10-20 {
     description "Initial revision.";

--- a/src/sonic-yang-models/yang-models/sonic-feature.yang
+++ b/src/sonic-yang-models/yang-models/sonic-feature.yang
@@ -9,7 +9,7 @@ module sonic-feature{
         prefix stypes;
     }
 
-    description "SONiC service/feature enable, disable, and auto-restart control YANG module.";
+    description "Service/feature enable, disable, and auto-restart control.";
 
     typedef feature-state {
         description "configuration to set the feature running state";
@@ -43,10 +43,10 @@ module sonic-feature{
             list FEATURE_LIST {
 
                 key "name";
-                description "A SONiC feature/service entry keyed by name.";
+                description "A feature/service entry keyed by name.";
 
                 leaf name {
-                    description "Name of the SONiC feature or service.";
+                    description "Name of the feature or service.";
                     type string {
                         length 1..32;
                     }

--- a/src/sonic-yang-models/yang-models/sonic-fine-grained-ecmp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-fine-grained-ecmp.yang
@@ -28,7 +28,7 @@ module sonic-fine-grained-ecmp {
         "SONiC";
 
     description
-        "SONIC Fine Grained ECMP";
+        "Fine Grained ECMP configuration";
 
     revision 2024-09-15 {
         description "Added support for dynamic nexthop group.";

--- a/src/sonic-yang-models/yang-models/sonic-fips.yang
+++ b/src/sonic-yang-models/yang-models/sonic-fips.yang
@@ -10,7 +10,7 @@ module sonic-fips {
         prefix stypes;
     }
 
-    description "Federal Information Processing Standards (FIPS) 140-3 compliance YANG module for SONiC OS.";
+    description "Federal Information Processing Standards (FIPS) 140-3 compliance configuration";
 
     revision 2023-06-20 {
         description "First Revision";

--- a/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
@@ -13,7 +13,7 @@ module sonic-flex_counter {
         prefix stypes;
     }
 
-    description "FLEX COUNTER YANG Module for SONiC OS";
+    description "FLEX COUNTER configuration";
 
     revision 2020-04-10 {
         description "First Revision";

--- a/src/sonic-yang-models/yang-models/sonic-gnmi.yang
+++ b/src/sonic-yang-models/yang-models/sonic-gnmi.yang
@@ -18,7 +18,7 @@ module sonic-gnmi {
     contact
         "SONiC";
 
-    description "GNMI YANG Module for SONiC OS";
+    description "GNMI configuration";
 
     revision 2025-09-01 {
         description "Add VRF support for GNMI service";

--- a/src/sonic-yang-models/yang-models/sonic-grpcclient.yang
+++ b/src/sonic-yang-models/yang-models/sonic-grpcclient.yang
@@ -10,7 +10,7 @@ module sonic-grpcclient {
         "SONiC";
 
     description
-        "SONiC DualToR grpc client configuration data";
+        "DualToR grpc client configuration data";
 
     revision 2024-10-14 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-hash.yang
+++ b/src/sonic-yang-models/yang-models/sonic-hash.yang
@@ -9,7 +9,7 @@ module sonic-hash {
         prefix stypes;
     }
 
-    description "HASH YANG Module for SONiC OS";
+    description "HASH configuration";
 
     revision 2023-09-25 {
         description "Added hashing algorithm configuration";

--- a/src/sonic-yang-models/yang-models/sonic-heartbeat.yang
+++ b/src/sonic-yang-models/yang-models/sonic-heartbeat.yang
@@ -11,7 +11,7 @@ module sonic-heartbeat {
     contact
         "SONiC";
 
-    description "HEARTBEAT YANG Module for SONiC OS";
+    description "HEARTBEAT configuration";
 
     revision 2025-01-09 {
         description "First Revision";

--- a/src/sonic-yang-models/yang-models/sonic-high-frequency-telemetry.yang
+++ b/src/sonic-yang-models/yang-models/sonic-high-frequency-telemetry.yang
@@ -21,7 +21,7 @@ module sonic-high-frequency-telemetry {
         prefix bql;
     }
 
-    description "Sub-second counter polling configuration for high-frequency telemetry in SONiC.";
+    description "Sub-second counter polling configuration for high-frequency telemetry.";
 
     container sonic-high-frequency-telemetry {
         container HIGH_FREQUENCY_TELEMETRY_PROFILE {

--- a/src/sonic-yang-models/yang-models/sonic-kubernetes_master.yang
+++ b/src/sonic-yang-models/yang-models/sonic-kubernetes_master.yang
@@ -14,7 +14,7 @@ module sonic-kubernetes_master {
         prefix stypes;
     }
 
-    description "KUBERNETES_MASTER YANG Module for SONiC OS";
+    description "KUBERNETES_MASTER configuration";
 
     revision 2022-10-09 {
         description "First Revision";

--- a/src/sonic-yang-models/yang-models/sonic-leak-control.yang
+++ b/src/sonic-yang-models/yang-models/sonic-leak-control.yang
@@ -5,7 +5,7 @@ module sonic-leak-control {
     namespace "http://github.com/sonic-net/sonic-leak-control";
     prefix leak_ctrl;
 
-    description "YANG model for BMC liquid-cooling leak control policy and leak sensor profiles";
+    description "BMC liquid-cooling leak control policy and leak sensor profiles";
 
     revision 2026-04-16 {
         description "Initial version";

--- a/src/sonic-yang-models/yang-models/sonic-lldp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-lldp.yang
@@ -14,7 +14,7 @@ module sonic-lldp {
         "SONiC";
 
     description
-        "SONiC LLDP yang model";
+        "LLDP configuration";
 
     revision 2021-07-08 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-logger.yang
+++ b/src/sonic-yang-models/yang-models/sonic-logger.yang
@@ -9,7 +9,7 @@ module sonic-logger{
         prefix stypes;
     }
 
-    description "Per-component log verbosity and output configuration YANG module for SONiC OS.";
+    description "Per-component log verbosity and output configuration";
 
     typedef swss_loglevel {
         type enumeration {
@@ -47,7 +47,7 @@ module sonic-logger{
                 description "A logger entry keyed by component name.";
 
                 leaf name {
-                    description "Name of the SONiC component (e.g. orchagent, syncd, SAI modules).";
+                    description "Name of the component (e.g. orchagent, syncd, SAI modules).";
                     type string;
                 }
 

--- a/src/sonic-yang-models/yang-models/sonic-lossless-traffic-pattern.yang
+++ b/src/sonic-yang-models/yang-models/sonic-lossless-traffic-pattern.yang
@@ -6,7 +6,7 @@ module sonic-lossless-traffic-pattern {
 
     prefix lossless-traffic-pattern;
 
-    description "LOSSLESS_TRAFFIC_PATTERN YANG module for SONiC OS";
+    description "LOSSLESS_TRAFFIC_PATTERN configuration";
 
     revision 2022-05-31 {
         description "Initial version";
@@ -37,7 +37,7 @@ module sonic-lossless-traffic-pattern {
                 leaf mtu {
                     type uint16 {
                         range 1..9216 {
-                            error-message "Invaild MTU which should be in [1, 9216].";
+                            error-message "Invalid MTU which should be in [1, 9216].";
                         }
                     }
                     mandatory true;

--- a/src/sonic-yang-models/yang-models/sonic-macsec.yang
+++ b/src/sonic-yang-models/yang-models/sonic-macsec.yang
@@ -10,7 +10,7 @@ module sonic-macsec {
         prefix stypes;
     }
 
-    description "IEEE 802.1AE MACsec link-layer encryption YANG module for SONiC OS.";
+    description "IEEE 802.1AE MACsec link-layer encryption configuration";
 
     revision 2022-04-12 {
         description "First Revision";

--- a/src/sonic-yang-models/yang-models/sonic-mclag.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mclag.yang
@@ -27,7 +27,7 @@ module sonic-mclag {
         "SONiC";
 
     description
-        "SONIC MCLAG";
+        "MCLAG configuration";
 
     revision 2019-10-01 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-memory-statistics.yang
+++ b/src/sonic-yang-models/yang-models/sonic-memory-statistics.yang
@@ -4,7 +4,7 @@ module sonic-memory-statistics {
     namespace "http://github.com/sonic-net/sonic-memory-statistics";
     prefix memstats;
 
-    description "YANG module for configuring memory statistics in SONiC-based OS.";
+    description "Memory statistics configuration.";
 
     revision 2024-07-22 {
         description "First Revision";

--- a/src/sonic-yang-models/yang-models/sonic-mgmt_interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mgmt_interface.yang
@@ -62,7 +62,7 @@ module sonic-mgmt_interface {
                     }
                     ordered-by user;
                     description
-                        "This configuration allows addtional routes to be added to default VRF table
+                        "This configuration allows additional routes to be added to default VRF table
                          or mgmt VRF table, based on if Management VRF is configured.
                          Details can be found in interfaces.j2.";
                 }

--- a/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
@@ -18,7 +18,7 @@ module sonic-mirror-session {
     }
 
     description
-        "SONiC Mirror session yang model";
+        "Mirror session configuration";
 
     revision 2026-04-14 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-mpls-tc-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mpls-tc-map.yang
@@ -17,7 +17,7 @@ module sonic-mpls-tc-map {
         "SONiC";
 
     description
-        "MPLS_TC_TO_TC_MAP yang Module for SONiC OS";
+        "MPLS_TC_TO_TC_MAP configuration";
 
     revision 2021-04-15 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-mux-cable.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mux-cable.yang
@@ -47,7 +47,7 @@ module sonic-mux-cable {
                         enum active-standby;
                     }
                     default active-standby;
-                    description "SONiC DualToR interface cable type.";
+                    description "DualToR interface cable type.";
                 }
 
                 leaf prober_type {

--- a/src/sonic-yang-models/yang-models/sonic-mux-linkmgr.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mux-linkmgr.yang
@@ -10,7 +10,7 @@ module sonic-mux-linkmgr {
         "SONiC";
 
     description
-        "SONiC DualToR Linkmgrd configuration data";
+        "DualToR Linkmgrd configuration data";
 
     revision 2023-06-07 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-nat.yang
+++ b/src/sonic-yang-models/yang-models/sonic-nat.yang
@@ -23,7 +23,7 @@ module sonic-nat {
         "SONiC";
 
     description
-        "SONiC NAT yang model";
+        "NAT configuration";
 
     revision 2021-03-14 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-neigh.yang
+++ b/src/sonic-yang-models/yang-models/sonic-neigh.yang
@@ -26,7 +26,7 @@ module sonic-neigh {
 	organization "SONiC";
 	contact "SONiC";
 
-	description "NEIGH YANG Module for SONiC OS";
+	description "NEIGH configuration";
 
 	revision 2023-03-31 {
 		description "Initial Revision";

--- a/src/sonic-yang-models/yang-models/sonic-ntp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-ntp.yang
@@ -38,7 +38,7 @@ module sonic-ntp {
     }
 
     description
-        "Network Time Protocol (NTP) client configuration YANG module for SONiC OS.";
+        "Network Time Protocol (NTP) client configuration";
 
     revision 2021-04-07 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-nvgre-tunnel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-nvgre-tunnel.yang
@@ -16,7 +16,7 @@ module sonic-nvgre-tunnel {
         "SONiC";
 
     description
-        "NVGRE Tunnel YANG Module for SONiC OS";
+        "NVGRE Tunnel configuration";
 
     revision 2021-10-31 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-passwh.yang
+++ b/src/sonic-yang-models/yang-models/sonic-passwh.yang
@@ -3,7 +3,7 @@ module sonic-passwh {
     namespace "http://github.com/sonic-net/sonic-passwh";
     prefix password;
 
-    description "Password hardening policy YANG module for SONiC OS.";
+    description "Password hardening policy configuration";
 
     revision 2022-05-03 {
         description "First Revision";

--- a/src/sonic-yang-models/yang-models/sonic-pbh.yang
+++ b/src/sonic-yang-models/yang-models/sonic-pbh.yang
@@ -21,7 +21,7 @@ module sonic-pbh {
 		prefix lag;
 	}
 
-	description "PBH YANG Module for SONiC OS: hashing for NVGRE & VxLAN with IPv4/IPv6 inner 5-tuple";
+	description "PBH configuration: hashing for NVGRE & VxLAN with IPv4/IPv6 inner 5-tuple";
 
 	revision 2021-04-23 {
 		description "First Revision";

--- a/src/sonic-yang-models/yang-models/sonic-peer-switch.yang
+++ b/src/sonic-yang-models/yang-models/sonic-peer-switch.yang
@@ -18,7 +18,7 @@ module sonic-peer-switch {
         "SONiC";
 
     description
-        "SONiC DualToR peer switch data";
+        "DualToR peer switch data";
 
     revision 2022-08-23 {
         description
@@ -35,13 +35,13 @@ module sonic-peer-switch {
                 leaf peer_switch {
                     type stypes:hostname;
 
-                    description "SONiC DualToR peer host name.";
+                    description "DualToR peer host name.";
                 }
 
                 leaf address_ipv4 {
                     type inet:ipv4-address;
 
-                    description "SONiC DualToR peer's IPv4 address.";
+                    description "DualToR peer's IPv4 address.";
                 }
             }
         }

--- a/src/sonic-yang-models/yang-models/sonic-pfc-priority-priority-group-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-pfc-priority-priority-group-map.yang
@@ -13,7 +13,7 @@ module sonic-pfc-priority-priority-group-map {
         "SONiC";
 
     description
-        "PFC_PRIORITY_TO_PRIORITY_GROUP_MAP yang Module for SONiC OS";
+        "PFC_PRIORITY_TO_PRIORITY_GROUP_MAP configuration";
 
     revision 2021-04-15 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-pfc-priority-queue-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-pfc-priority-queue-map.yang
@@ -13,7 +13,7 @@ module sonic-pfc-priority-queue-map {
         "SONiC";
 
     description
-        "PFC_PRIORITY_TO_QUEUE_MAP yang Module for SONiC OS";
+        "PFC_PRIORITY_TO_QUEUE_MAP configuration";
 
     revision 2021-04-15 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-pfcwd.yang
+++ b/src/sonic-yang-models/yang-models/sonic-pfcwd.yang
@@ -15,7 +15,7 @@ module sonic-pfcwd {
         "SONiC";
 
     description
-        "SONIC PFC Watchdog parameters";
+        "PFC Watchdog parameters configuration";
 
     revision 2021-07-01 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -17,7 +17,7 @@ module sonic-port{
 		prefix macsec;
 	}
 
-	description "PORT yang Module for SONiC OS";
+	description "PORT configuration";
 
 	revision 2019-07-01 {
 		description "First Revision";
@@ -55,7 +55,7 @@ module sonic-port{
 				}
 
 				leaf num_voq {
-					description "The number of virtual output queue supportted on this port.";
+					description "The number of virtual output queue supported on this port.";
 					type string {
 						length 1..16;
 					}
@@ -126,7 +126,7 @@ module sonic-port{
 				}
 
 				leaf-list adv_speeds {
-					description "Port advertised speeds, valid value could be a list of interger or all";
+					description "Port advertised speeds, valid value could be a list of integer or all";
 
 					type union {
 						type uint32 {

--- a/src/sonic-yang-models/yang-models/sonic-queue.yang
+++ b/src/sonic-yang-models/yang-models/sonic-queue.yang
@@ -37,7 +37,7 @@ module sonic-queue {
         "SONiC";
 
     description
-	"QUEUE yang Module for SONiC OS";
+	"QUEUE configuration";
 
     revision 2021-04-01 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-restapi.yang
+++ b/src/sonic-yang-models/yang-models/sonic-restapi.yang
@@ -11,7 +11,7 @@ module sonic-restapi {
     contact
         "SONiC";
 
-    description "RESTAPI YANG Module for SONiC OS";
+    description "RESTAPI configuration";
 
     revision 2022-10-05 {
         description "First Revision";

--- a/src/sonic-yang-models/yang-models/sonic-route-common.yang
+++ b/src/sonic-yang-models/yang-models/sonic-route-common.yang
@@ -18,7 +18,7 @@ module sonic-route-common {
         "SONiC";
 
     description
-        "SONIC ROUTE common YANG";
+        "ROUTE common configuration";
 
     revision 2021-02-26 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-route-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-route-map.yang
@@ -38,7 +38,7 @@ module sonic-route-map {
         "SONiC";
 
     description
-        "SONIC Route map YANG";
+        "Route map configuration";
 
     revision 2021-02-26 {
         description
@@ -219,7 +219,7 @@ module sonic-route-map {
                     }
                     ordered-by user;
                     description
-                        "IP addresse or interface for match operation.";
+                        "IP address or interface for match operation.";
                     max-elements 1;
                 }
 

--- a/src/sonic-yang-models/yang-models/sonic-routing-policy-sets.yang
+++ b/src/sonic-yang-models/yang-models/sonic-routing-policy-sets.yang
@@ -18,7 +18,7 @@ module sonic-routing-policy-sets {
         "SONiC";
 
     description
-        "SONiC ROUTING POLICY SETS";
+        "Routing policy sets configuration";
 
     revision 2021-02-26 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-scheduler.yang
+++ b/src/sonic-yang-models/yang-models/sonic-scheduler.yang
@@ -13,7 +13,7 @@ module sonic-scheduler {
         "SONiC";
 
     description
-        "SCHEDULER yang Module for SONiC OS";
+        "SCHEDULER configuration";
 
     revision 2021-04-01 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-serial-console.yang
+++ b/src/sonic-yang-models/yang-models/sonic-serial-console.yang
@@ -6,7 +6,7 @@ module sonic-serial-console {
     import sonic-types {
         prefix stypes;
     }
-    description "Serial console session policy YANG module for SONiC OS.";
+    description "Serial console session policy configuration";
     revision 2023-06-07 {
         description "First Revision";
     }

--- a/src/sonic-yang-models/yang-models/sonic-sflow.yang
+++ b/src/sonic-yang-models/yang-models/sonic-sflow.yang
@@ -33,7 +33,7 @@ module sonic-sflow{
     }
 
 
-    description "SFLOW yang Module for SONiC OS";
+    description "SFLOW configuration";
 
     revision 2023-04-11 {
         description "Add direction command to support egress sflow";

--- a/src/sonic-yang-models/yang-models/sonic-smart-switch.yang
+++ b/src/sonic-yang-models/yang-models/sonic-smart-switch.yang
@@ -23,7 +23,7 @@ module sonic-smart-switch {
 	contact
 		"SONiC";
 
-	description "Smart Switch yang Module for SONiC OS";
+	description "Smart Switch configuration";
 
 	revision 2023-10-17 {
 		description "First Revision";

--- a/src/sonic-yang-models/yang-models/sonic-snmp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-snmp.yang
@@ -13,7 +13,7 @@ module sonic-snmp {
     "SONiC";
 
   description
-    "Simple Network Management Protocol (SNMP) agent configuration YANG module for SONiC OS.";
+    "Simple Network Management Protocol (SNMP) agent configuration";
 
   revision 2022-05-13 {
     description

--- a/src/sonic-yang-models/yang-models/sonic-spanning-tree.yang
+++ b/src/sonic-yang-models/yang-models/sonic-spanning-tree.yang
@@ -17,7 +17,7 @@ module sonic-spanning-tree {
 		"SONiC";
 
 	description
-		"YANG model for Spanning Tree Protocol (STP) in SONiC, supporting PVST and MSTP";
+		"Spanning Tree Protocol (STP) configuration, supporting PVST and MSTP";
 
 	revision 2025-03-15 {
 		description
@@ -108,7 +108,7 @@ module sonic-spanning-tree {
 
 	container sonic-spanning-tree {
 		description
-			"SONiC Spanning Tree Protocol (STP) configuration";
+			"Spanning Tree Protocol (STP) configuration";
 
 		container STP {
 			description
@@ -354,7 +354,7 @@ module sonic-spanning-tree {
 						}
 					}
 					description
-						"Key node identifier. It's value is always GLOBAL";
+						"Key node identifier. Its value is always GLOBAL";
 				}
 
 				leaf name {

--- a/src/sonic-yang-models/yang-models/sonic-srv6.yang
+++ b/src/sonic-yang-models/yang-models/sonic-srv6.yang
@@ -12,7 +12,7 @@ module sonic-srv6 {
 	}
 
     description
-        "Segment Routing over IPv6 (SRv6) configuration for SONiC.";
+        "Segment Routing over IPv6 (SRv6) configuration.";
 
     revision 2024-12-05 {
 		description

--- a/src/sonic-yang-models/yang-models/sonic-ssh-server.yang
+++ b/src/sonic-yang-models/yang-models/sonic-ssh-server.yang
@@ -5,7 +5,7 @@ module sonic-ssh-server {
     namespace "http://github.com/sonic-net/sonic-ssh-server";
     prefix sshg;
 
-    description "SSH server daemon configuration YANG module for SONiC OS.";
+    description "SSH server daemon configuration";
 
     revision 2022-08-29 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-static-anycast-gateway.yang
+++ b/src/sonic-yang-models/yang-models/sonic-static-anycast-gateway.yang
@@ -15,7 +15,7 @@ module sonic-static-anycast-gateway {
     contact
         "SONiC";
 
-    description "SAG yang Module for SONiC OS";
+    description "SAG configuration";
 
     revision 2025-04-22 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-static-route.yang
+++ b/src/sonic-yang-models/yang-models/sonic-static-route.yang
@@ -10,7 +10,7 @@ module sonic-static-route {
   contact
     "SONiC";
   description
-    "STATIC ROUTE yang Module for SONiC OS";
+    "STATIC ROUTE configuration";
 
   revision 2022-03-17 {
     description

--- a/src/sonic-yang-models/yang-models/sonic-stormond-config.yang
+++ b/src/sonic-yang-models/yang-models/sonic-stormond-config.yang
@@ -5,7 +5,7 @@ module sonic-stormond-config{
     namespace "http://github.com/sonic-net/sonic-stormond-config";
     prefix stormond-config;
 
-    description "STORMOND_CONFIG Table yang Module for SONiC";
+    description "STORMOND_CONFIG table configuration";
 
     container sonic-stormond-config {
 

--- a/src/sonic-yang-models/yang-models/sonic-subnet-decap.yang
+++ b/src/sonic-yang-models/yang-models/sonic-subnet-decap.yang
@@ -14,7 +14,7 @@ module sonic-subnet-decap {
         prefix stypes;
     }
 
-    description "Subnet-based IPinIP tunnel decapsulation rules for SONiC.";
+    description "Subnet-based IPinIP tunnel decapsulation rules.";
 
     revision 2024-12-19 {
         description "Initial version";

--- a/src/sonic-yang-models/yang-models/sonic-suppress-asic-sdk-health-event.yang
+++ b/src/sonic-yang-models/yang-models/sonic-suppress-asic-sdk-health-event.yang
@@ -13,7 +13,7 @@ module sonic-suppress-asic-sdk-health-event {
         "SONiC";
 
     description
-        "Suppress ASIC/SDK health event yang Module for SONiC OS";
+        "Suppress ASIC/SDK health event configuration";
 
     revision 2023-11-29 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-syslog.yang
+++ b/src/sonic-yang-models/yang-models/sonic-syslog.yang
@@ -21,7 +21,7 @@ module sonic-syslog {
         prefix feature;
     }
 
-    description "Remote syslog server and logging configuration YANG module for SONiC OS.";
+    description "Remote syslog server and logging configuration";
 
     revision 2022-04-18 {
         description "Initial revision.";

--- a/src/sonic-yang-models/yang-models/sonic-system-aaa.yang
+++ b/src/sonic-yang-models/yang-models/sonic-system-aaa.yang
@@ -11,7 +11,7 @@ module sonic-system-aaa {
         prefix tacacs;
     }
 
-    description "Authentication, Authorization, and Accounting (AAA) YANG module for SONiC OS.";
+    description "Authentication, Authorization, and Accounting (AAA) configuration";
 
     revision 2021-10-12 {
         description "Add AAA authorization/accounting support.";
@@ -48,7 +48,7 @@ module sonic-system-aaa {
                 }
 
                 must 'not(./type = "authentication" and contains(./login, "tacacs+") and not(/tacacs:sonic-system-tacacs/tacacs:TACPLUS/tacacs:global/tacacs:passkey))' {
-                    error-message "Authentication with 'tacacs+' is not allowed when passkey not exists.";
+                    error-message "Authentication with 'tacacs+' is not allowed when no passkey exists.";
                 }
 
                 leaf failthrough {

--- a/src/sonic-yang-models/yang-models/sonic-system-defaults.yang
+++ b/src/sonic-yang-models/yang-models/sonic-system-defaults.yang
@@ -9,7 +9,7 @@ module sonic-system-defaults{
         prefix stypes;
     }
 
-    description "System-wide default feature settings YANG module for SONiC OS.";
+    description "System-wide default feature settings configuration";
 
     revision 2026-06-02 {
         description "Documented swss_zmq and async_rec as SYSTEM_DEFAULTS list entries.";

--- a/src/sonic-yang-models/yang-models/sonic-system-ldap.yang
+++ b/src/sonic-yang-models/yang-models/sonic-system-ldap.yang
@@ -7,7 +7,7 @@ module sonic-system-ldap {
         prefix inet;
     }
 
-    description "Lightweight Directory Access Protocol (LDAP) authentication YANG module for SONiC OS.";
+    description "Lightweight Directory Access Protocol (LDAP) authentication configuration";
 
     revision 2023-10-01 {
         description "First Revision";

--- a/src/sonic-yang-models/yang-models/sonic-system-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-system-port.yang
@@ -9,7 +9,7 @@ module sonic-system-port {
         prefix stypes;
     }
 
-    description "VoQ system port configuration YANG module for SONiC OS.";
+    description "VoQ system port configuration";
 
     revision 2022-11-10 {
         description "First Revision";
@@ -52,7 +52,7 @@ module sonic-system-port {
 
                 leaf core_port_index {
                     type uint16;
-                    description "Local port index index to an ASIC core.";
+                    description "Local port index to an ASIC core.";
                 }
 
                 leaf num_voq {

--- a/src/sonic-yang-models/yang-models/sonic-system-radius.yang
+++ b/src/sonic-yang-models/yang-models/sonic-system-radius.yang
@@ -29,7 +29,7 @@ module sonic-system-radius {
     }
 
     description
-        "Remote Authentication Dial-In User Service (RADIUS) YANG module for SONiC OS.";
+        "Remote Authentication Dial-In User Service (RADIUS) configuration";
 
     revision 2022-11-11 {
         description "Initial revision.";

--- a/src/sonic-yang-models/yang-models/sonic-system-tacacs.yang
+++ b/src/sonic-yang-models/yang-models/sonic-system-tacacs.yang
@@ -29,7 +29,7 @@ module sonic-system-tacacs {
         prefix mgmt-port;
     }
 
-    description "Terminal Access Controller Access-Control System Plus (TACACS+) YANG module for SONiC OS.";
+    description "Terminal Access Controller Access-Control System Plus (TACACS+) configuration";
 
     revision 2021-04-15 {
         description "Initial revision.";

--- a/src/sonic-yang-models/yang-models/sonic-tc-dscp-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-tc-dscp-map.yang
@@ -17,7 +17,7 @@ module sonic-tc-dscp-map {
         "SONiC";
 
     description
-        "TC_TO_DSCP_MAP yang Module for SONiC OS";
+        "TC_TO_DSCP_MAP configuration";
 
     revision 2025-01-10 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-tc-priority-group-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-tc-priority-group-map.yang
@@ -17,7 +17,7 @@ module sonic-tc-priority-group-map {
         "SONiC";
 
     description
-        "TC_TO_PRIORITY_GROUP_MAP yang Module for SONiC OS";
+        "TC_TO_PRIORITY_GROUP_MAP configuration";
 
     revision 2021-04-15 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-tc-queue-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-tc-queue-map.yang
@@ -17,7 +17,7 @@ module sonic-tc-queue-map {
         "SONiC";
 
     description
-        "TC_TO_QUEUE_MAP yang Module for SONiC OS";
+        "TC_TO_QUEUE_MAP configuration";
 
     revision 2021-04-15 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-telemetry.yang
+++ b/src/sonic-yang-models/yang-models/sonic-telemetry.yang
@@ -19,7 +19,7 @@ module sonic-telemetry {
     contact
         "SONiC";
 
-    description "TELEMETRY YANG Module for SONiC OS";
+    description "TELEMETRY configuration";
 
     revision 2025-09-01 {
         description "Add VRF support for Telemetry service";

--- a/src/sonic-yang-models/yang-models/sonic-telemetry_client.yang
+++ b/src/sonic-yang-models/yang-models/sonic-telemetry_client.yang
@@ -16,7 +16,7 @@ module sonic-telemetry_client {
         "SONiC";
 
     description
-        "TELEMETRY_CLIENT yang Module for SONiC OS";
+        "TELEMETRY_CLIENT configuration";
 
     revision 2023-01-12 {
         description
@@ -32,7 +32,7 @@ module sonic-telemetry_client {
         }
     }
     typedef path_target {
-        description "SONiC database target for telemetry subscriptions.";
+        description "Database target for telemetry subscriptions.";
         type enumeration {
             enum APPL_DB;
             enum CONFIG_DB;

--- a/src/sonic-yang-models/yang-models/sonic-trimming.yang
+++ b/src/sonic-yang-models/yang-models/sonic-trimming.yang
@@ -5,7 +5,7 @@ module sonic-trimming {
     namespace "http://github.com/sonic-net/sonic-trimming";
     prefix trim;
 
-    description "TRIMMING YANG Module for SONiC OS";
+    description "TRIMMING configuration";
 
     revision 2024-11-01 {
         description "First Revision";

--- a/src/sonic-yang-models/yang-models/sonic-tunnel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-tunnel.yang
@@ -18,7 +18,7 @@ module sonic-tunnel {
 		"SONiC";
 
 	description
-		"SONiC DualToR tunnel data";
+		"DualToR tunnel data";
 
 	revision 2022-08-23 {
 		description
@@ -27,7 +27,7 @@ module sonic-tunnel {
 
 	container sonic-tunnel {
 		container TUNNEL {
-			description "TUNNEL configuration for SONiC Dual-ToR";
+			description "TUNNEL configuration for Dual-ToR";
 			list TUNNEL_LIST {
 				key "mux_tunnel";
 
@@ -46,7 +46,7 @@ module sonic-tunnel {
 				}
 
 				leaf src_ip {
-					description "source IPv4 address off the tunnel. Must be SONiC DualToR peer IPv4 address.";
+					description "source IPv4 address off the tunnel. Must be the DualToR peer IPv4 address.";
 					type leafref {
 						path "/ps:sonic-peer-switch/ps:PEER_SWITCH/ps:PEER_SWITCH_LIST/ps:address_ipv4";
 					}

--- a/src/sonic-yang-models/yang-models/sonic-versions.yang
+++ b/src/sonic-yang-models/yang-models/sonic-versions.yang
@@ -6,7 +6,7 @@ module sonic-versions {
     prefix versions;
 
 
-    description "VERSIONS YANG Module for SONiC OS";
+    description "VERSIONS configuration";
 
     revision 2020-04-10 {
         description "First Revision";

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -45,7 +45,7 @@ module sonic-vlan {
 		prefix sag;
 	}
 
-	description "VLAN yang Module for SONiC OS";
+	description "VLAN configuration";
 
 	revision 2025-04-22 {
 		description "Add SAG support";

--- a/src/sonic-yang-models/yang-models/sonic-voq-inband-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-voq-inband-interface.yang
@@ -14,7 +14,7 @@ module sonic-voq-inband-interface {
         "SONiC";
 
     description
-        "SONIC BGP Internal Neighbor for voq chassis platforms";
+        "BGP Internal Neighbor for voq chassis platforms";
 
     revision 2022-10-06 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-vxlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vxlan.yang
@@ -21,7 +21,7 @@ module sonic-vxlan {
         "SONiC";
 
     description
-        "VXLAN tunnel and EVPN NVO configuration for SONiC.";
+        "VXLAN tunnel and EVPN NVO configuration.";
 
     revision 2021-04-12 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-wred-profile.yang
+++ b/src/sonic-yang-models/yang-models/sonic-wred-profile.yang
@@ -13,7 +13,7 @@ module sonic-wred-profile {
         "SONiC";
 
     description
-        "WRED_PROFILE yang Module for SONiC OS";
+        "WRED_PROFILE configuration";
 
     revision 2021-04-01 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-xcvrd-log.yang
+++ b/src/sonic-yang-models/yang-models/sonic-xcvrd-log.yang
@@ -10,7 +10,7 @@ module sonic-xcvrd-log {
         "SONiC";
 
     description
-        "SONiC DualToR xcvrd logging configuration data";
+        "DualToR xcvrd logging configuration data";
 
     revision 2024-10-14 {
         description

--- a/src/sonic-yang-models/yang-models/sonic-ztp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-ztp.yang
@@ -5,7 +5,7 @@ module sonic-ztp {
     namespace "http://github.com/sonic-net/sonic-ztp";
     prefix ztp;
 
-    description "Zero Touch Provisioning (ZTP) configuration YANG module for SONiC OS.";
+    description "Zero Touch Provisioning (ZTP) configuration";
 
     revision 2025-04-03 {
         description "First Revision";

--- a/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
@@ -41,7 +41,7 @@ module sonic-acl {
 		prefix sms;
 	}
 
-	description "ACL YANG Module for SONiC OS";
+	description "ACL configuration";
 
 	revision 2019-07-01 {
 		description "First Revision";
@@ -92,7 +92,7 @@ module sonic-acl {
 				}
 
 				leaf INNER_SRC_MAC_REWRITE_ACTION {
-					description "Inner Source Mac-adress rewrite action mapped to mac address";
+					description "Inner source MAC address rewrite action mapped to MAC address";
 					type yang:mac-address;
 				}
 

--- a/src/sonic-yang-models/yang-templates/sonic-extension.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-extension.yang.j2
@@ -5,7 +5,7 @@ module sonic-extension {
     namespace "http://github.com/sonic-net/sonic-extension";
     prefix sonic-extension;
 
-    description "Extension yang Module for SONiC OS";
+    description "Extension configuration";
 
     revision 2019-07-01 {
         description "First Revision";

--- a/src/sonic-yang-models/yang-templates/sonic-policer.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-policer.yang.j2
@@ -14,7 +14,7 @@ module sonic-policer {
 		prefix stypes;
 	}
 
-	description "Policer YANG Module for SONiC OS";
+	description "Policer configuration";
 
 	revision 2022-02-03 {
 		description

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -5,7 +5,7 @@ module sonic-types {
     namespace "http://github.com/sonic-net/sonic-head";
     prefix sonic-types;
 
-    description "SONiC type for yang Models of SONiC OS";
+    description "Common type definitions";
     /*
      * Try to define only sonic specific types here. Rest can be written in
      * respective YANG files.
@@ -346,7 +346,7 @@ module sonic-types {
     }
 
     typedef process_name {
-        description "SONiC process name identifier";
+        description "Process name identifier";
         type string {
             pattern '[a-zA-Z0-9]{1}([-a-zA-Z0-9_]{0,31})' {
                 error-message "Invalid process_name.";


### PR DESCRIPTION
#### Why I did it

Documentation and command-reference generators, `sonic-cfg-help`, and config validators read the YANG `description` / `error-message` strings directly and surface them to operators as help text. A number of those strings contain misspellings, small grammatical errors, and redundant boilerplate — "SONiC" / "YANG" qualifiers that convey nothing inside a SONiC YANG model — all of which then show up verbatim in the generated user assistance. This cleans up the wording so that tooling produces clear, consistent help.

Only human-readable `description` / `error-message` text is changed. No schema identifiers, keys, `pattern`s, enum values, or defaults are touched, so there is no configuration or backward-compatibility impact.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- **Misspellings**: fixed typos in descriptions and error-messages (e.g. `cummulative`, `congiured`, `talbe`, `supportted`, `interger`, `addtional`, `Invaild`, `verifed`, `doesnt`), plus typos in test-case labels and `doc/Configuration.md`. Verified with `codespell`.
- **Grammar/wording**: e.g. `"an notification"` → `"a notification"`, `"if enable ..."` → `"whether to enable ..."`, `"when passkey not exists"` → `"when no passkey exists"`, and a doubled `"index index"`.
- **Redundant qualifiers**: dropped `SONiC` / `YANG` where they add no information (e.g. `"ACL YANG Module for SONiC OS"` → `"ACL configuration"`). Genuine references were kept — cross-module names (`sonic-*`), `/etc/sonic` paths, and text that is actually about YANG model validation.
- Updated the `sonic-cfg-help` golden output (`src/sonic-yang-mgmt/tests/test_cfghelp.py`) and a YANG model test expectation (`aaa.json`) to match the corrected strings. The fixed-width help table was re-wrapped where a now-shorter word reflowed a column.

#### How to verify it

- `pushd src/sonic-yang-models && pytest ; popd` — YANG model tests pass with the updated expectations.
- `pushd src/sonic-yang-mgmt && pytest tests/test_cfghelp.py ; popd` — `sonic-cfg-help` golden tests pass.
- `codespell src/sonic-yang-models` reports no misspellings (remaining hits `ND`, `RO`, `RW` are legitimate abbreviations — Neighbor Discovery, read-only, read-write).

#### Which release branch to backport (provide reason below if selected)

<!-- Wording-only cleanup targeting master; no backport requested. -->

#### Tested branch

- [x] master
