### PR TITLE
[cisco-8000]: Update platform ref to 202605.1.0.2

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202605.1.0.1
+ref=202605.1.0.2


### PR DESCRIPTION
#### Why I did it
Update Cisco 8000 platform checkout ref from 202605.1.0.1 to 202605.1.0.2 on the 202605 branch.

#### How I did it
Updated ref in platform/checkout/cisco-8000.ini.

#### How to verify it
Build with the Cisco 8000 platform and verify the platform-cisco-8000 submodule is checked out at tag 202605.1.0.2.
MSFT internal test can finish without blocking issue. Test plan id: 6a6485a783fc55ca64cbccb7

#### Release notes :
      Fix for test_show_platform_syseeprom