### PR TITLE
Remove accidental creation of UEFI kvm image for non VS builds

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -178,7 +178,10 @@ elif [ "$IMAGE_TYPE" = "kvm" ]; then
     generate_onie_installer_image
     # Generate single asic KVM image
     generate_kvm_image 1
-    generate_kvm_image 1 UEFI
+    # Generate the UEFI image only for the VS platform.
+    if [ "$CONFIGURED_PLATFORM" = "vs" ]; then
+        generate_kvm_image 1 UEFI
+    fi
     if [ "$BUILD_MULTIASIC_KVM" == "y" ]; then
         # Generate 4-asic KVM image
         generate_kvm_image 4


### PR DESCRIPTION
#### Why I did it
Commit 275799ff66 added a UEFI image for VS builds but also invoked the same path for
vendor specifc VM builds, where UEFI installation is unsupported and hangs while waiting for
a GRUB screen that never appears.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it
- Guarded UEFI KVM image generation with `CONFIGURED_PLATFORM=vs`.
- Kept the existing BIOS KVM build unchanged for non VS platforms.

#### How to verify it
Built non VS VM image. The build completed successfully without invoking
UEFI image creation or encountering the previous KVM hang.

#### Which release branch to backport (provide reason below if selected)
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch
- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result
- master: tested on a build between 202605 and 202611; the custom non VS image completed
  successfully without UEFI image creation.

#### Description for the changelog
Build UEFI KVM images only for the VS platform