### PR TITLE
[Aspeed] separate internal and public changes

### DIFF
--- a/platform/aspeed/one-image.mk
+++ b/platform/aspeed/one-image.mk
@@ -43,3 +43,7 @@ $(SONIC_ONE_IMAGE)_LAZY_INSTALLS += $(MLNX_HW_MANAGEMENT_BMC)
 
 $(SONIC_ONE_IMAGE)_DOCKERS = $(DOCKER_DATABASE) $(DOCKER_GNMI) $(DOCKER_PLATFORM_MONITOR) $(DOCKER_LLDP) $(DOCKER_TELEMETRY) $(DOCKER_SYSMGR) $(DOCKER_SONIC_REDFISH)
 SONIC_INSTALLERS += $(SONIC_ONE_IMAGE)
+
+####################################
+# Internal changes below this line #
+####################################


### PR DESCRIPTION
#### Why I did it
This is the public-facing counterpart to the internal change already merged internally, which quarantines internal-only lines below a demarcation banner in `platform/aspeed/one-image.mk`.

Adding the same banner to the public master repository establishes a stable anchor line on both branches, so future internal ↔ master syncs are conflict-free on this file: the top portion stays identical and internal-only additions land cleanly below the marker.



##### Work item tracking
- Microsoft ADO **(**38868644**)**

#### How I did it
Appended a 4-line demarcation banner to the end of `platform/aspeed/one-image.mk`:

```
####################################
# Internal changes below this line #
####################################
```

Nothing is placed below the banner in the public branch; internal branches add their internal-only entries below it.

#### How to verify it
- No functional change. `make` behavior for the Aspeed platform is identical: only comment lines are added.
- Optional: `make configure PLATFORM=aspeed && make target/sonic-aspeed-arm64.bin` still produces the same set of `SONIC_ONE_IMAGE_DOCKERS`.

#### Which release branch to backport (provide reason below if selected)
None — infra-only marker; not needed in release branches.

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)
- [ ] `master` – comment-only change, verified locally with `git diff`.

#### Description for the changelog
[Aspeed] Add "Internal changes below this line" demarcation banner in `platform/aspeed/one-image.mk` to keep internal ↔ master syncs conflict-free.

#### Link to config_db schema for YANG module changes
N/A.

#### A picture of a cute animal (not mandatory but encouraged)
