### PR TITLE
[ci] fix docker-ptf pipeline: scapy submodule and open version PR

### DIFF
--- a/.azure-pipelines/docker-ptf.yml
+++ b/.azure-pipelines/docker-ptf.yml
@@ -111,7 +111,7 @@ stages:
 
     - bash: |
         set -xe
-        git submodule update --init --recursive -- src/ptf src/ptf-py3 src/sonic-sairedis src/sonic-frr/frr src/sonic-swss-common
+        git submodule update --init --recursive -- src/ptf src/ptf-py3 src/scapy src/sonic-sairedis src/sonic-frr/frr src/sonic-swss-common
         # TODO: ENABLE_SBOM=y
         BUILD_OPTIONS="SONIC_BUILD_JOBS=$(nproc) DEFAULT_CONTAINER_REGISTRY=publicmirror.azurecr.io ENABLE_DOCKER_BASE_PULL=y MIRROR_SNAPSHOT=$MIRROR_SNAPSHOT 
                       SONIC_BUILD_RETRY_COUNT=3 SONIC_BUILD_RETRY_INTERVAL=600 DOCKER_BUILDKIT=0 $(VERSION_CONTROL_OPTIONS)"
@@ -298,6 +298,14 @@ stages:
         git push origin HEAD:refs/heads/$BRANCH_NAME -f
 
         TITLE="[${SOURCE_BRANCH#refs/heads/}] Upgrade docker-ptf package versions"
+        # The branch was already force pushed above, so an open pull request
+        # picks up the new commit and does not need to be recreated.
+        PR_URL=$(gh pr list -R $REPO_NAME -H $BRANCH_NAME -B ${SOURCE_BRANCH#refs/heads/} --state open --json url --jq '.[].url' | head -1)
+        if [ -n "$PR_URL" ]; then
+          echo "Skipped to send the pull request, an open pull request was updated: $PR_URL"
+          exit 0
+        fi
+
         RET=0
         if ! gh pr create -t "$TITLE" -b "$TITLE" -B $(Build.SourceBranch) -R $(Build.Repository.Name) > pr.log 2>&1; then
           if ! grep -q "already exists" pr.log; then


### PR DESCRIPTION
#### Why I did it

Two problems in the `Azure.docker-ptf` pipeline (`.azure-pipelines/docker-ptf.yml`).

**1. `Build docker-ptf.gz` fails because `src/scapy` is never initialized**

```
[ FAIL LOG START ] [ target/python-wheels/trixie/scapy-2.6.1.dev0-py3-none-any.whl ]
/sonic/src/scapy /sonic
Applying patch ../scapy.patch/0001-Fix-version-string-generation-when-scapy-is-a-submod.patch
can't find file to patch at input line 15
No file to patch.  Skipping patch.
1 out of 1 hunk ignored
Patch ../scapy.patch/0001-Fix-version-string-generation-when-scapy-is-a-submod.patch does not apply (enforce with -f)
[  FAIL LOG END  ] [ target/python-wheels/trixie/scapy-2.6.1.dev0-py3-none-any.whl ]
make: *** [slave.mk:1136: target/python-wheels/trixie/scapy-2.6.1.dev0-py3-none-any.whl] Error 1
make: *** [Makefile.work:719: target/docker-ptf.gz] Error 2
```

`docker-ptf` depends on `$(P4LANG_P4C)` (`platform/vs/docker-ptf.mk`), and since #27890 `p4lang-p4c` carries `$(P4LANG_P4C)_WHEEL_DEPENDS = $(SCAPY)`, so `target/docker-ptf.gz` now transitively requires the locally built scapy wheel. The pipeline only initializes a subset of submodules and `src/scapy` is not in that list, so the directory stays empty and applying `src/scapy.patch` fails.

**2. `Send Pull Request` reports a failure whenever the previous version PR is still open**

```
pull request create failed: GraphQL: A pull request already exists for sonic-net:repd/docker-ptf-versions/master. (createPullRequest)
```

The step unconditionally runs `gh pr create`, which fails when the version bump pull request from a previous run has not been merged yet. The branch is force pushed just before, so the open pull request already carries the new commit and nothing else needs to happen.

#### How I did it

- Added `src/scapy` to the `git submodule update --init --recursive` list.
- In `Send Pull Request`, look up an open pull request for the branch with `gh pr list` and skip the creation when one exists, printing its URL. The existing `already exists` tolerance is kept as a guard against a race between the lookup and the creation.

#### How to verify it

Run the `Azure.docker-ptf` pipeline:

- the scapy wheel builds and `target/docker-ptf.gz` completes;
- when a version bump pull request is already open, `Send Pull Request` prints `Skipped to send the pull request, an open pull request was updated: <url>` instead of the `gh pr create` failure.

The new scapy dependency can be confirmed locally with a dry run:

```
make -f slave.mk BLDENV=trixie PLATFORM=vs CONFIGURED_ARCH=amd64 INCLUDE_PTF=y -n target/docker-ptf.gz | grep scapy
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

- [ ] master

#### Description for the changelog

[ci] Initialize the src/scapy submodule in the docker-ptf pipeline and reuse an already open version bump pull request instead of failing gh pr create.
