### PR TITLE
[yang] sonic-static-route: give STATIC_ROUTE_TEMPLATE_LIST the same non-key leaves as STATIC_ROUTE_LIST

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/static_route.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/static_route.json
@@ -62,6 +62,36 @@
     },
     "STATIC_ROUTE_TEST_NEXTHOP_EMPTY_VRF": {
         "desc": "Configure with null value for VRF"
+    },
+    "STATIC_ROUTE_TEMPLATE_TEST": {
+        "desc": "Configure a default-VRF static route using the bare-prefix (template) key"
+    },
+    "STATIC_ROUTE_TEMPLATE_TEST_WITH_DISTANCE": {
+        "desc": "Configure distance on a bare-prefix static route"
+    },
+    "STATIC_ROUTE_TEMPLATE_TEST_WITH_BLACKHOLE": {
+        "desc": "Configure blackhole on a bare-prefix static route"
+    },
+    "STATIC_ROUTE_TEMPLATE_TEST_WITH_NEXTHOP_VRF": {
+        "desc": "Configure nexthop-vrf on a bare-prefix static route"
+    },
+    "STATIC_ROUTE_TEMPLATE_TEST_WITH_TAG": {
+        "desc": "Configure a route tag on a bare-prefix static route"
+    },
+    "STATIC_ROUTE_TEST_WITH_TAG": {
+        "desc": "Configure a route tag on a VRF-qualified static route"
+    },
+    "STATIC_ROUTE_TEMPLATE_TEST_DISTANCE_INVALID": {
+        "desc": "Configure an out-of-range distance on a bare-prefix static route",
+        "eStrKey": "Pattern"
+    },
+    "STATIC_ROUTE_TEMPLATE_TEST_TAG_INVALID": {
+        "desc": "Configure an out-of-range tag on a bare-prefix static route",
+        "eStrKey": "Pattern"
+    },
+    "STATIC_ROUTE_TEST_TAG_INVALID": {
+        "desc": "Configure an out-of-range tag on a VRF-qualified static route",
+        "eStrKey": "Pattern"
     }
 
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/static-route.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/static-route.json
@@ -1165,6 +1165,124 @@
                 }]
             }
         }
