### PR TITLE
[Mellanox] thermal_updater: stop writing 0 for ASIC not-ready/error

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
@@ -52,6 +52,12 @@ ASIC_DEFAULT_TEMP_CRITICAL_THRESHOLD = 120000
 
 ERROR_READ_THERMAL_DATA = 254000
 
+# Written to hw-management 'thermal/asic' when the ASIC temperature is not yet
+# available in STATE_DB (startup / not-ready window). An empty value makes
+# hw-management-tc take the recoverable SENSOR_READ_ERR path (int() ValueError)
+# instead of the latched EMERGENCY caused by writing 0.
+ASIC_TEMP_NOT_READY = ''
+
 TC_CONFIG_FILE = '/run/hw-management/config/tc_config.json'
 logger = logger.Logger('thermal-updater')
 
@@ -247,31 +253,41 @@ class ThermalUpdater:
             self.update_single_module(sfp)
 
     def update_asic(self):
+        # Pre-initialize so the except block below can't raise UnboundLocalError
+        # if get_asic_count() fails before the loop assigns it.
+        asic_index = 0
         try:
             for asic_index in range(DeviceDataManager.get_asic_count()):
                 asic_temp = self.get_asic_temp(self._asic_names[asic_index])
-                warn_threshold = self.get_asic_temp_warning_threshold()
-                critical_threshold = self.get_asic_temp_critical_threshold()
                 fault = 0
                 if asic_temp is None:
+                    # ready but read/parse failed → assume hot, force fans up
                     logger.log_error(f'Failed to read ASIC {asic_index} temperature, send fault to hw-management-tc')
-                    asic_temp = warn_threshold
+                    asic_temp = ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD
                     fault = ERROR_READ_THERMAL_DATA
+                elif asic_temp == 0:
+                    # ASIC not ready (missing / N/A in STATE_DB; a real ASIC
+                    # never reads 0). Write empty so hw-management-tc takes the
+                    # recoverable SENSOR_READ_ERR path instead of latching a
+                    # false EMERGENCY on 0.
+                    asic_temp = ASIC_TEMP_NOT_READY
 
                 hw_management_independent_mode_update.thermal_data_set_asic(
                     asic_index,
                     asic_temp,
-                    critical_threshold,
-                    warn_threshold,
+                    ASIC_DEFAULT_TEMP_CRITICAL_THRESHOLD,
+                    ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD,
                     fault
                 )
         except Exception as e:
+            # Unexpected failure: assume hot (warn threshold, never 0) so TC
+            # drives fans up rather than latching a false EMERGENCY on 0.
             logger.log_error(f'Failed to update ASIC thermal data - {e}')
             hw_management_independent_mode_update.thermal_data_set_asic(
                 asic_index,
-                0,
-                0,
-                0,
+                ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD,
+                ASIC_DEFAULT_TEMP_CRITICAL_THRESHOLD,
+                ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD,
                 ERROR_READ_THERMAL_DATA
             )
 

--- a/platform/mellanox/mlnx-platform-api/tests/test_thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_thermal_updater.py
@@ -22,7 +22,9 @@ from unittest import mock
 from sonic_platform import utils
 from sonic_platform.thermal_updater import ThermalUpdater, hw_management_independent_mode_update, clean_thermal_data
 from sonic_platform.thermal_updater import ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD, \
