### PR TITLE
[ci] build docker-ptf for trixie and freeze version files properly

### DIFF
--- a/.azure-pipelines/docker-ptf.yml
+++ b/.azure-pipelines/docker-ptf.yml
@@ -268,7 +268,8 @@ stages:
         FREEZE_TMPDIR=$(mktemp -d)
         make freeze FREEZE_VERSION_OPTIONS="-r -s $FREEZE_TMPDIR"
 
-        rsync -av "$FREEZE_TMPDIR/files/build/versions/" dockers/docker-ptf/files/
+        mkdir -p dockers/docker-ptf/files
+        rsync -av --delete "$FREEZE_TMPDIR/files/build/versions/" dockers/docker-ptf/files/
         rm -rf "$FREEZE_TMPDIR"
         git diff dockers/docker-ptf/files
       displayName: 'Update docker-ptf version files'

--- a/.azure-pipelines/docker-ptf.yml
+++ b/.azure-pipelines/docker-ptf.yml
@@ -116,8 +116,8 @@ stages:
         BUILD_OPTIONS="SONIC_BUILD_JOBS=$(nproc) DEFAULT_CONTAINER_REGISTRY=publicmirror.azurecr.io ENABLE_DOCKER_BASE_PULL=y MIRROR_SNAPSHOT=$MIRROR_SNAPSHOT 
                       SONIC_BUILD_RETRY_COUNT=3 SONIC_BUILD_RETRY_INTERVAL=600 DOCKER_BUILDKIT=0 $(VERSION_CONTROL_OPTIONS)"
 
-        make NOBUSTER=1 NOBULLSEYE=1 $BUILD_OPTIONS configure PLATFORM=vs NOTRIXIE=1 # docker-ptf is built for bookworm, disable trixie currently to save build time. will enable it after migrating to trixie.
-        make -f Makefile.work BLDENV=bookworm $BUILD_OPTIONS target/docker-ptf.gz
+        make NOBUSTER=1 NOBULLSEYE=1 NOBOOKWORM=1 $BUILD_OPTIONS configure PLATFORM=vs
+        make -f Makefile.work BLDENV=trixie $BUILD_OPTIONS target/docker-ptf.gz
         cp -r target $(Build.ArtifactStagingDirectory)/target
         cp $(Pipeline.Workspace)/vs-images/target/sonic*-vs.img.gz $(Build.ArtifactStagingDirectory)/target/
       displayName: Build docker-ptf.gz
@@ -263,10 +263,13 @@ stages:
         # preserving the subdirectory structure (dockers/docker-ptf/, default/, etc.).
         # This keeps them separate from the global files/build/versions tree so the
         # UpgradeVersion pipeline does not overwrite them.
-        VERSIONS_SRC=$(Pipeline.Workspace)/sonic-buildimage.vs/target/versions
-        VERSIONS_DST=dockers/docker-ptf/files
-        mkdir -p $VERSIONS_DST
-        rsync -av $VERSIONS_SRC/ $VERSIONS_DST/
+        mkdir -p target
+        cp -r $(Pipeline.Workspace)/sonic-buildimage.vs/target/versions target/
+        FREEZE_TMPDIR=$(mktemp -d)
+        make freeze FREEZE_VERSION_OPTIONS="-r -s $FREEZE_TMPDIR"
+
+        rsync -av "$FREEZE_TMPDIR/files/build/versions/" dockers/docker-ptf/files/
+        rm -rf "$FREEZE_TMPDIR"
         git diff dockers/docker-ptf/files
       displayName: 'Update docker-ptf version files'
 


### PR DESCRIPTION
#### Why I did it

The `docker-ptf` image in the pipeline was temporarily pinned to **bookworm** (`NOTRIXIE=1`, `BLDENV=bookworm`) to save build time while the codebase was being migrated to **trixie**. Now that trixie is ready, this PR migrates the `docker-ptf` CI build to trixie and removes the temporary bookworm pin.

It also fixes how the committed `docker-ptf` version-lock files are generated so they are properly frozen instead of raw copies of the build output.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Changes are limited to `.azure-pipelines/docker-ptf.yml`:

1. **Build stage** – build `docker-ptf` for trixie instead of bookworm:
   - `configure`: dropped `NOTRIXIE=1` and added `NOBOOKWORM=1`.
   - `target/docker-ptf.gz`: `BLDENV=bookworm` → `BLDENV=trixie`.
   - Removed the now-obsolete "docker-ptf is built for bookworm" comment.

2. **Update docker-ptf version files stage** – instead of raw-copying `target/versions` into `dockers/docker-ptf/files/`, the built versions are placed under `target/` and `make freeze FREEZE_VERSION_OPTIONS="-r -s $FREEZE_TMPDIR"` is run to regenerate the frozen version-lock files into a temp dir. The properly frozen files under `$FREEZE_TMPDIR/files/build/versions/` are then rsync'd into `dockers/docker-ptf/files/`, and the temp dir is cleaned up.

#### How to verify it

- The `docker-ptf` pipeline completes successfully with `docker-ptf.gz` built under the trixie build environment.
- The "Update docker-ptf version files" stage produces correctly frozen version files under `dockers/docker-ptf/files/` (verified via the `git diff dockers/docker-ptf/files` step) and opens the auto version-update PR only when versions actually change.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A (CI-only change, not backported)
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
-->

#### Description for the changelog

[ci] Build docker-ptf for trixie and freeze docker-ptf version files properly

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)
