### PR TITLE
[dhcpmon] Classify nested VLAN members as downlinks

### DIFF
--- a/dockers/docker-dhcp-relay/cli-plugin-tests/test_show_dhcpmon_counters.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/test_show_dhcpmon_counters.py
@@ -35,16 +35,29 @@ def test_plugin_registration():
 
 def test_get_vlan_members_from_config_db():
     mock_db = MagicMock()
-    mock_db.keys.return_value = [
-        "VLAN_MEMBER|Vlan1000|Ethernet1",
-        "VLAN_MEMBER|Vlan1000|Ethernet2",
-        "VLAN_MEMBER|Vlan2000|Ethernet3"
-    ]
+    def mock_keys(_, pattern):
+        if pattern.startswith("VLAN_MEMBER"):
+            return [
+                "VLAN_MEMBER|Vlan1000|Ethernet1",
+                "VLAN_MEMBER|Vlan1000|PortChannel1001",
+                "VLAN_MEMBER|Vlan2000|Ethernet3"
+            ]
+        if pattern == "PORTCHANNEL_MEMBER|*":
+            return [
+                "PORTCHANNEL_MEMBER|PortChannel1001|Ethernet2",
+                "PORTCHANNEL_MEMBER|PortChannel1001|Ethernet4",
+                "PORTCHANNEL_MEMBER|PortChannel2001|Ethernet5"
+            ]
+        return []
+
+    mock_db.keys.side_effect = mock_keys
     result = show_dhcp_relay.get_vlan_members_from_config_db(
         mock_db, "Vlan1000"
     )
     assert result == {
-        "Vlan1000": set(["Ethernet1", "Ethernet2"])
+        "Vlan1000": set([
+            "Ethernet1", "PortChannel1001", "Ethernet2", "Ethernet4"
+        ])
     }
 
 

--- a/dockers/docker-dhcp-relay/cli/show/plugins/show_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli/show/plugins/show_dhcp_relay.py
@@ -513,6 +513,8 @@ def get_vlan_members_from_config_db(db, vlan_interface):
     )
     for key in (db.keys(db.CONFIG_DB, pattern) or []):
         splits = key.split(CONFIG_DB_SEPRATOR)
+        if len(splits) < 3:
+            continue
         if not splits[1].endswith(vlan_interface):
             continue
         if splits[1] not in vlan_members:

--- a/dockers/docker-dhcp-relay/cli/show/plugins/show_dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli/show/plugins/show_dhcp_relay.py
@@ -77,6 +77,7 @@ DHCPMON_V6_DISPLAY_TYPES = [
 # --- DB Key Separators ---
 
 VLAN_MEMBER_TABLE_PREFIX = "VLAN_MEMBER"
+PORTCHANNEL_MEMBER_TABLE_PREFIX = "PORTCHANNEL_MEMBER"
 COUNTERS_DB_SEPRATOR = ":"
 CONFIG_DB_SEPRATOR = "|"
 MGMT_PORT_TABLE = "MGMT_PORT"
@@ -496,6 +497,16 @@ def get_vlan_members_from_config_db(db, vlan_interface):
     Returns dict: {vlan_name: set(member_interfaces)}
     """
     vlan_members = {}
+    portchannel_members = {}
+    member_pattern = (
+        PORTCHANNEL_MEMBER_TABLE_PREFIX + CONFIG_DB_SEPRATOR + "*"
+    )
+    for key in (db.keys(db.CONFIG_DB, member_pattern) or []):
+        splits = key.split(CONFIG_DB_SEPRATOR)
+        if len(splits) < 3:
+            continue
+        portchannel_members.setdefault(splits[1], set()).add(splits[2])
+
     pattern = (
         VLAN_MEMBER_TABLE_PREFIX + CONFIG_DB_SEPRATOR
         + vlan_interface + "*"
@@ -506,7 +517,11 @@ def get_vlan_members_from_config_db(db, vlan_interface):
             continue
         if splits[1] not in vlan_members:
             vlan_members[splits[1]] = set()
-        vlan_members[splits[1]].add(splits[2])
+        member = splits[2]
+        vlan_members[splits[1]].add(member)
+        vlan_members[splits[1]].update(
+            portchannel_members.get(member, set())
+        )
     return vlan_members
 
 


### PR DESCRIPTION
#### Why I did it

sonic-dhcpmon PR https://github.com/sonic-net/sonic-dhcpmon/pull/89 adds
counter rows for physical members beneath a PortChannel that belongs to the
downstream VLAN:

`Ethernet312 -> PortChannel1005 -> Vlan1000`

The current `show dhcp_relay ipv4/ipv6 counters` implementation classifies
downlinks from direct `VLAN_MEMBER` entries only. The nested Ethernet members
exist in `PORTCHANNEL_MEMBER`, so the CLI would incorrectly display their new
counter rows as `Uplink`.

##### Work item tracking
- Microsoft ADO **(number only)**: 38615656

#### How I did it

- Read all `PORTCHANNEL_MEMBER` keys once and build a parent-to-children map.
- When a direct VLAN member is a PortChannel, add its physical children to the
  existing VLAN downlink set.
- Preserve the current command, columns, counter keys, and classification of
  direct VLAN members, uplinks, and management interfaces.
- Extend the focused CLI unit test with a VLAN-backed PortChannel and an
  unrelated PortChannel to verify that only the correct children are included.

#### How to verify it

1. Let this PR's Azure CI run the existing docker-dhcp-relay CLI plugin tests.
2. With sonic-dhcpmon PR #89 installed, run:
   - `show dhcp_relay ipv4 counters Vlan1000`
   - `show dhcp_relay ipv6 counters Vlan1000`
3. Confirm direct VLAN members, the VLAN-backed PortChannel, and its physical
   members display as `Downlink`, while unrelated interfaces remain `Uplink`.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

No backport is requested. This repair targets master only.

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type:

#### Tested branch

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

Pending this PR's Azure CI and combined master hardware validation with
sonic-dhcpmon PR #89.

#### Description for the changelog

Classify physical members of a VLAN-backed PortChannel as downlinks in dhcpmon
counter output.

#### Link to config_db schema for YANG module changes

N/A - no YANG or CONFIG_DB schema changes.

#### A picture of a cute animal (not mandatory but encouraged)

N/A.
