### PR TITLE
[202505] Install pygnmi==0.8.15 for docker-sonic-mgmt

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -81,6 +81,7 @@ RUN python3 -m pip install aiohttp \
                  prettytable \
                  psutil \
                  ptf \
+                 pygnmi==0.8.15 \
                  pyasn1==0.4.8 \
                  pycryptodome==3.9.8 \
                  pyfiglet \


### PR DESCRIPTION
Manual cherry-pick of #28339 to 202505 (automated cherry-pick conflicted: 202505's docker-sonic-mgmt still uses the `python3 -m pip install` package list, master uses `uv pip install`). Change applied into the python3 install block; python2 block untouched (pygnmi is py3-only).

#### Why I did it
sonic-mgmt is migrating gNMI tests to a native pygnmi client (sonic-net/sonic-mgmt#26013); docker-sonic-mgmt needs the library preinstalled.

#### How I did it
`git cherry-pick -x 86b830af0c`, resolved the pip-block conflict by inserting `pygnmi==0.8.15` into the python3 package list.

#### How to verify it
- docker-sonic-mgmt build in this PR's CI.
- Functional: `tests/gnmi/test_pygnmi_client.py` (20 tests) run with pygnmi 0.8.15 from docker-sonic-mgmt : 20/20 PASS.