### PR TITLE
stp: Fix docker-stp image and build templates for PVST

### DIFF
--- a/dockers/docker-stp/Dockerfile.j2
+++ b/dockers/docker-stp/Dockerfile.j2
@@ -15,8 +15,8 @@ RUN apt-get update      && \
         libdaemon0         \
         libjansson4        \
         libpython3.11      \
-        libjemalloc2        \
-        ebtables
+        libjemalloc2       \
+        nftables
 
 {% if docker_stp_debs.strip() -%}
 # Copy locally-built Debian package dependencies

--- a/dockers/docker-stp/supervisord.conf
+++ b/dockers/docker-stp/supervisord.conf
@@ -8,29 +8,37 @@ command=/usr/bin/start.sh
 priority=1
 autostart=true
 autorestart=false
-stdout_logfile=syslog
-stderr_logfile=syslog
+stdout_logfile=NONE
+stdout_syslog=true
+stderr_logfile=NONE
+stderr_syslog=true
 
 [program:rsyslogd]
 command=/usr/sbin/rsyslogd -n
 priority=2
 autostart=false
 autorestart=false
-stdout_logfile=syslog
-stderr_logfile=syslog
+stdout_logfile=NONE
+stdout_syslog=true
+stderr_logfile=NONE
+stderr_syslog=true
 
 [program:stpd]
 command=/usr/bin/stpd
 priority=3
 autostart=false
 autorestart=false
-stdout_logfile=syslog
-stderr_logfile=syslog
+stdout_logfile=NONE
+stdout_syslog=true
+stderr_logfile=NONE
+stderr_syslog=true
 
 [program:stpmgrd]
 command=/usr/bin/stpmgrd
 priority=3
 autostart=false
 autorestart=false
-stdout_logfile=syslog
-stderr_logfile=syslog
+stdout_logfile=NONE
+stdout_syslog=true
+stderr_logfile=NONE
+stderr_syslog=true

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -91,6 +91,7 @@
 {%- if include_dhcp_server == "y" %}{% do features.append(("dhcp_server", "disabled", false, "enabled")) %}{% endif %}
 {%- if sonic_asic_platform == "vs" %}{% do features.append(("gbsyncd", "enabled", false, "enabled")) %}{% endif %}
 {%- if include_iccpd == "y" %}{% do features.append(("iccpd", "disabled", false, "enabled")) %}{% endif %}
+{%- if include_stp == "y" %}{% do features.append(("stp", "disabled", false, "enabled")) %}{% endif %}
 {%- if include_mgmt_framework == "y" %}{% do features.append(("mgmt-framework", "enabled", true, "enabled")) %}{% endif %}
 {%- if include_mux == "y" %}{% do features.append(("mux", "{% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %}enabled{% else %}always_disabled{% endif %}", false, "enabled")) %}{% endif %}
 {%- if include_nat == "y" %}{% do features.append(("nat", "disabled", false, "enabled")) %}{% endif %}

--- a/files/build_templates/stp.service.j2
+++ b/files/build_templates/stp.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=STP container
-Requires=updategraph.service swss.service
-After=updategraph.service swss.service syncd.service
+Requires=config-setup.service swss.service
+After=config-setup.service swss.service syncd.service
 Before=ntp-config.service
 BindsTo=sonic.target
 After=sonic.target

--- a/files/image_config/copp/copp_cfg.j2
+++ b/files/image_config/copp/copp_cfg.j2
@@ -106,6 +106,10 @@
 		    "trap_ids": "lldp",
 		    "trap_group": "queue4_group3"
 	    },
+	    "stp": {
+		    "trap_ids": "stp,pvrst",
+		    "trap_group": "queue4_group3"
+	    },
 	    "dhcp_relay": {
 		    "trap_ids": "dhcp,dhcpv6",
 		    "trap_group": "queue4_group3"


### PR DESCRIPTION
## Summary
- Update `docker-stp` to use `nftables` instead of `ebtables` (required
  functionality no longer available in ebtables).
- Modernize `supervisord.conf` to the current format.
- Fix STP build/service integration: disable STP on boot via `init_cfg.json.j2`,
  use `config-setup.service` instead of unsupported `updategraph.service` in
  `stp.service.j2`, and add STP CoPP punt rules in `copp_cfg.j2`.

## Motivation
PVST configuration fails when the STP docker image, service startup, and build
templates are out of date. This PR aligns `sonic-buildimage` with the STP/STPMGR
and utilities fixes so PVST can be configured and packets are handled correctly
on the control plane.

## Changes
### docker-stp
- Replace `ebtables` with `nftables` in the image apt install path
- Update `supervisord.conf` to current supervisord format
### Build / config templates
- `init_cfg.json.j2`: disable STP feature on start when the build includes STP
- `stp.service.j2`: depend on `config-setup.service` instead of
  `updategraph.service` (no longer supported)
- `copp_cfg.j2`: add STP entries to punt STP packets to the control plane

## Related PRs
| Repo | PR |
|------|-----|
| sonic-stp | sonic-net/sonic-stp#97 |
| sonic-swss | sonic-net/sonic-swss#4790 |
| sonic-utilities | sonic-net/sonic-utilities#4716 |

## Verification
- Built `sonic-vs` image with this change set
- 3-node PVST topology in GNS3 (`sonic-vs`): PVST config applied, state
    reached STP daemon, protocol converged
- Marvell Prestera switches: same PVST config/convergence validation

## Notes for reviewers
- This PR is the buildimage piece of a multi-repo PVST fix; review together
  with linked PRs above.
- `docker-stp` nftables change is driven by loss of required ebtables support.
