### PR TITLE
[sonic-otn] Add OTN attenuator and amplifier sonic yang model

### DIFF
--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -223,6 +223,8 @@ yang_files = [
     'sonic-fast-linkup.yang',
     'sonic-alarm.yang',
     'sonic-event.yang',
+    'sonic-optical-amplifier.yang',
+    'sonic-optical-attenuator.yang',
 ]
 
 class my_build_py(build_py):

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -3297,6 +3297,31 @@
                 "mac_holdtime": "1000",
                 "neigh_holdtime": "600"
             }
+        },
+        "OTN_OA": {
+            "OA0-0": {
+                "type": "EDFA",
+                "target-gain": "15.0",
+                "min-gain": "5.0",
+                "max-gain": "25.0",
+                "target-gain-tilt": "0.0",
+                "gain-range": "LOW_GAIN_RANGE",
+                "amp-mode": "CONSTANT_GAIN",
+                "target-output-power": "23.0",
+                "max-output-power": "23.0",
+                "enabled": "true",
+                "fiber-type-profile": "SSMF"
+            }
+        },
+        "OTN_OSC": {
+            "OSC0-0": {}
+        },
+        "OTN_ATTENUATOR": {
+            "VOA0-0": {
+                "attenuation-mode": "CONSTANT_ATTENUATION",
+                "target-output-power": "5.0",
+                "attenuation": "10.0",
+                "enabled": "true"            }
         }
     },
     "SAMPLE_CONFIG_DB_UNKNOWN": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/optical_amplifier.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/optical_amplifier.json