+    },
+    "STATIC_ROUTE_TEMPLATE_TEST": {
+        "sonic-static-route:sonic-static-route": {
+                "sonic-static-route:STATIC_ROUTE": {
+                        "STATIC_ROUTE_TEMPLATE_LIST": [
+                                {
+                                        "prefix": "100.100.100.0/24",
+                                        "nexthop": "10.10.10.1"
+                                }
+                        ]
+                }
+        }
+    },
+    "STATIC_ROUTE_TEMPLATE_TEST_WITH_DISTANCE": {
+        "sonic-static-route:sonic-static-route": {
+                "sonic-static-route:STATIC_ROUTE": {
+                        "STATIC_ROUTE_TEMPLATE_LIST": [
+                                {
+                                        "prefix": "100.100.101.0/24",
+                                        "nexthop": "10.10.10.1",
+                                        "distance": "5"
+                                }
+                        ]
+                }
+        }
+    },
+    "STATIC_ROUTE_TEMPLATE_TEST_WITH_BLACKHOLE": {
+        "sonic-static-route:sonic-static-route": {
+                "sonic-static-route:STATIC_ROUTE": {
+                        "STATIC_ROUTE_TEMPLATE_LIST": [
+                                {
+                                        "prefix": "100.100.102.0/24",
+                                        "nexthop": "0.0.0.0",
+                                        "blackhole": "true"
+                                }
+                        ]
+                }
+        }
+    },
+    "STATIC_ROUTE_TEMPLATE_TEST_WITH_NEXTHOP_VRF": {
+        "sonic-static-route:sonic-static-route": {
+                "sonic-static-route:STATIC_ROUTE": {
+                        "STATIC_ROUTE_TEMPLATE_LIST": [
+                                {
+                                        "prefix": "100.100.103.0/24",
+                                        "nexthop": "10.10.10.1",
+                                        "nexthop-vrf": "default"
+                                }
+                        ]
+                }
+        }
+    },
+    "STATIC_ROUTE_TEMPLATE_TEST_WITH_TAG": {
+        "sonic-static-route:sonic-static-route": {
+                "sonic-static-route:STATIC_ROUTE": {
+                        "STATIC_ROUTE_TEMPLATE_LIST": [
+                                {
+                                        "prefix": "100.100.105.0/24",
+                                        "nexthop": "10.10.10.1",
+                                        "tag": "1234"
+                                }
+                        ]
+                }
+        }
+    },
+    "STATIC_ROUTE_TEST_WITH_TAG": {
+        "sonic-static-route:sonic-static-route": {
+                "sonic-static-route:STATIC_ROUTE": {
+                        "STATIC_ROUTE_LIST": [
+                                {
+                                        "vrf_name": "default",
+                                        "prefix": "100.100.106.0/24",
+                                        "nexthop": "10.10.10.1",
+                                        "tag": "1234"
+                                }
+                        ]
+                }
+        }
+    },
+    "STATIC_ROUTE_TEMPLATE_TEST_DISTANCE_INVALID": {
+        "sonic-static-route:sonic-static-route": {
+                "sonic-static-route:STATIC_ROUTE": {
+                        "STATIC_ROUTE_TEMPLATE_LIST": [
+                                {
+                                        "prefix": "100.100.107.0/24",
+                                        "nexthop": "10.10.10.1",
+                                        "distance": "300"
+                                }
+                        ]
+                }
+        }
+    },
+    "STATIC_ROUTE_TEMPLATE_TEST_TAG_INVALID": {
+        "sonic-static-route:sonic-static-route": {
+                "sonic-static-route:STATIC_ROUTE": {
+                        "STATIC_ROUTE_TEMPLATE_LIST": [
+                                {
+                                        "prefix": "100.100.108.0/24",
+                                        "nexthop": "10.10.10.1",
+                                        "tag": "99999999999"
+                                }
+                        ]
+                }
+        }
+    },
+    "STATIC_ROUTE_TEST_TAG_INVALID": {
+        "sonic-static-route:sonic-static-route": {
+                "sonic-static-route:STATIC_ROUTE": {
+                        "STATIC_ROUTE_LIST": [
+                                {
+                                        "vrf_name": "default",
+                                        "prefix": "100.100.109.0/24",
+                                        "nexthop": "10.10.10.1",
+                                        "tag": "99999999999"
+                                }
+                        ]
+                }
+        }
     }
 
 }

