### PR TITLE
[arp_update]: Fix dualtor performance regression by setting arping/nd…

### DIFF
--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -42,14 +42,14 @@ run_arping_with_retry() {
     local ifname="$1"
     local ip="$2"
     run_with_retry_cmd "arping on ${ifname} to ${ip}" \
-        arping -q -w 1 -c 1 -i "$ifname" "$ip" >/dev/null 2>&1
+        arping -q -w 0 -c 1 -i "$ifname" "$ip" >/dev/null 2>&1
 }
 
 run_ndisc6_with_retry() {
     local ifname="$1"
     local ip="$2"
     run_with_retry_cmd "ndisc6 on ${ifname} to ${ip}" \
-        ndisc6 -q -w 1 -1 "$ip" "$ifname" >/dev/null 2>&1
+        ndisc6 -q -w 0 -1 "$ip" "$ifname" >/dev/null 2>&1
 }
 
 while /bin/true; do
@@ -155,8 +155,8 @@ while /bin/true; do
   SUBTYPE=$(sonic-db-cli CONFIG_DB hget 'DEVICE_METADATA|localhost' 'subtype' | tr '[:upper:]' '[:lower:]')
   for vlan in $VLAN; do
       # generate a list of arping commands:
-      #   arping -q -w 1 -c 1 -i <VLAN interface> <IP 1>;
-      #   arping -q -w 1 -c 1 -i <VLAN interface> <IP 2>;
+      #   arping -q -w 0 -c 1 -i <VLAN interface> <IP 1>;
+      #   arping -q -w 0 -c 1 -i <VLAN interface> <IP 2>;
       #   ...
       while read -r ip ifname; do
           [ -z "$ip" ] && continue
@@ -168,8 +168,8 @@ while /bin/true; do
       eval $ping6cmd
 
       # generate a list of ndisc6 commands (exclude link-local addrs since it is done above):
-      #   ndisc6 -q -w 1 -1 <IP 1> <VLAN interface>;
-      #   ndisc6 -q -w 1 -1 <IP 2> <VLAN interface>;
+      #   ndisc6 -q -w 0 -1 <IP 1> <VLAN interface>;
+      #   ndisc6 -q -w 0 -1 <IP 2> <VLAN interface>;
       #   ...
       while read -r ip ifname; do
           [ -z "$ip" ] && continue


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Cherry-pick the upstream master fix for a 202605 dual-ToR
  active-active ARP neighbor learning failure.

  `arp_update` currently uses `arping -w 1` and `ndisc6 -w 1`
  for unsolicited ARP/NDP refresh. GARP and unsolicited NA are
  announcements and do not need to wait for a reply.

  On dual-ToR active-active testbeds with many Vlan1000 neighbors,
  the per-neighbor 1 second wait delays `arp_update`. The sonic-mgmt
  test `arp/test_arp_dualtor.py::test_standby_unsolicited_neigh_learning`
  can then time out while waiting for the standby ToR neighbor entry,
  showing repeated `KeyError` for the missing neighbor.

##### Work item tracking
- Microsoft ADO **(number only)**: 38614055
- Fixes : https://github.com/sonic-net/sonic-mgmt/issues/26396

#### How I did it
 Cherry-picked upstream commit:

  f19b7928f8e62836cff0790ef8581532c0ec9947

  This changes unsolicited refresh commands in `files/scripts/arp_update`:

  - `arping -q -w 1` -> `arping -q -w 0`
  - `ndisc6 -q -w 1` -> `ndisc6 -q -w 0`

  The retry-wrapper structure from PR #25169 is preserved.

  #### How to verify it

   Verified the patched 202605 branch uses zero wait:

  `grep -n "arping -q -w\\|ndisc6 -q -w" files/scripts/arp_update`

  **Result:**

```

  45:        arping -q -w 0 -c 1 -i "$ifname" "$ip" >/dev/null 2>&1
  52:        ndisc6 -q -w 0 -1 "$ip" "$ifname" >/dev/null 2>&1
```

  Validated the failure scenario by running:

  arp/test_arp_dualtor.py::test_standby_unsolicited_neigh_learning

  The test passed after applying the change.

  Before the fix, saved logs showed repeated missing-neighbor failures:

  KeyError: '192.168.0.14'
  KeyError: 'fc02:1000::26'

  **Test environment:**

  branch: 202605
  topology: dualtor-aa-56
  testbed: dtAA56
  platform: x86_64-arista_7260cx3_64
  hwsku: Arista-7260CX3-C64
  image: branch.202605-ars.f2e092bc-buildimage.17a11c3c9aa389a1e836d56151305c1e33c26d62-nightly-2026.06.24.14.40


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
**202605: Pass Logs** 
[test_standby_unsolicited_neigh_learning_pass_tst-esx-62_2026-07-07.log](https://github.com/user-attachments/files/30213055/test_standby_unsolicited_neigh_learning_pass_tst-esx-62_2026-07-07.log)
[test_standby_unsolicited_neigh_learning_pass_tst-esx-62_2026-07-07.xml](https://github.com/user-attachments/files/30213057/test_standby_unsolicited_neigh_learning_pass_tst-esx-62_2026-07-07.xml)


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->
Use zero wait for unsolicited ARP/NDP refresh in arp_update.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