-                                           ASIC_DEFAULT_TEMP_CRITICAL_THRESHOLD
+                                           ASIC_DEFAULT_TEMP_CRITICAL_THRESHOLD, \
+                                           ASIC_TEMP_NOT_READY, \
+                                           ERROR_READ_THERMAL_DATA
 
 
 mock_tc_config = """
@@ -142,6 +144,71 @@ class TestThermalUpdater:
         assert updater.get_asic_temp('ASIC') == 0
         assert updater.get_asic_temp_warning_threshold() == ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD
         assert updater.get_asic_temp_critical_threshold() == ASIC_DEFAULT_TEMP_CRITICAL_THRESHOLD
+
+    @mock.patch('sonic_platform.thermal_updater.get_db_table_helper')
+    def test_update_asic_not_ready(self, mock_get_db_table_helper):
+        hw_management_independent_mode_update.reset_mock()
+        mock_temp_table = mock.MagicMock()
+        mock_db_table_helper = mock.MagicMock()
+        mock_db_table_helper.get_temperature_info_table.return_value = mock_temp_table
+        mock_get_db_table_helper.return_value = mock_db_table_helper
+
+        # ASIC not present in STATE_DB yet (startup not-ready window)
+        mock_temp_table.hget.return_value = (False, None)
+
+        updater = ThermalUpdater(None)
+        updater.update_asic()
+        # not-ready remaps 0 -> '' so hw-management-tc takes the recoverable
+        # SENSOR_READ_ERR path, never 0 (which would latch a false EMERGENCY).
+        hw_management_independent_mode_update.thermal_data_set_asic.assert_called_once_with(
+            0,
+            ASIC_TEMP_NOT_READY,
+            ASIC_DEFAULT_TEMP_CRITICAL_THRESHOLD,
+            ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD,
+            0
+        )
+
+    @mock.patch('sonic_platform.thermal_updater.get_db_table_helper')
+    def test_update_asic_read_error(self, mock_get_db_table_helper):
+        hw_management_independent_mode_update.reset_mock()
+        mock_temp_table = mock.MagicMock()
+        mock_db_table_helper = mock.MagicMock()
+        mock_db_table_helper.get_temperature_info_table.return_value = mock_temp_table
+        mock_get_db_table_helper.return_value = mock_db_table_helper
+
+        # ASIC present but the read/parse fails -> get_asic_temp() returns None
+        mock_temp_table.hget.side_effect = Exception('db read failed')
+
+        updater = ThermalUpdater(None)
+        updater.update_asic()
+        # read error -> assume hot: warn threshold temperature + fault, never 0.
+        hw_management_independent_mode_update.thermal_data_set_asic.assert_called_once_with(
+            0,
+            ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD,
+            ASIC_DEFAULT_TEMP_CRITICAL_THRESHOLD,
+            ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD,
+            ERROR_READ_THERMAL_DATA
+        )
+
+    @mock.patch('sonic_platform.thermal_updater.logger')
+    def test_update_asic_exception_assumes_hot(self, mock_logger):
+        hw_management_independent_mode_update.reset_mock()
+        # Construct before patching get_asic_count so __init__ succeeds.
+        updater = ThermalUpdater(None)
+        # Fail inside update_asic before the loop assigns asic_index.
+        with mock.patch('sonic_platform.thermal_updater.DeviceDataManager.get_asic_count',
+                        side_effect=Exception('boom')):
+            updater.update_asic()  # must not raise UnboundLocalError
+        # assume hot: fake temperature to warn threshold, keep real thresholds
+        # (same shape as the None path), never 0.
+        hw_management_independent_mode_update.thermal_data_set_asic.assert_called_once_with(
+            0,
+            ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD,
+            ASIC_DEFAULT_TEMP_CRITICAL_THRESHOLD,
+            ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD,
+            ERROR_READ_THERMAL_DATA
+        )
+        mock_logger.log_error.assert_called()
 
     def test_update_module(self):
         from sonic_platform.sfp import SFP


### PR DESCRIPTION
#### Why I did it
During the ASIC not-ready window at startup, `TEMPERATURE_INFO|ASIC` is not yet present in STATE_DB, so `ThermalUpdater.get_asic_temp()` returns `0` and `update_asic()` forwarded that `0` to hw-management. hw-management-tc interprets an ASIC temperature of `0` (while the ASIC is marked ready) as a critical i2c/bus error and, after 3 consecutive reads (~9s), latches the fans to full speed until hw-management/TC is restarted. This is reachable on every host-management platform during the common startup race.

The outer `except` in `update_asic()` also hard-coded `0`, and could itself raise `UnboundLocalError` if `get_asic_count()` failed before the loop was entered.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Fixed `update_asic()` so it never writes `0` for the ASIC (`get_asic_temp()` is unchanged; all hw-management write policy stays in `update_asic()`):
- **not-ready** (`get_asic_temp() == 0`): write an empty string, so hw-management-tc takes the recoverable "sensor read error" path (`int()` raises `ValueError`) and auto-recovers once a real temperature is available, instead of latching a false emergency.
- **read error** (`get_asic_temp()` returns `None`) and the outer `except`: write the warning threshold ("assume hot" to drive fans up), never `0`.
- Pre-initialize `asic_index` before the loop so the outer `except` cannot raise `UnboundLocalError`.

#### How to verify it
- Unit tests: `pytest platform/mellanox/mlnx-platform-api/tests/test_thermal_updater.py` — added `test_update_asic_not_ready`, `test_update_asic_read_error` and `test_update_asic_exception_assumes_hot`.
- On a host-management platform: during an ASIC not-ready window, confirm `/var/run/hw-management/thermal/asic` is written empty (not `0`), `/var/run/hw-management/config/thermal_enforced_full_speed` is not set to `1`, and the fans recover automatically once the ASIC temperature becomes available.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Description for the changelog
[Mellanox] thermal_updater: stop writing 0 for ASIC not-ready/error to avoid a false hw-management fan emergency

#### Link to config_db schema for YANG module changes
N/A (no config_db / YANG change)
