### PR TITLE
[sonic-yang-models] Update VNET_ROUTE_TUNNEL to support IPv6 route prefix

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -2912,8 +2912,8 @@ monitoring sessions for the vnet routes and is optional.
 
 ### VNET_ROUTE
 
-VNET_ROUTE table has vnet_name|prefix as the object key, where vnet_name is the name of the VNet and prefix is the ip4 prefix associated with the vnet route. The table includes the following attributes:
-- NEXTHOP: Comma-separated nexthop IPs (mandatory). They are used to identify the nexthops of the vnet route.
+VNET_ROUTE table has vnet_name|prefix as the object key, where vnet_name is the name of the VNet and prefix is the IPv4 or IPv6 prefix associated with the vnet route. The table includes the following attributes:
+- NEXTHOP: Comma-separated nexthop IPs (mandatory). IPv4 and IPv6 addresses are supported. They are used to identify the nexthops of the vnet route.
 - IFNAME: The interface names (mandatory), such as "Ethernet1". It identifies the outgoing interfaces for the vnet route.
 
 ```
@@ -2926,6 +2926,10 @@ VNET_ROUTE table has vnet_name|prefix as the object key, where vnet_name is the 
     "Vnet_3000|100.100.4.0/24": {
         "nexthop": "100.100.4.1",
         "ifname": "Ethernet2"
+    },
+    "Vnet_4000|fc00::/64": {
+        "nexthop": "2001:db8::1,2001:db8::2",
+        "ifname": "Ethernet3,Ethernet4"
     }
   }
 }
@@ -2933,8 +2937,8 @@ VNET_ROUTE table has vnet_name|prefix as the object key, where vnet_name is the 
 
 ### VNET_ROUTE_TUNNEL
 
-VNET_ROUTE_TUNNEL table has vnet_name|prefix as the object key, where vnet_name is the name of the VNet and prefix is the ip4 prefix associated with the route tunnel. The table includes the following attributes:
-- ENDPOINT: Comma-separated endpoint/nexthop tunnel IPs (mandatory). They are used to identify the endpoints of the tunnel.
+VNET_ROUTE_TUNNEL table has vnet_name|prefix as the object key, where vnet_name is the name of the VNet and prefix is the IPv4 or IPv6 prefix associated with the route tunnel. The table includes the following attributes:
+- ENDPOINT: Comma-separated endpoint/nexthop tunnel IPs (mandatory). IPv4 and IPv6 addresses are supported. They are used to identify the endpoints of the tunnel.
 - MAC_ADDRESS: Comma-separated inner destination MAC addresses in the encapsulated packet (optional).  They should be 12-hexadecimal digit values.
 - VNI: Comma-separated VNI values in the encapsulated packet (optional). They should be numeric values.
 - CONSISTENT_HASHING_BUCKETS: Number of consistent hashing buckets to use, if consistent hashing is desired (optional). It should be a numeric value.
@@ -2942,7 +2946,7 @@ VNET_ROUTE_TUNNEL table has vnet_name|prefix as the object key, where vnet_name 
 ```
 {
   "VNET_ROUTE_TUNNEL": {
-        "Vnet_1000|100.200.1.1/32": {
+    "Vnet_1000|100.200.1.1/32": {
         "endpoint": "192.174.1.1,192.174.1.2",
         "mac_address": "f8:25:84:98:22:a1,f8:25:84:98:22:a2",
         "vni": "10010,10011",
@@ -2956,6 +2960,11 @@ VNET_ROUTE_TUNNEL table has vnet_name|prefix as the object key, where vnet_name 
         "endpoint": "192.168.1.2",
         "mac_address": "f8:22:83:99:22:a2",
         "vni": "10012"
+    },
+    "Vnetv6_v6-0|fc00::/64": {
+        "endpoint": "2001:db8::1,2001:db8::2",
+        "mac_address": "f8:22:83:99:22:a3,f8:22:83:99:22:a4",
+        "vni": "10013,10014"
     }
   }
 }

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2518,6 +2518,10 @@
             "vnet1|100.100.4.0/24": {
                 "nexthop": "100.100.4.1,100.100.4.2",
                 "ifname": "Ethernet1,Ethernet2"
+            },
+            "vnet1|fc00::/64": {
+                "nexthop": "2001:db8::1",
+                "ifname": "Ethernet3"
             }
         },
         "VNET_ROUTE_TUNNEL" : {
@@ -2527,6 +2531,11 @@
                 "vni": "10011,10012",
                 "consistent_hashing_buckets": "10",
                 "metric": "0"
+            },
+            "vnet1|fc00:1::/64" : {
+                "endpoint": "2001:db8::1",
+                "mac_address": "f9:22:83:99:22:a3",
+                "vni": "10013"
             }
         },
         "PORT_QOS_MAP": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vnet.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vnet.json
