### PR TITLE
sonic-yang: model BGP afi_safi as an enumeration instead of an unconstrained string

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
@@ -242,6 +242,53 @@
     "BGP_SENTINEL_INVALID_RANGE_IPV6": {
         "desc": "does not satisfy.",
         "eStr": "Invalid value \"fc00:f0::/129\" in \"ip_range\" element."
+    },
+    "BGP_GLOBALS_RR_CLUSTER_ID_DOTTED_VALID": {
+        "desc": "rr_cluster_id accepts dotted-quad notation."
+    },
+    "BGP_GLOBALS_RR_CLUSTER_ID_INTEGER_VALID": {
+        "desc": "rr_cluster_id accepts a 32-bit integer (top of range, unambiguously not dotted-quad)."
+    },
+    "BGP_GLOBALS_RR_CLUSTER_ID_INVALID": {
+        "desc": "rr_cluster_id must reject a value that is neither an IPv4 address nor a 32-bit integer.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["rr_cluster_id"]
+    },
+    "BGP_GLOBALS_AF_SRPOLICY_INVALID": {
+        "desc": "BGP_GLOBALS_AF has no global AFI-SAFI configuration for SR-Policy SAFI; afi_safi=ipv4_srpolicy must be rejected outright by the restricted key type.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["afi_safi"]
+    },
+    "BGP_GLOBALS_AF_AFI_SAFI_HYPHENATED_INVALID": {
+        "desc": "BGP_GLOBALS_AF with a hyphenated afi_safi spelling (ipv4-unicast) must be rejected; the canonical form is underscore-separated.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["afi_safi"]
+    },
+    "BGP_GLOBALS_AF_AGGREGATE_ADDR_SRPOLICY_INVALID": {
+        "desc": "BGP_GLOBALS_AF_AGGREGATE_ADDR with an SR-Policy afi_safi must be rejected by the restricted key type.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["afi_safi"]
+    },
+    "BGP_GLOBALS_AF_NETWORK_SRPOLICY_INVALID": {
+        "desc": "BGP_GLOBALS_AF_NETWORK with an SR-Policy afi_safi must be rejected by the restricted key type.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["afi_safi"]
+    },
+    "BGP_NEIGHBOR_AF_L2VPN_EVPN_VALID": {
+        "desc": "BGP_NEIGHBOR_AF accepts l2vpn_evpn, which is required to activate a neighbor for EVPN."
+    },
+    "BGP_NEIGHBOR_AF_AFI_SAFI_HYPHENATED_INVALID": {
+        "desc": "BGP_NEIGHBOR_AF with a hyphenated afi_safi spelling (ipv4-unicast) must be rejected; the canonical form is underscore-separated.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["afi_safi"]
+    },
+    "BGP_PEER_GROUP_AF_SRPOLICY_VALID": {
+        "desc": "BGP_PEER_GROUP_AF (with BGP_NEIGHBOR_AF) is one of only two tables carrying the full bgp_afi_safi vocabulary; both SR-Policy families must remain admissible keys."
+    },
+    "BGP_PEER_GROUP_AF_AFI_SAFI_HYPHENATED_INVALID": {
+        "desc": "BGP_PEER_GROUP_AF with a hyphenated afi_safi spelling (ipv4-unicast) must be rejected; the canonical form is underscore-separated.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["afi_safi"]
     }
 }
 

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_device_global.json
@@ -77,6 +77,19 @@
     "BGP_DEVICE_GLOBAL_CONFED" : {
         "desc": "Load bgp device global table with confederation asn and peers"
     },
+    "BGP_DEVICE_GLOBAL_CONFED_PEERS_SINGLE_VALID" : {
+        "desc": "Load bgp device global table with a single confederation sub-ASN and no separator"
+    },
+    "BGP_DEVICE_GLOBAL_CONFED_PEERS_TRAILING_SEPARATOR_INVALID" : {
+        "desc": "A trailing semi-colon in the confederation peers list must be rejected",
+        "eStrKey": "Pattern",
+        "eStr": ["peers"]
+    },
+    "BGP_DEVICE_GLOBAL_CONFED_PEERS_NON_NUMERIC_INVALID" : {
+        "desc": "A non-numeric sub-ASN in the confederation peers list must be rejected",
+        "eStrKey": "Pattern",
+        "eStr": ["peers"]
+    },
     "BGP_DEVICE_GLOBAL_CONFED_INVALID_ASN" : {
         "desc": "Load bgp device global table with confederation invalid asn",
         "eStrKey": "InvalidValue",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
@@ -2160,6 +2160,268 @@
                 ]
             }
         }
