### PR TITLE
[ci][202605] Stop building aspeed_arm64 platform

### DIFF
--- a/.azure-pipelines/azure-pipelines-build.yml
+++ b/.azure-pipelines/azure-pipelines-build.yml
@@ -119,12 +119,6 @@ jobs:
           variables:
             PLATFORM_ARCH: arm64
 
-        - name: aspeed-arm64
-          pool: sonicso1ES-arm64
-          variables:
-            PLATFORM_NAME: aspeed
-            PLATFORM_ARCH: arm64
-
         - name: vpp
           variables:
             dbg_image: yes

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -117,11 +117,6 @@ stages:
         pool: sonicso1ES-arm64
         variables:
           PLATFORM_ARCH: arm64
-      - name: aspeed-arm64
-        pool: sonicso1ES-arm64
-        variables:
-          PLATFORM_NAME: aspeed
-          PLATFORM_ARCH: arm64
 
 - stage: Test
   dependsOn: BuildVS


### PR DESCRIPTION
#### Why I did it

The aspeed_arm64 platform build fails on the 202605 branch and blocks PR CI (definition Azure.sonic-buildimage). Root cause: the sonic-redfish submodule on 202605 (9703e90) does not pin the stdexec meson subproject used by bmcweb.

sdbusplus declares its stdexec subproject as "revision = HEAD" (floating). On master, sonic-redfish PR sonic-net/sonic-redfish#3 (commit f86121a3) added a STDEXEC_REVISION mechanism in the redfish Makefile that writes a pinned bmcweb/subprojects/stdexec.wrap, forcing stdexec to a known-good revision. That change was never backported to 202605, so bmcweb floats to a newer stdexec tip that fails to compile under trixie GCC on aarch64:

    __spin_loop_pause.hpp: error: duplicate inline

Master does not hit this because its redfish pins stdexec; 202605 does not.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Removed the aspeed-arm64 build job from the two 202605 pipeline definitions:
- azure-pipelines.yml (PR-gating pipeline)
- .azure-pipelines/azure-pipelines-build.yml

aspeed_arm64 is not a shipping platform on this branch, so dropping the job unblocks 202605 PR CI. This is a stop-gap; the proper fix is to backport the sonic-redfish STDEXEC_REVISION pin to 202605, after which the aspeed_arm64 job can be restored.

#### How to verify it

- Confirm both YAML files no longer contain an aspeed-arm64 job entry.
- YAML parses cleanly (validated locally).
- 202605 PR builds no longer spawn/fail the aspeed_arm64 leg.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

Not applicable — this change is specific to the 202605 branch pipeline.

#### Description for the changelog

[ci] Stop building aspeed_arm64 on 202605 (unpinned redfish stdexec break).
