### PR TITLE
Fix Vendor SFP Code

### DIFF
--- a/platform/broadcom/sonic-platform-modules-dell/e3224f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/e3224f/sonic_platform/sfp.py
@@ -13,6 +13,7 @@ try:
     import struct
     import mmap
     from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
+    from sonic_platform_base.sonic_xcvr.eeprom_rw import ModuleEepromLowerMemoryInfo
 
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
@@ -115,7 +116,7 @@ class Sfp(SfpOptoeBase):
         Reads optic eeprom byte to determine media type inserted
         """
         eeprom_raw = []
-        eeprom_raw = self._xcvr_api_factory._get_id()
+        eeprom_raw = ModuleEepromLowerMemoryInfo(self.read_eeprom).get_id()
         if eeprom_raw is not None:
             eeprom_raw = hex(eeprom_raw)
             if eeprom_raw in SFP_TYPE_LIST:

--- a/platform/broadcom/sonic-platform-modules-dell/s5212f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5212f/sonic_platform/sfp.py
@@ -14,6 +14,7 @@ try:
     import struct
     import mmap
     from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
+    from sonic_platform_base.sonic_xcvr.eeprom_rw import ModuleEepromLowerMemoryInfo
 
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
@@ -275,7 +276,7 @@ class Sfp(SfpOptoeBase):
         Reads optic eeprom byte to determine media type inserted
         """
         eeprom_raw = []
-        eeprom_raw = self._xcvr_api_factory._get_id() 
+        eeprom_raw = ModuleEepromLowerMemoryInfo(self.read_eeprom).get_id()
         if eeprom_raw is not None:
             eeprom_raw = hex(eeprom_raw)
             if eeprom_raw in SFP_TYPE_LIST:

--- a/platform/broadcom/sonic-platform-modules-dell/s5224f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5224f/sonic_platform/sfp.py
@@ -14,6 +14,7 @@ try:
     import struct
     import mmap
     from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
+    from sonic_platform_base.sonic_xcvr.eeprom_rw import ModuleEepromLowerMemoryInfo
 
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
@@ -275,7 +276,7 @@ class Sfp(SfpOptoeBase):
         Reads optic eeprom byte to determine media type inserted
         """
         eeprom_raw = []
-        eeprom_raw = self._xcvr_api_factory._get_id() 
+        eeprom_raw = ModuleEepromLowerMemoryInfo(self.read_eeprom).get_id()
         if eeprom_raw is not None:
             eeprom_raw = hex(eeprom_raw)
             if eeprom_raw in SFP_TYPE_LIST:

--- a/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5232f/sonic_platform/sfp.py
@@ -14,6 +14,7 @@ try:
     import struct
     import mmap
     from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
+    from sonic_platform_base.sonic_xcvr.eeprom_rw import ModuleEepromLowerMemoryInfo
 
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
@@ -253,7 +254,7 @@ class Sfp(SfpOptoeBase):
         Reads optic eeprom byte to determine media type inserted
         """
         eeprom_raw = []
-        eeprom_raw = self._xcvr_api_factory._get_id() 
+        eeprom_raw = ModuleEepromLowerMemoryInfo(self.read_eeprom).get_id()
         if eeprom_raw is not None:
             eeprom_raw = hex(eeprom_raw)
             if eeprom_raw in SFP_TYPE_LIST:

--- a/platform/broadcom/sonic-platform-modules-dell/s5248f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5248f/sonic_platform/sfp.py
@@ -14,6 +14,7 @@ try:
     import struct
     import mmap
     from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
+    from sonic_platform_base.sonic_xcvr.eeprom_rw import ModuleEepromLowerMemoryInfo
 
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
@@ -253,7 +254,7 @@ class Sfp(SfpOptoeBase):
         Reads optic eeprom byte to determine media type inserted
         """
         eeprom_raw = []
-        eeprom_raw = self._xcvr_api_factory._get_id() 
+        eeprom_raw = ModuleEepromLowerMemoryInfo(self.read_eeprom).get_id()
         if eeprom_raw is not None:
             eeprom_raw = hex(eeprom_raw)
             if eeprom_raw in SFP_TYPE_LIST:

--- a/platform/broadcom/sonic-platform-modules-dell/s5296f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5296f/sonic_platform/sfp.py
@@ -14,6 +14,7 @@ try:
     import struct
     import mmap
     from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
+    from sonic_platform_base.sonic_xcvr.eeprom_rw import ModuleEepromLowerMemoryInfo
 
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
@@ -269,7 +270,7 @@ class Sfp(SfpOptoeBase):
         Reads optic eeprom byte to determine media type inserted
         """
         eeprom_raw = []
-        eeprom_raw = self._xcvr_api_factory._get_id() 
+        eeprom_raw = ModuleEepromLowerMemoryInfo(self.read_eeprom).get_id()
         if eeprom_raw is not None:
             eeprom_raw = hex(eeprom_raw)
             if eeprom_raw in SFP_TYPE_LIST:

--- a/platform/broadcom/sonic-platform-modules-dell/s5448f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/s5448f/sonic_platform/sfp.py
@@ -14,6 +14,7 @@ try:
     import time
     import mmap
     from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
