### PR TITLE
sonic-yang-models: static L2 forwarding YANG (per-VLAN mac_learning, BUM flood, sonic-fdb)

### DIFF
--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -133,6 +133,7 @@ yang_files = [
     'sonic-extension.yang',
     'sonic-fabric-monitor.yang',
     'sonic-fabric-port.yang',
+    'sonic-fdb.yang',
     'sonic-feature.yang',
     'sonic-fine-grained-ecmp.yang',
     'sonic-fips.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -473,6 +473,11 @@
             }
 
         },
+        "FDB": {
+            "Vlan100|00:11:22:33:44:55": {
+                "port": "Ethernet0"
+            }
+        },
         "DEVICE_NEIGHBOR": {
             "Ethernet112": {
                 "name": "dccsw01.nw",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/fdb.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/fdb.json
@@ -1,0 +1,13 @@
+{
+    "FDB_VALID": {
+        "desc": "Configure a static FDB (MAC) entry."
+    },
+    "FDB_WITH_NON_EXIST_VLAN": {
+        "desc": "Static FDB entry referencing a non-existent VLAN.",
+        "eStrKey": "LeafRef"
+    },
+    "FDB_WITH_NON_EXIST_PORT": {
+        "desc": "Static FDB entry referencing a non-existent port.",
+        "eStrKey": "InvalidValue"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
@@ -2,6 +2,14 @@
     "VALID_VLAN": {
         "desc": "Configure VLAN table."
     },
+    "VLAN_VALID_MAC_LEARNING": {
+        "desc": "Configure a valid mac_learning in VLAN table."
+    },
+    "VLAN_INVALID_MAC_LEARNING": {
+        "desc": "INCORRECT MAC_LEARNING IN VLAN TABLE.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["mac_learning"]
+    },
     "VLAN_INTERFACE_IPPREFIX_MUST_CONDITION_FALSE": {
         "desc": "Vlan Interface Ip-prefix must condition failure.",
         "eStrKey" : "Must"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vlan.json
@@ -10,6 +10,14 @@
         "eStrKey": "InvalidValue",
         "eStr": ["mac_learning"]
     },
+    "VLAN_VALID_BUM_FLOOD": {
+        "desc": "Configure per-VLAN BUM flood control."
+    },
+    "VLAN_INVALID_BUM_FLOOD": {
+        "desc": "Configure an invalid per-VLAN flood control value.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["unknown_unicast_flood"]
+    },
     "VLAN_INTERFACE_IPPREFIX_MUST_CONDITION_FALSE": {
         "desc": "Vlan Interface Ip-prefix must condition failure.",
         "eStrKey" : "Must"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/fdb.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/fdb.json
@@ -1,0 +1,89 @@
+{
+    "FDB_VALID": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet0",
+                        "lanes": "65",
+                        "speed": "25000",
+                        "mtu": "9100",
+                        "admin_status": "up"
+                    }
+                ]
+            }
+        },
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "name": "Vlan100",
+                        "admin_status": "up",
+                        "mtu": "9100"
+                    }
+                ]
+            }
+        },
+        "sonic-fdb:sonic-fdb": {
+            "sonic-fdb:FDB": {
+                "FDB_LIST": [
+                    {
+                        "name": "Vlan100",
+                        "mac": "00:11:22:33:44:55",
+                        "port": "Ethernet0"
+                    }
+                ]
+            }
+        }
+    },
+    "FDB_WITH_NON_EXIST_VLAN": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet0",
+                        "lanes": "65",
+                        "speed": "25000",
+                        "mtu": "9100",
+                        "admin_status": "up"
+                    }
+                ]
+            }
+        },
+        "sonic-fdb:sonic-fdb": {
+            "sonic-fdb:FDB": {
+                "FDB_LIST": [
+                    {
+                        "name": "Vlan100",
+                        "mac": "00:11:22:33:44:55",
+                        "port": "Ethernet0"
+                    }
+                ]
+            }
+        }
+    },
+    "FDB_WITH_NON_EXIST_PORT": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "name": "Vlan100",
+                        "admin_status": "up",
+                        "mtu": "9100"
+                    }
+                ]
+            }
+        },
+        "sonic-fdb:sonic-fdb": {
+            "sonic-fdb:FDB": {
+                "FDB_LIST": [
+                    {
+                        "name": "Vlan100",
+                        "mac": "00:11:22:33:44:55",
+                        "port": "Ethernet99"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
@@ -1,4 +1,32 @@
 {
+    "VLAN_VALID_BUM_FLOOD": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "name": "Vlan100",
+                        "admin_status": "up",
+                        "mtu": "9100",
+                        "unknown_unicast_flood": "disabled",
+                        "unknown_multicast_flood": "disabled",
+                        "broadcast_flood": "disabled"
+                    }
+                ]
+            }
+        }
+    },
+    "VLAN_INVALID_BUM_FLOOD": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "name": "Vlan100",
+                        "unknown_unicast_flood": "bogus"
+                    }
+                ]
+            }
+        }
+    },
     "VALID_VLAN": {
         "sonic-vlan:sonic-vlan": {
             "sonic-vlan:VLAN": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vlan.json
@@ -28,6 +28,30 @@
             }
         }
     },
