### PR TITLE
Fix Arista goldfinch platform jsons and console configuration

### DIFF
--- a/device/arista/arm64-arista_goldfinch-r0/99-switchCpu.rules
+++ b/device/arista/arm64-arista_goldfinch-r0/99-switchCpu.rules
@@ -1,0 +1,2 @@
+# Arista Goldfinch BMC: Map host CPU console /dev/ttyS1 to common alias /dev/ttySwitchCpu0
+SUBSYSTEM=="tty", KERNEL=="ttyS1", SYMLINK+="ttySwitchCpu0", MODE="0666"

--- a/device/arista/arm64-arista_goldfinch-r0/platform.json
+++ b/device/arista/arm64-arista_goldfinch-r0/platform.json
@@ -1,16 +1,27 @@
 {
     "chassis": {
-        "name": "Goldfinch",
+        "name": "SKU_GOLDFINCH",
         "thermal_manager": false,
         "status_led": {},
         "components": [
             {
-                "name": "BIOS"
+                "name": "Ast2720()"
+            },
+            {
+                "name": "Uboot()"
+            },
+            {
+                "name": "SysCpld(addr=12-0043)"
             }
         ],
         "fans": [],
         "psus": [],
-        "thermals": [],
+        "thermals": [
+            {
+                "name": "BMC temp sensor",
+                "controllable": false
+            }
+        ],
         "sfps": []
     },
     "interfaces": {}

--- a/device/arista/arm64-arista_goldfinch-r0/platform_components.json
+++ b/device/arista/arm64-arista_goldfinch-r0/platform_components.json
@@ -1,8 +1,10 @@
 {
     "chassis": {
-        "Goldfinch": {
+        "SKU_GOLDFINCH": {
             "component": {
-                "BIOS": {}
+                "Ast2720()": {},
+                "Uboot()": {},
+                "SysCpld(addr=12-0043)": {}
             }
         }
     }

--- a/device/arista/arm64-arista_goldfinch-r0/switch_cpu_console.conf
+++ b/device/arista/arm64-arista_goldfinch-r0/switch_cpu_console.conf
@@ -1,0 +1,5 @@
+# Switch CPU console settings for Arista Goldfinch (AST2700)
+
+CONSOLE_BAUD_RATE=115200
+CONSOLE_FLOW_CONTROL=0
+CONSOLE_REMOTE_DEVICE=SwitchCpu

--- a/device/arista/arm64-arista_goldfinch-r0/udevprefix.conf
+++ b/device/arista/arm64-arista_goldfinch-r0/udevprefix.conf
@@ -1,1 +1,1 @@
-
+ttySwitchCpu


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To add correct platform/compornt json and console config for Arista's platform Goldfinch.
##### Work item tracking
- Microsoft ADO **(number only)**: NA

#### How I did it
Added the correct info to goldfinch platform dir files.
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [X] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result
With the fix consutil connect works from goldfinch bmc device to the host cpu.
<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
