### PR TITLE
[docker-telemetry-sidecar]: Gate health-checker sync behind two env flag

### DIFF
--- a/dockers/docker-telemetry-sidecar/Dockerfile.j2
+++ b/dockers/docker-telemetry-sidecar/Dockerfile.j2
@@ -56,4 +56,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Pass the image_version to container
 ENV IMAGE_VERSION=$image_version
 
+# K8s will override this
+ENV CONTAINER_CHECKER_SYNC_ENABLED=false
+
+# K8s will override this
+ENV SERVICE_CHECKER_SYNC_ENABLED=false
+
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/dockers/docker-telemetry-sidecar/cli-plugin-tests/test_systemd_stub.py
+++ b/dockers/docker-telemetry-sidecar/cli-plugin-tests/test_systemd_stub.py
@@ -131,6 +131,11 @@ def ss(tmp_path, monkeypatch):
     if "systemd_stub" in sys.modules:
         del sys.modules["systemd_stub"]
 
+    # Enable both health-checker sync gates so the shared sync tests exercise the
+    # branch-specific container_checker and service_checker (module defaults off).
+    monkeypatch.setenv("CONTAINER_CHECKER_SYNC_ENABLED", "true")
+    monkeypatch.setenv("SERVICE_CHECKER_SYNC_ENABLED", "true")
+
     # Fake host filesystem and command recorder
     host_fs = {}
     commands = []
@@ -1262,3 +1267,189 @@ def test_reconcile_enabled_uses_apply_patch_command(ss):
     # Verify the end state
     assert config_db.get("TELEMETRY|gnmi", {}).get("user_auth") == "cert"
     assert config_db.get("GNMI_CLIENT_CERT|test.example.com", {}).get("role") == ["admin"]