@@ -37,7 +37,8 @@
     },
     "VNET_ROUTE_TEST_INVALID_NEXTHOP": {
         "desc": "VNET route configuration with invalid nexthop IP value (256.256.256.256) in VNET_ROUTE_LIST table.",
-        "eStrKey": "Pattern"
+        "eStrKey": "InvalidValue",
+        "eStr": ["nexthop"]
     },
     "VNET_ROUTE_TEST_INVALID_NAME_FORMAT": {
         "desc": "VNET route configuration with invalid name format (missing prefix) in VNET_ROUTE_LIST table.",
@@ -45,7 +46,8 @@
     },
     "VNET_ROUTE_TEST_INVALID_PREFIX": {
         "desc": "VNET route configuration with invalid prefix format (300.100.4.0/24) in name field.",
-        "eStrKey": "Pattern"
+        "eStrKey": "InvalidValue",
+        "eStr": ["prefix"]
     },
     "VNET_ROUTE_TEST_MISSING_NEXTHOP": {
         "desc": "VNET route configuration with missing mandatory attribute (nexthop) in VNET_ROUTE_LIST table.",
@@ -64,7 +66,8 @@
     },
     "VNET_ROUTE_TEST_INVALID_MULTI_NEXTHOP": {
         "desc": "VNET route configuration with invalid IP in comma-separated nexthop list.",
-        "eStrKey": "Pattern"
+        "eStrKey": "InvalidValue",
+        "eStr": ["nexthop"]
     },
 
     "VNET_ROUTE_TUNNEL_MIN_TEST": {
@@ -86,7 +89,8 @@
 
     "VNET_ROUTE_TUNNEL_TEST_INVALID_ENDPOINT": {
         "desc": "VNET route tunnel configuration with invalid endpoint IP value (256.256.256.256) in VNET_ROUTE_TUNNEL_LIST table.",
-        "eStrKey": "Pattern"
+        "eStrKey": "InvalidValue",
+        "eStr": ["endpoint"]
     },
 
     "VNET_ROUTE_TUNNEL_TEST_INVALID_MAC": {
@@ -154,7 +158,8 @@
 
     "VNET_ROUTE_TUNNEL_TEST_INVALID_MULTI_ENDPOINT": {
         "desc": "VNET route tunnel configuration with invalid IP in comma-separated endpoint list.",
-        "eStrKey": "Pattern"
+        "eStrKey": "InvalidValue",
+        "eStr": ["endpoint"]
     },
 
     "VNET_ROUTE_TUNNEL_TEST_INVALID_MULTI_MAC": {
@@ -186,5 +191,41 @@
     "VNET_ROUTE_TUNNEL_TEST_INVALID_CONSISTENT_HASHING": {
         "desc": "VNET route tunnel configuration with invalid consistent_hashing_buckets value (exceeds uint16 max).",
         "eStr": "does not satisfy the constraint"
+    },
+
+    "VNET_ROUTE_V6_PREFIX_TEST": {
+        "desc": "Valid VNET route configuration with IPv6 prefix and IPv4 nexthop in VNET_ROUTE_LIST table."
+    },
+
+    "VNET_ROUTE_V6_NEXTHOP_TEST": {
+        "desc": "Valid VNET route configuration with IPv6 prefix and IPv6 nexthop in VNET_ROUTE_LIST table."
+    },
+
+    "VNET_ROUTE_V6_MULTI_NEXTHOP_TEST": {
+        "desc": "Valid VNET route configuration with IPv6 prefix and multiple comma-separated IPv6 nexthops in VNET_ROUTE_LIST table."
+    },
+
+    "VNET_ROUTE_V6_INVALID_NEXTHOP_TEST": {
+        "desc": "VNET route configuration with invalid IPv6 nexthop value in VNET_ROUTE_LIST table.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["nexthop"]
+    },
+
+    "VNET_ROUTE_TUNNEL_V6_PREFIX_TEST": {
+        "desc": "Valid VNET route tunnel configuration with IPv6 prefix and IPv4 endpoint in VNET_ROUTE_TUNNEL_LIST table."
+    },
+
+    "VNET_ROUTE_TUNNEL_V6_ENDPOINT_TEST": {
+        "desc": "Valid VNET route tunnel configuration with IPv6 prefix and IPv6 endpoint in VNET_ROUTE_TUNNEL_LIST table."
+    },
+
+    "VNET_ROUTE_TUNNEL_V6_MULTI_ENDPOINT_TEST": {
+        "desc": "Valid VNET route tunnel configuration with IPv6 prefix and multiple comma-separated IPv6 endpoints in VNET_ROUTE_TUNNEL_LIST table."
+    },
+
+    "VNET_ROUTE_TUNNEL_V6_INVALID_ENDPOINT_TEST": {
+        "desc": "VNET route tunnel configuration with invalid IPv6 endpoint value in VNET_ROUTE_TUNNEL_LIST table.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["endpoint"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/vnet.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/vnet.json
@@ -106,7 +106,24 @@
 
     "VNET_ROUTE_TUNNEL_TEST_INVALID_PREFIX": {
         "desc": "VNET route tunnel configuration with invalid prefix format (300.168.1.0/24) in name field.",
-        "eStrKey": "Pattern"
+        "eStrKey": "InvalidValue",
+        "eStr": ["prefix"]
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_INVALID_PREFIX_LEN": {
+        "desc": "VNET route tunnel configuration with invalid IPv4 prefix length (10.0.0.0/33) in VNET_ROUTE_TUNNEL_LIST table.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["prefix"]
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_IPV6_PREFIX": {
+        "desc": "VNET route tunnel configuration with IPv6 prefix in VNET_ROUTE_TUNNEL_LIST table."
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_INVALID_IPV6_PREFIX": {
+        "desc": "VNET route tunnel configuration with invalid IPv6 prefix format in VNET_ROUTE_TUNNEL_LIST table.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["prefix"]
     },
 
     "VNET_ROUTE_TUNNEL_TEST_MISSING_ENDPOINT": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vnet.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vnet.json
@@ -1541,5 +1541,289 @@
                 ]
             }
         }
+    },
+
+    "VNET_ROUTE_V6_PREFIX_TEST": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE": {
+                "VNET_ROUTE_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix": "fc00::/64",
+                        "nexthop": "100.100.1.1",
+                        "ifname": "Ethernet0"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_V6_NEXTHOP_TEST": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE": {
+                "VNET_ROUTE_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix": "fc00::/64",
+                        "nexthop": "2001:db8::1",
+                        "ifname": "Ethernet0"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_V6_MULTI_NEXTHOP_TEST": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE": {
+                "VNET_ROUTE_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix": "fc00::/64",
+                        "nexthop": "2001:db8::1,2001:db8::2,2001:db8::3",
+                        "ifname": "Ethernet1,Ethernet2,Ethernet3"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_V6_INVALID_NEXTHOP_TEST": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE": {
+                "VNET_ROUTE_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix": "fc00::/64",
+                        "nexthop": "zzzz::invalid",
+                        "ifname": "Ethernet0"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_V6_PREFIX_TEST": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix": "fc00::/64",
+                        "endpoint": "192.168.1.1"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_V6_ENDPOINT_TEST": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix": "fc00::/64",
+                        "endpoint": "2001:db8::1"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_V6_MULTI_ENDPOINT_TEST": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix": "fc00::/64",
+                        "endpoint": "2001:db8::1,2001:db8::2,2001:db8::3"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_V6_INVALID_ENDPOINT_TEST": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix": "fc00::/64",
+                        "endpoint": "zzzz::invalid"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/vnet.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/vnet.json
@@ -1400,6 +1400,113 @@
         }
     },
 
+    "VNET_ROUTE_TUNNEL_TEST_INVALID_PREFIX_LEN": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1",
+                        "prefix": "10.0.0.0/33",
+                        "endpoint": "192.168.1.1"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_IPV6_PREFIX": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1000",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1000",
+                        "prefix": "2001:db8:30::2/128",
+                        "endpoint": "100.0.1.12",
+                        "mac_address": "52:54:00:00:00:aa",
+                        "vni": "10002"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VNET_ROUTE_TUNNEL_TEST_INVALID_IPV6_PREFIX": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1000",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10001"
+                    }
+                ]
+            },
+
+            "sonic-vnet:VNET_ROUTE_TUNNEL": {
+                "VNET_ROUTE_TUNNEL_LIST": [
+                    {
+                        "vnet_name": "Vnet1000",
+                        "prefix": "2001:db8:gg::1/128",
+                        "endpoint": "100.0.1.12"
+                    }
+                ]
+            }
+        }
+    },
+
     "VNET_ROUTE_TUNNEL_TEST_INVALID_CONSISTENT_HASHING": {
         "sonic-vxlan:sonic-vxlan": {
             "sonic-vxlan:VXLAN_TUNNEL": {

--- a/src/sonic-yang-models/yang-models/sonic-vnet.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vnet.yang
@@ -123,13 +123,16 @@ module sonic-vnet {
                 }
 
                 leaf prefix {
-                    description "IPv4 prefix in CIDR format";
-                    type stypes:sonic-ip4-prefix;
+                    description "IP prefix in CIDR format (IPv4 or IPv6)";
+                    type stypes:sonic-ip-prefix;
                 }
 
                 leaf nexthop {
-                    description "Nexthop IP addresses";
-                    type stypes:ipv4-address-list;
+                    description "Nexthop IP addresses (IPv4 or IPv6, comma-separated)";
+                    type union {
+                        type stypes:ipv4-address-list;
+                        type stypes:ipv6-address-list;
+                    }
                     mandatory true;
                 }
 
@@ -164,8 +167,11 @@ module sonic-vnet {
                 }
                 
                 leaf endpoint {
-                    description "Endpoint/nexthop tunnel IPs";
-                    type stypes:ipv4-address-list;
+                    description "Endpoint/nexthop tunnel IPs (IPv4 or IPv6, comma-separated)";
+                    type union {
+                        type stypes:ipv4-address-list;
+                        type stypes:ipv6-address-list;
+                    }
                     mandatory true;
                 }
 

--- a/src/sonic-yang-models/yang-models/sonic-vnet.yang
+++ b/src/sonic-yang-models/yang-models/sonic-vnet.yang
@@ -159,8 +159,8 @@ module sonic-vnet {
                 }
                 
                 leaf prefix {
-                    description "IPv4 prefix in CIDR format";
-                    type stypes:sonic-ip4-prefix;
+                    description "IP prefix in CIDR format (IPv4 or IPv6)";
+                    type stypes:sonic-ip-prefix;
                 }
                 
                 leaf endpoint {

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -68,6 +68,23 @@ module sonic-types {
             "Comma-separated IPv4 addresses";
     }
 
+    typedef ipv6-address-list {
+        type string {
+            pattern '(((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'
+                + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'
+                + '(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}'
+                + '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))'
+                + '(%[\p{N}\p{L}]+)?)'
+                + '(,(((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'
+                + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'
+                + '(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}'
+                + '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))'
+                + '(%[\p{N}\p{L}]+)?))*';
+        }
+        description
+            "Comma-separated IPv6 addresses";
+    }
+
     typedef admin_status {
         description "Administrative status (up/down)";
         type enumeration {


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
`VNET_ROUTE` and `VNET_ROUTE_TUNNEL` only accepted IPv4 prefixes, nexthops, and endpoints. This extends both tables with full IPv6 support.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
**Commit 1** — Update VNET_ROUTE_TUNNEL prefix to support IPv6
- `VNET_ROUTE_TUNNEL.prefix`: `sonic-ip4-prefix` → `sonic-ip-prefix` (union of IPv4/IPv6)
- Updated `VNET_ROUTE_TUNNEL_TEST_INVALID_PREFIX` to `InvalidValue` (union error format)
- Added tests: `VNET_ROUTE_TUNNEL_TEST_IPV6_PREFIX`, `VNET_ROUTE_TUNNEL_TEST_INVALID_PREFIX_LEN`, `VNET_ROUTE_TUNNEL_TEST_INVALID_IPV6_PREFIX`

**Commit 2** — Add IPv6 support for VNET_ROUTE and VNET_ROUTE_TUNNEL nexthop/endpoint
- Added `ipv6-address-list` typedef to `sonic-types.yang.j2`
- `VNET_ROUTE.prefix`: `sonic-ip4-prefix` → `sonic-ip-prefix`
- `VNET_ROUTE.nexthop`: `ipv4-address-list` → `union { ipv4-address-list | ipv6-address-list }`
- `VNET_ROUTE_TUNNEL.endpoint`: `ipv4-address-list` → `union { ipv4-address-list | ipv6-address-list }`
- Updated all invalid-value tests for union leaves (`nexthop`, `endpoint`, `prefix`) from `Pattern` to `InvalidValue` with the failing leaf name
- Added 8 new tests covering valid/invalid IPv6 prefixes, nexthops, and endpoints
- Updated `doc/Configuration.md` and `tests/files/sample_config_db.json` with IPv6 examples


#### How to verify it
Run the YANG model tests:
```bash
cd src/sonic-yang-models
python3 -m pytest tests/yang_model_tests/test_yang_model.py -v
```


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [x] 202506

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
