### PR TITLE
[yang] port: add learn_mode leaf to PORT_LIST

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -642,7 +642,8 @@
                 "laser_freq": "191600",
                 "tx_power": "-26.6",
                 "mode":"trunk",
-                "dhcp_rate_limit": "300"
+                "dhcp_rate_limit": "300",
+                "learn_mode": "disable"
             },
             "Ethernet1": {
                 "alias": "Eth1/2",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/port.json
@@ -13,6 +13,14 @@
         "eStrKey" : "Pattern",
         "eStr": ["rc"]
     },
+    "PORT_VALID_LEARN_MODE": {
+        "desc": "Configure a valid learn_mode in PORT table."
+    },
+    "PORT_INVALID_LEARN_MODE": {
+        "desc": "INCORRECT LEARN_MODE IN PORT TABLE.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["learn_mode"]
+    },
      "PORT_VALID_DHCP_RATE_LIMIT": {
          "desc": "PORT_VALID_DHCP_RATE_LIMIT no failure."
      },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/port.json
@@ -20,6 +20,40 @@
             }
         }
     },
+    "PORT_VALID_LEARN_MODE": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "alias": "eth8",
+                        "lanes": "65",
+                        "speed": 25000,
+                        "mtu": 9100,
+                        "mode": "trunk",
+                        "learn_mode": "disable"
+                    }
+                ]
+            }
+        }
+    },
+    "PORT_INVALID_LEARN_MODE": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet8",
+                        "alias": "eth8",
+                        "lanes": "65",
+                        "speed": 25000,
+                        "mtu": 9100,
+                        "mode": "trunk",
+                        "learn_mode": "invalid"
+                    }
+                ]
+            }
+        }
+    },
     "PORT_TEST": {
         "sonic-port:sonic-port": {
             "sonic-port:PORT": {

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -255,6 +255,35 @@ module sonic-port{
 					description "Enable or disable fast link-up on the port";
 				}
 
+				leaf learn_mode {
+					description
+						"MAC address learning mode for the port bridge port. portmgr
+						 propagates this value from CONFIG_DB to APPL_DB and portsorch
+						 applies it as the SAI bridge-port FDB learning mode. When unset,
+						 hardware learning is used.";
+					type enumeration {
+						enum drop {
+							description "Drop packets with an unknown source MAC and do not learn.";
+						}
+						enum disable {
+							description "Do not learn new source MACs. Forwarding is unaffected.";
+						}
+						enum hardware {
+							description "Learn source MACs in hardware. This is the default.";
+						}
+						enum cpu_trap {
+							description "Trap packets with an unknown source MAC to the CPU and do not learn in hardware.";
+						}
+						enum cpu_log {
+							description "Copy packets with an unknown source MAC to the CPU for logging and do not learn in hardware.";
+						}
+						enum notification {
+							description "Raise an FDB event for an unknown source MAC and do not learn in hardware.";
+						}
+					}
+					default hardware;
+				}
+
 
 			} /* end of list PORT_LIST */
 


### PR DESCRIPTION
#### Why I did it

`learn_mode` is a valid CONFIG_DB `PORT` field handled end to end by swss, but the
`sonic-port` YANG model does not define it. Any configuration that sets `learn_mode`
on a physical port fails YANG validation, so `config apply-patch`, GenericConfigUpdater
and **gNMI** reject the whole configuration.

- `portmgr` propagates `learn_mode` from the CONFIG_DB `PORT` table to the APPL_DB
  `PORT_TABLE` (`cfgmgr/portmgr.cpp`, `PortMgr::doTask`).
- `portsorch` parses it (`orchagent/port/porthlpr.cpp`, `portLearnModeMap` —
  `drop`, `disable`, `hardware`, `cpu_trap`, `cpu_log`, `notification`) and programs
  `SAI_BRIDGE_PORT_ATTR_FDB_LEARNING_MODE` on the port's bridge port in
  `PortsOrch::doPortTask` (via `setBridgePortLearnMode`). The default is `hardware`.

Fixes #28530

#### How I did it

Added the `learn_mode` leaf to `PORT_LIST` in `sonic-port.yang` as an enumeration of
the six values accepted by orchagent, with `default hardware`, plus positive/negative
sonic-yang-models tests.

#### How to verify it

Run the sonic-yang-models model tests:

```
cd src/sonic-yang-models && pytest tests/yang_model_tests/test_yang_model.py
```

The new `PORT_VALID_LEARN_MODE` / `PORT_INVALID_LEARN_MODE` cases exercise the leaf.

#### Test result

Verified on a Juniper QFX5241 (HwSKU `Juniper-QFX5241-64-OD`, Broadcom ASIC), SONiC
master image, through the full `config_db.json` + `config reload` path.

**Before** — setting `learn_mode` on a physical port is rejected by YANG validation
(`config apply-patch` and the gNMI native write both fail with `Data Loading Failed`).

**After** — with `learn_mode: disable` set on a VLAN member (bridge) port in
`config_db.json`, it survives `config reload` and is programmed end to end to the ASIC:

- CONFIG_DB `PORT|Ethernet8 learn_mode = disable`
- APPL_DB `PORT_TABLE:Ethernet8 learn_mode = disable`
- ASIC_DB bridge port `SAI_BRIDGE_PORT_ATTR_FDB_LEARNING_MODE = SAI_BRIDGE_PORT_FDB_LEARNING_MODE_DISABLE`

#### Tested branch

- [x] master