+
+
+# ─────────────────────────── Health-checker sync gates ───────────────────────────
+# The container_checker (monit) and service_checker.py (system-health) syncs are
+# each gated behind their own env flag. Both default off; only the gnmi DaemonSet
+# flips them on at runtime, so this sidecar ships identical code but is a no-op
+# syncer for the two checkers unless explicitly enabled. These tests prove the
+# two gates are independent.
+
+def test_checker_sync_env_defaults_off(monkeypatch):
+    """Both health-checker sync gates default to False when unset."""
+    if "systemd_stub" in sys.modules:
+        del sys.modules["systemd_stub"]
+    monkeypatch.delenv("CONTAINER_CHECKER_SYNC_ENABLED", raising=False)
+    monkeypatch.delenv("SERVICE_CHECKER_SYNC_ENABLED", raising=False)
+    ss = importlib.import_module("systemd_stub")
+    assert ss.CONTAINER_CHECKER_SYNC_ENABLED is False
+    assert ss.SERVICE_CHECKER_SYNC_ENABLED is False
+
+
+def test_container_checker_sync_env_true(monkeypatch):
+    """CONTAINER_CHECKER_SYNC_ENABLED reads true from the environment."""
+    if "systemd_stub" in sys.modules:
+        del sys.modules["systemd_stub"]
+    monkeypatch.setenv("CONTAINER_CHECKER_SYNC_ENABLED", "true")
+    ss = importlib.import_module("systemd_stub")
+    assert ss.CONTAINER_CHECKER_SYNC_ENABLED is True
+
+
+def test_service_checker_sync_env_true(monkeypatch):
+    """SERVICE_CHECKER_SYNC_ENABLED reads true from the environment."""
+    if "systemd_stub" in sys.modules:
+        del sys.modules["systemd_stub"]
+    monkeypatch.setenv("SERVICE_CHECKER_SYNC_ENABLED", "true")
+    ss = importlib.import_module("systemd_stub")
+    assert ss.SERVICE_CHECKER_SYNC_ENABLED is True
+
+
+def test_both_checkers_synced_when_both_enabled(ss):
+    """With both gates on (fixture default), ensure_sync writes both checkers."""
+    ss_mod, container_fs, host_fs, commands, config_db = ss
+    ss_mod._get_branch_name = lambda: "202412"
+    ss_mod.SYNC_ITEMS[:] = []
+
+    container_fs["/usr/share/sonic/systemd_scripts/container_checker_202412"] = b"CHECKER"
+    container_fs["/usr/share/sonic/systemd_scripts/service_checker.py_202412"] = b"SERVICE-CHECKER"
+    host_fs["/bin/container_checker"] = b"OLD"
+    host_fs[ss_mod.HOST_SERVICE_CHECKER] = b"OLD"
+
+    ok = ss_mod.ensure_sync()
+    assert ok is True
+    assert host_fs["/bin/container_checker"] == b"CHECKER"
+    assert host_fs[ss_mod.HOST_SERVICE_CHECKER] == b"SERVICE-CHECKER"
+
+
+def test_only_container_checker_synced_when_service_gate_off(ss, monkeypatch):
+    """Container gate on, service gate off -> only /bin/container_checker is written."""
+    ss_mod, container_fs, host_fs, commands, config_db = ss
+    monkeypatch.setattr(ss_mod, "CONTAINER_CHECKER_SYNC_ENABLED", True)
+    monkeypatch.setattr(ss_mod, "SERVICE_CHECKER_SYNC_ENABLED", False)
+    ss_mod._get_branch_name = lambda: "202412"
+    ss_mod.SYNC_ITEMS[:] = []
+
+    container_fs["/usr/share/sonic/systemd_scripts/container_checker_202412"] = b"CHECKER"
+    host_fs["/bin/container_checker"] = b"OLD"
+    host_fs.pop(ss_mod.HOST_SERVICE_CHECKER, None)
+
+    ok = ss_mod.ensure_sync()
+    assert ok is True
+    assert host_fs["/bin/container_checker"] == b"CHECKER"
+    assert ss_mod.HOST_SERVICE_CHECKER not in host_fs
+
+
+def test_only_service_checker_synced_when_container_gate_off(ss, monkeypatch):
+    """Service gate on, container gate off -> only service_checker.py is written."""
+    ss_mod, container_fs, host_fs, commands, config_db = ss
+    monkeypatch.setattr(ss_mod, "CONTAINER_CHECKER_SYNC_ENABLED", False)
+    monkeypatch.setattr(ss_mod, "SERVICE_CHECKER_SYNC_ENABLED", True)
+    ss_mod._get_branch_name = lambda: "202412"
+    ss_mod.SYNC_ITEMS[:] = []
+
+    container_fs["/usr/share/sonic/systemd_scripts/service_checker.py_202412"] = b"SERVICE-CHECKER"
+    host_fs[ss_mod.HOST_SERVICE_CHECKER] = b"OLD"
+    host_fs.pop("/bin/container_checker", None)
+
+    ok = ss_mod.ensure_sync()
+    assert ok is True
+    assert host_fs[ss_mod.HOST_SERVICE_CHECKER] == b"SERVICE-CHECKER"
+    assert "/bin/container_checker" not in host_fs
+
+
+def test_neither_checker_synced_when_both_gates_off(ss, monkeypatch):
+    """Both gates off (production default) -> neither checker is written."""
+    ss_mod, container_fs, host_fs, commands, config_db = ss
+    monkeypatch.setattr(ss_mod, "CONTAINER_CHECKER_SYNC_ENABLED", False)
+    monkeypatch.setattr(ss_mod, "SERVICE_CHECKER_SYNC_ENABLED", False)
+    ss_mod._get_branch_name = lambda: "202412"
+    ss_mod.SYNC_ITEMS[:] = []
+    host_fs.pop("/bin/container_checker", None)
+    host_fs.pop(ss_mod.HOST_SERVICE_CHECKER, None)
+
+    ok = ss_mod.ensure_sync()
+    assert ok is True
+    assert "/bin/container_checker" not in host_fs
+    assert ss_mod.HOST_SERVICE_CHECKER not in host_fs
+
+
+def test_both_gates_off_skips_branch_check(ss, monkeypatch):
+    """With both gates off, an unsupported branch does NOT abort the base sync
+    (the branch only matters when a checker is actually synced)."""
+    ss_mod, container_fs, host_fs, commands, config_db = ss
+    monkeypatch.setattr(ss_mod, "CONTAINER_CHECKER_SYNC_ENABLED", False)
+    monkeypatch.setattr(ss_mod, "SERVICE_CHECKER_SYNC_ENABLED", False)
+    ss_mod._get_branch_name = lambda: "master"
+
+    item = ss_mod.SyncItem("/container/telemetry.sh", "/usr/local/bin/telemetry.sh", 0o755)
+    container_fs[item.src_in_container] = b"NEW"
+    host_fs[item.dst_on_host] = b"OLD"
+    ss_mod.SYNC_ITEMS[:] = [item]
+
+    ok = ss_mod.ensure_sync()
+    assert ok is True
+    assert host_fs[item.dst_on_host] == b"NEW"
+
+
+def test_enabled_gate_aborts_for_unsupported_branch(ss, monkeypatch):
+    """With a gate on, an unsupported branch aborts the sync to trigger rollback."""
+    ss_mod, container_fs, host_fs, commands, config_db = ss
+    monkeypatch.setattr(ss_mod, "CONTAINER_CHECKER_SYNC_ENABLED", True)
+    monkeypatch.setattr(ss_mod, "SERVICE_CHECKER_SYNC_ENABLED", False)
+    ss_mod._get_branch_name = lambda: "master"
+
+    item = ss_mod.SyncItem("/container/telemetry.sh", "/usr/local/bin/telemetry.sh", 0o755)
+    container_fs[item.src_in_container] = b"NEW"
+    host_fs[item.dst_on_host] = b"OLD"
+    ss_mod.SYNC_ITEMS[:] = [item]
+
+    ok = ss_mod.ensure_sync()
+    assert ok is False
+    # Nothing is synced when the sync aborts early.
+    assert host_fs[item.dst_on_host] == b"OLD"
+
+
+def test_service_checker_post_copy_uses_try_restart(ss, monkeypatch):
+    """When service_checker.py changes, the post-copy action is
+    'systemctl try-restart system-health' (never a plain restart)."""
+    ss_mod, container_fs, host_fs, commands, config_db = ss
+    monkeypatch.setattr(ss_mod, "CONTAINER_CHECKER_SYNC_ENABLED", False)
+    monkeypatch.setattr(ss_mod, "SERVICE_CHECKER_SYNC_ENABLED", True)
+    ss_mod._get_branch_name = lambda: "202412"
+    ss_mod.SYNC_ITEMS[:] = []
+    # POST_COPY_ACTIONS must be non-empty for the dynamic try-restart to be added
+    # (mirrors the --no-post-actions guard). Seed an unrelated entry.
+    ss_mod.POST_COPY_ACTIONS["/unrelated"] = [["sudo", "true"]]
+
+    container_fs["/usr/share/sonic/systemd_scripts/service_checker.py_202412"] = b"NEW-SERVICE-CHECKER"
+    host_fs[ss_mod.HOST_SERVICE_CHECKER] = b"OLD"
+
+    ok = ss_mod.ensure_sync()
+    assert ok is True
+    post_cmds = [args for _, args in commands if args and args[0] == "sudo"]
+    assert ("sudo", "systemctl", "try-restart", "system-health") in post_cmds
+    assert ("sudo", "systemctl", "restart", "system-health") not in post_cmds
+
+
+def test_service_checker_no_post_action_when_post_actions_disabled(ss, monkeypatch):
+    """Under --no-post-actions (POST_COPY_ACTIONS cleared), the service_checker sync
+    still happens but no try-restart is issued."""
+    ss_mod, container_fs, host_fs, commands, config_db = ss
+    monkeypatch.setattr(ss_mod, "CONTAINER_CHECKER_SYNC_ENABLED", False)
+    monkeypatch.setattr(ss_mod, "SERVICE_CHECKER_SYNC_ENABLED", True)
+    ss_mod._get_branch_name = lambda: "202412"
+    ss_mod.SYNC_ITEMS[:] = []
+    # The fixture already cleared POST_COPY_ACTIONS to {} (like --no-post-actions).
+    assert ss_mod.POST_COPY_ACTIONS == {}
+
+    container_fs["/usr/share/sonic/systemd_scripts/service_checker.py_202412"] = b"NEW-SERVICE-CHECKER"
+    host_fs[ss_mod.HOST_SERVICE_CHECKER] = b"OLD"
+
+    ok = ss_mod.ensure_sync()
+    assert ok is True
+    # File is still synced...
+    assert host_fs[ss_mod.HOST_SERVICE_CHECKER] == b"NEW-SERVICE-CHECKER"
+    # ...but no try-restart fired.
+    post_cmds = [args for _, args in commands if args and args[0] == "sudo"]
+    assert ("sudo", "systemctl", "try-restart", "system-health") not in post_cmds

