### PR TITLE
[cache validation][rules]: add dpkg cache .dep for grpc and iproute2

### DIFF
--- a/rules/grpc.dep
+++ b/rules/grpc.dep
@@ -1,0 +1,16 @@
+
+# grpc is only built in the bullseye build environment (see rules/grpc.mk).
+# Guard the cache rule with the same condition so $(GRPC) is defined and the
+# git ls-files below is scoped to the module source path.
+ifeq ($(BLDENV),bullseye)
+
+SPATH       := $($(GRPC)_SRC_PATH)
+DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/grpc.mk rules/grpc.dep
+DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
+DEP_FILES   += $(shell git ls-files $(SPATH))
+
+$(GRPC)_CACHE_MODE  := GIT_CONTENT_SHA
+$(GRPC)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)
+$(GRPC)_DEP_FILES   := $(DEP_FILES)
+
+endif

--- a/rules/iproute2.dep
+++ b/rules/iproute2.dep
@@ -1,0 +1,16 @@
+
+# iproute2 is only built in the trixie build environment (see rules/iproute2.mk).
+# Guard the cache rule with the same condition so $(IPROUTE2) is defined and the
+# git ls-files below is scoped to the module source path.
+ifeq ($(BLDENV),trixie)
+
+SPATH       := $($(IPROUTE2)_SRC_PATH)
+DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/iproute2.mk rules/iproute2.dep
+DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
+DEP_FILES   += $(shell git ls-files $(SPATH))
+
+$(IPROUTE2)_CACHE_MODE  := GIT_CONTENT_SHA
+$(IPROUTE2)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)
+$(IPROUTE2)_DEP_FILES   := $(DEP_FILES)
+
+endif


### PR DESCRIPTION
#### Why I did it

`grpc` (`rules/grpc.mk`, bullseye) and `iproute2` (`rules/iproute2.mk`, trixie) are built
from source (`SONIC_MAKE_DEBS` with a `_SRC_PATH`) but had no `rules/*.dep` file, so the
cache framework registered no cache rule for them. Their source changes were therefore
not reflected in any cache key, and cached downstream dependents could be reused despite
source changes.

##### Work item tracking
- Microsoft ADO **(number only)**: 38869283

#### How I did it

Added BLDENV-guarded `.dep` files modeled on `rules/bash.dep`, tracking the in-tree
source via `git ls-files $(SPATH)`. The BLDENV guard matches each `.mk` so the module
variable is defined and `git ls-files` is scoped to the module path.

New files: `rules/grpc.dep`, `rules/iproute2.dep`.

#### How to verify it

With cache enabled, edit a source file under each module and confirm the cache key
changes and the artifact is rebuilt rather than restored.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Description for the changelog

Add dpkg cache .dep rules for grpc and iproute2 so their source changes invalidate the
cache.
