### PR TITLE
[202511][Broadcom][SAI] Upgrade Broadcom XGS SAI 14.3.0.0.0.0.30.0 -> 14.3.0.0.0.0.31.0

### DIFF
--- a/platform/broadcom/sai-xgs.mk
+++ b/platform/broadcom/sai-xgs.mk
@@ -1,5 +1,5 @@
 # Broadcom XGS SAI definitions
-LIBSAIBCM_XGS_VERSION = 14.3.0.0.0.0.30.0
+LIBSAIBCM_XGS_VERSION = 14.3.0.0.0.0.31.0
 LIBSAIBCM_XGS_BRANCH_NAME = SAI_14.3.0_GA
 
 LIBSAIBCM_XGS_URL_PREFIX = "https://packages.trafficmanager.net/public/sai/sai-broadcom/$(LIBSAIBCM_XGS_BRANCH_NAME)/$(LIBSAIBCM_XGS_VERSION)/xgs"


### PR DESCRIPTION
#### Why I did it
Bump the Broadcom XGS SAI on the 202511 branch from `14.3.0.0.0.0.30.0` to `14.3.0.0.0.0.31.0`. Change since `14.3.0.0.0.0.30.0`:

- `14.3.0.0.0.0.31.0`: Trident6 (TH6) VCO selection / VCO-violation handling. Generalizes the per-speed VCO lookup (`_brcm_sai_pm_get_vco_for_speed`) to select the correct FEC→VCO capability table per chip (TH6C/Condor `PM8x200`, TH6P/Peregrine `PM8x100_G3`), adds explicit VCO values (51/53 GHz) to the port FEC-capability tables, enables the "set same speed on all core ports" workaround when a VCO violation fails a `speed_set`, and adds TH6 to new-device-onboarding physical-port-base mapping. Also fixes an error-log argument in the port resource-config path.

##### Work item tracking
- Microsoft ADO **(number only)**: 38992626

#### How I did it
Bump `LIBSAIBCM_XGS_VERSION` from `14.3.0.0.0.0.30.0` to `14.3.0.0.0.0.31.0` in `platform/broadcom/sai-xgs.mk`. The corresponding `libsaibcm` and `libsaibcm-dev` 14.3.0.0.0.0.31.0 packages are already published under `SAI_14.3.0_GA/14.3.0.0.0.0.31.0/xgs`.

#### How to verify it
- Build the 202511 Broadcom SWI and install it on a Broadcom XGS DUT.
- Run the SAI qualification set (12 scripts) via Elastictest and confirm no regressions.

#### Qualification results
Qualified on real Broadcom XGS hardware via Elastictest (bed `testbed-bjw2-can-t0-7050-1`, Arista-7050CX3-32S-C32 / Trident3, t0).

**A/B smoke** (baseline `.30.0` vs candidate `.31.0`) — plan `6a6a58ccc738d690ad9c1a2a`: fib 12/12, everflow_testbed 18/18, everflow_per_interface 8/8 (38 pass / 0 fail / 0 err).

**12-script SAI qualification** — plan `6a6a6c56c738d690ad9c1a3c`:
- 9 functional scripts PASSED: crm, vlan, fdb, fib, vxlan_decap, decap, pfcwd, everflow_testbed, everflow_per_interface.
- 1 conditionally SKIPPED: `ipfwd/test_nhop_group`.
- SAI dataplane 100% clean — all three A/B-overlap scripts passed on `.31.0`.

Two non-dataplane failures, both confirmed **environmental** (not caused by this SAI bump):
- `platform_tests/test_reboot.py` (fast/warm) — "DUT did not shutdown / did not reboot". Reproduced on the **baseline `.30.0`** image on the same bed (control plan `6a6b3ce6101ed2146e80977c`: identical fast/warm failures; cold/watchdog/continuous pass), confirming a **pre-existing bed/infra** issue rather than a `.31.0` regression.
- `acl/test_acl.py` — teardown could not find `/etc/sonic/golden_config_db.json` (test-harness/env issue; all 192/192 ACL traffic assertions passed).

#### Which release branch to backport (provide reason below if selected)
N/A - this PR targets 202511 directly (master is on SAI 15.2).

Signed-off-by: Aaron Bernardino <aaronber@microsoft.com>
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
