### PR TITLE
[cache validation][rules/libnl3]: register libnl-nf-3-200-dbgsym under top-level libnl3

### DIFF
--- a/rules/libnl3.mk
+++ b/rules/libnl3.mk
@@ -55,7 +55,7 @@ $(eval $(call add_derived_package,$(LIBNL3),$(LIBNL_NF3)))
 LIBNL_NF3_DBG = libnl-nf-3-200-dbgsym_$(LIBNL3_VERSION_SONIC)_$(CONFIGURED_ARCH).deb
 $(LIBNL_NF3_DBG)_DEPENDS += $(LIBNL_NF3)
 $(LIBNL_NF3_DBG)_RDEPENDS += $(LIBNL_NF3)
-$(eval $(call add_derived_package,$(LIBNL_NF3),$(LIBNL_NF3_DBG)))
+$(eval $(call add_derived_package,$(LIBNL3),$(LIBNL_NF3_DBG)))
 
 LIBNL_NF3_DEV = libnl-nf-3-dev_$(LIBNL3_VERSION_SONIC)_$(CONFIGURED_ARCH).deb
 $(LIBNL_NF3_DEV)_DEPENDS += $(LIBNL_NF3)


### PR DESCRIPTION
#### Why I did it

`libnl-nf-3-200-dbgsym` was registered as a derived package of `libnl-nf-3-200`, which is
itself a derived package of `libnl3`. The cache save/restore path only tars first-level
derived debs and does not recurse, so this nested derived deb was dropped from the cache
tarball and was missing on a cache hit.

##### Work item tracking
- Microsoft ADO **(number only)**: 38869286

#### How I did it

Registered the dbgsym directly against `libnl3`, matching every sibling dbgsym in the
file (`libnl-3-200-dbgsym`, `libnl-genl-3-200-dbgsym`, `libnl-route-3-200-dbgsym`,
`libnl-cli-3-200-dbgsym`):

    -$(eval $(call add_derived_package,$(LIBNL_NF3),$(LIBNL_NF3_DBG)))
    +$(eval $(call add_derived_package,$(LIBNL3),$(LIBNL_NF3_DBG)))

This is the only nested `add_derived_package` in the repo.

#### How to verify it

After a libnl3 cache hit, confirm `libnl-nf-3-200-dbgsym` is present in the restored
artifacts (previously absent).

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Description for the changelog

Register libnl-nf-3-200-dbgsym under top-level libnl3 so it survives dpkg cache
save/restore.
