### PR TITLE
[202605] Backport docker-sonic-mgmt and pipeline updates from master

### DIFF
--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -8,24 +8,25 @@ schedules:
 - cron: "0 8 * * *"
   branches:
     include:
-    - master
+    - 202605
   always: true
 
 trigger: none
 pr:
   branches:
     include:
-    - master
+    - 202605
   paths:
     include:
     - dockers/docker-sonic-mgmt
+    - .azure-pipelines/docker-sonic-mgmt.yml
 
 resources:
   repositories:
   - repository: sonic-mgmt
     type: github
     name: sonic-net/sonic-mgmt
-    ref: master
+    ref: 202605
     endpoint: sonic-net
 
 parameters:
@@ -69,20 +70,20 @@ stages:
     - bash: |
         set -ex
         docker load -i $(Build.ArtifactStagingDirectory)/target/docker-sonic-mgmt.gz
-        docker tag docker-sonic-mgmt:latest $REGISTRY_SERVER/docker-sonic-mgmt:lastbuild
+        docker tag docker-sonic-mgmt:latest $REGISTRY_SERVER/docker-sonic-mgmt:202605-lastbuild
         docker images
       env:
         REGISTRY_SERVER: ${{ parameters.registry_url }}
-      displayName: 'Load and tag docker-sonic-mgmt as lastbuild'
+      displayName: 'Load and tag docker-sonic-mgmt as 202605-lastbuild'
 
     - task: Docker@2
-      displayName: 'Push docker-sonic-mgmt:lastbuild to registry'
+      displayName: 'Push docker-sonic-mgmt:202605-lastbuild to registry'
       condition: succeeded()
       inputs:
         containerRegistry: ${{ parameters.registry_conn }}
         repository: docker-sonic-mgmt
         command: push
-        tags: lastbuild
+        tags: 202605-lastbuild
 
 - stage: Test
   dependsOn: Build
@@ -94,12 +95,9 @@ stages:
   jobs:
   - job: sbom_vuln_scan
     displayName: "[OPTIONAL] SBOM-based vulnerability scan (docker-sonic-mgmt)"
-    # Disabled for now; remove this `condition: false` (or change to
-    # `and(succeeded(), in(dependencies.Build.result, 'Succeeded'))`)
-    # to re-enable the docker-sonic-mgmt SBOM vulnerability scan.
-    # The SBOM itself is still produced by the Build stage above
-    # when ENABLE_SBOM=y; only the post-build scan is gated.
-    condition: false
+    # The SBOM is produced by the Build stage (ENABLE_SBOM=y); this job
+    # scans it with grype and reports CVEs. Informational only
+    # (continueOnError: true) so findings do not block the pipeline.
     pool: sonic-ubuntu-1c
     continueOnError: true
     timeoutInMinutes: 30
@@ -112,7 +110,7 @@ stages:
       displayName: "Download docker-sonic-mgmt artifact (includes SBOM)"
     - script: |
         set -ex
-        sudo apt-get install -y python3-pip jq
+        sudo apt-get install -y jq
       displayName: "Install dependencies"
     - script: |
         set -x
@@ -156,10 +154,10 @@ stages:
     parameters:
       CHECKOUT_SONIC_MGMT: true
       # todo: enable vpp build in sonic-mgmt docker image build pipeline, and add vpp test pipeline back.
-      INCLUDE_JOBS: "t0_job,t1_job,t2_job,t0_2vlans_job,t0_sonic_job,dpu_job,t1_multi_asic_job"
+      INCLUDE_JOBS: "all"
       OVERRIDE_PARAMS:
         REPO_NAME: "sonic-mgmt"
-        SETUP_CONTAINER_PARAMS: "-i ${{ parameters.registry_url }}/docker-sonic-mgmt:lastbuild"
+        SETUP_CONTAINER_PARAMS: "-i ${{ parameters.registry_url }}/docker-sonic-mgmt:202605-lastbuild"
 
 - stage: Publish
   dependsOn: Test
@@ -176,17 +174,17 @@ stages:
     - bash: |
         set -ex
         docker load -i $(Pipeline.Workspace)/docker-sonic-mgmt/target/docker-sonic-mgmt.gz
-        docker tag docker-sonic-mgmt:latest $REGISTRY_SERVER/docker-sonic-mgmt:latest
+        docker tag docker-sonic-mgmt:latest $REGISTRY_SERVER/docker-sonic-mgmt:202605
         docker images
       env:
         REGISTRY_SERVER: ${{ parameters.registry_url }}
-      displayName: 'Load and tag docker-sonic-mgmt as latest'
+      displayName: 'Load and tag docker-sonic-mgmt as 202605'
 
     - task: Docker@2
