### PR TITLE
[test-only][DO NOT MERGE] Pin sonic-sairedis to MPLS VPP branch to build a test image

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,8 @@
 	url = https://github.com/sonic-net/sonic-linux-kernel
 [submodule "sonic-sairedis"]
 	path = src/sonic-sairedis
-	url = https://github.com/sonic-net/sonic-sairedis
+	url = https://github.com/augusdn/sonic-sairedis
+	branch = augusdn/vpp-mpls-inseg-25782
 [submodule "sonic-swss"]
 	path = src/sonic-swss
 	url = https://github.com/sonic-net/sonic-swss


### PR DESCRIPTION
#### Why I did it

**Test-only PR — please do not merge.** I'm using it purely to get a CI-built `sonic-vpp`
image that contains an unmerged `sonic-sairedis` change, so I can validate the matching
sonic-mgmt test changes before raising the real PRs.

The work adds MPLS data-plane support to the VPP SAI backend so `tests/mpls/test_mpls.py`
can run on the `t1-lag-vpp` testbed — sonic-net/sonic-buildimage#25782.

I'll close this PR once the image is built and the tests have run.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Pinned `src/sonic-sairedis` to my working branch, following the same approach as
sonic-net/sonic-buildimage#27555:

- `.gitmodules`: point the `sonic-sairedis` submodule at
  `https://github.com/augusdn/sonic-sairedis`, branch `augusdn/vpp-mpls-inseg-25782`
- bump the `src/sonic-sairedis` gitlink to `2e436c29`

That branch is one commit on top of the sairedis master commit this repo already pins
(`24c799da`), so the only delta is the MPLS backend itself.

#### How to verify it

`BuildVS vpp` produces the image, and `Test impacted-area-kvmtest-t1-lag-vpp by
Elastictest` exercises it. The MPLS tests themselves already pass locally on a
`vms-kvm-vpp-t1-lag` KVM testbed with this code (3 passed, 1 skipped — the skipped one
is MPLS push, which orchagent never installs into ASIC_DB).

#### Which release branch to backport (provide reason below if selected)

<!-- Test-only PR, no backport. -->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Description for the changelog

Test-only, not for merge.
