### PR TITLE
[FPM]: Encode missing nexthop information for SRv6 route programming

### DIFF
--- a/src/sonic-frr/dplane_fpm_sonic/dplane_fpm_sonic.c
+++ b/src/sonic-frr/dplane_fpm_sonic/dplane_fpm_sonic.c
@@ -1530,6 +1530,47 @@ static ssize_t netlink_vpn_route_msg_encode(int cmd,
 	return NLMSG_ALIGN(req->n.nlmsg_len);
 }
 
+static bool netlink_route_add_gateway_info(struct nlmsghdr *nlmsg,
+					   size_t req_size,
+					   uint8_t route_family,
+					   const struct nexthop *nexthop)
+{
+	const void *gateway;
+	uint8_t via[sizeof(uint16_t) + IPV6_MAX_BYTELEN];
+	uint16_t gateway_family;
+	uint16_t via_family;
+	size_t gateway_len;
+
+	switch (nexthop->type) {
+	case NEXTHOP_TYPE_IPV4:
+	case NEXTHOP_TYPE_IPV4_IFINDEX:
+		gateway = &nexthop->gate.ipv4;
+		gateway_family = AF_INET;
+		gateway_len = IPV4_MAX_BYTELEN;
+		break;
+	case NEXTHOP_TYPE_IPV6:
+	case NEXTHOP_TYPE_IPV6_IFINDEX:
+		gateway = &nexthop->gate.ipv6;
+		gateway_family = AF_INET6;
+		gateway_len = IPV6_MAX_BYTELEN;
+		break;
+	case NEXTHOP_TYPE_IFINDEX:
+	default:
+		return true;
+	}
+
+	if (route_family == gateway_family)
+		return nl_attr_put(nlmsg, req_size, RTA_GATEWAY, gateway,
+				   gateway_len);
+
+	via_family = gateway_family;
+	memcpy(via, &via_family, sizeof(via_family));
+	memcpy(via + sizeof(via_family), gateway, gateway_len);
+
+	return nl_attr_put(nlmsg, req_size, RTA_VIA, via,
+			   sizeof(via_family) + gateway_len);
+}
+
 static bool netlink_srv6_vpn_route_msg_encode_multipath(int cmd, struct zebra_dplane_ctx *ctx,
 							uint8_t *data, size_t datalen,
 							const struct nexthop *nexthop,
@@ -1541,12 +1582,20 @@ static bool netlink_srv6_vpn_route_msg_encode_multipath(int cmd, struct zebra_dp
 	struct interface *ifp;
 	struct in6_addr encap_src_addr = {};
 	struct connected *connected;
+	const struct prefix *p;
 	struct vrf *vrf;
 	struct prefix *cp;
+
+	p = dplane_ctx_get_dest(ctx);
 
 	rtnh = nl_attr_rtnh(nlmsg, req_size);
 	if (rtnh == NULL)
 		return false;
+
+	if (!netlink_route_add_gateway_info(nlmsg, req_size, p->family,
+					    nexthop))
+		return false;
+	rtnh->rtnh_ifindex = nexthop->ifindex;
 
 	if (!nl_attr_put16(nlmsg, req_size, RTA_ENCAP_TYPE, FPM_ROUTE_ENCAP_SRV6))
 		return false;
@@ -1618,6 +1667,7 @@ static ssize_t netlink_srv6_vpn_route_msg_encode(int cmd,
 	struct vrf *vrf;
 	struct prefix *cp;
 	unsigned int nexthop_num;
+	bool use_parent_nexthops;
 
 	struct {
 		struct nlmsghdr n;
@@ -1689,13 +1739,20 @@ static ssize_t netlink_srv6_vpn_route_msg_encode(int cmd,
 			nl_msg_type_to_str(cmd), p, dplane_ctx_get_vrf(ctx),
 			table_id);
 
+	use_parent_nexthops =
+		(cmd == RTM_DELROUTE ? dplane_ctx_get_old_type(ctx)
+				     : dplane_ctx_get_type(ctx)) == ZEBRA_ROUTE_BGP;
+
 	/*
 	 * Counts the number of nexthops to determine if the route is singlepath
 	 * (single nexthop) or multipath (multiple nexthops)
 	 */
 	nexthop_num = 0;
 	for (ALL_NEXTHOPS_PTR(dplane_ctx_get_ng(ctx), nexthop)) {
-		if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
+		if (use_parent_nexthops) {
+			if (nexthop->rparent)
+				continue;
+		} else if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
 			continue;
 		if (!NEXTHOP_IS_ACTIVE(nexthop->flags))
 			continue;
@@ -1713,11 +1770,17 @@ static ssize_t netlink_srv6_vpn_route_msg_encode(int cmd,
 
 		nexthop_num = 0;
 		for (ALL_NEXTHOPS_PTR(dplane_ctx_get_ng(ctx), nexthop)) {
-			if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
+			if (use_parent_nexthops) {
+				if (nexthop->rparent)
+					continue;
+			} else if (CHECK_FLAG(nexthop->flags,
+					      NEXTHOP_FLAG_RECURSIVE))
 				continue;
 
 			/* Skip non-SRv6 nexthops */
-			if (!nexthop->nh_srv6 || sid_zero(nexthop->nh_srv6->seg6_segs))
+			if (!nexthop->nh_srv6 ||
+			    !nexthop->nh_srv6->seg6_segs ||
+			    sid_zero(nexthop->nh_srv6->seg6_segs))
 				continue;
 
 			if (NEXTHOP_IS_ACTIVE(nexthop->flags)) {
@@ -1744,11 +1807,16 @@ static ssize_t netlink_srv6_vpn_route_msg_encode(int cmd,
 	/* Singlepath case */
 	nexthop_num = 0;
 	for (ALL_NEXTHOPS_PTR(dplane_ctx_get_ng(ctx), nexthop)) {
-		if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
+		if (use_parent_nexthops) {
+			if (nexthop->rparent)
+				continue;
+		} else if (CHECK_FLAG(nexthop->flags, NEXTHOP_FLAG_RECURSIVE))
 			continue;
 		if (!NEXTHOP_IS_ACTIVE(nexthop->flags))
 			continue;
-		if (!nexthop->nh_srv6 || sid_zero(nexthop->nh_srv6->seg6_segs))
+		if (!nexthop->nh_srv6 ||
+		    !nexthop->nh_srv6->seg6_segs ||
+		    sid_zero(nexthop->nh_srv6->seg6_segs))
 			continue;
 
 		nexthop_num++;
@@ -1761,6 +1829,13 @@ static ssize_t netlink_srv6_vpn_route_msg_encode(int cmd,
 
 		return NLMSG_ALIGN(req->n.nlmsg_len);
 	}
+
+	if (!netlink_route_add_gateway_info(&req->n, datalen, p->family,
+					    nexthop))
+		return false;
+	if (nexthop->ifindex &&
+	    !nl_attr_put32(&req->n, datalen, RTA_OIF, nexthop->ifindex))
+		return false;
 
 	if (!nl_attr_put16(&req->n, datalen, RTA_ENCAP_TYPE,
 				FPM_ROUTE_ENCAP_SRV6))


### PR DESCRIPTION
#### Why I did it

SRv6 route programming in SONiC needs the nexthop information in the FPM netlink message.
Without this information, fpmsyncd does not have enough context to correctly program SRv6 route nexthops.

#### How I did it

Added nexthop encoding for SRv6 route nexthops in the FPM netlink message.

The corresponding fpmsyncd changes to parse this nexthop information and program the SONiC databases are included in this PR: https://github.com/sonic-net/sonic-swss/pull/4026

#### How to verify it

Configure SRv6 routes and confirm fpmsyncd receives route messages containing the SID and the nexthop information.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Description for the changelog

Encode nexthop information for SRv6 FPM route messages.