-      displayName: 'Push docker-sonic-mgmt:latest to registry'
+      displayName: 'Push docker-sonic-mgmt:202605 to registry'
       condition: succeeded()
       inputs:
         containerRegistry: ${{ parameters.registry_conn }}
         repository: docker-sonic-mgmt
         command: push
-        tags: latest
+        tags: 202605

--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -63,7 +63,7 @@ RUN sed -i 's|^PATH="|PATH="/opt/venv/bin:|' /etc/environment \
 RUN uv pip install --no-cache \
     aiohttp \
     allure-pytest \
-    ansible \
+    ansible==13.6.0 \
     azure-storage-blob \
     azure-kusto-data \
     azure-kusto-ingest \
@@ -71,7 +71,7 @@ RUN uv pip install --no-cache \
     celery[redis] \
     cffi \
     contextlib2 \
-    "cryptography>=46.0.7,<47" \
+    "cryptography>=48.0.1" \
     ctypesgen \
     debugpy \
     dpkt \
@@ -103,6 +103,7 @@ RUN uv pip install --no-cache \
     pexpect \
     prettytable \
     "protobuf>=5.29.6,<6" \
+    "pygnmi==0.8.15" \
     psutil \
     ptf==0.10.0 \
     pyasn1 \
@@ -161,10 +162,10 @@ RUN install -m 0755 -d /etc/apt/keyrings \
     && apt-get install -y docker-ce-cli \
     && curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
-# Patch Azure CLI's bundled cryptography for CVE-2026-39892
+# Patch Azure CLI's bundled cryptography for CVE-2026-39892 and GHSA-537c-gmf6-5ccf (bundled OpenSSL)
 RUN az_site_packages=$(/opt/az/bin/python -c "import site; print(site.getsitepackages()[0])") \
-    && /opt/az/bin/python -m pip install --no-cache-dir --target "$az_site_packages" 'cryptography>=46.0.7,<47' \
-    && find "$az_site_packages" -name 'cryptography-46.0.6*' -type d -exec rm -rf {} + 2>/dev/null; true
+    && /opt/az/bin/python -m pip install --no-cache-dir --target "$az_site_packages" 'cryptography>=48.0.1' \
+    && find "$az_site_packages" -name 'cryptography-4[0-7].*' -type d -exec rm -rf {} + 2>/dev/null; true
 
 # Install dash-api
 RUN tmpdir=$(mktemp -d) \

--- a/scripts/build_sbom.py
+++ b/scripts/build_sbom.py
@@ -506,10 +506,26 @@ def apply_licenses(components: list, license_map: dict) -> tuple:
 
 def observation_components_for_scope(
     target_path: str, scope: str, arch: str, supplier: str,
+    distro: Optional[tuple] = None,
 ) -> list:
-    """Emit observation-only components for everything in post-versions/."""
+    """Emit observation-only components for everything in post-versions/.
+
+    When ``distro`` is a ``(id, version_id)`` tuple (e.g. ``("ubuntu",
+    "24.04")``), deb PURLs are namespaced to that distro and carry a
+    ``distro=`` qualifier so grype selects the right OS advisory feed.
+    When ``None`` the legacy ``pkg:deb/debian/`` form is preserved.
+    """
     components = []
     seen: set = set()
+
+    if distro and distro[0]:
+        deb_ns = distro[0]
+        deb_qual = f"&distro={distro[0]}-{distro[1]}" if distro[1] else ""
+        deb_supplier = distro[0].capitalize()
+    else:
+        deb_ns = "debian"
+        deb_qual = ""
+        deb_supplier = supplier
 
     for vfile in find_post_versions(target_path, scope, "deb", arch):
         for name, ver in parse_versions_file(vfile):