+    "VLAN_VALID_MAC_LEARNING": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "name": "Vlan100",
+                        "mac_learning": "disabled"
+                    }
+                ]
+            }
+        }
+    },
+    "VLAN_INVALID_MAC_LEARNING": {
+        "sonic-vlan:sonic-vlan": {
+            "sonic-vlan:VLAN": {
+                "VLAN_LIST": [
+                    {
+                        "name": "Vlan100",
+                        "mac_learning": "invalid"
+                    }
+                ]
+            }
+        }
+    },
     "INCORRECT_VLAN_NAME": {
         "sonic-vlan:sonic-vlan": {
             "sonic-vlan:VLAN": {

--- a/src/sonic-yang-models/yang-models/sonic-fdb.yang
+++ b/src/sonic-yang-models/yang-models/sonic-fdb.yang
@@ -1,0 +1,72 @@
+module sonic-fdb {
+
+	yang-version 1.1;
+
+	namespace "http://github.com/sonic-net/sonic-fdb";
+	prefix fdb;
+
+	import ietf-yang-types {
+		prefix yang;
+	}
+
+	import sonic-vlan {
+		prefix vlan;
+	}
+
+	import sonic-port {
+		prefix port;
+		revision-date 2019-07-01;
+	}
+
+	import sonic-portchannel {
+		prefix lag;
+	}
+
+	description "FDB (static MAC) YANG module for SONiC OS";
+
+	revision 2026-07-21 {
+		description "Initial revision: static FDB (MAC) configuration.";
+	}
+
+	container sonic-fdb {
+
+		container FDB {
+
+			description "Static FDB (MAC) entries in CONFIG_DB. Programmed as
+			             SAI static FDB by orchagent via APPL_DB FDB_TABLE.";
+
+			list FDB_LIST {
+
+				key "name mac";
+
+				leaf name {
+					description "VLAN of the static FDB entry.";
+					type leafref {
+						path "/vlan:sonic-vlan/vlan:VLAN/vlan:VLAN_LIST/vlan:name";
+					}
+				}
+
+				leaf mac {
+					description "Destination MAC address of the static FDB entry.";
+					type yang:mac-address;
+				}
+
+				leaf port {
+					description "Interface (port or PortChannel) the static MAC is bound to.";
+					mandatory true;
+					type union {
+						type leafref {
+							path "/port:sonic-port/port:PORT/port:PORT_LIST/port:name";
+						}
+						type leafref {
+							path "/lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:name";
+						}
+					}
+				}
+			}
+			/* end of list FDB_LIST */
+		}
+		/* end of container FDB */
+	}
+	/* end of container sonic-fdb */
+}

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -47,6 +47,10 @@ module sonic-vlan {
 
 	description "VLAN yang Module for SONiC OS";
 
+	revision 2026-07-21 {
+		description "Add leaf mac_learning to VLAN_LIST";
+	}
+
 	revision 2025-04-22 {
 		description "Add SAG support";
 	}
@@ -285,6 +289,23 @@ module sonic-vlan {
 
 				leaf mac {
 					type yang:mac-address;
+				}
+
+				leaf mac_learning {
+					description
+						"Per-VLAN dynamic MAC learning control. vlanmgr propagates this
+						 value from CONFIG_DB to APPL_DB VLAN_TABLE, and PortsOrch applies
+						 it to the SAI VLAN object (SAI_VLAN_ATTR_LEARN_DISABLE). Default is
+						 enabled, preserving current behavior.";
+					type enumeration {
+						enum enabled {
+							description "Dynamic MAC learning is enabled on the VLAN. This is the default.";
+						}
+						enum disabled {
+							description "Dynamic MAC learning is disabled on the VLAN.";
+						}
+					}
+					default enabled;
 				}
 			}
 			/* end of VLAN_LIST */

--- a/src/sonic-yang-models/yang-models/sonic-vlan.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vlan.yang
@@ -47,6 +47,9 @@ module sonic-vlan {
 
 	description "VLAN yang Module for SONiC OS";
 
+	revision 2026-07-22 {
+		description "Add per-VLAN BUM flood control leaves to VLAN_LIST";
+	}
 	revision 2026-07-21 {
 		description "Add leaf mac_learning to VLAN_LIST";
 	}
@@ -304,6 +307,30 @@ module sonic-vlan {
 						enum disabled {
 							description "Dynamic MAC learning is disabled on the VLAN.";
 						}
+					}
+					default enabled;
+				}
+				leaf unknown_unicast_flood {
+					description "Per-VLAN unknown-unicast flood control.";
+					type enumeration {
+						enum enabled;
+						enum disabled;
+					}
+					default enabled;
+				}
+				leaf unknown_multicast_flood {
+					description "Per-VLAN unknown-multicast flood control.";
+					type enumeration {
+						enum enabled;
+						enum disabled;
+					}
+					default enabled;
+				}
+				leaf broadcast_flood {
+					description "Per-VLAN broadcast flood control.";
+					type enumeration {
+						enum enabled;
+						enum disabled;
 					}
 					default enabled;
 				}


### PR DESCRIPTION
#### Why I did it

YANG for config-driven static L2 forwarding — three independent, per-VLAN features (defaults
preserve current behavior). Without these models, the fields can't be set via
`config apply-patch` / gNMI (GCU rejects them). HLD: sonic-net/SONiC#2468.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

1. `sonic-vlan.yang` — `mac_learning` leaf on `VLAN_LIST` (enabled|disabled, default enabled)
2. `sonic-vlan.yang` — `unknown_unicast_flood` / `unknown_multicast_flood` / `broadcast_flood` leaves
3. `sonic-fdb.yang` — new model for the CONFIG_DB `FDB` table (static MAC → port)

#### How to verify it

`sonic-yang-models` model tests (`tests/yang_model_tests/tests/{vlan,fdb}.json` + `tests_config/`),
positive and negative cases. Also validated on hardware via `config apply-patch` / gNMI
(GCU accepts the leaves + `FDB` table) through to the ASIC.

#### Which release branch to backport (provide reason below if selected)

N/A — feature, not a fix.

#### Tested branch

- [x] master

#### Test result

master: YANG model tests pass; hardware config→ASIC validated.