+    from sonic_platform_base.sonic_xcvr.eeprom_rw import ModuleEepromLowerMemoryInfo
 
 except ImportError as err:
     raise ImportError(str(err) + "- required module not found")
@@ -275,7 +276,7 @@ class Sfp(SfpOptoeBase):
         Reads optic eeprom byte to determine media type inserted
         """
         eeprom_raw = []
-        eeprom_raw = self._xcvr_api_factory._get_id()
+        eeprom_raw = ModuleEepromLowerMemoryInfo(self.read_eeprom).get_id()
         if eeprom_raw is not None:
             eeprom_raw = hex(eeprom_raw)
             if eeprom_raw in SFP_TYPE_LIST:

--- a/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9264f/sonic_platform/sfp.py
@@ -14,6 +14,7 @@ try:
     import struct
     import mmap
     from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
+    from sonic_platform_base.sonic_xcvr.eeprom_rw import ModuleEepromLowerMemoryInfo
 
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
@@ -255,7 +256,7 @@ class Sfp(SfpOptoeBase):
         Reads optic eeprom byte to determine media type inserted
         """
         eeprom_raw = []
-        eeprom_raw = self._xcvr_api_factory._get_id()
+        eeprom_raw = ModuleEepromLowerMemoryInfo(self.read_eeprom).get_id()
         if eeprom_raw is not None:
             eeprom_raw = hex(eeprom_raw)
             if eeprom_raw in SFP_TYPE_LIST:

--- a/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9332f/sonic_platform/sfp.py
@@ -14,6 +14,7 @@ try:
     import time
     import mmap
     from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
+    from sonic_platform_base.sonic_xcvr.eeprom_rw import ModuleEepromLowerMemoryInfo
 
 except ImportError as err:
     raise ImportError(str(err) + "- required module not found")
@@ -307,7 +308,7 @@ class Sfp(SfpOptoeBase):
         Reads optic eeprom byte to determine media type inserted
         """
         eeprom_raw = []
-        eeprom_raw = self._xcvr_api_factory._get_id()
+        eeprom_raw = ModuleEepromLowerMemoryInfo(self.read_eeprom).get_id()
         if eeprom_raw is not None:
             eeprom_raw = hex(eeprom_raw)
             if eeprom_raw in SFP_TYPE_LIST:

--- a/platform/broadcom/sonic-platform-modules-dell/z9432f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9432f/sonic_platform/sfp.py
@@ -14,6 +14,7 @@ try:
     import time
     import mmap
     from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
+    from sonic_platform_base.sonic_xcvr.eeprom_rw import ModuleEepromLowerMemoryInfo
 
 except ImportError as err:
     raise ImportError(str(err) + "- required module not found")
@@ -275,7 +276,7 @@ class Sfp(SfpOptoeBase):
         Reads optic eeprom byte to determine media type inserted
         """
         eeprom_raw = []
-        eeprom_raw = self._xcvr_api_factory._get_id()
+        eeprom_raw = ModuleEepromLowerMemoryInfo(self.read_eeprom).get_id()
         if eeprom_raw is not None:
             eeprom_raw = hex(eeprom_raw)
             if eeprom_raw in SFP_TYPE_LIST:

--- a/platform/broadcom/sonic-platform-modules-dell/z9664f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9664f/sonic_platform/sfp.py
@@ -14,6 +14,7 @@ try:
     import time
     import mmap
     from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
+    from sonic_platform_base.sonic_xcvr.eeprom_rw import ModuleEepromLowerMemoryInfo
     from sonic_platform.hwaccess import get_fpga_buspath
 
 except ImportError as err:
@@ -272,7 +273,7 @@ class Sfp(SfpOptoeBase):
         Reads optic eeprom byte to determine media type inserted
         """
         eeprom_raw = []
-        eeprom_raw = self._xcvr_api_factory._get_id()
+        eeprom_raw = ModuleEepromLowerMemoryInfo(self.read_eeprom).get_id()
         if eeprom_raw is not None:
             eeprom_raw = hex(eeprom_raw)
             if eeprom_raw in SFP_TYPE_LIST:

--- a/platform/broadcom/sonic-platform-modules-dell/z9864f/sonic_platform/sfp.py
+++ b/platform/broadcom/sonic-platform-modules-dell/z9864f/sonic_platform/sfp.py
@@ -16,6 +16,7 @@ try:
     import time
     import mmap
     from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
+    from sonic_platform_base.sonic_xcvr.eeprom_rw import ModuleEepromLowerMemoryInfo
     from sonic_platform.hwaccess import get_fpga_buspath
 
 except ImportError as err:
@@ -368,7 +369,7 @@ class Sfp(SfpOptoeBase):
         Reads optic eeprom byte to determine media type inserted
         """
         eeprom_raw = []
-        eeprom_raw = self._xcvr_api_factory._get_id()
+        eeprom_raw = ModuleEepromLowerMemoryInfo(self.read_eeprom).get_id()
         if eeprom_raw is not None:
             eeprom_raw = hex(eeprom_raw)
             if eeprom_raw in SFP_TYPE_LIST:

--- a/platform/marvell-teralynx/sonic-platform-modules-supermicro/sse-t7132s/sonic_platform/sfp.py
+++ b/platform/marvell-teralynx/sonic-platform-modules-supermicro/sse-t7132s/sonic_platform/sfp.py
@@ -13,6 +13,7 @@ try:
     import os
     import time
     from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
+    from sonic_platform_base.sonic_xcvr.eeprom_rw import ModuleEepromLowerMemoryInfo
 
 except ImportError as err:
     raise ImportError(str(err) + "- required module not found")
@@ -324,7 +325,7 @@ class Sfp(SfpOptoeBase):
         Reads optic eeprom byte to determine media type inserted
         """
         eeprom_raw = []
-        eeprom_raw = self._xcvr_api_factory._get_id()
+        eeprom_raw = ModuleEepromLowerMemoryInfo(self.read_eeprom).get_id()
         if eeprom_raw is not None:
             eeprom_raw = hex(eeprom_raw)
             if eeprom_raw in SFP_TYPE_LIST:

--- a/platform/marvell-teralynx/sonic-platform-modules-wistron/6512-32r/sonic_platform/sfp.py
+++ b/platform/marvell-teralynx/sonic-platform-modules-wistron/6512-32r/sonic_platform/sfp.py
@@ -6,6 +6,7 @@
 #############################################################################
 try:
     from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
+    from sonic_platform_base.sonic_xcvr.eeprom_rw import ModuleEepromLowerMemoryInfo
     from sonic_py_common.logger import Logger
     import sys
     import time
@@ -118,7 +119,7 @@ class Sfp(SfpOptoeBase):
 
     def _detect_sfp_type(self, sfp_type):
         eeprom_raw = []
-        eeprom_raw = self._xcvr_api_factory._get_id()
+        eeprom_raw = ModuleEepromLowerMemoryInfo(self.read_eeprom).get_id()
         if eeprom_raw is not None:
             eeprom_raw = hex(eeprom_raw)
             if eeprom_raw in QSFP_TYPE_CODE_LIST:

--- a/platform/marvell-teralynx/sonic-platform-modules-wistron/sw-to3200k/sonic_platform/sfp.py
+++ b/platform/marvell-teralynx/sonic-platform-modules-wistron/sw-to3200k/sonic_platform/sfp.py
@@ -6,6 +6,7 @@
 #############################################################################
 try:
     from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
+    from sonic_platform_base.sonic_xcvr.eeprom_rw import ModuleEepromLowerMemoryInfo
     from sonic_py_common.logger import Logger
     import sys
     import time
@@ -111,7 +112,7 @@ class Sfp(SfpOptoeBase):
 
     def _detect_sfp_type(self, sfp_type):
         eeprom_raw = []
-        eeprom_raw = self._xcvr_api_factory._get_id()
+        eeprom_raw = ModuleEepromLowerMemoryInfo(self.read_eeprom).get_id()
         if eeprom_raw is not None:
             eeprom_raw = hex(eeprom_raw)
             if eeprom_raw in QSFP_TYPE_CODE_LIST:

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_sfp.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_sfp.py
@@ -6,6 +6,7 @@
 
 try:
     from sonic_platform_base.sonic_xcvr.sfp_optoe_base import SfpOptoeBase
+    from sonic_platform_base.sonic_xcvr.eeprom_rw import ModuleEepromLowerMemoryInfo
     import time
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
@@ -213,7 +214,7 @@ class PddfSfp(SfpOptoeBase):
 
         lpmode = None
 
-        xcvr_id = self._xcvr_api_factory._get_id()
+        xcvr_id = ModuleEepromLowerMemoryInfo(self.read_eeprom).get_id()
         if xcvr_id is not None:
             if xcvr_id == 0x18 or xcvr_id == 0x19 or xcvr_id == 0x1e:
                 # QSFP-DD or OSFP (CMIS)
@@ -360,7 +361,7 @@ class PddfSfp(SfpOptoeBase):
 
         status = False
 
-        xcvr_id = self._xcvr_api_factory._get_id()
+        xcvr_id = ModuleEepromLowerMemoryInfo(self.read_eeprom).get_id()
         if xcvr_id is not None:
             if xcvr_id == 0x18 or xcvr_id == 0x19 or xcvr_id == 0x1e:
                 # QSFP-DD or OSFP (CMIS)


### PR DESCRIPTION
#### Why I did it

https://github.com/sonic-net/sonic-platform-common/pull/699/ recently refactored `XcvrApiFactory` to no longer define some private methods on the class itself, but instead use a helper class called `ModuleEepromLowerMemoryInfo`.

Some vendor Sfp subclasses were directly calling these private methods on `XcvrApiFactory` and are now broken after the above refactor. Vendor code should probably not be calling private methods like this that are subject to change. This PR fixes those to use the new helper module instead.

##### Work item tracking
N/A

#### How I did it
Changed all callsites to use the `ModuleEepromLowerMemoryInfo` helper class.

#### How to verify it

Relying on CI.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
Fix Vendor SFP Code

#### Link to config_db schema for YANG module changes
N/A

#### A picture of a cute animal (not mandatory but encouraged)
