### PR TITLE
[202605][system-health] [system-health] Fix 90s stop timeout during cold reboot and system-health.service stop

### DIFF
--- a/src/system-health/health_checker/sysmonitor.py
+++ b/src/system-health/health_checker/sysmonitor.py
@@ -76,6 +76,8 @@ class MonitorSystemBusTask(ThreadTaskBase):
     def __init__(self,myQ):
         ThreadTaskBase.__init__(self)
         self.task_queue = myQ
+        self.loop = None
+        self.GLib = None
 
     def on_job_removed(self, id, job, unit, result):
         if result == "done" or result == "failed":
@@ -90,6 +92,7 @@ class MonitorSystemBusTask(ThreadTaskBase):
         from gi.repository import GLib
         from dbus.mainloop.glib import DBusGMainLoop
 
+        self.GLib = GLib
         DBusGMainLoop(set_as_default=True)
         bus = dbus.SystemBus()
         systemd = bus.get_object('org.freedesktop.systemd1', '/org/freedesktop/systemd1')
@@ -97,8 +100,8 @@ class MonitorSystemBusTask(ThreadTaskBase):
         manager.Subscribe()
         manager.connect_to_signal('JobRemoved', self.on_job_removed)
 
-        loop = GLib.MainLoop()
-        loop.run()
+        self.loop = GLib.MainLoop()
+        self.loop.run()
 
     def task_worker(self):
         if self.task_stopping_event.is_set():
@@ -110,8 +113,14 @@ class MonitorSystemBusTask(ThreadTaskBase):
         # Signal the thread to stop
         self.task_stopping_event.set()
         
-        # Note: GLib.MainLoop() doesn't respond to thread stopping event gracefully
-        # The thread will be daemon-like and terminate when main program exits
+        # Stop GLib.MainLoop to unblock the thread
+        if self.loop is not None and self.GLib is not None:
+            self.GLib.idle_add(self.loop.quit)
+
+        # Wait for the thread to exit
+        if self._task_thread is not None:
+            self._task_thread.join(TASK_STOP_TIMEOUT)
+
         return True
 
     def task_notify(self, msg):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Cherry-pick conflict to 202605 through automation. Manually addressed so that the changes in https://github.com/sonic-net/sonic-buildimage/pull/26809 can land on 202605

##### Work item tracking
- Microsoft ADO **(number only)**: 38982909

#### How I did it
Cherry-picked and resolved conflicts

#### How to verify it

Run `systemctl stop system-health.service` and the stop duration should be ~90s faster

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

#### system-health.service takes 90s to stop during cold reboot (#26754)
**Without fix**
Run `systemctl stop system-health.service` then in syslog:
```
2026 Jul 29 05:53:16.919542 strtk5-7260-01 NOTICE healthd[20798]: Caught SIGTERM - exiting...
2026 Jul 29 05:53:16.919885 strtk5-7260-01 INFO systemd[1]: Stopping system-health.service - SONiC system health monitor...
2026 Jul 29 05:54:47.047726 strtk5-7260-01 WARNING systemd[1]: system-health.service: State 'stop-sigterm' timed out. Killing.
2026 Jul 29 05:54:47.047889 strtk5-7260-01 NOTICE systemd[1]: system-health.service: Killing process 20798 (healthd) with signal SIGKILL.
2026 Jul 29 05:54:47.048016 strtk5-7260-01 NOTICE systemd[1]: system-health.service: Killing process 20802 (healthd) with signal SIGKILL.
2026 Jul 29 05:54:47.060972 strtk5-7260-01 WARNING systemd[1]: system-health.service: Main process exited, code=killed, status=9/KILL
2026 Jul 29 05:54:47.061306 strtk5-7260-01 WARNING systemd[1]: system-health.service: Failed with result 'timeout'.
2026 Jul 29 05:54:47.062419 strtk5-7260-01 INFO systemd[1]: Stopped system-health.service - SONiC system health monitor.
2026 Jul 29 05:54:47.063224 strtk5-7260-01 INFO systemd[1]: system-health.service: Consumed 2.915s CPU time, 66.7M memory peak.
```
~90s to stop

**With Fix**
Run `systemctl stop system-health.service` then in syslog:
```
2026 Jul 29 05:46:59.912552 strtk5-7260-01 INFO systemd[1]: Stopping system-health.service - SONiC system health monitor...
2026 Jul 29 05:47:01.081462 strtk5-7260-01 INFO systemd[1]: system-health.service: Deactivated successfully.
2026 Jul 29 05:47:01.081729 strtk5-7260-01 INFO systemd[1]: Stopped system-health.service - SONiC system health monitor.
2026 Jul 29 05:47:01.082306 strtk5-7260-01 INFO systemd[1]: system-health.service: Consumed 7.016s CPU time, 67.1M memory peak
```
~1-2s to stop

#### Fast-reboot shutdown increase
Fix for issue described in PR https://github.com/sonic-net/sonic-mgmt/pull/26386

**Without Fix**
Run `fast-reboot` then in syslog:
```
2026 Jul 28 05:04:29.720942 strtk5-7260-01 NOTICE root: Starting fast-reboot
...
2026 Jul 28 05:07:57.638271 strtk5-7260-01 INFO kernel: [    0.000000] Command line: reboot=p console=ttyS0...
```
207.917 seconds total from starting fast-reboot to the first kernel log on the boot side.

**With Fix**
Run `fast-reboot` then in syslog:
```
2026 Jul 29 03:55:21.563157 strtk5-7260-01 NOTICE root: Starting fast-reboot
...
2026 Jul 29 03:57:12.781422 strtk5-7260-01 INFO kernel: [    0.000000] Command line: reboot=p console=ttyS0...
```
111.218 seconds total from starting fast-reboot to the first kernel log on the boot side.

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->



#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
