### PR TITLE
[sonic-yang-models]: Add ipv6_use_link_local_only to VLAN_SUB_INTERFACE YANG model

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -1682,7 +1682,8 @@ These tables have a number of shared attributes as described below:
     "VLAN_SUB_INTERFACE": {
         "Ethernet0.555": {
             "vrf_name": "Blue",
-            "vlan": "555"
+            "vlan": "555",
+            "ipv6_use_link_local_only": "enable"
         }
     }
 }

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1298,7 +1298,8 @@
         "VLAN_SUB_INTERFACE": {
             "Ethernet12.10": {
                 "admin_status": "up",
-                "loopback_action": "drop"
+                "loopback_action": "drop",
+                "ipv6_use_link_local_only": "enable"
             },
             "Ethernet12.10|10.0.1.56/31": {},
             "Ethernet12.10|fc00::1:71/126": {},

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vlan_sub_interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vlan_sub_interface.json
@@ -71,7 +71,14 @@
         "desc": "Configure PortChannel VLAN sub interface with VNET reference."
     },
     "VLAN_SUB_INTERFACE_WITH_MISSING_VNET": {
-        "desc": "Configure VLAN sub interface with VNET reference but no VNET exsiting.",
+        "desc": "Configure VLAN sub interface with VNET reference but no VNET existing.",
         "eStrKey": "LeafRef"
+    },
+    "VLAN_SUB_INTERFACE_ENABLE_IPV6_LINK_LOCAL": {
+        "desc": "Configure VLAN sub interface with ipv6_use_link_local_only enabled."
+    },
+    "VLAN_SUB_INTERFACE_INVALID_IPV6_LINK_LOCAL": {
+        "desc": "Configure VLAN sub interface with an invalid ipv6_use_link_local_only value.",
+        "eStr": "Invalid value \"true\" in \"ipv6_use_link_local_only\" element."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan_sub_interface.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan_sub_interface.json
@@ -779,5 +779,59 @@
                 ]
             }
         }
+    },
+    "VLAN_SUB_INTERFACE_ENABLE_IPV6_LINK_LOCAL": {
+        "sonic-vlan-sub-interface:sonic-vlan-sub-interface": {
+            "sonic-vlan-sub-interface:VLAN_SUB_INTERFACE": {
+                "VLAN_SUB_INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8.10",
+                        "ipv6_use_link_local_only": "enable"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "admin_status": "up",
+                        "alias": "Ethernet8/1",
+                        "description": "Ethernet8",
+                        "lanes": "45,46,47,48",
+                        "mtu": 9000,
+                        "speed": 100000
+                    }
+                ]
+            }
+        }
+    },
+    "VLAN_SUB_INTERFACE_INVALID_IPV6_LINK_LOCAL": {
+        "sonic-vlan-sub-interface:sonic-vlan-sub-interface": {
+            "sonic-vlan-sub-interface:VLAN_SUB_INTERFACE": {
+                "VLAN_SUB_INTERFACE_LIST": [
+                    {
+                        "name": "Ethernet8.10",
+                        "ipv6_use_link_local_only": "true"
+                    }
+                ]
+            }
+        },
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "admin_status": "up",
+                        "alias": "Ethernet8/1",
+                        "description": "Ethernet8",
+                        "lanes": "45,46,47,48",
+                        "mtu": 9000,
+                        "speed": 100000
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan-sub-interface.yang
@@ -28,9 +28,13 @@ module sonic-vlan-sub-interface {
 
     description "VLAN sub-interface configuration for dot1q encapsulated sub-ports on physical or PortChannel interfaces";
 
-	revision 2025-03-06 {
-		description "Add leaf vnet_name";
-	}
+    revision 2026-07-20 {
+        description "Add leaf ipv6_use_link_local_only";
+    }
+
+    revision 2025-03-06 {
+        description "Add leaf vnet_name";
+    }
     
     revision 2021-11-11 {
         description "Initial version";
@@ -90,6 +94,12 @@ module sonic-vlan-sub-interface {
                     type leafref {
                         path "/svnet:sonic-vnet/svnet:VNET/svnet:VNET_LIST/svnet:name";
                     }   
+                }
+
+                leaf ipv6_use_link_local_only {
+                    description "Enable/Disable IPv6 link local address on vlan sub-interface";
+                    type stypes:mode-status;
+                    default disable;
                 }
 
                 leaf loopback_action {


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The `ipv6_use_link_local_only` field is already supported by the SONiC backend for other L3 interface types (`INTERFACE`, `PORTCHANNEL_INTERFACE`, `VLAN_INTERFACE`) but was missing from the `VLAN_SUB_INTERFACE` YANG schema.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added the `ipv6_use_link_local_only` leaf to `VLAN_SUB_INTERFACE_LIST` in `sonic-vlan-sub-interface.yang`, using `stypes:mode-status` with default `disable`, consistent with all other L3 interface YANG models.
- `doc/Configuration.md`: document `VLAN_SUB_INTERFACE`-specific attributes including `ipv6_use_link_local_only`
- `tests/files/sample_config_db.json`: add example usage
- `yang_model_tests`: add positive (`enable`) and negative (invalid value) test cases
#### How to verify it
Run the YANG model unit tests:
```bash
cd src/sonic-yang-models
python3 -m pytest tests/yang_model_pytests/ -v
python3 setup.py test
```

Verify the new field can be set in CONFIG_DB on a subinterface:
```
config interface ip add Ethernet0.100 10.0.0.1/24
redis-cli -n 4 HSET "VLAN_SUB_INTERFACE|Ethernet0.100" ipv6_use_link_local_only enable
sonic-cfggen -d --print-data | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['VLAN_SUB_INTERFACE'])"
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#l3-interfaces 

#### A picture of a cute animal (not mandatory but encouraged)