+    },
+
+    "BGP_GLOBALS_AF_SRPOLICY_INVALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "local_asn": 65001
+                    }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "afi_safi": "ipv4_srpolicy"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_AFI_SAFI_HYPHENATED_INVALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "local_asn": 65001
+                    }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF": {
+                "BGP_GLOBALS_AF_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "afi_safi": "ipv4-unicast"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_AGGREGATE_ADDR_SRPOLICY_INVALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "local_asn": 65001
+                    }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF_AGGREGATE_ADDR": {
+                "BGP_GLOBALS_AF_AGGREGATE_ADDR_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "afi_safi": "ipv4_srpolicy",
+                        "ip_prefix": "192.168.0.0/24"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_AF_NETWORK_SRPOLICY_INVALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "local_asn": 65001
+                    }
+                ]
+            },
+            "sonic-bgp-global:BGP_GLOBALS_AF_NETWORK": {
+                "BGP_GLOBALS_AF_NETWORK_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "afi_safi": "ipv4_srpolicy",
+                        "ip_prefix": "192.168.0.0/24"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_NEIGHBOR_AF_L2VPN_EVPN_VALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "local_asn": 65001
+                    }
+                ]
+            }
+        },
+        "sonic-bgp-neighbor:sonic-bgp-neighbor": {
+            "sonic-bgp-neighbor:BGP_NEIGHBOR": {
+                "BGP_NEIGHBOR_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "neighbor": "20.0.0.1",
+                        "local_asn": 1,
+                        "name": "BGP nbr 1",
+                        "asn": 65003
+                    }
+                ]
+            },
+            "sonic-bgp-neighbor:BGP_NEIGHBOR_AF": {
+                "BGP_NEIGHBOR_AF_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "neighbor": "20.0.0.1",
+                        "afi_safi": "l2vpn_evpn",
+                        "admin_status": "up"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_NEIGHBOR_AF_AFI_SAFI_HYPHENATED_INVALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "local_asn": 65001
+                    }
+                ]
+            }
+        },
+        "sonic-bgp-neighbor:sonic-bgp-neighbor": {
+            "sonic-bgp-neighbor:BGP_NEIGHBOR": {
+                "BGP_NEIGHBOR_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "neighbor": "20.0.0.1",
+                        "local_asn": 1,
+                        "name": "BGP nbr 1",
+                        "asn": 65003
+                    }
+                ]
+            },
+            "sonic-bgp-neighbor:BGP_NEIGHBOR_AF": {
+                "BGP_NEIGHBOR_AF_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "neighbor": "20.0.0.1",
+                        "afi_safi": "ipv4-unicast",
+                        "admin_status": "up"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PEER_GROUP_AF_AFI_SAFI_HYPHENATED_INVALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "local_asn": 65001
+                    }
+                ]
+            }
+        },
+        "sonic-bgp-peergroup:sonic-bgp-peergroup": {
+            "sonic-bgp-peergroup:BGP_PEER_GROUP": {
+                "BGP_PEER_GROUP_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "peer_group_name": "PG1"
+                    }
+                ]
+            },
+            "sonic-bgp-peergroup:BGP_PEER_GROUP_AF": {
+                "BGP_PEER_GROUP_AF_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "peer_group_name": "PG1",
+                        "afi_safi": "ipv4-unicast",
+                        "admin_status": "up"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_PEER_GROUP_AF_SRPOLICY_VALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "local_asn": 65001
+                    }
+                ]
+            }
+        },
+        "sonic-bgp-peergroup:sonic-bgp-peergroup": {
+            "sonic-bgp-peergroup:BGP_PEER_GROUP": {
+                "BGP_PEER_GROUP_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "peer_group_name": "PG1"
+                    }
+                ]
+            },
+            "sonic-bgp-peergroup:BGP_PEER_GROUP_AF": {
+                "BGP_PEER_GROUP_AF_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "peer_group_name": "PG1",
+                        "afi_safi": "ipv4_srpolicy",
+                        "admin_status": "up"
+                    },
+                    {
+                        "vrf_name": "default",
+                        "peer_group_name": "PG1",
+                        "afi_safi": "ipv6_srpolicy",
+                        "admin_status": "up"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_RR_CLUSTER_ID_DOTTED_VALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "local_asn": 65001,
+                        "rr_cluster_id": "1.1.1.1"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_RR_CLUSTER_ID_INTEGER_VALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "local_asn": 65001,
+                        "rr_cluster_id": "4294967295"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_GLOBALS_RR_CLUSTER_ID_INVALID": {
+        "sonic-bgp-global:sonic-bgp-global": {
+            "sonic-bgp-global:BGP_GLOBALS": {
+                "BGP_GLOBALS_LIST": [
+                    {
+                        "vrf_name": "default",
+                        "local_asn": 65001,
+                        "rr_cluster_id": "cluster-one"
+                    }
+                ]
+            }
+        }
     }
 }
 

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_device_global.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_device_global.json
@@ -123,6 +123,36 @@
             }
         }
     },
