### PR TITLE
[DRAFT] Drop p4lang/behavioral-model version-control whitelist (no-cache CI test)

### DIFF
--- a/platform/vs/docker-dash-engine/Dockerfile.j2
+++ b/platform/vs/docker-dash-engine/Dockerfile.j2
@@ -7,6 +7,7 @@ FROM $BASE AS base
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
+
 ## Update apt source list to ubuntu Azure mirror
 RUN sed -i 's|http://.*.ubuntu.com|http://azure.archive.ubuntu.com|g' /etc/apt/sources.list
 

--- a/scripts/docker_version_control.sh
+++ b/scripts/docker_version_control.sh
@@ -27,7 +27,7 @@ tag=`echo $image_tag | cut -f2 -d:`
 
 if [[ ",$SONIC_VERSION_CONTROL_COMPONENTS," == *,all,* ]] || [[ ",$SONIC_VERSION_CONTROL_COMPONENTS," == *,docker,* ]]; then
     # if docker image not in white list, exit
-    if [[ "$image_tag" != */debian:* ]] && [[ "$image_tag" != debian:* ]] && [[ "$image_tag" != multiarch/debian-debootstrap:* ]] && [[ "$image_tag" != *p4lang/behavioral-model:* ]];then
+    if [[ "$image_tag" != */debian:* ]] && [[ "$image_tag" != debian:* ]] && [[ "$image_tag" != multiarch/debian-debootstrap:* ]];then
         exit 0
     fi
     if [ -f $version_file ];then


### PR DESCRIPTION
> **Draft / experiment — not for merge.**

#### Why I did it

To run a **no-cache CI** without the `p4lang/behavioral-model` entry that was added to the reproducible-build docker version-control whitelist in #28532, so we can confirm whether that base-image pin is actually taking effect (i.e. whether `docker_version_control.sh` rewrites the `docker-dash-engine` base to the pinned `@sha256` digest, or the build still pulls `:latest`).

#### How I did it

Revert only the whitelist line in `scripts/docker_version_control.sh` back to the debian-only form (drop `&& [[ "$image_tag" != *p4lang/behavioral-model:* ]]`). The base-agnostic `pip3` install from #28532 is left in place.

#### How to verify it

Run the docker-dash-engine / `sonic-vs` build with docker layer cache disabled and compare the base image resolution against master (which has the whitelist entry).

#### Description for the changelog

N/A — draft, not for merge.