--- a/src/sonic-yang-models/yang-models/sonic-static-route.yang
+++ b/src/sonic-yang-models/yang-models/sonic-static-route.yang
@@ -12,6 +12,12 @@ module sonic-static-route {
   description
     "STATIC ROUTE yang Module for SONiC OS";
 
+  revision 2026-07-21 {
+    description
+      "Align STATIC_ROUTE_TEMPLATE_LIST with STATIC_ROUTE_LIST (distance, nexthop-vrf, blackhole)
+       and add the route tag attribute to both lists.";
+  }
+
   revision 2022-03-17 {
     description
       "First Revision";
@@ -46,6 +52,48 @@ module sonic-static-route {
           }
           default "false";
           description "Advertise this static route to BGP, comma-separated per nexthop.";
+        }
+        leaf distance {
+          type string {
+            pattern "((25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?),)*(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)";
+          }
+          default "0";
+          description
+            "Administrative Distance (preference) of the entry.  The
+             preference defines the order of selection when multiple
+             sources (protocols, static, etc.) contribute to the same
+             prefix entry.  The lower the preference, the more preferable the
+             prefix is.  When this value is not specified, the preference is
+             inherited from the default preference of the implementation for
+             static routes.  Comma-separated list with one entry per nexthop.";
+        }
+        leaf nexthop-vrf {
+          type string {
+            pattern "((((Vrf[a-zA-Z0-9_-]+)|(default)|(mgmt)),)*((Vrf[a-zA-Z0-9_-]+)|(default)|(mgmt)))?";
+          }
+          description
+            "VRF name of the nexthop, used for VRF leaking. Comma-separated list with one
+             entry per nexthop.";
+        }
+        leaf blackhole {
+          type string {
+            pattern "((true|false),)*(true|false)";
+          }
+          default "false";
+          description
+            "blackhole refers to a route that, if matched, discards the message silently.
+             Comma-separated list with one entry per nexthop.";
+        }
+        leaf tag {
+          type string {
+            pattern "(0|[1-9][0-9]{0,9})(,(0|[1-9][0-9]{0,9}))*";
+          }
+          default "0";
+          description
+            "Route tag applied to the static route (0-4294967295), comma-separated for multiple nexthops.
+             Value 0 means no tag is applied. Matches the FRR `tag (1-4294967295)` static-route parameter,
+             with 0 reserved to express the absence of a tag.
+             Note: Pattern allows up to 10 digits; values above 4294967295 will be rejected by application logic.";
         }
         leaf bfd {
           type string {
@@ -108,14 +156,15 @@ module sonic-static-route {
              prefix entry.  The lower the preference, the more preferable the
              prefix is.  When this value is not specified, the preference is
              inherited from the default preference of the implementation for
-             static routes.";
+             static routes.  Comma-separated list with one entry per nexthop.";
         }
         leaf nexthop-vrf {
           type string {
             pattern "((((Vrf[a-zA-Z0-9_-]+)|(default)|(mgmt)),)*((Vrf[a-zA-Z0-9_-]+)|(default)|(mgmt)))?";
           }
           description
-            "VRF name of the nexthop. This is for vrf leaking";
+            "VRF name of the nexthop, used for VRF leaking. Comma-separated list with one
+             entry per nexthop.";
         }
         leaf blackhole {
           type string {
@@ -123,7 +172,19 @@ module sonic-static-route {
           }
           default "false";
           description
-            "blackhole refers to a route that, if matched, discards the message silently.";
+            "blackhole refers to a route that, if matched, discards the message silently.
+             Comma-separated list with one entry per nexthop.";
+        }
+        leaf tag {
+          type string {
+            pattern "(0|[1-9][0-9]{0,9})(,(0|[1-9][0-9]{0,9}))*";
+          }
+          default "0";
+          description
+            "Route tag applied to the static route (0-4294967295), comma-separated for multiple nexthops.
+             Value 0 means no tag is applied. Matches the FRR `tag (1-4294967295)` static-route parameter,
+             with 0 reserved to express the absence of a tag.
+             Note: Pattern allows up to 10 digits; values above 4294967295 will be rejected by application logic.";
         }
       } /* end of list STATIC_ROUTE_LIST */
     } /* end of container STATIC_ROUTE */


### PR DESCRIPTION
#### Why I did it

`STATIC_ROUTE_TEMPLATE_LIST` (key: `prefix`) and `STATIC_ROUTE_LIST` (key: `vrf_name prefix`) model the same table for the two CONFIG_DB key shapes, but their non-key leaf sets had drifted apart. `distance`, `nexthop-vrf`, `blackhole` and the `sidlist` list existed only on the two-component form.

**The daemons make no such distinction**, so the model was describing less than the implementation supports:

* `bgpcfgd` (`bgpcfgd/managers_static_rt.py`) splits the key **first** and then reads the fields unconditionally. `split_key` maps a bare prefix onto `('default', prefix)`, which is indistinguishable from `default|<prefix>` — after that point nothing downstream can tell the two shapes apart.
* `frrcfgd` (`frrcfgd/frrcfgd.py`) rewrites a single-component `STATIC_ROUTE` key to `<default-vrf>|<key>` before handling it, and declares its consumed field set per **table**, not per key shape.

The practical effect: a one-component key can only match the template list, so **every default-VRF static route carrying `distance` was rejected by YANG validation**. That blocks the field on any device whose routes are stored in the collapsed form, and breaks restoring a saved configuration on such a device. It is not tool-specific — it reproduces through `sonic_yang` directly, so it affects the Generic Config Updater equally.

This also adds the route `tag` attribute, which `frrcfgd` reads for **both** key shapes and renders into FRR's `tag (1-4294967295)` static-route parameter, but which neither list declared. Value `0` expresses the absence of a tag, matching how `frrcfgd` represents an unset tag and mirroring the existing `color` leaf.

**Deliberately not added: `track`.** `frrcfgd`'s static route map references it, but FRR's static route CLI has no such keyword — `grep -c track staticd/static_vty.c` returns `0`, and the only occurrences in `staticd` are internal nexthop-tracking flags. Modelling it would legitimise a field the backend cannot apply.

#### How I did it

Every added leaf is copied **verbatim** from its sibling in `STATIC_ROUTE_LIST` — same type, pattern, default and description — so the two lists now differ only by the `vrf_name` key. The change is purely additive: it can only widen the accepted set and cannot invalidate a configuration that validates today.

Separately, three descriptions now state that the leaf is a comma-separated per-nexthop list. `advertise`, `bfd*` and `color` already documented this; `distance`, `nexthop-vrf` and `blackhole` did not, so the multi-value encoding was only discoverable by reading the `(X,)*X` pattern. This touches the pre-existing `STATIC_ROUTE_LIST` copies too, which keeps the two lists byte-identical apart from the `vrf_name` key.

Also adds the **first test coverage for `STATIC_ROUTE_TEMPLATE_LIST`**, which had none. Every existing static-route case exercised `STATIC_ROUTE_LIST`, which is how the drift went unnoticed — `bfd*` and `color` were each correctly added to both lists in a single commit, so keeping them in sync is the established convention.

#### How to verify it

YANG model tests:

```
pytest src/sonic-yang-models/tests/yang_model_tests/test_yang_model.py -k STATIC_ROUTE
```

Verified end-to-end on gold218 (`main.Nexthop.122165`, libyang3 3.12.2) against `sonic_yang` — the reference validator the Generic Config Updater uses — by swapping only this model file in `/usr/local/yang-models`:

| config | before | after |
|---|---|---|
| `{'10.99.0.0/16': {'nexthop': ..., 'distance': '1'}}` | REJECTED | **ACCEPTED** |
| `{'10.99.1.0/24': {'nexthop': ..., 'blackhole': 'true'}}` | REJECTED | **ACCEPTED** |
| `{'10.99.2.0/24': {'nexthop': ..., 'nexthop-vrf': 'default'}}` | REJECTED | **ACCEPTED** |
| `{'10.99.3.0/24': {'nexthop': ..., 'tag': '1234'}}` | REJECTED | **ACCEPTED** |
| `{'default\|10.99.4.0/24': {..., 'distance': '1'}}` | ACCEPTED | ACCEPTED (unregressed) |
| `{'10.99.5.0/24': {..., 'distance': '300'}}` | REJECTED (arity) | REJECTED (**pattern**) |

The last row is the important one: the invalid value is now rejected by the `distance` *pattern* on the template list —

```
Unsatisfied pattern - "300" does not conform to "((25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?),)*..."
Data path: /sonic-static-route:sonic-static-route/STATIC_ROUTE/STATIC_ROUTE_TEMPLATE_LIST[prefix='10.99.5.0/24']/distance
```

— rather than the field being unreachable. The constraint is enforced, not merely accepted.

Consumers inherit the fix with **no code change** (models are loaded at runtime). 

#### Which release branch to port

- [x] 202605
- [x] 202511
- [ ] 202505

#### Tested branch (Please provide the tested image version)

- [x] master as of 20260722

#### Description for the changelog

[yang] sonic-static-route: allow distance, nexthop-vrf, blackhole and sidlist on default-VRF (bare-prefix) static routes, and add the route tag attribute to both key forms.

#### Link to config_db schema for YANG module changes

https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#static_route

#### A picture of a cute animal (not mandatory but encouraged)