@@ -1,0 +1,9 @@
+{
+    "VALID_OTN_OA": {
+        "desc": "Load valid OTN_OA configuration"
+    },
+
+    "VALID_OTN_OSC": {
+        "desc": "Load valid OTN_OSC configuration"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/optical_attenuator.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/optical_attenuator.json
@@ -1,0 +1,5 @@
+{
+    "VALID_OTN_ATTENUATOR": {
+        "desc": "Load valid OTN_ATTENUATOR configuration"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/optical_amplifier.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/optical_amplifier.json
@@ -1,0 +1,36 @@
+{
+    "VALID_OTN_OA": {
+        "sonic-optical-amplifier:sonic-optical-amplifier": {
+            "sonic-optical-amplifier:OTN_OA": {
+                "OTN_OA_LIST": [
+                    {
+                        "name": "OA0-0",
+                        "type": "EDFA",
+                        "target-gain": "15.0",
+                        "min-gain": "5.0",
+                        "max-gain": "25.0",
+                        "target-gain-tilt": "0.0",
+                        "gain-range": "LOW_GAIN_RANGE",
+                        "amp-mode": "CONSTANT_GAIN",
+                        "target-output-power": "23.0",
+                        "max-output-power": "23.0",
+                        "enabled": true,
+                        "fiber-type-profile": "SSMF"
+                    }
+                ]
+            }
+        }
+    },
+
+    "VALID_OTN_OSC": {
+        "sonic-optical-amplifier:sonic-optical-amplifier": {
+            "sonic-optical-amplifier:OTN_OSC": {
+                "OTN_OSC_LIST": [
+                    {
+                        "interface": "OSC0-0"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/optical_attenuator.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/optical_attenuator.json
@@ -1,0 +1,17 @@
+{
+    "VALID_OTN_ATTENUATOR": {
+        "sonic-optical-attenuator:sonic-optical-attenuator": {
+            "sonic-optical-attenuator:OTN_ATTENUATOR": {
+                "OTN_ATTENUATOR_LIST": [
+                    {
+                        "name": "VOA0-0",
+                        "attenuation-mode": "CONSTANT_ATTENUATION",
+                        "target-output-power": "5.0",
+                        "attenuation": "10.0",
+                        "enabled": true
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-optical-amplifier.yang
+++ b/src/sonic-yang-models/yang-models/sonic-optical-amplifier.yang
@@ -1,0 +1,249 @@
+module sonic-optical-amplifier {
+  yang-version 1.1;
+  namespace "http://github.com/sonic-net/sonic-optical-amplifier";
+  prefix opt-amp;
+
+  organization
+    "SONiC";
+  contact
+    "SONiC";
+  description
+    "OTN_OA and OTN_OSC YANG Module for SONiC OS";
+
+  revision 2026-06-01 {
+    description
+      "First revision, derived from openconfig yang model";
+    reference
+      "openconfig-optical-amplifier.yang, version 2019-12-06";
+  }
+
+  typedef optical-amplifier-type {
+    type enumeration {
+      enum EDFA {
+        description
+          "Erbium doped fiber amplifer (EDFA)";
+      }
+      enum FORWARD_RAMAN {
+        description
+          "Forward pumping Raman amplifier";
+      }
+      enum BACKWARD_RAMAN {
+        description
+          "Backward pumping Raman amplifier";
+      }
+      enum HYBRID {
+        description
+          "Hybrid backward pumping Raman + EDFA amplifier";
+      }
+    }
+    description
+      "Type definition for different types of optical amplifiers.
+       Derived from the OPTICAL_AMPLIFIER_TYPE identity in
+       openconfig-optical-amplifier.yang";
+  }
+
+  typedef optical-amplifier-mode {
+    type enumeration {
+      enum CONSTANT_POWER {
+        description
+          "Constant power mode. In constant power mode, the amplifier
+           will maintain a constant output power by adjusting the
+           amplifier gain and/or related variable optical attenuators";
+      }
+      enum CONSTANT_GAIN {
+        description
+          "Constant gain mode. In constant gain mode, the amplifier
+           will maintain a constant amplifier gain";
+      }
+      enum DYNAMIC_GAIN {
+        description
+          "Dynamic gain mode. In dynamic gain mode, the amplifier will
+           automatically adjust gain to stay within parameters defined
+           by target-gain, min-gain and max-gain";
+      }
+    }
+    description
+      "Type definition for different types of optical amplifier
+       operating modes. Derived from the OPTICAL_AMPLIFIER_MODE
+       identity in openconfig-optical-amplifier.yang";
+  }
+
+  typedef gain-range {
+    type enumeration {
+      enum LOW_GAIN_RANGE {
+        description
+          "LOW gain range setting";
+      }
+      enum MID_GAIN_RANGE {
+        description
+          "MID gain range setting";
+      }
+      enum HIGH_GAIN_RANGE {
+        description
+          "HIGH gain range setting";
+      }
+      enum FIXED_GAIN_RANGE {
+        description
+          "Fixed or non-switched gain amplfier";
+      }
+    }
+    description
+      "Base type for expressing the gain range for a switched gain
+       amplifier. Derived from the GAIN_RANGE identity in
+       openconfig-optical-amplifier.yang";
+  }
+
+  typedef fiber-type-profile {
+    type enumeration {
+      enum DSF {
+        description
+          "Dispersion shifted fiber";
+      }
+      enum LEAF {
+        description
+          "Large effective area fiber";
+      }
+      enum SSMF {
+        description
+          "Standard single mode fiber";
+      }
+      enum TWC {
+        description
+          "True wave classic";
+      }
+      enum TWRS {
+        description
+          "True wave reduced slope";
+      }
+    }
+    description
+      "Type definition for different profiles of fiber types.
+       Derived from the FIBER_TYPE_PROFILE identity in
+       openconfig-optical-amplifier.yang";
+  }
+
+  container sonic-optical-amplifier {
+    description
+      "Top-level container for the OTN optical amplifier configuration";
+    container OTN_OA {
+      description
+        "Enclosing container for list of amplifiers";
+      list OTN_OA_LIST {
+        key "name";
+        description
+          "List of optical amplifiers, keyed by amplifier name";
+        leaf name {
+          type string;
+          description
+            "User-defined name assigned to identify a specific amplifier
+             in the device";
+        }
+        leaf type {
+          type optical-amplifier-type;
+          description
+            "Type of the amplifier";
+        }
+        leaf target-gain {
+          type decimal64 {
+            fraction-digits 2;
+            range "0..max";
+          }
+          units "dB";
+          description
+            "Positive gain applied by the amplifier. This is used
+             when the amp-mode is in CONSTANT_GAIN or DYNAMIC_GAIN
+             mode to set the target gain that the amplifier should
+             achieve.";
+        }
+        leaf min-gain {
+          type decimal64 {
+            fraction-digits 2;
+          }
+          units "dB";
+          description
+            "The minimum allowed gain of the amplifier. This is used
+             when the amp-mode is in CONSTANT_POWER or DYNAMIC_GAIN mode
+             to prevent the gain from dropping below a desired threshold.
+             If left empty, the platform will apply a minimum gain based
+             on hardware specifications.";
+        }
+        leaf max-gain {
+          type decimal64 {
+            fraction-digits 2;
+          }
+          units "dB";
+          description
+            "The maximum allowed gain of the amplifier. This is used
+             when the amp-mode is in CONSTANT_POWER or DYNAMIC_GAIN mode
+             to prevent the gain from exceeding a desired threshold. If
+             left empty, the platform will apply a maximum gain based on
+             hardware specifications.";
+        }
+        leaf target-gain-tilt {
+          type decimal64 {
+            fraction-digits 2;
+          }
+          units "dB";
+          description
+            "Gain tilt control";
+        }
+        leaf gain-range {
+          type gain-range;
+          description
+            "Selected gain range.  The gain range is a platform-defined
+             value indicating the switched gain amplifier setting";
+        }
+        leaf amp-mode {
+          type optical-amplifier-mode;
+          description
+            "The operating mode of the amplifier";
+        }
+        leaf target-output-power {
+          type decimal64 {
+            fraction-digits 2;
+          }
+          units "dBm";
+          description
+            "Output optical power of the amplifier.";
+        }
+        leaf max-output-power {
+          type decimal64 {
+            fraction-digits 2;
+          }
+          units "dBm";
+          description
+            "The maximum optical output power of the amplifier. This
+             may be used to prevent the output power from exceeding a
+             desired threshold.";
+        }
+        leaf enabled {
+          type boolean;
+          description
+            "Turns power on / off to the amplifiers gain module.";
+        }
+        leaf fiber-type-profile {
+          type fiber-type-profile;
+          description
+            "The fiber type profile specifies details about the
+             fiber type which are needed to accurately determine
+             the gain and perform efficient amplification. This is
+             only needed for Raman type amplifiers.";
+        }
+      }
+    }
+    container OTN_OSC {
+      description
+        "Enclosing container for list of supervisory channels";
+      list OTN_OSC_LIST {
+        key "interface";
+        description
+          "List of optical supervisory channels, keyed by interface";
+        leaf interface {
+          type string;
+          description
+            "Reference to an OSC interface";
+        }
+      }
+    }
+  }
+}

--- a/src/sonic-yang-models/yang-models/sonic-optical-attenuator.yang
+++ b/src/sonic-yang-models/yang-models/sonic-optical-attenuator.yang
@@ -1,0 +1,89 @@
+module sonic-optical-attenuator {
+  yang-version 1.1;
+  namespace "http://github.com/sonic-net/sonic-optical-attenuator";
+  prefix opt-att;
+
+  organization
+    "SONiC";
+  contact
+    "SONiC";
+  description
+    "OTN_ATTENUATOR YANG Module for SONiC OS";
+
+  revision 2026-06-01 {
+    description
+      "First revision, derived from openconfig yang model";
+    reference
+      "openconfig-optical-attenuator.yang, version 2019-07-19";
+  }
+
+  typedef optical-attenuator-mode {
+    type enumeration {
+      enum CONSTANT_POWER {
+        description
+          "In constant power mode, the attenuator will apply
+           attenuation such as to maintain a constant output power";
+      }
+      enum CONSTANT_ATTENUATION {
+        description
+          "In constant attenuation mode, the attenuator will apply
+           a constant attenuation";
+      }
+    }
+    description
+      "Type definition for different types of optical attenuator
+       operating modes. Derived from the OPTICAL_ATTENUATOR_MODE
+       identity in openconfig-optical-attenuator.yang";
+  }
+
+  container sonic-optical-attenuator {
+    description
+      "Top-level container for the OTN optical attenuator configuration";
+    container OTN_ATTENUATOR {
+      description
+        "Enclosing container for list of attenuators";
+      list OTN_ATTENUATOR_LIST {
+        key "name";
+        description
+          "List of optical attenuators, keyed by attenuator name";
+        leaf name {
+          type string;
+          description
+            "User-defined name assigned to identify a specific attenuator
+             in the device";
+        }
+        leaf attenuation-mode {
+          type optical-attenuator-mode;
+          description
+            "The operating mode of the attenuator";
+        }
+        leaf target-output-power {
+          type decimal64 {
+            fraction-digits 2;
+          }
+          units "dBm";
+          description
+            "Power level set on the output of attenuator.  This leaf is
+             only relevant when in CONSTANT_POWER mode.";
+        }
+        leaf attenuation {
+          type decimal64 {
+            fraction-digits 2;
+            range "0..max";
+          }
+          units "dB";
+          description
+            "Attenuation applied by the attenuator.  This leaf is only
+             relevant when in CONSTANT_ATTENUATION mode.";
+        }
+        leaf enabled {
+          type boolean;
+          description
+            "When true, attenuator is set to specified attenuation or varies to
+             maintain constant output power.  When false, the attenuator is set
+             max attenuation or blocked.";
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION


#### Why I did it
Add SONiC YANG models for OTN optical **attenuator** and optical **amplifier** (including OSC), so these OTN line-system components can be represented and validated in CONFIG_DB, as well as import to sonic-mgmt-common for CVL. Corresponding table names for State DB, Counter DB and AppDB are merged in https://github.com/sonic-net/sonic-swss-common/pull/1223

Contributed by sonic-otn-wg. https://lists.sonicfoundation.dev/g/sonic-wg-otn

#### How I did it
* Added `sonic-optical-amplifier.yang` (optical amplifier + OSC).
* Added `sonic-optical-attenuator.yang` (variable optical attenuator).
* Added YANG model tests and test configs for the new models.
* Registered the new models in `setup.py` and added a `sample_config_db.json` snippet.

#### How to verify it
Ran the YANG model tests from `src/sonic-yang-models` against the full model set. The three new tests validate cleanly:

```
PASS  VALID_OTN_OA           (validated cleanly)
PASS  VALID_OTN_OSC          (validated cleanly)
PASS  VALID_OTN_ATTENUATOR   (validated cleanly)
```

Both new models load and compile alongside all existing SONiC YANG models with no dependency or syntax breakage.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
[sonic-otn] Add OTN attenuator and amplifier SONiC YANG models.