### PR TITLE
[cisco-8000]: Update platform ref to 202605.1.0.2

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202511.1.0.8
+ref=202605.1.0.2


### PR DESCRIPTION
#### Why I did it
Update Cisco 8000 platform checkout ref from 202511.1.0.8 to 202605.1.0.2 on master.

#### How I did it
Updated ref in platform/checkout/cisco-8000.ini.

#### How to verify it
Build with the Cisco 8000 platform and verify the platform-cisco-8000 submodule is checked out at tag 202605.1.0.2.

#### Release notes :
      Fix for test_show_platform_syseeprom