### PR TITLE
[build] Fix KVM image build failure with QEMU 10.x (trixie)

### DIFF
--- a/scripts/build_kvm_image.sh
+++ b/scripts/build_kvm_image.sh
@@ -103,8 +103,8 @@ fi
     -netdev user,id=onienet \
     -nographic \
     -drive file=$DISK,media=disk,if=virtio,index=0 \
-    -drive file=$INSTALLER_DISK,if=virtio,index=1 \
-    -serial telnet:127.0.0.1:$KVM_PORT,server > $kvm_log 2>&1 &
+    -drive file=$INSTALLER_DISK,format=raw,if=virtio,index=1 \
+    -serial telnet:127.0.0.1:$KVM_PORT,server=on,wait=off > $kvm_log 2>&1 &
 
 kvm_pid=$!
 
@@ -133,7 +133,7 @@ echo "Booting up SONiC"
     -nographic \
     -snapshot \
     -drive file=$DISK,media=disk,if=virtio,index=0 \
-    -serial telnet:127.0.0.1:$KVM_PORT,server > $kvm_log 2>&1 &
+    -serial telnet:127.0.0.1:$KVM_PORT,server=on,wait=off > $kvm_log 2>&1 &
 
 kvm_pid=$!
 


### PR DESCRIPTION
Supersedes #28567 (closed by mistake; branch was force-pushed so it could not be reopened).

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

When building the KVM image with a trixie-based slave (QEMU 10.0.8), the VM does not start executing until a telnet client connects, because "-serial telnet:...,server" implies wait=on. In this mode install_sonic.py times out (pexpect, 1200s) waiting for the GRUB menu on the serial console, and the build fails with:

  make: *** [slave.mk:1685: target/sonic-<platform>.img.gz] Error 1

Fix by starting the serial telnet server with server=on,wait=off so the VM boots immediately, matching the effective behavior the build relied on with bookworm. The explicit spelling is used because the short-form boolean options ("server", "nowait") are deprecated since QEMU 6.0.

Also specify format=raw for the installer disk to avoid image format probing; QEMU 10.x otherwise restricts writes to block 0 of the probed raw image.

Fixes #28565

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Start the serial telnet server with `server=on,wait=off` so the VM boots immediately, matching the effective behavior the build relied on with bookworm. The explicit spelling is used because short-form boolean options (`server`, `nowait`) are deprecated since QEMU 6.0. Both QEMU invocations in the script (ONIE install and `check_install.py` verification) are updated.
- Specify `format=raw` for the installer disk to avoid image format probing and the block-0 write restriction.

Note: with `wait=off`, serial output emitted before the telnet client attaches is discarded. This is safe here: `wait_kvm_ready` connects within ~2 seconds, well before GRUB is reached.

#### How to verify it
Build a KVM image with a trixie slave, e.g.:
```
BLDENV=trixie make target/sonic-vs.img.gz
```
Verified on a trixie build environment (QEMU 10.0.8) with a UEFI KVM image:
previously `install_sonic.py` timed out after 1200s at the GRUB menu; with this change the ONIE installation and the subsequent `check_install.py` login check both complete, and the image builds successfully. Bookworm builds are unaffected (`wait=off` and `format=raw` are valid there as well).
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
Fix KVM image build failure with QEMU 10.x (trixie) in build_kvm_image.sh (serial telnet wait=off, explicit raw format for installer disk).
#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
