### PR TITLE
Add route-map option to bgp-aggregate-address.yang model

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1845,7 +1845,8 @@
                 "bbr-required": "true",
                 "summary-only": "false",
                 "aggregate-address-prefix-list": "AGG_ROUTES_V4",
-                "contributing-address-prefix-list": "AGG_CONTRIBUTING_ROUTES_V4"
+                "contributing-address-prefix-list": "AGG_CONTRIBUTING_ROUTES_V4",
+                "route-map": "AGG_ROUTE_MAP_V4"
             },
             "fc00::/63": {
                 "bbr-required": "true",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_aggregate_address.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_aggregate_address.json
@@ -1,0 +1,17 @@
+{
+    "BGP_AGGREGATE_ADDRESS_WITH_ROUTE_MAP": {
+        "desc": "Load BGP aggregate address table with a route-map leaf.",
+        "verify": {
+            "xpath": "/sonic-bgp-aggregate-address:sonic-bgp-aggregate-address/BGP_AGGREGATE_ADDRESS/BGP_AGGREGATE_ADDRESS_LIST[aggregate-address='192.168.0.0/24']/route-map",
+            "key": "sonic-bgp-aggregate-address:route-map",
+            "value": "AGG_ROUTE_MAP_V4"
+        }
+    },
+    "BGP_AGGREGATE_ADDRESS_WITHOUT_ROUTE_MAP": {
+        "desc": "Load BGP aggregate address table without a route-map leaf."
+    },
+    "BGP_AGGREGATE_ADDRESS_WITH_INVALID_ROUTE_MAP": {
+        "desc": "Load BGP aggregate address table with an invalid route-map value.",
+        "eStrKey": "Pattern"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_aggregate_address.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp_aggregate_address.json
@@ -1,6 +1,7 @@
 {
     "BGP_AGGREGATE_ADDRESS_WITH_ROUTE_MAP": {
         "desc": "Load BGP aggregate address table with a route-map leaf.",
+        "eStrKey": "Verify",
         "verify": {
             "xpath": "/sonic-bgp-aggregate-address:sonic-bgp-aggregate-address/BGP_AGGREGATE_ADDRESS/BGP_AGGREGATE_ADDRESS_LIST[aggregate-address='192.168.0.0/24']/route-map",
             "key": "sonic-bgp-aggregate-address:route-map",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_aggregate_address.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp_aggregate_address.json
@@ -1,0 +1,45 @@
+{
+    "BGP_AGGREGATE_ADDRESS_WITH_ROUTE_MAP": {
+        "sonic-bgp-aggregate-address:sonic-bgp-aggregate-address": {
+            "sonic-bgp-aggregate-address:BGP_AGGREGATE_ADDRESS": {
+                "BGP_AGGREGATE_ADDRESS_LIST": [
+                    {
+                        "aggregate-address": "192.168.0.0/24",
+                        "bbr-required": true,
+                        "summary-only": false,
+                        "as-set": false,
+                        "aggregate-address-prefix-list": "AGG_ROUTES_V4",
+                        "contributing-address-prefix-list": "AGG_CONTRIBUTING_ROUTES_V4",
+                        "route-map": "AGG_ROUTE_MAP_V4"
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_AGGREGATE_ADDRESS_WITHOUT_ROUTE_MAP": {
+        "sonic-bgp-aggregate-address:sonic-bgp-aggregate-address": {
+            "sonic-bgp-aggregate-address:BGP_AGGREGATE_ADDRESS": {
+                "BGP_AGGREGATE_ADDRESS_LIST": [
+                    {
+                        "aggregate-address": "fc00::/63",
+                        "bbr-required": true,
+                        "summary-only": true,
+                        "as-set": true
+                    }
+                ]
+            }
+        }
+    },
+    "BGP_AGGREGATE_ADDRESS_WITH_INVALID_ROUTE_MAP": {
+        "sonic-bgp-aggregate-address:sonic-bgp-aggregate-address": {
+            "sonic-bgp-aggregate-address:BGP_AGGREGATE_ADDRESS": {
+                "BGP_AGGREGATE_ADDRESS_LIST": [
+                    {
+                        "aggregate-address": "192.168.0.0/24",
+                        "route-map": "invalid route map"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-bgp-aggregate-address.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-aggregate-address.yang
@@ -75,6 +75,15 @@ module sonic-bgp-aggregate-address {
                     default "";
                     description "Prefix list used to filter which contributing routes are considered for the aggregate.";
                 }
+
+                leaf route-map {
+                    type string {
+						pattern "[0-9a-zA-Z_-]*";
+                        length 0..128;
+					}
+                    default "";
+                    description "Route map attached to the aggregate address";
+                }
             }
         }
     }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To attach a route-map to the BGP aggregate address configured

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Enhance bgp aggregate address yang model to include config option for route-map

#### How to verify it
Basic unit tests

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