+    "BGP_DEVICE_GLOBAL_CONFED_PEERS_SINGLE_VALID": {
+        "sonic-bgp-device-global:sonic-bgp-device-global": {
+            "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
+                "CONFED": {
+                    "asn": 65100,
+                    "peers": "66000"
+                }
+            }
+        }
+    },
+    "BGP_DEVICE_GLOBAL_CONFED_PEERS_TRAILING_SEPARATOR_INVALID": {
+        "sonic-bgp-device-global:sonic-bgp-device-global": {
+            "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
+                "CONFED": {
+                    "asn": 65100,
+                    "peers": "66000;63000;"
+                }
+            }
+        }
+    },
+    "BGP_DEVICE_GLOBAL_CONFED_PEERS_NON_NUMERIC_INVALID": {
+        "sonic-bgp-device-global:sonic-bgp-device-global": {
+            "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {
+                "CONFED": {
+                    "asn": 65100,
+                    "peers": "66000;abc"
+                }
+            }
+        }
+    },
     "BGP_DEVICE_GLOBAL_CONFED_INVALID_ASN": {
         "sonic-bgp-device-global:sonic-bgp-device-global": {
             "sonic-bgp-device-global:BGP_DEVICE_GLOBAL": {

--- a/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-common.yang
@@ -49,9 +49,54 @@ module sonic-bgp-common {
     description
         "SONIC BGP common YANG attributes for Neighbors and Peer group";
 
+    revision 2026-07-22 {
+        description
+            "Add bgp_afi_safi typedef (and the bgp_afi_safi_global restriction) and use it for
+             the afi_safi list keys, which were previously an unconstrained 'type string'.
+             Constraining the key rejects non-canonical spellings such as 'ipv4-unicast' at
+             validation time and lets YANG-derived CLIs offer the valid values as completion
+             candidates.";
+    }
+
     revision 2021-02-26 {
         description
             "Initial revision.";
+    }
+
+    typedef bgp_afi_safi {
+        type enumeration {
+            enum ipv4_unicast {
+                description "IPv4 unicast address family";
+            }
+            enum ipv6_unicast {
+                description "IPv6 unicast address family";
+            }
+            enum l2vpn_evpn {
+                description "L2VPN EVPN address family";
+            }
+            enum ipv4_srpolicy {
+                description "IPv4 SR-Policy address family";
+            }
+            enum ipv6_srpolicy {
+                description "IPv6 SR-Policy address family";
+            }
+        }
+        description
+            "Address family identifier and subsequent address family identifier, as stored
+             in CONFIG_DB. The underscore-separated form is canonical; hyphenated spellings
+             such as 'ipv4-unicast' are not valid.";
+    }
+
+    typedef bgp_afi_safi_global {
+        type bgp_afi_safi {
+            enum ipv4_unicast;
+            enum ipv6_unicast;
+            enum l2vpn_evpn;
+        }
+        description
+            "bgp_afi_safi restricted to the address families valid in a BGP global
+             address-family context. The SR-Policy families are excluded; SR-Policy is
+             configured per-neighbor on BGP_NEIGHBOR_AF / BGP_PEER_GROUP_AF.";
     }
 
     typedef bgp_peer_type {
@@ -337,7 +382,7 @@ module sonic-bgp-common {
     grouping sonic-bgp-cmn-af {
 
         leaf afi_safi {
-            type string;
+            type bgp_afi_safi;
             description "Address family";
         }
 

--- a/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-device-global.yang
@@ -12,6 +12,11 @@ module sonic-bgp-device-global {
     description
         "SONIC Device-specific BGP global data";
 
+    revision 2026-07-22 {
+        description "Add a pattern to the BGP confederation peers leaf, previously an
+                     unconstrained string, enforcing its semi-colon-separated sub-ASN shape.";
+    }
+
     revision 2024-01-28 {
         description "Add Weighted ECMP using BGP link bandwidth";
     }
@@ -75,8 +80,12 @@ module sonic-bgp-device-global {
 
                 /* List of peer ASN part of the confederation */
                 leaf peers {
-                    type string;
-                    description "List of sub-ASNs in the confederation separated by semi-colon";
+                    type string {
+                        pattern "[1-9][0-9]*(;[1-9][0-9]*)*";
+                    }
+                    description "List of sub-ASNs in the confederation separated by semi-colon.
+                                 The pattern enforces the semi-colon-separated shape; it does not
+                                 range-check each sub-ASN against the 32-bit AS number maximum.";
                 }
             }
             /* end of CONFED container */

--- a/src/sonic-yang-models/yang-models/sonic-bgp-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-global.yang
@@ -19,6 +19,10 @@ module sonic-bgp-global {
         prefix ext;
     }
 
+    import sonic-bgp-common {
+        prefix bgpcmn;
+    }
+
     organization
         "SONiC";
 
@@ -27,6 +31,15 @@ module sonic-bgp-global {
 
     description
         "SONIC BGP Global YANG";
+
+    revision 2026-07-22 {
+        description
+            "Constrain the afi_safi keys of BGP_GLOBALS_AF_LIST, BGP_GLOBALS_AF_AGGREGATE_ADDR_LIST
+             and BGP_GLOBALS_AF_NETWORK_LIST to bgp_afi_safi_global instead of an unconstrained
+             string, so the SR-Policy families are rejected at validation time.
+             Also constrain rr_cluster_id, previously an unconstrained string, to a union of an
+             IPv4 address and a 32-bit integer.";
+    }
 
     revision 2021-02-26 {
         description
@@ -113,8 +126,15 @@ module sonic-bgp-global {
                 }
 
                 leaf rr_cluster_id {
-                    type string;
-                    description "Route reflector cluster ID used to identify the reflector cluster.";
+                    type union {
+                        type inet:ipv4-address;
+                        type uint32 {
+                            range "1..4294967295";
+                        }
+                    }
+                    description "Route reflector cluster ID used to identify the reflector cluster.
+                                 Expressed either in dotted-quad notation or as a non-zero 32-bit
+                                 integer (1..4294967295).";
                 }
 
                 leaf rr_allow_out_policy {
@@ -333,7 +353,7 @@ module sonic-bgp-global {
                 }
 
                 leaf afi_safi {
-                    type string;
+                    type bgpcmn:bgp_afi_safi_global;
                     description "Address family name and subsequent address family name";
                 }
 
@@ -478,7 +498,7 @@ module sonic-bgp-global {
                 }
 
                 leaf afi_safi {
-                    type string;
+                    type bgpcmn:bgp_afi_safi_global;
                     description "Address family name and subsequent address family name";
                 }
 
@@ -518,7 +538,7 @@ module sonic-bgp-global {
                 }
 
                 leaf afi_safi {
-                    type string;
+                    type bgpcmn:bgp_afi_safi_global;
                     description "Address family name and subsequent address family name";
                 }
 


### PR DESCRIPTION
#### Why I did it

The `afi_safi` list keys across the BGP models were declared `type string` with no enumeration, so any value was valid YANG. Both `ipv4-unicast` (hyphen) and `ipv4_unicast` (underscore) validated and committed, producing two distinct AF rows — only the underscore spelling is functional, since CONFIG_DB, bgpcfgd and frrcfgd all use underscores.

This is a model gap, not a CLI defect. nhcli derives all config-mode validation and completion from the YANG, so an unconstrained key is faithfully accepted; the fix belongs in the model. It also explains the original report (Randy Williams) that tab-completion walks you to the `afi-safi` position and then leaves you to type the value blind — there were no enum values for the CLI to offer.

Two further BGP leaves had the same shape of problem — declared `type string` while their consumers accept only a specific form — and are fixed here too: `BGP_GLOBALS.rr_cluster_id` and the `BGP_DEVICE_GLOBAL` confederation `peers` list.

#### How I did it

Added a `bgp_afi_safi` typedef to `sonic-bgp-common.yang` with the canonical underscore values, plus two restrictions for the contexts whose vocabulary is narrower, and wired all five `afi_safi` leaves to them:

| Table | Type | Values |
|---|---|---|
| `BGP_NEIGHBOR_AF` / `BGP_PEER_GROUP_AF` | `bgp_afi_safi` | `ipv4_unicast`, `ipv6_unicast`, `l2vpn_evpn`, `ipv4_srpolicy`, `ipv6_srpolicy` |
| `BGP_GLOBALS_AF` | `bgp_afi_safi_global` | as above, minus SR-Policy |
| `BGP_GLOBALS_AF_AGGREGATE_ADDR` | `bgp_afi_safi_global` | " |
| `BGP_GLOBALS_AF_NETWORK` | `bgp_afi_safi_global` | " |
| `BGP_DEVICE_GLOBAL_AF` | `bgp_afi_safi_device_global` | `ipv4_unicast`, `ipv6_unicast` |

The per-context sets are derived from the actual consumers, not from prose. SR-Policy is excluded from the globals tables because frrcfgd installs no global SR-Policy config (`frrcfgd.py:3618`). `BGP_DEVICE_GLOBAL_AF` is unicast-only because `AFI_SAFI_MAP` in `bgpcfgd/managers_device_global_af.py:9` has exactly two entries and `log_warn`s away anything else. This follows how these files already model sibling leaves (`bgp_peer_type`, `bgp_community_type`, `bgp_tx_add_paths_type` are all enumerations).

Constraining the key type makes several hand-written guards unreachable, so they are removed:

- the three `must "not(contains(., 'srpolicy'))"` clauses on the `BGP_GLOBALS_AF` lists
- the `install_backup_path` unicast `must` on `BGP_DEVICE_GLOBAL_AF`, whose key type now admits only the two unicast families

The equivalent `install_backup_path` guard on `BGP_GLOBALS_AF` is **kept** — `l2vpn_evpn` is still a valid key there, so that constraint is still live.

`*_multicast` is deliberately excluded: no consumer implements it. The `BGP_DEVICE_GLOBAL_AF_LIST` description previously advertised `ipv4_multicast` / `ipv6_multicast` / `l2vpn_evpn`, none of which `AFI_SAFI_MAP` supports; that description is corrected.

No CLI code changes. libyang validates a list key against its declared type, so an out-of-enum `afi_safi` is rejected at commit across every entry point, and the enum values become completion candidates.

**Additionally constrained (same class of gap, not `afi_safi`):**

- `sonic-bgp-global.yang` `rr_cluster_id` — renders into `bgp cluster-id`, which takes an IPv4 address or a 32-bit integer. Now a union of `inet:ipv4-address` and `uint32 { range "1..4294967295"; }`.
- `sonic-bgp-device-global.yang` CONFED `peers` — documented as semi-colon-separated sub-ASNs, previously unvalidated. Now `pattern "[1-9][0-9]*(;[1-9][0-9]*)*"`. The pattern enforces the shape only; it does not range-check each sub-ASN against the 32-bit AS maximum, which would need a leaf-list.

The existing `"66000;63000"` sample in the tests and in `doc/Configuration.md` satisfies the new pattern. No existing `rr_cluster_id` values exist anywhere in the repo.

#### How to verify it
Build and see yang model tests succeed.

#### Which release branch to port

- [ ] 202605
- [ ] 202511
- [ ] 202505

#### Tested branch (Please provide the tested image version)

- [x] master as of 20260723

#### Description for the changelog

sonic-yang: constrain BGP afi_safi list keys, rr_cluster_id and confederation peers instead of leaving them unconstrained strings

#### Link to config_db schema for YANG module changes

https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#bgp_globals_af

#### A picture of a cute animal (not mandatory but encouraged)
