### PR TITLE
[202511] Install pygnmi==0.8.15 for docker-sonic-mgmt

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -97,6 +97,7 @@ RUN uv pip install --no-cache \
     passlib \
     pexpect \
     prettytable \
+    "pygnmi==0.8.15" \
     psutil \
     ptf==0.10.0 \
     pyasn1 \


### PR DESCRIPTION
Manual cherry-pick of #28339 to 202511 (automated cherry-pick conflicted on adjacent context: master's package list carries `protobuf>=5.29.6,<6` which 202511 does not; only the pygnmi line is taken).

#### Why I did it
sonic-mgmt is migrating gNMI tests to a native pygnmi client (sonic-net/sonic-mgmt#26013); docker-sonic-mgmt needs the library preinstalled.

#### How I did it
`git cherry-pick -x 86b830af0c`, resolved by adding only `"pygnmi==0.8.15"` to the `uv pip install` list (no protobuf change).

#### How to verify it
- docker-sonic-mgmt build in this PR's CI.
- Functional: `tests/gnmi/test_pygnmi_client.py` (20 tests) with pygnmi 0.8.15 from docker-sonic-mgmt.