@@ -517,13 +533,16 @@ def observation_components_for_scope(
             if key in seen:
                 continue
             seen.add(key)
+            deb_purl = (
+                f"pkg:deb/{deb_ns}/{name}@{ver}?arch={arch}{deb_qual}"
+            )
             comp: dict[str, Any] = {
-                "bom-ref": f"pkg:deb/debian/{name}@{ver}?arch={arch}",
+                "bom-ref": deb_purl,
                 "type": "library",
                 "name": name,
                 "version": ver,
-                "purl": f"pkg:deb/debian/{name}@{ver}?arch={arch}",
-                "supplier": {"name": supplier},
+                "purl": deb_purl,
+                "supplier": {"name": deb_supplier},
                 "properties": [
                     {"name": "sonic:fragment_kind", "value": "observation"},
                     {"name": "sonic:scope", "value": scope},
@@ -1016,6 +1035,154 @@ def _promote_cpe(winner: dict, loser: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Container distro detection (needed for deb/OS-package vuln matching)
+# ---------------------------------------------------------------------------
+
+
+def _parse_os_release(text: str) -> Optional[tuple]:
+    """Parse /etc/os-release content into ``(ID, VERSION_ID)``.
+
+    Returns None when no ``ID`` field is present.
+    """
+    kv: dict = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        kv[k] = v.strip().strip('"').strip("'")
+    did = kv.get("ID")
+    if not did:
+        return None
+    return (did, kv.get("VERSION_ID", ""))
+
+
+def detect_container_distro(gz_path: str) -> Optional[tuple]:
+    """Return the container's ``(distro_id, version_id)`` by reading
+    ``/etc/os-release`` from the image archive, e.g. ``("ubuntu", "24.04")``.
+
+    The env var ``SBOM_CONTAINER_DISTRO`` (``id-version``, e.g.
+    ``ubuntu-24.04``) overrides detection. Returns None when the distro
+    can't be determined; callers then skip emitting distro metadata and
+    the SBOM keeps its legacy (distro-less) shape.
+    """
+    override = os.environ.get("SBOM_CONTAINER_DISTRO", "").strip()
+    if override:
+        # Accept "id" or "id-version"; split on the LAST '-' so distro
+        # ids that themselves contain hyphens (e.g. "cbl-mariner-2.0")
+        # keep their id intact. Ignore a value with an empty id.
+        if "-" in override:
+            oid, over = override.rsplit("-", 1)
+        else:
+            oid, over = override, ""
+        if oid:
+            return (oid, over)
+        warn(f"ignoring malformed SBOM_CONTAINER_DISTRO={override!r}")
+
+    import shutil
+    import tarfile
+    import tempfile
+
+    def _search(tf) -> Optional[tuple]:
+        for member in tf:
+            # /etc/os-release is commonly a symlink to /usr/lib/os-release,
+            # so don't require a regular file (symlinks report isfile()==
+            # False) and match both paths. extractfile() follows in-tar
+            # symlinks and returns the target content.
+            nm = member.name.lstrip("./").rstrip("/")
+            if nm.endswith("etc/os-release") or nm.endswith("usr/lib/os-release"):
+                ex = tf.extractfile(member)
+                if ex is not None:
+                    got = _parse_os_release(
+                        ex.read().decode("utf-8", "replace")
+                    )
+                    if got:
+                        return got
+        return None
+
+    try:
+        with tarfile.open(gz_path, "r:*") as outer:
+            for m in outer:
+                nm = m.name.lstrip("./").rstrip("/")
+                # os-release directly present in a flattened rootfs archive
+                # (may be a symlink to usr/lib/os-release)
+                if nm.endswith("etc/os-release") or nm.endswith(
+                    "usr/lib/os-release"
+                ):
+                    ex = outer.extractfile(m)
+                    if ex is not None:
+                        got = _parse_os_release(
+                            ex.read().decode("utf-8", "replace")
+                        )
+                        if got:
+                            return got
+                    continue
+                if not m.isfile():
+                    continue
+                # nested image layers (docker-archive: */layer.tar or
+                # *.tar; OCI: blobs/sha256/*) — peek inside for os-release
+                looks_like_layer = (
+                    nm.endswith(".tar")
+                    or nm.endswith("layer.tar")
+                    or "blobs/sha256" in nm
+                    or nm.endswith(".tar.gz")
+                )
+                if not looks_like_layer:
+                    continue
+                ex = outer.extractfile(m)
+                if ex is None:
+                    continue
+                # Spill the layer to a temp file, then parse with random
+                # access. Opening a nested tar directly off the gzip outer
+                # stream (mode="r|*") silently finds no members, and
+                # buffering whole layers in memory risks OOM on large
+                # images, so stream to disk (bounded memory) and seek.
+                tmp = tempfile.NamedTemporaryFile(
+                    prefix="sbom-distro-", suffix=".tar",
+                    dir=os.path.dirname(os.path.abspath(gz_path)) or None,
+                    delete=False,
+                )
+                try:
+                    shutil.copyfileobj(ex, tmp, 1024 * 1024)
+                    tmp.close()
+                    with tarfile.open(tmp.name, "r:*") as inner:
+                        got = _search(inner)
+                except tarfile.TarError:
+                    got = None
+                finally:
+                    try:
+                        os.unlink(tmp.name)
+                    except OSError:
+                        pass
+                if got:
+                    return got
+    except Exception as e:  # defensive: never fail the build on this
+        warn(f"container distro detection failed for {gz_path}: {e}")
+    return None
+
+
+def operating_system_component(distro_id: str, version_id: str) -> dict:
+    """Build a CycloneDX ``operating-system`` component carrying the
+    distro. grype keys OS-package (deb/rpm/apk) matching off the
+    ``syft:distro:*`` properties, so without such a component every deb
+    package is silently skipped.
+    """
+    ver = version_id or "unknown"
+    props = [{"name": "syft:distro:id", "value": distro_id}]
+    if version_id:
+        props.append(
+            {"name": "syft:distro:versionID", "value": version_id}
+        )
+    return {
+        "bom-ref": f"os:{distro_id}-{ver}",
+        "type": "operating-system",
+        "name": distro_id,
+        "version": ver,
+        "properties": props,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Top-level orchestration
 # ---------------------------------------------------------------------------
 
@@ -1083,10 +1250,21 @@ def _container_main(container_filename: str) -> int:
                 {"alg": "SHA-256", "content": sha}
             ]
 
+    # Detect the container's OS/distro so grype can vuln-match deb/OS
+    # packages. Without a distro the SBOM carries no OS context and
+    # grype silently skips every deb component, scanning only language
+    # packages. See README.sbom.md "Vulnerability scanning".
+    distro = detect_container_distro(gz_path)
+    if distro:
+        info(f"Container distro: {distro[0]} {distro[1]}")
+    else:
+        warn("container distro undetected; deb/OS packages will not be "
+             "vuln-matched by grype for this container SBOM")
+
     # Observation: only this container's scope.
     scope = f"dockers/{cname}"
     obs = observation_components_for_scope(
-        target_path, scope, arch, "Debian",
+        target_path, scope, arch, "Debian", distro=distro,
     )
     info(f"Container observation: {len(obs)} components")
 
@@ -1117,6 +1295,13 @@ def _container_main(container_filename: str) -> int:
         lockfile_components,
         scanner_components,
     )
+
+    # Emit an operating-system component so grype can identify the
+    # distro and match deb/OS packages against the right advisory feed.
+    if distro:
+        all_components.append(
+            operating_system_component(distro[0], distro[1])
+        )
     info(f"Final merged: {len(all_components)} unique components")
 
     # License resolution (per-scope copyrights tarball + fallback to


### PR DESCRIPTION
#### Why I did it

`dockers/docker-sonic-mgmt/` and `.azure-pipelines/docker-sonic-mgmt.yml` on `202605` were behind `master`. This aligns the docker-sonic-mgmt image and its build/scan pipeline on `202605` with master (dependency/security pins, per-container SBOM + SBOM-based vulnerability scan, and the PR-test `INCLUDE_JOBS: all`).

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Took master's version of the affected files directly (rather than per-commit cherry-picks) and adjusted the branch-specific bits, as a **single signed-off commit**:

- `.azure-pipelines/docker-sonic-mgmt.yml`, `dockers/docker-sonic-mgmt/Dockerfile.j2` and `scripts/build_sbom.py` are taken from `master` (`Dockerfile.j2` and `build_sbom.py` are byte-identical to master).
- Branch-specific fields target this branch: the `schedules`/`pr` branch filters and the `sonic-mgmt` resource `ref` → `202605`.
- The published image is tagged with the **branch name** — `docker-sonic-mgmt:202605` and `docker-sonic-mgmt:202605-lastbuild` — instead of `:latest`/`:lastbuild`, so a 202605 build never overwrites master's shared `docker-sonic-mgmt:latest`/`:lastbuild` in the registry. (The local build image tag `docker-sonic-mgmt:latest` is left unchanged.)

SBOM is kept: 202605 was branched from master *after* the SBOM feature (#27455) landed, so it already carries the `ENABLE_SBOM` machinery + `scripts/sbom_vuln_scan.py` + `vex/`.

Squashed into one commit authored & signed off by me so DCO passes — the earlier per-commit cherry-picks failed DCO because the upstream squash-merge author identities did not match their `Signed-off-by` lines.

#### How to verify it

Build docker-sonic-mgmt on 202605 with `ENABLE_SBOM=y`; confirm the package set/versions and the SBOM/scan output match master. The pipeline publishes `docker-sonic-mgmt:202605`.

#### Which release branch to backport (provide reason below if selected)

This PR is itself the backport to `202605` of changes already on master.

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch

- [ ] 202605

#### Test result

Pending a build; will update with the tested image version.

#### Description for the changelog

Align docker-sonic-mgmt image and its SBOM/build pipeline on 202605 with master; publish the image under a branch-qualified tag (`docker-sonic-mgmt:202605`).

#### Link to config_db schema for YANG module changes

N/A. No YANG or config_db schema changes.