--- a/dockers/docker-telemetry-sidecar/systemd_stub.py
+++ b/dockers/docker-telemetry-sidecar/systemd_stub.py
@@ -68,6 +68,17 @@ GNMI_CLIENT_CERTS: List[Dict[str, Union[str, List[str]]]] = _parse_client_certs(
 logger.log_notice(f"IS_V1_ENABLED={IS_V1_ENABLED}")
 logger.log_notice(f"GNMI_CLIENT_CERTS={GNMI_CLIENT_CERTS}")
 
+# Gate host-side syncing of the two health checkers: container_checker (for
+# monit) and the system-health service_checker.py.  Every sidecar ships the same
+# per-branch checkers, so each sync is gated by its own env flag and the rollout
+# enables them on exactly one sidecar (gnmi).  This keeps the sidecar sync code
+# identical while ensuring a single syncer, so the sidecars never race on the
+# same host files.  Both default off.
+CONTAINER_CHECKER_SYNC_ENABLED = get_bool_env_var("CONTAINER_CHECKER_SYNC_ENABLED", default=False)
+SERVICE_CHECKER_SYNC_ENABLED = get_bool_env_var("SERVICE_CHECKER_SYNC_ENABLED", default=False)
+logger.log_notice(f"CONTAINER_CHECKER_SYNC_ENABLED={CONTAINER_CHECKER_SYNC_ENABLED}")
+logger.log_notice(f"SERVICE_CHECKER_SYNC_ENABLED={SERVICE_CHECKER_SYNC_ENABLED}")
+
 _TELEMETRY_SRC = (
     "/usr/share/sonic/systemd_scripts/telemetry_v1.sh"
     if IS_V1_ENABLED
@@ -162,9 +173,6 @@ POST_COPY_ACTIONS = {
     "/bin/container_checker": [
         ["sudo", "systemctl", "daemon-reload"],
         ["sudo", "systemctl", "restart", "monit"],
-    ],
-    "/usr/local/lib/python3.11/dist-packages/health_checker/service_checker.py": [
-        ["sudo", "systemctl", "restart", "system-health"],
     ],
     "/usr/share/sonic/scripts/docker-telemetry-sidecar/k8s_pod_control.sh": [
         ["sudo", "systemctl", "daemon-reload"],
@@ -360,21 +368,36 @@ def _cleanup_stale_service_unit() -> None:
 
 def ensure_sync() -> bool:
     _cleanup_stale_service_unit()
-    branch_name = _get_branch_name()
-
-    if branch_name not in ("202411", "202412", "202505"):
-        logger.log_error(f"Unsupported branch '{branch_name}'; aborting sync to trigger rollback")
-        return False
-
-    # For supported branches, use the branch-specific container_checker and service_checker
-    container_checker_src = f"/usr/share/sonic/systemd_scripts/container_checker_{branch_name}"
-    service_checker_src = f"/usr/share/sonic/systemd_scripts/service_checker.py_{branch_name}"
-
-    items: List[SyncItem] = SYNC_ITEMS + [
-        SyncItem(container_checker_src, "/bin/container_checker"),
-        SyncItem(service_checker_src, HOST_SERVICE_CHECKER),
-    ]
-    return sync_items(items, POST_COPY_ACTIONS)
+    items: List[SyncItem] = list(SYNC_ITEMS)
+    # ── Health-checker sync (identical across the gnmi/acms/restapi sidecars) ──
+    # The k8s-disabled gnmi container is whitelisted out of both checkers so it
+    # stops raising false "container down" alerts.  Every sidecar ships the same
+    # per-branch checkers; each sync is gated by its own flag so exactly one
+    # sidecar (gnmi) syncs them at runtime and they never race on the host files.
+    post_copy_actions = dict(POST_COPY_ACTIONS)
+    if CONTAINER_CHECKER_SYNC_ENABLED or SERVICE_CHECKER_SYNC_ENABLED:
+        # Detect the host OS branch only when a checker actually needs syncing, so
+        # the default-off path skips version detection (and its nsenter fallback).
+        branch_name = _get_branch_name()
+        if branch_name not in ("202411", "202412", "202505"):
+            logger.log_error(f"Unsupported branch '{branch_name}'; aborting sync to trigger rollback")
+            return False
+        if CONTAINER_CHECKER_SYNC_ENABLED:
+            container_checker_src = f"/usr/share/sonic/systemd_scripts/container_checker_{branch_name}"
+            items.append(SyncItem(container_checker_src, "/bin/container_checker"))
+        if SERVICE_CHECKER_SYNC_ENABLED:
+            service_checker_src = f"/usr/share/sonic/systemd_scripts/service_checker.py_{branch_name}"
+            items.append(SyncItem(service_checker_src, HOST_SERVICE_CHECKER, mode=0o644))
+            # healthd imports service_checker once at startup and caches it, so a
+            # freshly synced file only takes effect after a restart.  try-restart
+            # reloads a running daemon but is a no-op when system-health is inactive
+            # (an intentionally-stopped daemon is never started; it picks up the new
+            # file whenever it next starts).  Skipped under --no-post-actions.
+            if POST_COPY_ACTIONS:
+                post_copy_actions[HOST_SERVICE_CHECKER] = [
+                    ["sudo", "systemctl", "try-restart", "system-health"],
+                ]
+    return sync_items(items, post_copy_actions)
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(


### PR DESCRIPTION
…lags

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Multiple sidecar will overwrite container/service_checker files repeatedly, now we need env flag to make sure only one owns source of truth.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added two env and get the sync logic.

#### How to verify it
local verified the script which works fine.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
