### PR TITLE
[docker-dash-engine]: pin behavioral-model base image to a digest

### DIFF
--- a/platform/vs/docker-dash-engine/Dockerfile.j2
+++ b/platform/vs/docker-dash-engine/Dockerfile.j2
@@ -1,5 +1,5 @@
 {% set prefix = DEFAULT_CONTAINER_REGISTRY %}
-ARG BASE={{ prefix }}p4lang/behavioral-model:latest
+ARG BASE={{ prefix }}p4lang/behavioral-model@sha256:d74a2174bd9a6a73fcad22bde6f258e9cfbf5e8447575f6325514e4499fd245c
 ## ARG BASE=docker-config-engine-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 FROM $BASE AS base


### PR DESCRIPTION
#### Why I did it

`platform/vs/docker-dash-engine/Dockerfile.j2` is built `FROM {{ prefix }}p4lang/behavioral-model:latest`
(an unpinned external base) and copies the whole base filesystem (`COPY --from=base / /`).
`libpi.so.0.0.0` comes entirely from that base image; no SONiC-built deb provides it, and
the image `.dep` can only hash local build-dir files. When the upstream `:latest` tag
moves, every SONiC-tracked input is unchanged, so the cache serves a stale image
(observed as roughly 29% / ~16 KB `.text`/`.rodata` drift and a different BuildID). This
is a non-reproducible-build gap that the cache cannot detect.

##### Work item tracking
- Microsoft ADO **(number only)**: 38869282

#### How I did it

Pinned the base image to an immutable digest so fresh and cached builds resolve the same
base:

    ARG BASE={{ prefix }}p4lang/behavioral-model@sha256:d74a2174bd9a6a73fcad22bde6f258e9cfbf5e8447575f6325514e4499fd245c

The digest should be advanced deliberately under review when a base bump is intended.

#### How to verify it

Rebuild `target/docker-dash-engine.gz` cached versus fresh and confirm identical
`libpi.so` BuildID. The base image is now explicit and immutable in the Dockerfile.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Description for the changelog

Pin the docker-dash-engine behavioral-model base image to a digest for reproducible
builds.
