### PR TITLE
[docker-sonic-mgmt] upgrade tar and gzip to fix USN-8477/8510/8512 vulnerabilities

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -55,6 +55,7 @@ RUN apt-get update \
 # layer so image security scans no longer flag the vulnerable base-image versions.
 RUN apt-get update \
     && apt-get install -y --only-upgrade tar gzip \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv - a fast Python package manager that replaces pip/venv/wheel.

--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -46,6 +46,17 @@ RUN apt-get update \
     && apt-get autoclean \
     && rm -rf /var/lib/apt/lists/*
 
+# Remediate Ubuntu security advisories reported against the base-image tar and
+# gzip packages in the sonic-mgmt container:
+#   tar  - USN-8477-1 / USN-8477-2 (CVE-2026-5704), USN-8510-1 (CVE-2025-45582)
+#   gzip - USN-8512-1 (CVE-2026-41991, CVE-2026-41992)
+# The `apt-get upgrade` above covers these on a clean build, but upgrading them
+# explicitly guarantees the patched versions are installed and refreshes this
+# layer so image security scans no longer flag the vulnerable base-image versions.
+RUN apt-get update \
+    && apt-get install -y --only-upgrade tar gzip \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install uv - a fast Python package manager that replaces pip/venv/wheel.
 # This eliminates the need for python3-pip, python3-venv, and python3-wheel
 # system packages, avoiding vulnerabilities like USN-8221-1.


### PR DESCRIPTION
#### Why I did it

Image security scanning of the `docker-sonic-mgmt` container flagged its base-image `tar` and `gzip` packages against the following Ubuntu Security Notices:

| USN | Package | CVE(s) |
| --- | --- | --- |
| USN-8477-1 | tar | CVE-2026-5704 |
| USN-8477-2 (regression fix) | tar | CVE-2026-5704 |
| USN-8510-1 | tar | CVE-2025-45582 |
| USN-8512-1 | gzip | CVE-2026-41991, CVE-2026-41992 |

`tar` and `gzip` ship with the `ubuntu:24.04` base image and were not being upgraded to their patched versions, so the scanner keeps reporting them.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added an explicit, documented `apt-get install -y --only-upgrade tar gzip` step to `dockers/docker-sonic-mgmt/Dockerfile.j2`. The existing `apt-get upgrade -y` normally covers these on a clean build, but upgrading them explicitly guarantees the patched versions are installed and refreshes the build layer so the scanner no longer reports the vulnerable base-image versions. This mirrors the repo's existing per-advisory remediation style (e.g. the Azure CLI cryptography CVE block).

Patched versions on Ubuntu 24.04 (noble):
- `tar >= 1.35+dfsg-3ubuntu0.3`
- `gzip >= 1.12-1ubuntu3.2`

#### How to verify it

1. Build the `docker-sonic-mgmt` image.
2. Inside the image confirm the patched versions:
   ```
   dpkg -s tar  | grep -i ^Version   # expect >= 1.35+dfsg-3ubuntu0.3
   dpkg -s gzip | grep -i ^Version   # expect >= 1.12-1ubuntu3.2
   ```
3. Re-run the container image security scan — USN-8477-1, USN-8477-2, USN-8510-1 and USN-8512-1 should no longer be reported.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: other (dependency/base-image CVE remediation)

#### Tested branch

- [x] master

#### Test result

Verified in the authoring environment (no Docker daemon available there, so the full image build + rescan is delegated to the buildimage CI):
- The `Dockerfile.j2` renders correctly with Jinja2 (FROM line and the new remediation block intact).
- The patched `tar` (`1.35+dfsg-3ubuntu0.3`) and `gzip` (`1.12-1ubuntu3.2`) packages are published in the Ubuntu 24.04 `noble-security` pocket, so `apt-get install --only-upgrade tar gzip` resolves to the fixed versions at build time.

#### Description for the changelog

docker-sonic-mgmt: upgrade tar and gzip to fix USN-8477-1/-2, USN-8510-1 (tar) and USN-8512-1 (gzip)

#### Link to config_db schema for YANG module changes

N/A — no YANG / config_db schema change.

#### A picture of a cute animal (not mandatory but encouraged)

```
 /\_/\
( o.o )  patched & purring
 > ^ <
```
