### PR TITLE
[dhcp-relay] Run SONiC relay only for active configuration

### DIFF
--- a/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
+++ b/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
@@ -6,22 +6,22 @@ programs=
 {% set vlan_list = [] %}
 {# Go through Vlan interfaces. Generate dhcpmon for any vlan with either dhcpv4 or dhcpv6 relay configured. #}
 {% for (vlan_name, prefix) in VLAN_INTERFACE | pfx_filter %}
-    {%- if prefix | ipv4 and 'has_sonic_dhcpv4_relay' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] == 'True' and DHCPV4_RELAY and vlan_name in DHCPV4_RELAY and 'dhcpv4_servers' in DHCPV4_RELAY[vlan_name] and DHCPV4_RELAY[vlan_name]['dhcpv4_servers']|length > 0 %}
+    {%- if prefix | ipv4 and vlan_name not in vlan_v4_list and 'has_sonic_dhcpv4_relay' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] == 'True' and DHCPV4_RELAY and vlan_name in DHCPV4_RELAY and 'dhcpv4_servers' in DHCPV4_RELAY[vlan_name] and DHCPV4_RELAY[vlan_name]['dhcpv4_servers']|length > 0 %}
         {%- for dhcp_server in DHCPV4_RELAY[vlan_name]['dhcpv4_servers'] %}
-            {%- if dhcp_server | ipv4 and vlan_name not in vlan_v4_list %}
+            {%- if dhcp_server | ipv4 %}
                 {%- set _ = vlan_v4_list.append(vlan_name) %}
             {%- endif %}
         {%- endfor %}
-    {%- elif prefix | ipv4 and ('has_sonic_dhcpv4_relay' not in DEVICE_METADATA['localhost'] or DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] != 'True') and VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
+    {%- elif prefix | ipv4 and vlan_name not in vlan_v4_list and ('has_sonic_dhcpv4_relay' not in DEVICE_METADATA['localhost'] or DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] != 'True') and VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
         {%- for dhcp_server in VLAN[vlan_name]['dhcp_servers'] %}
-            {%- if dhcp_server | ipv4 and vlan_name not in vlan_v4_list %}
+            {%- if dhcp_server | ipv4 %}
                 {%- set _ = vlan_v4_list.append(vlan_name) %}
             {%- endif %}
         {%- endfor %}
     {%- endif %}
-    {%- if prefix | ipv6 and DHCP_RELAY and vlan_name in DHCP_RELAY and 'dhcpv6_servers' in DHCP_RELAY[vlan_name] and DHCP_RELAY[vlan_name]['dhcpv6_servers']|length > 0 %}
+    {%- if prefix | ipv6 and vlan_name not in vlan_v6_list and DHCP_RELAY and vlan_name in DHCP_RELAY and 'dhcpv6_servers' in DHCP_RELAY[vlan_name] and DHCP_RELAY[vlan_name]['dhcpv6_servers']|length > 0 %}
         {%- for dhcpv6_server in DHCP_RELAY[vlan_name]['dhcpv6_servers'] %}
-            {%- if dhcpv6_server | ipv6 and vlan_name not in vlan_v6_list %}
+            {%- if dhcpv6_server | ipv6 %}
                 {%- set _ = vlan_v6_list.append(vlan_name) %}
             {%- endif %}
         {%- endfor %}

--- a/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
+++ b/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
@@ -1,25 +1,42 @@
 [group:dhcpmon]
 programs=
 {%- set add_preceding_comma = { 'flag': False } %}
+{% set vlan_v4_list = [] %}
+{% set vlan_v6_list = [] %}
 {% set vlan_list = [] %}
-{# Go through Vlan interfaces, if not ipv4 address or dhcpv4 server configured, then do not generate dhcpmon for them #}
+{# Go through Vlan interfaces. Generate dhcpmon for any vlan with either dhcpv4 or dhcpv6 relay configured. #}
 {% for (vlan_name, prefix) in VLAN_INTERFACE | pfx_filter %}
-    {%- if prefix | ipv4 and VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
+    {%- if prefix | ipv4 and 'has_sonic_dhcpv4_relay' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] == 'True' and DHCPV4_RELAY and vlan_name in DHCPV4_RELAY and 'dhcpv4_servers' in DHCPV4_RELAY[vlan_name] and DHCPV4_RELAY[vlan_name]['dhcpv4_servers']|length > 0 %}
+        {%- for dhcp_server in DHCPV4_RELAY[vlan_name]['dhcpv4_servers'] %}
+            {%- if dhcp_server | ipv4 and vlan_name not in vlan_v4_list %}
+                {%- set _ = vlan_v4_list.append(vlan_name) %}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif prefix | ipv4 and ('has_sonic_dhcpv4_relay' not in DEVICE_METADATA['localhost'] or DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] != 'True') and VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
         {%- for dhcp_server in VLAN[vlan_name]['dhcp_servers'] %}
-            {%- if dhcp_server | ipv4 %}
-                {%- set _ = vlan_list.append(vlan_name) %}
+            {%- if dhcp_server | ipv4 and vlan_name not in vlan_v4_list %}
+                {%- set _ = vlan_v4_list.append(vlan_name) %}
+            {%- endif %}
+        {%- endfor %}
+    {%- endif %}
+    {%- if prefix | ipv6 and DHCP_RELAY and vlan_name in DHCP_RELAY and 'dhcpv6_servers' in DHCP_RELAY[vlan_name] and DHCP_RELAY[vlan_name]['dhcpv6_servers']|length > 0 %}
+        {%- for dhcpv6_server in DHCP_RELAY[vlan_name]['dhcpv6_servers'] %}
+            {%- if dhcpv6_server | ipv6 and vlan_name not in vlan_v6_list %}
+                {%- set _ = vlan_v6_list.append(vlan_name) %}
             {%- endif %}
         {%- endfor %}
     {%- endif %}
 {% endfor %}
-{% for vlan_name in vlan_list | unique %}
+{%- for v in vlan_v4_list %}{% if v not in vlan_list %}{% set _ = vlan_list.append(v) %}{% endif %}{% endfor %}
+{%- for v in vlan_v6_list %}{% if v not in vlan_list %}{% set _ = vlan_list.append(v) %}{% endif %}{% endfor %}
+{% for vlan_name in vlan_list %}
     {%- if add_preceding_comma.flag %},{% endif %}
         {%- set _dummy = add_preceding_comma.update({'flag': True}) %}
 dhcpmon-{{ vlan_name }}
 {%- endfor%}
 
 
-{% for vlan_name in vlan_list | unique %}
+{% for vlan_name in vlan_list %}
 [program:dhcpmon-{{ vlan_name }}]
 {# We treat this VLAN as a downstream interface (-id), as we only want to listen for requests #}
 command=/usr/sbin/dhcpmon -id {{ vlan_name }}
@@ -50,10 +67,6 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-{% if 'has_sonic_dhcpv4_relay' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] == 'True' %}
-dependent_startup_wait_for=dhcp4relay:running
-{% else %}
-dependent_startup_wait_for=isc-dhcpv4-relay-{{ vlan_name }}:running
-{% endif %}
+dependent_startup_wait_for=start:exited
 
 {% endfor %}

--- a/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
+++ b/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
@@ -18,7 +18,7 @@ programs=
             {%- endif %}
         {%- endfor %}
     {%- endif %}
-    {%- if prefix | ipv6 and vlan_name not in vlan_v6_list and DHCP_RELAY and vlan_name in DHCP_RELAY and 'dhcpv6_servers' in DHCP_RELAY[vlan_name] and DHCP_RELAY[vlan_name]['dhcpv6_servers']|length > 0 %}
+    {%- if vlan_name not in vlan_v6_list and DHCP_RELAY and vlan_name in DHCP_RELAY and 'dhcpv6_servers' in DHCP_RELAY[vlan_name] and DHCP_RELAY[vlan_name]['dhcpv6_servers']|length > 0 %}
         {%- for dhcpv6_server in DHCP_RELAY[vlan_name]['dhcpv6_servers'] %}
             {%- if dhcpv6_server | ipv6 %}
                 {%- set _ = vlan_v6_list.append(vlan_name) %}

--- a/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
+++ b/dockers/docker-dhcp-relay/dhcp-relay.monitors.j2
@@ -3,7 +3,6 @@ programs=
 {%- set add_preceding_comma = { 'flag': False } %}
 {% set vlan_v4_list = [] %}
 {% set vlan_v6_list = [] %}
-{% set vlan_list = [] %}
 {# Go through Vlan interfaces. Generate dhcpmon for any vlan with either dhcpv4 or dhcpv6 relay configured. #}
 {% for (vlan_name, prefix) in VLAN_INTERFACE | pfx_filter %}
     {%- if prefix | ipv4 and vlan_name not in vlan_v4_list and 'has_sonic_dhcpv4_relay' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] == 'True' and DHCPV4_RELAY and vlan_name in DHCPV4_RELAY and 'dhcpv4_servers' in DHCPV4_RELAY[vlan_name] and DHCPV4_RELAY[vlan_name]['dhcpv4_servers']|length > 0 %}
@@ -27,16 +26,15 @@ programs=
         {%- endfor %}
     {%- endif %}
 {% endfor %}
-{%- for v in vlan_v4_list %}{% if v not in vlan_list %}{% set _ = vlan_list.append(v) %}{% endif %}{% endfor %}
-{%- for v in vlan_v6_list %}{% if v not in vlan_list %}{% set _ = vlan_list.append(v) %}{% endif %}{% endfor %}
-{% for vlan_name in vlan_list %}
+{% set vlan_list = vlan_v4_list + vlan_v6_list %}
+{% for vlan_name in vlan_list | unique %}
     {%- if add_preceding_comma.flag %},{% endif %}
         {%- set _dummy = add_preceding_comma.update({'flag': True}) %}
 dhcpmon-{{ vlan_name }}
 {%- endfor%}
 
 
-{% for vlan_name in vlan_list %}
+{% for vlan_name in vlan_list | unique %}
 [program:dhcpmon-{{ vlan_name }}]
 {# We treat this VLAN as a downstream interface (-id), as we only want to listen for requests #}
 command=/usr/sbin/dhcpmon -id {{ vlan_name }}

--- a/dockers/docker-dhcp-relay/dhcp-relay.programs.j2
+++ b/dockers/docker-dhcp-relay/dhcp-relay.programs.j2
@@ -17,9 +17,11 @@ dhcp6relay
 {# Create a program entry for sonic dhcpv4 relay agent #}
 {%- set add_preceding_comma = { 'flag': True } %}
 {# Append sonic DHCPv4 agent #}
+{% if ipv4_num_relays.count > 0 %}
 {% if add_preceding_comma.flag %},{% endif %}
 {% set _dummy = add_preceding_comma.update({'flag': True}) %}
 dhcp4relay
+{% endif %}
 {% else %}
 {%- set relay_for_ipv6 = { 'flag': False } %}
 {%- set add_preceding_comma = { 'flag': True } %}

--- a/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
+++ b/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
@@ -50,7 +50,13 @@ dependent_startup_wait_for=rsyslogd:running
 {% set ipv6_num_relays = { 'count': 0 } %}
 {% for vlan_name in VLAN_INTERFACE %}
 {% if 'has_sonic_dhcpv4_relay' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] == 'True' %}
-{% if DHCPV4_RELAY and vlan_name in DHCPV4_RELAY and 'dhcpv4_servers' in DHCPV4_RELAY[vlan_name] and DHCPV4_RELAY[vlan_name]['dhcpv4_servers']|length > 0 %}
+{% set vlan_has_dhcpv4_relay = { 'flag': False } %}
+{% if DHCPV4_RELAY and vlan_name in DHCPV4_RELAY and 'dhcpv4_servers' in DHCPV4_RELAY[vlan_name] %}
+{% for dhcpv4_server in DHCPV4_RELAY[vlan_name]['dhcpv4_servers'] %}
+{% if dhcpv4_server | trim %}{% set _dummy = vlan_has_dhcpv4_relay.update({'flag': True}) %}{% endif %}
+{% endfor %}
+{% endif %}
+{% if vlan_has_dhcpv4_relay.flag %}
 {% set _dummy = ipv4_num_relays.update({'count': ipv4_num_relays.count + 1}) %}
 {% endif %}
 {% elif VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}

--- a/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
+++ b/dockers/docker-dhcp-relay/docker-dhcp-relay.supervisord.conf.j2
@@ -48,11 +48,12 @@ dependent_startup_wait_for=rsyslogd:running
 {# Count how many VLANs require a DHCP relay agent... #}
 {% set ipv4_num_relays = { 'count': 0 } %}
 {% set ipv6_num_relays = { 'count': 0 } %}
+{% for vlan_name in VLAN_INTERFACE %}
 {% if 'has_sonic_dhcpv4_relay' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] == 'True' %}
+{% if DHCPV4_RELAY and vlan_name in DHCPV4_RELAY and 'dhcpv4_servers' in DHCPV4_RELAY[vlan_name] and DHCPV4_RELAY[vlan_name]['dhcpv4_servers']|length > 0 %}
 {% set _dummy = ipv4_num_relays.update({'count': ipv4_num_relays.count + 1}) %}
 {% endif %}
-{% for vlan_name in VLAN_INTERFACE %}
-{% if VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
+{% elif VLAN and vlan_name in VLAN and 'dhcp_servers' in VLAN[vlan_name] and VLAN[vlan_name]['dhcp_servers']|length > 0 %}
 {% set _dummy = ipv4_num_relays.update({'count': ipv4_num_relays.count + 1}) %}
 {% endif %}
 {% if DHCP_RELAY and vlan_name in DHCP_RELAY and DHCP_RELAY[vlan_name]['dhcpv6_servers']|length > 0 %}
@@ -68,7 +69,9 @@ dependent_startup_wait_for=rsyslogd:running
 {% set relay_for_ipv6 = { 'flag': False } %}
 {# Decide the dhcpv4 relay agent based on the feature config #}
 {% if 'has_sonic_dhcpv4_relay' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] == 'True' %}
+{% if ipv4_num_relays.count > 0 %}
 {% include 'dhcpv4-sonic-relay.agents.j2' %}
+{% endif %}
 {% include 'dhcpv6-relay.agents.j2' %}
 {% include 'dhcp-relay.monitors.j2' %}
 {% else %}
@@ -83,10 +86,6 @@ dependent_startup_wait_for=rsyslogd:running
 {% include 'dhcpv6-relay.agents.j2' %}
 {% include 'dhcp-relay.monitors.j2' %}
 {% endif %}
-{% endif %}
-{% else %}
-{% if 'has_sonic_dhcpv4_relay' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['has_sonic_dhcpv4_relay'] == 'True' %}
-{% include 'dhcpv4-sonic-relay.agents.j2' %}
 {% endif %}
 {% endif %}
 [program:dhcprelayd]

--- a/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay-no-ip-helper.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay-no-ip-helper.supervisord.conf
@@ -84,7 +84,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=isc-dhcpv4-relay-Vlan1000:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcprelayd]
 command=/usr/local/bin/dhcprelayd

--- a/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay-secondary-subnets.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay-secondary-subnets.supervisord.conf
@@ -96,7 +96,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=isc-dhcpv4-relay-Vlan1000:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcpmon-Vlan2000]
 command=/usr/sbin/dhcpmon -id Vlan2000 -iu Vlan1000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 -im eth0
@@ -108,7 +108,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=isc-dhcpv4-relay-Vlan2000:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcprelayd]
 command=/usr/local/bin/dhcprelayd

--- a/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay-sonic-agent-no-relay-cfg.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay-sonic-agent-no-relay-cfg.supervisord.conf
@@ -43,24 +43,6 @@ stderr_syslog=true
 dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 
-[group:dhcp-relay]
-programs=dhcprelayd,dhcp4relay
-
-[program:dhcp4relay]
-command=/usr/sbin/dhcp4relay
-priority=3
-autostart=false
-autorestart=false
-stdout_logfile=NONE
-stdout_syslog=true
-stderr_logfile=NONE
-stderr_syslog=true
-dependent_startup=true
-dependent_startup_wait_for=start:exited
-
-[group:dhcpmon]
-programs=
-
 [program:dhcprelayd]
 command=/usr/local/bin/dhcprelayd
 priority=3

--- a/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay-sonic-agent.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay-sonic-agent.supervisord.conf
@@ -83,7 +83,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=dhcp4relay:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcpmon-Vlan2000]
 command=/usr/sbin/dhcpmon -id Vlan2000 -iu Vlan1000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -im eth0
@@ -95,7 +95,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=dhcp4relay:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcprelayd]
 command=/usr/local/bin/dhcprelayd

--- a/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
@@ -84,7 +84,7 @@ dependent_startup=true
 dependent_startup_wait_for=start:exited
 
 [group:dhcpmon]
-programs=dhcpmon-Vlan1000,dhcpmon-Vlan2000
+programs=dhcpmon-Vlan1000,dhcpmon-Vlan2000,dhcpmon-Vlan3000
 
 [program:dhcpmon-Vlan1000]
 command=/usr/sbin/dhcpmon -id Vlan1000 -iu Vlan2000 -iu Vlan3000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 -im eth0
@@ -100,6 +100,18 @@ dependent_startup_wait_for=start:exited
 
 [program:dhcpmon-Vlan2000]
 command=/usr/sbin/dhcpmon -id Vlan2000 -iu Vlan1000 -iu Vlan3000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 -im eth0
+priority=4
+autostart=false
+autorestart=false
+stdout_logfile=NONE
+stdout_syslog=true
+stderr_logfile=NONE
+stderr_syslog=true
+dependent_startup=true
+dependent_startup_wait_for=start:exited
+
+[program:dhcpmon-Vlan3000]
+command=/usr/sbin/dhcpmon -id Vlan3000 -iu Vlan1000 -iu Vlan2000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 -im eth0
 priority=4
 autostart=false
 autorestart=false

--- a/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
@@ -96,7 +96,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=isc-dhcpv4-relay-Vlan1000:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcpmon-Vlan2000]
 command=/usr/sbin/dhcpmon -id Vlan2000 -iu Vlan1000 -iu Vlan3000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 -im eth0
@@ -108,7 +108,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=isc-dhcpv4-relay-Vlan2000:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcprelayd]
 command=/usr/local/bin/dhcprelayd

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-no-ip-helper.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-no-ip-helper.supervisord.conf
@@ -84,7 +84,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=isc-dhcpv4-relay-Vlan1000:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcprelayd]
 command=/usr/local/bin/dhcprelayd

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-secondary-subnets.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-secondary-subnets.supervisord.conf
@@ -96,7 +96,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=isc-dhcpv4-relay-Vlan1000:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcpmon-Vlan2000]
 command=/usr/sbin/dhcpmon -id Vlan2000 -iu Vlan1000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -im eth0
@@ -108,7 +108,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=isc-dhcpv4-relay-Vlan2000:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcprelayd]
 command=/usr/local/bin/dhcprelayd

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-sonic-agent-no-relay-cfg.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-sonic-agent-no-relay-cfg.supervisord.conf
@@ -43,24 +43,6 @@ stderr_syslog=true
 dependent_startup=true
 dependent_startup_wait_for=rsyslogd:running
 
-[group:dhcp-relay]
-programs=dhcprelayd,dhcp4relay
-
-[program:dhcp4relay]
-command=/usr/sbin/dhcp4relay
-priority=3
-autostart=false
-autorestart=false
-stdout_logfile=NONE
-stdout_syslog=true
-stderr_logfile=NONE
-stderr_syslog=true
-dependent_startup=true
-dependent_startup_wait_for=start:exited
-
-[group:dhcpmon]
-programs=
-
 [program:dhcprelayd]
 command=/usr/local/bin/dhcprelayd
 priority=3

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-sonic-agent.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-sonic-agent.supervisord.conf
@@ -83,7 +83,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=dhcp4relay:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcpmon-Vlan2000]
 command=/usr/sbin/dhcpmon -id Vlan2000 -iu Vlan1000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -im eth0
@@ -95,7 +95,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=dhcp4relay:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcprelayd]
 command=/usr/local/bin/dhcprelayd

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
@@ -84,7 +84,7 @@ dependent_startup=true
 dependent_startup_wait_for=start:exited
 
 [group:dhcpmon]
-programs=dhcpmon-Vlan1000,dhcpmon-Vlan2000
+programs=dhcpmon-Vlan1000,dhcpmon-Vlan2000,dhcpmon-Vlan3000
 
 [program:dhcpmon-Vlan1000]
 command=/usr/sbin/dhcpmon -id Vlan1000 -iu Vlan2000 -iu Vlan3000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -im eth0
@@ -100,6 +100,18 @@ dependent_startup_wait_for=start:exited
 
 [program:dhcpmon-Vlan2000]
 command=/usr/sbin/dhcpmon -id Vlan2000 -iu Vlan1000 -iu Vlan3000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -im eth0
+priority=4
+autostart=false
+autorestart=false
+stdout_logfile=NONE
+stdout_syslog=true
+stderr_logfile=NONE
+stderr_syslog=true
+dependent_startup=true
+dependent_startup_wait_for=start:exited
+
+[program:dhcpmon-Vlan3000]
+command=/usr/sbin/dhcpmon -id Vlan3000 -iu Vlan1000 -iu Vlan2000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -im eth0
 priority=4
 autostart=false
 autorestart=false

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
@@ -96,7 +96,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=isc-dhcpv4-relay-Vlan1000:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcpmon-Vlan2000]
 command=/usr/sbin/dhcpmon -id Vlan2000 -iu Vlan1000 -iu Vlan3000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -im eth0
@@ -108,7 +108,7 @@ stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
 dependent_startup=true
-dependent_startup_wait_for=isc-dhcpv4-relay-Vlan2000:running
+dependent_startup_wait_for=start:exited
 
 [program:dhcprelayd]
 command=/usr/local/bin/dhcprelayd

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -213,8 +213,12 @@ class TestJ2Files(TestCase):
                                      'docker-dhcp-relay.supervisord.conf.j2')
         argument = ['-m', self.t0_minigraph, '-j', sample_data, '-p', self.t0_port_config, '-t', template_path]
         self.run_script(argument, output_file=self.output_file)
-        self.assertTrue(utils.cmp(os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR,
-                                               'docker-dhcp-relay-sonic-agent.supervisord.conf'), self.output_file))
+        with open(self.output_file, 'r') as output:
+            rendered = output.read()
+        self.assertIn("programs=dhcprelayd,dhcp6relay,dhcp4relay", rendered)
+        self.assertIn("[program:dhcp6relay]", rendered)
+        self.assertIn("[program:dhcpmon-Vlan1000]", rendered)
+        self.assertIn("[program:dhcpmon-Vlan2000]", rendered)
 
         # Test generation when only SONiC DHCPv4 relay servers are configured.
         sonic_dhcpv4_only_data = {

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -216,6 +216,22 @@ class TestJ2Files(TestCase):
         self.assertTrue(utils.cmp(os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR,
                                                'docker-dhcp-relay-sonic-agent.supervisord.conf'), self.output_file))
 
+        # Test generation when only SONiC DHCPv4 relay servers are configured.
+        sonic_dhcpv4_only_data = {
+            "DHCPV4_RELAY": {
+                "Vlan1000": {"dhcpv4_servers": ["192.0.0.1", "192.0.0.2"]}
+            }
+        }
+        argument = ['-m', self.sonic_dhcp4relay_minigraph, '-j', sample_data, '-p', self.t0_port_config,
+                    '-a', json.dumps(sonic_dhcpv4_only_data), '-t', template_path]
+        self.run_script(argument, output_file=self.output_file)
+        with open(self.output_file, 'r') as output:
+            rendered = output.read()
+        self.assertIn("programs=dhcprelayd,dhcp4relay", rendered)
+        self.assertIn("[program:dhcpmon-Vlan1000]", rendered)
+        self.assertNotIn("[program:dhcp6relay]", rendered)
+        self.assertNotIn("[program:dhcpmon-Vlan2000]", rendered)
+
         # Test generation when SONiC DHCPv4 and DHCPv6 relay servers are both configured.
         sample_data = os.path.join(self.test_dir, "dhcp-sonic-relay-enabled-sample.json")
         template_path = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-dhcp-relay',

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -215,8 +215,9 @@ class TestJ2Files(TestCase):
         self.run_script(argument, output_file=self.output_file)
         with open(self.output_file, 'r') as output:
             rendered = output.read()
-        self.assertIn("programs=dhcprelayd,dhcp6relay,dhcp4relay", rendered)
+        self.assertIn("programs=dhcprelayd,dhcp6relay", rendered)
         self.assertIn("[program:dhcp6relay]", rendered)
+        self.assertNotIn("[program:dhcp4relay]", rendered)
         self.assertIn("[program:dhcpmon-Vlan1000]", rendered)
         self.assertIn("[program:dhcpmon-Vlan2000]", rendered)
 

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -207,7 +207,16 @@ class TestJ2Files(TestCase):
         self.assertTrue(utils.cmp(os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR,
                                                'docker-dhcp-relay-secondary-subnets.supervisord.conf'), self.output_file))
 
-        # Test generation of docker-dhcp-relay.supervisord.conf when has_sonic_dhcpv4_relay is True and dhcp relay config is present
+        # Test generation when SONiC DHCPv4 is enabled and only DHCPv6 relay servers are configured.
+        sample_data = os.path.join(self.test_dir, "dhcp-sonic-relay-enabled-sample.json")
+        template_path = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-dhcp-relay',
+                                     'docker-dhcp-relay.supervisord.conf.j2')
+        argument = ['-m', self.t0_minigraph, '-j', sample_data, '-p', self.t0_port_config, '-t', template_path]
+        self.run_script(argument, output_file=self.output_file)
+        self.assertTrue(utils.cmp(os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR,
+                                               'docker-dhcp-relay-sonic-agent.supervisord.conf'), self.output_file))
+
+        # Test generation when SONiC DHCPv4 and DHCPv6 relay servers are both configured.
         sample_data = os.path.join(self.test_dir, "dhcp-sonic-relay-enabled-sample.json")
         template_path = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-dhcp-relay',
                                      'docker-dhcp-relay.supervisord.conf.j2')

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -211,7 +211,14 @@ class TestJ2Files(TestCase):
         sample_data = os.path.join(self.test_dir, "dhcp-sonic-relay-enabled-sample.json")
         template_path = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-dhcp-relay',
                                      'docker-dhcp-relay.supervisord.conf.j2')
-        argument = ['-m', self.t0_minigraph, '-j', sample_data, '-p', self.t0_port_config, '-t', template_path]
+        sonic_dhcpv4_relay_data = {
+            "DHCPV4_RELAY": {
+                "Vlan1000": {"dhcpv4_servers": ["192.0.0.1", "192.0.0.2"]},
+                "Vlan2000": {"dhcpv4_servers": ["192.0.0.3", "192.0.0.4"]}
+            }
+        }
+        argument = ['-m', self.t0_minigraph, '-j', sample_data, '-p', self.t0_port_config,
+                    '-a', json.dumps(sonic_dhcpv4_relay_data), '-t', template_path]
         self.run_script(argument, output_file=self.output_file)
         self.assertTrue(utils.cmp(os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR,
                                                'docker-dhcp-relay-sonic-agent.supervisord.conf'), self.output_file))

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -261,6 +261,18 @@ class TestJ2Files(TestCase):
         self.assertTrue(utils.cmp(os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR,
                                                'docker-dhcp-relay-sonic-agent-no-relay-cfg.supervisord.conf'), self.output_file))
 
+        # Empty SONiC DHCPv4 server values must remain equivalent to no relay configuration.
+        empty_sonic_dhcpv4_relay_data = {
+            "DHCPV4_RELAY": {
+                "Vlan1000": {"dhcpv4_servers": [""]}
+            }
+        }
+        argument = ['-m', self.sonic_dhcp4relay_minigraph, '-j', sample_data, '-p', self.t0_port_config,
+                    '-a', json.dumps(empty_sonic_dhcpv4_relay_data), '-t', template_path]
+        self.run_script(argument, output_file=self.output_file)
+        self.assertTrue(utils.cmp(os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR,
+                                               'docker-dhcp-relay-sonic-agent-no-relay-cfg.supervisord.conf'), self.output_file))
+
         # Test generation of docker-dhcp-relay.supervisord.conf when has_sonic_dhcpv4_relay is False
         sample_data = os.path.join(self.test_dir, "dhcp-sonic-relay-disabled-sample.json")
         template_path = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-dhcp-relay',

--- a/src/sonic-dhcp-utilities/dhcp_utilities/common/dhcp_db_monitor.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/common/dhcp_db_monitor.py
@@ -9,6 +9,7 @@ DHCP_SERVER_IPV4 = "DHCP_SERVER_IPV4"
 DHCP_SERVER_IPV4_PORT = "DHCP_SERVER_IPV4_PORT"
 DHCP_SERVER_IPV4_RANGE = "DHCP_SERVER_IPV4_RANGE"
 DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS = "DHCP_SERVER_IPV4_CUSTOMIZED_OPTIONS"
+DHCPV4_RELAY = "DHCPV4_RELAY"
 VLAN = "VLAN"
 VLAN_MEMBER = "VLAN_MEMBER"
 VLAN_INTERFACE = "VLAN_INTERFACE"
@@ -212,6 +213,23 @@ class DhcpServerTableIntfEnablementEventChecker(ConfigDbEventChecker):
             if key in enabled_dhcp_interfaces:
                 return True
         return False
+
+
+class DhcpV4RelayTableEventChecker(ConfigDbEventChecker):
+    """
+    This event checker is interested in all DHCPV4_RELAY table changes.
+    """
+    table_name = DHCPV4_RELAY
+
+    def __init__(self, sel, db):
+        self.table_name = DHCPV4_RELAY
+        ConfigDbEventChecker.__init__(self, sel, db)
+
+    def _get_parameter(self, db_snapshot):
+        return True, None
+
+    def _process_check(self, key, op, entry, parameter):
+        return True
 
 
 class DhcpPortTableEventChecker(ConfigDbEventChecker):

--- a/src/sonic-dhcp-utilities/dhcp_utilities/dhcprelayd/dhcprelayd.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/dhcprelayd/dhcprelayd.py
@@ -259,7 +259,11 @@ class DhcpRelayd(object):
 
     def _is_sonic_dhcpv4_relay_configured(self):
         relay_table = self.db_connector.get_config_db_table(DHCPV4_RELAY)
-        return any(config.get("dhcpv4_servers") for config in relay_table.values())
+        return any(
+            server and server.strip()
+            for config in relay_table.values()
+            for server in config.get("dhcpv4_servers", [])
+        )
 
     def _check_sonic_dhcpv4_relay_config_transition(self):
         if not self.has_sonic_dhcpv4_relay:

--- a/src/sonic-dhcp-utilities/dhcp_utilities/dhcprelayd/dhcprelayd.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/dhcprelayd/dhcprelayd.py
@@ -280,7 +280,7 @@ class DhcpRelayd(object):
 
     def _execute_supervisor_dhcp_relay_process(self, op, programs=None):
         """
-        Start or stop relay releated processes managed by supervisord
+        Start or stop relay related processes managed by supervisord
         Args:
             op: string of operation, require to be "start" or "stop"
             programs: optional subset of parsed supervisor programs to operate on

--- a/src/sonic-dhcp-utilities/dhcp_utilities/dhcprelayd/dhcprelayd.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/dhcprelayd/dhcprelayd.py
@@ -288,12 +288,25 @@ class DhcpRelayd(object):
         target_programs = configured_programs if programs is None else \
             [program for program in programs if program in configured_programs]
         for program in target_programs:
-            supervisor_program = "dhcp-relay:dhcp4relay" if program == "dhcp4relay" else program
-            cmds = ["supervisorctl", op, supervisor_program]
-            syslog.syslog(syslog.LOG_INFO, "Execute {} for {} by: {}".format(op, supervisor_program, cmds))
-            res = subprocess.run(cmds, check=True)
-            if res.returncode != 0:
-                syslog.syslog(syslog.LOG_ERR, "Error in execute: {}".format(res))
+            supervisor_programs = ["dhcp-relay:dhcp4relay", "dhcp4relay"] \
+                if program == "dhcp4relay" else [program]
+            for index, supervisor_program in enumerate(supervisor_programs):
+                cmds = ["supervisorctl", op, supervisor_program]
+                syslog.syslog(syslog.LOG_INFO, "Execute {} for {} by: {}".format(op, supervisor_program, cmds))
+                try:
+                    res = subprocess.run(cmds, check=True)
+                except subprocess.CalledProcessError as error:
+                    if index + 1 < len(supervisor_programs):
+                        continue
+                    syslog.syslog(syslog.LOG_ERR, "Error in execute: {}".format(error))
+                    sys.exit(1)
+                if res.returncode != 0:
+                    if index + 1 < len(supervisor_programs):
+                        continue
+                    syslog.syslog(syslog.LOG_ERR, "Error in execute: {}".format(res))
+                    sys.exit(1)
+                break
+            else:
                 sys.exit(1)
             syslog.syslog(syslog.LOG_INFO, "Supervisor {} for {} succeeded".format(op, program))
 

--- a/src/sonic-dhcp-utilities/dhcp_utilities/dhcprelayd/dhcprelayd.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/dhcprelayd/dhcprelayd.py
@@ -194,7 +194,9 @@ class DhcpRelayd(object):
                 if self.has_sonic_dhcpv4_relay:
                     if check_res.get(DHCPV4_RELAY_CHECKER, False):
                         self._check_sonic_dhcpv4_relay_config_transition()
-                    if not self.sonic_dhcp_server_relay_active:
+                    if self.sonic_dhcp_server_relay_active:
+                        self._check_sonic_dhcp_server_relay_process()
+                    else:
                         self._check_dhcp_relay_processes()
 
         # If dhcp_server feature is disabled, dhcprelayd will checke whether dhcpmon/dhcrelay processes,
@@ -313,6 +315,20 @@ class DhcpRelayd(object):
             else:
                 sys.exit(1)
             syslog.syslog(syslog.LOG_INFO, "Supervisor {} for {} succeeded".format(op, program))
+
+    def _check_sonic_dhcp_server_relay_process(self):
+        """
+        Check whether the dynamically-owned SONiC DHCPv4 relay process is running.
+        """
+        for proc in psutil.process_iter():
+            try:
+                if proc.name() == "dhcp4relay":
+                    return
+            except psutil.NoSuchProcess:
+                continue
+
+        syslog.syslog(syslog.LOG_ERR, "Dynamically-owned dhcp4relay process is not running")
+        sys.exit(1)
 
     def _check_dhcp_relay_processes(self):
         """

--- a/src/sonic-dhcp-utilities/dhcp_utilities/dhcprelayd/dhcprelayd.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/dhcprelayd/dhcprelayd.py
@@ -10,12 +10,14 @@ import time
 from swsscommon import swsscommon
 from dhcp_utilities.common.utils import DhcpDbConnector, terminate_proc, is_smart_switch
 from dhcp_utilities.common.dhcp_db_monitor import DhcpRelaydDbMonitor, DhcpServerTableIntfEnablementEventChecker, \
-     VlanTableEventChecker, VlanIntfTableEventChecker, DhcpServerFeatureStateChecker, MidPlaneTableEventChecker
+     VlanTableEventChecker, VlanIntfTableEventChecker, DhcpServerFeatureStateChecker, MidPlaneTableEventChecker, \
+     DhcpV4RelayTableEventChecker
 
 REDIS_SOCK_PATH = "/var/run/redis/redis.sock"
 SUPERVISORD_CONF_PATH = "/etc/supervisor/conf.d/docker-dhcp-relay.supervisord.conf"
 DHCP_SERVER_IPV4_SERVER_IP = "DHCP_SERVER_IPV4_SERVER_IP"
 DHCP_SERVER_IPV4 = "DHCP_SERVER_IPV4"
+DHCPV4_RELAY = "DHCPV4_RELAY"
 VLAN = "VLAN"
 MID_PLANE_BRIDGE = "MID_PLANE_BRIDGE"
 DEVICE_METADATA = "DEVICE_METADATA"
@@ -23,6 +25,7 @@ DEFAULT_SELECT_TIMEOUT = 5000  # millisecond
 DHCP_SERVER_INTERFACE = "eth0"
 FEATURE_CHECKER = "DhcpServerFeatureStateChecker"
 DHCP_SERVER_CHECKER = "DhcpServerTableIntfEnablementEventChecker"
+DHCPV4_RELAY_CHECKER = "DhcpV4RelayTableEventChecker"
 VLAN_CHECKER = "VlanTableEventChecker"
 VLAN_INTF_CHECKER = "VlanIntfTableEventChecker"
 MID_PLANE_CHECKER = "MidPlaneTableEventChecker"
@@ -39,6 +42,8 @@ class DhcpRelayd(object):
     supervisord_conf_path = ""
     enabled_checkers = set()
     smart_switch = False
+    has_sonic_dhcpv4_relay = False
+    sonic_dhcp_server_relay_active = False
 
     def __init__(self, db_connector, db_monitor, supervisord_conf_path=SUPERVISORD_CONF_PATH,
                  enabled_checkers=[FEATURE_CHECKER]):
@@ -54,6 +59,8 @@ class DhcpRelayd(object):
         self.dhcp_server_feature_enabled = None
         self.supervisord_conf_path = supervisord_conf_path
         self.enabled_checkers = set(enabled_checkers)
+        self.has_sonic_dhcpv4_relay = False
+        self.sonic_dhcp_server_relay_active = False
 
     def start(self):
         """
@@ -63,13 +70,21 @@ class DhcpRelayd(object):
         self.dhcp_server_feature_enabled = self._is_dhcp_server_enabled()
         device_metadata = self.db_connector.get_config_db_table(DEVICE_METADATA)
         self.smart_switch = is_smart_switch(device_metadata)
+        self.has_sonic_dhcpv4_relay = \
+            device_metadata.get("localhost", {}).get("has_sonic_dhcpv4_relay", "False") == "True"
+        if self.has_sonic_dhcpv4_relay:
+            self.enabled_checkers.add(DHCPV4_RELAY_CHECKER)
         # Sleep to wait dhcrelay process start
         time.sleep(5)
         if self.dhcp_server_feature_enabled:
-            # If dhcp_server is enabled, need to stop related relay processes start by supervisord
-            self._execute_supervisor_dhcp_relay_process("stop")
+            # ISC local mode always replaces the supervisor-owned relay. SONiC takes
+            # ownership only after an enabled local DHCP interface is configured.
+            if not self.has_sonic_dhcpv4_relay:
+                self._execute_supervisor_dhcp_relay_process("stop")
             self.enabled_checkers.add(DHCP_SERVER_CHECKER)
         self.dhcp_relayd_monitor.enable_checkers(self.enabled_checkers)
+        if self.dhcp_server_feature_enabled:
+            self.refresh_dhcrelay()
 
     def refresh_dhcrelay(self, force_kill=False):
         """
@@ -78,7 +93,6 @@ class DhcpRelayd(object):
             force_kill: if True, force kill old processes
         """
         syslog.syslog(syslog.LOG_INFO, "Start to refresh dhcrelay related processes")
-        dhcp_server_ip = self._get_dhcp_server_ip()
         dhcp_server_ipv4_table = self.db_connector.get_config_db_table(DHCP_SERVER_IPV4)
         vlan_table = self.db_connector.get_config_db_table(VLAN)
         mid_plane_table = self.db_connector.get_config_db_table(MID_PLANE_BRIDGE)
@@ -103,14 +117,33 @@ class DhcpRelayd(object):
                 checkers_to_be_enabled |= set([MID_PLANE_CHECKER])
         self._enable_checkers(checkers_to_be_enabled - self.enabled_checkers)
 
-        # Checkers for FEATURE and DHCP_SERVER_IPV4 table should not be disabled
+        # Checkers for feature, DHCP server, and external SONiC relay state should not be disabled.
         checkers_to_be_disabled = self.enabled_checkers - checkers_to_be_enabled - \
-            set([FEATURE_CHECKER, DHCP_SERVER_CHECKER])
+            set([FEATURE_CHECKER, DHCP_SERVER_CHECKER, DHCPV4_RELAY_CHECKER])
         self._disable_checkers(checkers_to_be_disabled)
 
-        feature_table = self.db_connector.get_config_db_table("DEVICE_METADATA")
-        if feature_table.get("localhost", {}).get("has_sonic_dhcpv4_relay", "False") == "False":
-           self._start_dhcrelay_process(dhcp_interfaces, dhcp_server_ip, force_kill)
+        device_metadata = self.db_connector.get_config_db_table(DEVICE_METADATA)
+        self.has_sonic_dhcpv4_relay = \
+            device_metadata.get("localhost", {}).get("has_sonic_dhcpv4_relay", "False") == "True"
+        if self.has_sonic_dhcpv4_relay:
+            local_relay_active = bool(dhcp_interfaces)
+            if local_relay_active:
+                if (not self.sonic_dhcp_server_relay_active and
+                   "dhcp4relay" in self.dhcp_relay_supervisor_config):
+                    self._execute_supervisor_dhcp_relay_process("stop", ["dhcp4relay"])
+                cmds = ["/usr/sbin/dhcp4relay"]
+                if device_metadata.get("localhost", {}).get("subtype") == "DualToR":
+                    cmds += ["-u", "Loopback0"]
+                self._start_sonic_dhcp_relay_process(dhcp_interfaces, cmds, force_kill)
+            elif self.sonic_dhcp_server_relay_active:
+                self._kill_exist_relay_releated_process([], "dhcp4relay", True)
+                self._check_sonic_dhcpv4_relay_config_transition()
+                if "dhcp4relay" in self.dhcp_relay_supervisor_config:
+                    self._execute_supervisor_dhcp_relay_process("start", ["dhcp4relay"])
+            self.sonic_dhcp_server_relay_active = local_relay_active
+        else:
+            dhcp_server_ip = self._get_dhcp_server_ip() if dhcp_interfaces else None
+            self._start_dhcrelay_process(dhcp_interfaces, dhcp_server_ip, force_kill)
 
         # TODO dhcpmon is not ready for count packet for dhcp_server, hence comment invoke it for now
         # self._start_dhcpmon_process(dhcp_interfaces, force_kill)
@@ -147,8 +180,8 @@ class DhcpRelayd(object):
             # disabled -> enabled, we need to enable dhcp_server checker and do refresh processes
             if dhcp_feature_status_changed:
                 self._enable_checkers([DHCP_SERVER_CHECKER])
-                # Stop dhcrelay process
-                self._execute_supervisor_dhcp_relay_process("stop")
+                if not self.has_sonic_dhcpv4_relay:
+                    self._execute_supervisor_dhcp_relay_process("stop")
                 self.refresh_dhcrelay()
             # enabled -> enabled, just need to check dhcp_server related tables to see whether need to refresh
             else:
@@ -158,6 +191,11 @@ class DhcpRelayd(object):
                     self.refresh_dhcrelay(True)
                 elif check_res.get(VLAN_CHECKER, False) or check_res.get(DHCP_SERVER_CHECKER, False):
                     self.refresh_dhcrelay(False)
+                if self.has_sonic_dhcpv4_relay:
+                    if check_res.get(DHCPV4_RELAY_CHECKER, False):
+                        self._check_sonic_dhcpv4_relay_config_transition()
+                    if not self.sonic_dhcp_server_relay_active:
+                        self._check_dhcp_relay_processes()
 
         # If dhcp_server feature is disabled, dhcprelayd will checke whether dhcpmon/dhcrelay processes,
         # if they are not running as expected, dhcprelayd will kill itself to make dhcp_relay container restart.
@@ -169,12 +207,25 @@ class DhcpRelayd(object):
                 if self.smart_switch:
                     checkers_to_be_disabled.append(MID_PLANE_CHECKER)
                 self._disable_checkers(self.enabled_checkers & set(checkers_to_be_disabled))
-                self._kill_exist_relay_releated_process([], "dhcpmon", True)
-                self._kill_exist_relay_releated_process([], "dhcrelay", True)
-                self._execute_supervisor_dhcp_relay_process("start")
+                if self.has_sonic_dhcpv4_relay:
+                    if self.sonic_dhcp_server_relay_active:
+                        self._kill_exist_relay_releated_process([], "dhcp4relay", True)
+                        self.sonic_dhcp_server_relay_active = False
+                        self._check_sonic_dhcpv4_relay_config_transition()
+                        if "dhcp4relay" in self.dhcp_relay_supervisor_config:
+                            self._execute_supervisor_dhcp_relay_process("start", ["dhcp4relay"])
+                    else:
+                        self._check_sonic_dhcpv4_relay_config_transition()
+                        self._check_dhcp_relay_processes()
+                else:
+                    self._kill_exist_relay_releated_process([], "dhcpmon", True)
+                    self._kill_exist_relay_releated_process([], "dhcrelay", True)
+                    self._execute_supervisor_dhcp_relay_process("start")
             # disabled -> disabled, to check whether dhcpmon/dhcrelay running status consistent with supervisord
             # configuration
             else:
+                if check_res.get(DHCPV4_RELAY_CHECKER, False):
+                    self._check_sonic_dhcpv4_relay_config_transition()
                 self._check_dhcp_relay_processes()
 
     def _enable_checkers(self, checkers):
@@ -206,27 +257,50 @@ class DhcpRelayd(object):
         feature_table = self.db_connector.get_config_db_table("FEATURE")
         return feature_table.get("dhcp_server", {}).get("state", "disabled") == "enabled"
 
-    def _execute_supervisor_dhcp_relay_process(self, op):
+    def _is_sonic_dhcpv4_relay_configured(self):
+        relay_table = self.db_connector.get_config_db_table(DHCPV4_RELAY)
+        return any(config.get("dhcpv4_servers") for config in relay_table.values())
+
+    def _check_sonic_dhcpv4_relay_config_transition(self):
+        if not self.has_sonic_dhcpv4_relay:
+            return
+
+        relay_configured = self._is_sonic_dhcpv4_relay_configured()
+        supervisor_relay_configured = "dhcp4relay" in self.dhcp_relay_supervisor_config
+        if relay_configured != supervisor_relay_configured:
+            syslog.syslog(
+                syslog.LOG_INFO,
+                "DHCPv4 relay configuration presence changed; restart dhcp_relay to regenerate supervisor config"
+            )
+            sys.exit(1)
+
+    def _execute_supervisor_dhcp_relay_process(self, op, programs=None):
         """
         Start or stop relay releated processes managed by supervisord
         Args:
             op: string of operation, require to be "start" or "stop"
+            programs: optional subset of parsed supervisor programs to operate on
         """
         if op not in ["stop", "start"]:
             syslog.syslog(syslog.LOG_ERR, "Error operation: {}".format(op))
             sys.exit(1)
-        for program in self.dhcp_relay_supervisor_config.keys():
-            cmds = ["supervisorctl", op, program]
-            syslog.syslog(syslog.LOG_INFO, "Starting stop {} by: {}".format(program, cmds))
+        configured_programs = self.dhcp_relay_supervisor_config.keys()
+        target_programs = configured_programs if programs is None else \
+            [program for program in programs if program in configured_programs]
+        for program in target_programs:
+            supervisor_program = "dhcp-relay:dhcp4relay" if program == "dhcp4relay" else program
+            cmds = ["supervisorctl", op, supervisor_program]
+            syslog.syslog(syslog.LOG_INFO, "Execute {} for {} by: {}".format(op, supervisor_program, cmds))
             res = subprocess.run(cmds, check=True)
             if res.returncode != 0:
                 syslog.syslog(syslog.LOG_ERR, "Error in execute: {}".format(res))
                 sys.exit(1)
-            syslog.syslog(syslog.LOG_INFO, "Program {} stopped successfully".format(program))
+            syslog.syslog(syslog.LOG_INFO, "Supervisor {} for {} succeeded".format(op, program))
 
     def _check_dhcp_relay_processes(self):
         """
-        Check whether dhcrelay running as expected, if not, dhcprelayd will exit with code 1
+        Check whether IPv4 relay processes are running as expected.
+        If not, dhcprelayd will exit with code 1.
         """
         procs = {}
         for proc in psutil.process_iter():
@@ -234,7 +308,7 @@ class DhcpRelayd(object):
             for i in range(5):
                 err = None
                 try:
-                    if proc.name() == "dhcrelay":
+                    if proc.name() in ["dhcrelay", "dhcp4relay"]:
                         procs[proc.pid] = [proc.ppid(), proc.cmdline()]
                 except psutil.NoSuchProcess:
                     pass
@@ -254,7 +328,10 @@ class DhcpRelayd(object):
             running_cmds.append(cmdline)
 
         running_cmds.sort()
-        expected_cmds = [value for key, value in self.dhcp_relay_supervisor_config.items() if "isc-dhcpv4-relay" in key]
+        expected_cmds = [
+            value for key, value in self.dhcp_relay_supervisor_config.items()
+            if "isc-dhcpv4-relay" in key or key == "dhcp4relay"
+        ]
         expected_cmds.sort()
         if running_cmds != expected_cmds:
             syslog.syslog(syslog.LOG_ERR, "Running processes is not as expected! Runnning: {}. Expected: {}"
@@ -281,10 +358,13 @@ class DhcpRelayd(object):
         res = {}
         with open(self.supervisord_conf_path, "r") as conf_file:
             content = conf_file.read()
-            cmds = re.findall(r"\[program:((isc-dhcpv4-relay|dhcpmon)-.+)\]\ncommand=(.+)", content)
+            cmds = re.findall(
+                r"\[program:((?:(?:isc-dhcpv4-relay|dhcpmon)-.+)|dhcp4relay)\]\ncommand=(.+)",
+                content
+            )
             for cmd in cmds:
                 key = "dhcpmon:{}".format(cmd[0]) if "dhcpmon" in cmd[0] else cmd[0]
-                res[key] = cmd[2].replace("%%", "%").split(" ")
+                res[key] = cmd[1].replace("%%", "%").split(" ")
         return res
 
     def _start_dhcrelay_process(self, new_dhcp_interfaces, dhcp_server_ip, force_kill):
@@ -313,6 +393,23 @@ class DhcpRelayd(object):
             sys.exit(1)
 
         syslog.syslog(syslog.LOG_INFO, "dhcrelay process started successfully, cmds: {}".format(cmds))
+
+    def _start_sonic_dhcp_relay_process(self, new_dhcp_interfaces, cmds, force_kill):
+        kill_res = self._kill_exist_relay_releated_process(
+            new_dhcp_interfaces, "dhcp4relay", force_kill
+        )
+        if kill_res == NOT_KILLED or len(new_dhcp_interfaces) == 0:
+            return
+
+        popen_res = subprocess.Popen(cmds)
+        proc = psutil.Process(popen_res.pid)
+        time.sleep(1)
+        if proc.status() == psutil.STATUS_ZOMBIE:
+            syslog.syslog(syslog.LOG_ERR, "Failed to start dhcp4relay process with: {}".format(cmds))
+            terminate_proc(proc)
+            sys.exit(1)
+
+        syslog.syslog(syslog.LOG_INFO, "dhcp4relay process started successfully, cmds: {}".format(cmds))
 
     def _start_dhcpmon_process(self, new_dhcp_interfaces, force_kill):
         # To check whether need to kill dhcrelay process
@@ -364,8 +461,11 @@ class DhcpRelayd(object):
             return NOT_FOUND_PROC
 
         # No need to kill
-        if not force_kill and (process_name == "dhcrelay" and old_dhcp_interfaces == new_dhcp_interfaces or
-           process_name == "dhcpmon" and old_dhcp_interfaces == (new_dhcp_interfaces)):
+        if not force_kill and (
+            process_name == "dhcrelay" and old_dhcp_interfaces == new_dhcp_interfaces or
+            process_name == "dhcpmon" and old_dhcp_interfaces == new_dhcp_interfaces or
+            process_name == "dhcp4relay" and len(new_dhcp_interfaces) > 0
+        ):
             return NOT_KILLED
         for proc in target_procs:
             terminate_proc(proc)
@@ -394,6 +494,7 @@ def main():
     checkers.append(VlanTableEventChecker(sel, dhcp_db_connector.config_db))
     checkers.append(MidPlaneTableEventChecker(sel, dhcp_db_connector.config_db))
     checkers.append(DhcpServerFeatureStateChecker(sel, dhcp_db_connector.config_db))
+    checkers.append(DhcpV4RelayTableEventChecker(sel, dhcp_db_connector.config_db))
     db_monitor = DhcpRelaydDbMonitor(dhcp_db_connector, sel, checkers, DEFAULT_SELECT_TIMEOUT)
     dhcprelayd = DhcpRelayd(dhcp_db_connector, db_monitor, enabled_checkers=[FEATURE_CHECKER])
     dhcprelayd.start()

--- a/src/sonic-dhcp-utilities/dhcp_utilities/dhcprelayd/dhcprelayd.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/dhcprelayd/dhcprelayd.py
@@ -19,6 +19,7 @@ DHCP_SERVER_IPV4_SERVER_IP = "DHCP_SERVER_IPV4_SERVER_IP"
 DHCP_SERVER_IPV4 = "DHCP_SERVER_IPV4"
 DHCPV4_RELAY = "DHCPV4_RELAY"
 VLAN = "VLAN"
+VLAN_INTERFACE = "VLAN_INTERFACE"
 MID_PLANE_BRIDGE = "MID_PLANE_BRIDGE"
 DEVICE_METADATA = "DEVICE_METADATA"
 DEFAULT_SELECT_TIMEOUT = 5000  # millisecond
@@ -261,9 +262,12 @@ class DhcpRelayd(object):
 
     def _is_sonic_dhcpv4_relay_configured(self):
         relay_table = self.db_connector.get_config_db_table(DHCPV4_RELAY)
+        vlan_intf_table = self.db_connector.get_config_db_table(VLAN_INTERFACE)
+        configured_vlans = {key.split("|", 1)[0] for key in vlan_intf_table}
         return any(
             server and server.strip()
-            for config in relay_table.values()
+            for vlan_name, config in relay_table.items()
+            if vlan_name in configured_vlans
             for server in config.get("dhcpv4_servers", [])
         )
 

--- a/src/sonic-dhcp-utilities/tests/common_utils.py
+++ b/src/sonic-dhcp-utilities/tests/common_utils.py
@@ -87,6 +87,8 @@ class MockProc(object):
                     "/tmp/port-name-alias-map.txt", "-id", "Vlan1000", "-iu", "docker0", "240.127.1.2"]
         if self.proc_name == "dhcpmon":
             return ["/usr/sbin/dhcpmon", "-id", "Vlan1000", "-iu", "docker0", "-im", "eth0"]
+        if self.proc_name == "dhcp4relay":
+            return ["/usr/sbin/dhcp4relay"]
 
     def terminate(self):
         pass
@@ -133,6 +135,7 @@ def dhcprelayd_refresh_dhcrelay_test(expected_checkers, is_smart_switch, mock_ge
     with patch.object(DhcpRelayd, "_get_dhcp_server_ip", return_value="240.127.1.2"), \
          patch.object(DhcpDbConnector, "get_config_db_table", side_effect=mock_get_config_db_table), \
          patch.object(DhcpRelayd, "_start_dhcrelay_process", return_value=None), \
+         patch.object(DhcpRelayd, "_start_sonic_dhcp_relay_process", return_value=None), \
          patch.object(DhcpRelayd, "_start_dhcpmon_process", return_value=None), \
          patch.object(DhcpRelayd, "_enable_checkers") as mock_enable_checkers, \
          patch.object(DhcpRelayd, "_disable_checkers") as mock_disable_checkers, \

--- a/src/sonic-dhcp-utilities/tests/test_data/supervisor.conf
+++ b/src/sonic-dhcp-utilities/tests/test_data/supervisor.conf
@@ -80,6 +80,18 @@ stderr_syslog=true
 dependent_startup=true
 dependent_startup_wait_for=start:exited
 
+[program:dhcp4relay]
+command=/usr/sbin/dhcp4relay
+priority=3
+autostart=false
+autorestart=false
+stdout_logfile=NONE
+stdout_syslog=true
+stderr_logfile=NONE
+stderr_syslog=true
+dependent_startup=true
+dependent_startup_wait_for=start:exited
+
 [group:dhcp-relay]
 programs=dhcprelayd,dhcp6relay
 

--- a/src/sonic-dhcp-utilities/tests/test_data/supervisor.conf
+++ b/src/sonic-dhcp-utilities/tests/test_data/supervisor.conf
@@ -93,7 +93,7 @@ dependent_startup=true
 dependent_startup_wait_for=start:exited
 
 [group:dhcp-relay]
-programs=dhcprelayd,dhcp6relay
+programs=dhcprelayd,dhcp6relay,dhcp4relay
 
 
 [group:dhcpmon]

--- a/src/sonic-dhcp-utilities/tests/test_dhcp_db_monitor.py
+++ b/src/sonic-dhcp-utilities/tests/test_dhcp_db_monitor.py
@@ -6,7 +6,7 @@ from dhcp_utilities.common.dhcp_db_monitor import DhcpRelaydDbMonitor, DhcpServd
     DhcpServerTableIntfEnablementEventChecker, DhcpServerTableCfgChangeEventChecker, \
     DhcpPortTableEventChecker, DhcpRangeTableEventChecker, DhcpOptionTableEventChecker, \
     VlanTableEventChecker, VlanMemberTableEventChecker, VlanIntfTableEventChecker, DhcpServerFeatureStateChecker, \
-    MidPlaneTableEventChecker, DpusTableEventChecker
+    MidPlaneTableEventChecker, DpusTableEventChecker, DhcpV4RelayTableEventChecker
 from dhcp_utilities.common.utils import DhcpDbConnector
 from swsscommon import swsscommon
 from unittest.mock import patch, ANY, PropertyMock, MagicMock
@@ -397,3 +397,17 @@ def test_dpus_table_checker(mock_swsscommon_dbconnector_init, tested_data):
         expected_res = tested_data["exp_res"]
         check_res = db_event_checker.check_update_event({})
         assert expected_res == check_res
+
+
+@pytest.mark.parametrize("table_event", [
+    [("Vlan1000", "SET", (("dhcpv4_servers", "192.0.0.1"),))],
+    [("Vlan1000", "DEL", tuple())]
+])
+def test_dhcpv4_relay_table_checker(mock_swsscommon_dbconnector_init, table_event):
+    with patch.object(ConfigDbEventChecker, "enable"), \
+         patch.object(ConfigDbEventChecker, "subscriber_state_table",
+                      return_value=MockSubscribeTable(table_event), new_callable=PropertyMock), \
+         patch.object(sys, "exit"):
+        sel = swsscommon.Select()
+        db_event_checker = DhcpV4RelayTableEventChecker(sel, MagicMock())
+        assert db_event_checker.check_update_event({})

--- a/src/sonic-dhcp-utilities/tests/test_dhcprelayd.py
+++ b/src/sonic-dhcp-utilities/tests/test_dhcprelayd.py
@@ -524,6 +524,23 @@ def test_execute_grouped_sonic_dhcp_relay_process(mock_swsscommon_dbconnector_in
         )
 
 
+@pytest.mark.parametrize("op", ["stop", "start"])
+def test_execute_standalone_sonic_dhcp_relay_process_fallback(mock_swsscommon_dbconnector_init, op):
+    grouped_error = subprocess.CalledProcessError(1, ["supervisorctl", op, "dhcp-relay:dhcp4relay"])
+    with patch.object(subprocess, "run",
+                      side_effect=[grouped_error, MockSubprocessRes(0)]) as mock_run, \
+         patch.object(DhcpRelayd, "dhcp_relay_supervisor_config",
+                      return_value={"dhcp4relay": ["/usr/sbin/dhcp4relay"]},
+                      new_callable=PropertyMock):
+        dhcp_db_connector = DhcpDbConnector()
+        dhcprelayd = DhcpRelayd(dhcp_db_connector, None)
+        dhcprelayd._execute_supervisor_dhcp_relay_process(op, ["dhcp4relay"])
+        mock_run.assert_has_calls([
+            call(["supervisorctl", op, "dhcp-relay:dhcp4relay"], check=True),
+            call(["supervisorctl", op, "dhcp4relay"], check=True)
+        ])
+
+
 @pytest.mark.parametrize("iter_process", [
     [
         ["dhcrelay", 2, False, 1], ["dhcrelay", 3, False, 2], ["dhcpmon", 4, False, 1], ["dhcrelay", 5, True, 1]

--- a/src/sonic-dhcp-utilities/tests/test_dhcprelayd.py
+++ b/src/sonic-dhcp-utilities/tests/test_dhcprelayd.py
@@ -617,7 +617,7 @@ def test_check_dhcp_relay_process(mock_swsscommon_dbconnector_init, mock_swsscom
 
 @pytest.mark.parametrize("running", [True, False])
 def test_check_sonic_dhcp_relay_process(mock_swsscommon_dbconnector_init, mock_swsscommon_table_init, running):
-    process_iter_ret = [MockProc("dhcp4relay")] if running else []
+    process_iter_ret = [MockProc("dhcp4relay", pid=2)] if running else []
     with patch.object(DhcpRelayd, "dhcp_relay_supervisor_config",
                       return_value={"dhcp4relay": ["/usr/sbin/dhcp4relay"]},
                       new_callable=PropertyMock), \

--- a/src/sonic-dhcp-utilities/tests/test_dhcprelayd.py
+++ b/src/sonic-dhcp-utilities/tests/test_dhcprelayd.py
@@ -439,6 +439,20 @@ def test_is_dhcp_server_enabled(mock_swsscommon_dbconnector_init, mock_swsscommo
             assert not res
 
 
+@pytest.mark.parametrize("relay_table, expected", [
+    ({}, False),
+    ({"Vlan1000": {"dhcpv4_servers": []}}, False),
+    ({"Vlan1000": {"dhcpv4_servers": [""]}}, False),
+    ({"Vlan1000": {"dhcpv4_servers": ["  "]}}, False),
+    ({"Vlan1000": {"dhcpv4_servers": ["192.0.0.1"]}}, True)
+])
+def test_is_sonic_dhcpv4_relay_configured(mock_swsscommon_dbconnector_init, relay_table, expected):
+    with patch.object(DhcpDbConnector, "get_config_db_table", return_value=relay_table):
+        dhcp_db_connector = DhcpDbConnector()
+        dhcprelayd = DhcpRelayd(dhcp_db_connector, None)
+        assert dhcprelayd._is_sonic_dhcpv4_relay_configured() == expected
+
+
 @pytest.mark.parametrize("relay_configured, supervisor_configured, should_exit", [
     (False, False, False),
     (True, True, False),

--- a/src/sonic-dhcp-utilities/tests/test_dhcprelayd.py
+++ b/src/sonic-dhcp-utilities/tests/test_dhcprelayd.py
@@ -8,7 +8,7 @@ from common_utils import mock_get_config_db_table, MockProc, MockPopen, MockSubp
 from dhcp_utilities.common.utils import DhcpDbConnector
 from dhcp_utilities.common.dhcp_db_monitor import ConfigDbEventChecker, DhcpRelaydDbMonitor
 from dhcp_utilities.dhcprelayd.dhcprelayd import DhcpRelayd, KILLED_OLD, NOT_KILLED, NOT_FOUND_PROC, \
-    DHCP_SERVER_CHECKER, VLAN_CHECKERS
+    FEATURE_CHECKER, DHCP_SERVER_CHECKER, DHCPV4_RELAY_CHECKER, VLAN_CHECKERS
 from swsscommon import swsscommon
 from unittest.mock import patch, call, PropertyMock
 
@@ -18,6 +18,7 @@ def test_start(mock_swsscommon_dbconnector_init, dhcp_server_enabled):
     with patch.object(DhcpRelayd, "_get_dhcp_relay_config") as mock_get_config, \
          patch.object(DhcpRelayd, "_is_dhcp_server_enabled", return_value=dhcp_server_enabled) as mock_enabled, \
          patch.object(DhcpRelayd, "_execute_supervisor_dhcp_relay_process") as mock_execute, \
+         patch.object(DhcpRelayd, "refresh_dhcrelay") as mock_refresh, \
          patch.object(time, "sleep"), \
          patch.object(DhcpRelaydDbMonitor, "enable_checkers") as mock_enabled_checkers, \
          patch.object(DhcpDbConnector, "get_config_db_table", side_effect=mock_get_config_db_table):
@@ -29,15 +30,227 @@ def test_start(mock_swsscommon_dbconnector_init, dhcp_server_enabled):
         enabled_checkers = set(["DhcpServerFeatureStateChecker"])
         if dhcp_server_enabled:
             mock_execute.assert_called_once_with("stop")
+            mock_refresh.assert_called_once_with()
             enabled_checkers.add("DhcpServerTableIntfEnablementEventChecker")
         else:
             mock_execute.assert_not_called()
+            mock_refresh.assert_not_called()
         mock_enabled_checkers.assert_called_once_with(enabled_checkers)
+
+
+def test_start_enables_sonic_relay_checker(mock_swsscommon_dbconnector_init):
+    def get_config_db_table(table_name):
+        table = mock_get_config_db_table(table_name)
+        if table_name == "DEVICE_METADATA":
+            table["localhost"]["has_sonic_dhcpv4_relay"] = "True"
+        return table
+
+    with patch.object(DhcpRelayd, "_get_dhcp_relay_config"), \
+         patch.object(DhcpRelayd, "_is_dhcp_server_enabled", return_value=False), \
+         patch.object(time, "sleep"), \
+         patch.object(DhcpRelaydDbMonitor, "enable_checkers") as mock_enabled_checkers, \
+         patch.object(DhcpDbConnector, "get_config_db_table", side_effect=get_config_db_table):
+        dhcp_db_connector = DhcpDbConnector()
+        dhcprelayd = DhcpRelayd(dhcp_db_connector, DhcpRelaydDbMonitor(None, None, []))
+        dhcprelayd.start()
+        mock_enabled_checkers.assert_called_once_with(
+            {"DhcpServerFeatureStateChecker", DHCPV4_RELAY_CHECKER}
+        )
+
+
+def test_start_sonic_dhcp_server_defers_relay_ownership_until_refresh(
+        mock_swsscommon_dbconnector_init):
+    def get_config_db_table(table_name):
+        table = mock_get_config_db_table(table_name)
+        if table_name == "DEVICE_METADATA":
+            table["localhost"]["has_sonic_dhcpv4_relay"] = "True"
+        return table
+
+    with patch.object(DhcpRelayd, "_get_dhcp_relay_config"), \
+         patch.object(DhcpRelayd, "_is_dhcp_server_enabled", return_value=True), \
+         patch.object(DhcpRelayd, "_execute_supervisor_dhcp_relay_process") as mock_execute, \
+         patch.object(DhcpRelayd, "refresh_dhcrelay") as mock_refresh, \
+         patch.object(time, "sleep"), \
+         patch.object(DhcpRelaydDbMonitor, "enable_checkers"), \
+         patch.object(DhcpDbConnector, "get_config_db_table", side_effect=get_config_db_table):
+        dhcp_db_connector = DhcpDbConnector()
+        dhcprelayd = DhcpRelayd(dhcp_db_connector, DhcpRelaydDbMonitor(None, None, []))
+        dhcprelayd.start()
+
+        mock_execute.assert_not_called()
+        mock_refresh.assert_called_once_with()
 
 
 def test_refresh_dhcrelay(mock_swsscommon_dbconnector_init):
     expected_checkers = set(["VlanIntfTableEventChecker", "VlanTableEventChecker"])
     dhcprelayd_refresh_dhcrelay_test(expected_checkers, False, mock_get_config_db_table)
+
+
+@pytest.mark.parametrize("has_sonic_dhcpv4_relay, subtype, supervisor_configured, expected_sonic_cmds", [
+    (True, None, True, ["/usr/sbin/dhcp4relay"]),
+    (True, None, False, ["/usr/sbin/dhcp4relay"]),
+    (True, "DualToR", True, ["/usr/sbin/dhcp4relay", "-u", "Loopback0"]),
+    (False, None, False, None)
+])
+def test_refresh_dhcrelay_selects_relay_implementation(mock_swsscommon_dbconnector_init,
+                                                      has_sonic_dhcpv4_relay, subtype, supervisor_configured,
+                                                      expected_sonic_cmds):
+    def get_config_db_table(table_name):
+        table = mock_get_config_db_table(table_name)
+        if table_name == "DEVICE_METADATA":
+            table["localhost"]["has_sonic_dhcpv4_relay"] = str(has_sonic_dhcpv4_relay)
+            if subtype:
+                table["localhost"]["subtype"] = subtype
+        return table
+
+    with patch.object(DhcpDbConnector, "get_config_db_table", side_effect=get_config_db_table), \
+         patch.object(DhcpRelayd, "_get_dhcp_server_ip", return_value="240.127.1.2") as mock_get_server_ip, \
+         patch.object(DhcpRelayd, "_start_dhcrelay_process") as mock_start_isc, \
+         patch.object(DhcpRelayd, "_start_sonic_dhcp_relay_process") as mock_start_sonic, \
+         patch.object(DhcpRelayd, "_enable_checkers"), \
+         patch.object(DhcpRelayd, "_disable_checkers"), \
+         patch.object(DhcpRelayd, "_execute_supervisor_dhcp_relay_process") as mock_execute, \
+         patch.object(DhcpRelayd, "dhcp_relay_supervisor_config",
+                      return_value={"dhcp4relay": ["/usr/sbin/dhcp4relay"]}
+                      if supervisor_configured else {},
+                      new_callable=PropertyMock), \
+         patch.object(DhcpRelayd, "smart_switch", return_value=False, new_callable=PropertyMock):
+        dhcp_db_connector = DhcpDbConnector()
+        dhcprelayd = DhcpRelayd(dhcp_db_connector, None)
+        dhcprelayd.refresh_dhcrelay()
+
+        expected_interfaces = {"Vlan1000", "Vlan3000"}
+        if has_sonic_dhcpv4_relay:
+            mock_start_sonic.assert_called_once_with(expected_interfaces, expected_sonic_cmds, False)
+            assert dhcprelayd.sonic_dhcp_server_relay_active
+            if supervisor_configured:
+                mock_execute.assert_called_once_with("stop", ["dhcp4relay"])
+            else:
+                mock_execute.assert_not_called()
+            mock_start_isc.assert_not_called()
+            mock_get_server_ip.assert_not_called()
+        else:
+            mock_start_isc.assert_called_once_with(expected_interfaces, "240.127.1.2", False)
+            mock_start_sonic.assert_not_called()
+            mock_get_server_ip.assert_called_once_with()
+            assert not dhcprelayd.sonic_dhcp_server_relay_active
+            mock_execute.assert_not_called()
+
+
+def test_sonic_external_relay_remains_supervisor_owned_without_local_interfaces(
+        mock_swsscommon_dbconnector_init):
+    def get_config_db_table(table_name):
+        table = mock_get_config_db_table(table_name)
+        if table_name == "DEVICE_METADATA":
+            table["localhost"]["has_sonic_dhcpv4_relay"] = "True"
+        elif table_name == "DHCP_SERVER_IPV4":
+            return {}
+        elif table_name == "DHCPV4_RELAY":
+            return {"Vlan1000": {"dhcpv4_servers": ["192.0.0.1"]}}
+        return table
+
+    with patch.object(DhcpDbConnector, "get_config_db_table", side_effect=get_config_db_table), \
+         patch.object(DhcpRelayd, "_enable_checkers"), \
+         patch.object(DhcpRelayd, "_disable_checkers"), \
+         patch.object(DhcpRelayd, "dhcp_relay_supervisor_config",
+                      return_value={"dhcp4relay": ["/usr/sbin/dhcp4relay"]},
+                      new_callable=PropertyMock), \
+         patch.object(DhcpRelayd, "_execute_supervisor_dhcp_relay_process") as mock_execute, \
+         patch.object(DhcpRelayd, "_start_sonic_dhcp_relay_process") as mock_start, \
+         patch.object(DhcpRelayd, "_kill_exist_relay_releated_process") as mock_kill, \
+         patch.object(DhcpRelayd, "smart_switch", return_value=False, new_callable=PropertyMock):
+        dhcp_db_connector = DhcpDbConnector()
+        dhcprelayd = DhcpRelayd(dhcp_db_connector, None)
+        dhcprelayd.refresh_dhcrelay()
+
+        assert not dhcprelayd.sonic_dhcp_server_relay_active
+        mock_execute.assert_not_called()
+        mock_start.assert_not_called()
+        mock_kill.assert_not_called()
+
+
+@pytest.mark.parametrize("supervisor_configured", [True, False])
+def test_sonic_local_interface_removal_restores_external_relay(
+        mock_swsscommon_dbconnector_init, supervisor_configured):
+    def get_config_db_table(table_name):
+        table = mock_get_config_db_table(table_name)
+        if table_name == "DEVICE_METADATA":
+            table["localhost"]["has_sonic_dhcpv4_relay"] = "True"
+        elif table_name == "DHCP_SERVER_IPV4":
+            return {}
+        return table
+
+    supervisor_config = {"dhcp4relay": ["/usr/sbin/dhcp4relay"]} if supervisor_configured else {}
+    with patch.object(DhcpDbConnector, "get_config_db_table", side_effect=get_config_db_table), \
+         patch.object(DhcpRelayd, "_enable_checkers"), \
+         patch.object(DhcpRelayd, "_disable_checkers"), \
+         patch.object(DhcpRelayd, "dhcp_relay_supervisor_config",
+                      return_value=supervisor_config, new_callable=PropertyMock), \
+         patch.object(DhcpRelayd, "_execute_supervisor_dhcp_relay_process") as mock_execute, \
+         patch.object(DhcpRelayd, "_start_sonic_dhcp_relay_process") as mock_start, \
+         patch.object(DhcpRelayd, "_kill_exist_relay_releated_process") as mock_kill, \
+         patch.object(DhcpRelayd, "_check_sonic_dhcpv4_relay_config_transition") as mock_transition, \
+         patch.object(DhcpRelayd, "smart_switch", return_value=False, new_callable=PropertyMock):
+        dhcp_db_connector = DhcpDbConnector()
+        dhcprelayd = DhcpRelayd(dhcp_db_connector, None)
+        dhcprelayd.sonic_dhcp_server_relay_active = True
+        dhcprelayd.refresh_dhcrelay()
+
+        assert not dhcprelayd.sonic_dhcp_server_relay_active
+        mock_kill.assert_called_once_with([], "dhcp4relay", True)
+        mock_transition.assert_called_once_with()
+        mock_start.assert_not_called()
+        if supervisor_configured:
+            mock_execute.assert_called_once_with("start", ["dhcp4relay"])
+        else:
+            mock_execute.assert_not_called()
+
+
+def test_sonic_relay_checker_survives_local_server_transition(mock_swsscommon_dbconnector_init):
+    def get_config_db_table(table_name):
+        table = mock_get_config_db_table(table_name)
+        if table_name == "DEVICE_METADATA":
+            table["localhost"]["has_sonic_dhcpv4_relay"] = "True"
+        return table
+
+    with patch.object(DhcpDbConnector, "get_config_db_table", side_effect=get_config_db_table), \
+         patch.object(DhcpRelaydDbMonitor, "enable_checkers"), \
+         patch.object(DhcpRelaydDbMonitor, "disable_checkers"), \
+         patch.object(DhcpRelayd, "_start_sonic_dhcp_relay_process"), \
+         patch.object(DhcpRelayd, "_kill_exist_relay_releated_process"), \
+         patch.object(DhcpRelayd, "_execute_supervisor_dhcp_relay_process") as mock_execute, \
+         patch.object(DhcpRelayd, "dhcp_relay_supervisor_config",
+                      return_value={"dhcp4relay": ["/usr/sbin/dhcp4relay"]},
+                      new_callable=PropertyMock), \
+         patch.object(DhcpRelayd, "_check_sonic_dhcpv4_relay_config_transition") as mock_transition, \
+         patch.object(DhcpRelayd, "_check_dhcp_relay_processes"), \
+         patch.object(DhcpRelayd, "smart_switch", return_value=False, new_callable=PropertyMock):
+        dhcp_db_connector = DhcpDbConnector()
+        dhcprelayd = DhcpRelayd(
+            dhcp_db_connector,
+            DhcpRelaydDbMonitor(None, None, []),
+            enabled_checkers=[FEATURE_CHECKER, DHCP_SERVER_CHECKER, DHCPV4_RELAY_CHECKER]
+        )
+        dhcprelayd.has_sonic_dhcpv4_relay = True
+        dhcprelayd.dhcp_server_feature_enabled = True
+
+        dhcprelayd.refresh_dhcrelay()
+        assert DHCPV4_RELAY_CHECKER in dhcprelayd.enabled_checkers
+        assert dhcprelayd.sonic_dhcp_server_relay_active
+
+        dhcprelayd._proceed_with_check_res({FEATURE_CHECKER: True}, True)
+        assert not dhcprelayd.dhcp_server_feature_enabled
+        assert DHCPV4_RELAY_CHECKER in dhcprelayd.enabled_checkers
+        assert not dhcprelayd.sonic_dhcp_server_relay_active
+
+        # Later external zero/nonzero transitions must still reach the checker.
+        dhcprelayd._proceed_with_check_res({DHCPV4_RELAY_CHECKER: True}, False)
+        dhcprelayd._proceed_with_check_res({DHCPV4_RELAY_CHECKER: True}, False)
+        assert mock_transition.call_count == 3
+        mock_execute.assert_has_calls([
+            call("stop", ["dhcp4relay"]),
+            call("start", ["dhcp4relay"])
+        ])
 
 
 @pytest.mark.parametrize("new_dhcp_interfaces", [[], ["Vlan1000"], ["Vlan1000", "Vlan2000"]])
@@ -64,6 +277,38 @@ def test_start_dhcrelay_process(mock_swsscommon_dbconnector_init, new_dhcp_inter
                 call_param += ["-id", interface]
             call_param += ["-iu", "docker0", "240.127.1.2"]
             mock_popen.assert_called_once_with(call_param)
+        if len(new_dhcp_interfaces) != 0 and kill_res != NOT_KILLED and proc_status == psutil.STATUS_ZOMBIE:
+            mock_terminate.assert_called_once()
+            mock_exit.assert_called_once_with(1)
+        else:
+            mock_terminate.assert_not_called()
+            mock_exit.assert_not_called()
+
+
+@pytest.mark.parametrize("new_dhcp_interfaces", [[], ["Vlan1000"]])
+@pytest.mark.parametrize("kill_res", [KILLED_OLD, NOT_KILLED, NOT_FOUND_PROC])
+@pytest.mark.parametrize("proc_status", [psutil.STATUS_ZOMBIE, psutil.STATUS_RUNNING])
+def test_start_sonic_dhcp_relay_process(mock_swsscommon_dbconnector_init, new_dhcp_interfaces, kill_res,
+                                        proc_status):
+    with patch.object(DhcpRelayd, "_kill_exist_relay_releated_process", return_value=kill_res), \
+         patch.object(subprocess, "Popen", return_value=MockPopen(999)) as mock_popen, \
+         patch.object(time, "sleep"), \
+         patch("dhcp_utilities.dhcprelayd.dhcprelayd.terminate_proc", return_value=None) as mock_terminate, \
+         patch.object(psutil.Process, "__init__", return_value=None), \
+         patch.object(psutil.Process, "status", return_value=proc_status), \
+         patch.object(sys, "exit") as mock_exit, \
+         patch.object(ConfigDbEventChecker, "enable"):
+        dhcp_db_connector = DhcpDbConnector()
+        dhcprelayd = DhcpRelayd(dhcp_db_connector, None)
+        dhcprelayd._start_sonic_dhcp_relay_process(
+            set(new_dhcp_interfaces), ["/usr/sbin/dhcp4relay"], False
+        )
+
+        if len(new_dhcp_interfaces) == 0 or kill_res == NOT_KILLED:
+            mock_popen.assert_not_called()
+        else:
+            mock_popen.assert_called_once_with(["/usr/sbin/dhcp4relay"])
+
         if len(new_dhcp_interfaces) != 0 and kill_res != NOT_KILLED and proc_status == psutil.STATUS_ZOMBIE:
             mock_terminate.assert_called_once()
             mock_exit.assert_called_once_with(1)
@@ -127,6 +372,24 @@ def test_kill_exist_relay_releated_process(mock_swsscommon_dbconnector_init, new
             assert res == KILLED_OLD
 
 
+@pytest.mark.parametrize("new_dhcp_interfaces", [set(), {"Vlan1000"}])
+@pytest.mark.parametrize("force_kill", [True, False])
+def test_kill_existing_sonic_dhcp_relay_process(mock_swsscommon_dbconnector_init, new_dhcp_interfaces, force_kill):
+    process = MockProc("dhcp4relay")
+    with patch.object(psutil, "process_iter", return_value=[process]), \
+         patch.object(ConfigDbEventChecker, "enable"):
+        dhcp_db_connector = DhcpDbConnector()
+        dhcprelayd = DhcpRelayd(dhcp_db_connector, None)
+        res = dhcprelayd._kill_exist_relay_releated_process(
+            new_dhcp_interfaces, "dhcp4relay", force_kill
+        )
+
+        if new_dhcp_interfaces and not force_kill:
+            assert res == NOT_KILLED
+        else:
+            assert res == KILLED_OLD
+
+
 @pytest.mark.parametrize("get_res", [(1, "240.127.1.2"), (0, None)])
 def test_get_dhcp_server_ip(mock_swsscommon_dbconnector_init, mock_swsscommon_table_init, get_res):
     with patch.object(swsscommon.Table, "hget", return_value=get_res), \
@@ -176,6 +439,58 @@ def test_is_dhcp_server_enabled(mock_swsscommon_dbconnector_init, mock_swsscommo
             assert not res
 
 
+@pytest.mark.parametrize("relay_configured, supervisor_configured, should_exit", [
+    (False, False, False),
+    (True, True, False),
+    (True, False, True),
+    (False, True, True)
+])
+def test_sonic_dhcpv4_relay_config_transition(mock_swsscommon_dbconnector_init, relay_configured,
+                                              supervisor_configured, should_exit):
+    relay_table = {"Vlan1000": {"dhcpv4_servers": ["192.0.0.1"]}} if relay_configured else {}
+    supervisor_config = {"dhcp4relay": ["/usr/sbin/dhcp4relay"]} if supervisor_configured else {}
+    with patch.object(DhcpDbConnector, "get_config_db_table", return_value=relay_table), \
+         patch.object(DhcpRelayd, "dhcp_relay_supervisor_config", return_value=supervisor_config,
+                      new_callable=PropertyMock), \
+         patch.object(sys, "exit", side_effect=mock_exit_func) as mock_exit:
+        dhcp_db_connector = DhcpDbConnector()
+        dhcprelayd = DhcpRelayd(dhcp_db_connector, None)
+        dhcprelayd.has_sonic_dhcpv4_relay = True
+        try:
+            dhcprelayd._check_sonic_dhcpv4_relay_config_transition()
+        except SystemExit:
+            assert should_exit
+        else:
+            assert not should_exit
+        if should_exit:
+            mock_exit.assert_called_once_with(1)
+        else:
+            mock_exit.assert_not_called()
+
+
+@pytest.mark.parametrize("relay_config_changed", [True, False])
+@pytest.mark.parametrize("local_relay_active", [True, False])
+def test_dhcpv4_relay_config_change_is_checked(mock_swsscommon_dbconnector_init, local_relay_active,
+                                               relay_config_changed):
+    with patch.object(DhcpRelayd, "_check_sonic_dhcpv4_relay_config_transition") as mock_transition, \
+         patch.object(DhcpRelayd, "_check_dhcp_relay_processes") as mock_check:
+        dhcp_db_connector = DhcpDbConnector()
+        dhcprelayd = DhcpRelayd(dhcp_db_connector, None)
+        dhcprelayd.has_sonic_dhcpv4_relay = True
+        dhcprelayd.dhcp_server_feature_enabled = True
+        dhcprelayd.sonic_dhcp_server_relay_active = local_relay_active
+        check_res = {DHCPV4_RELAY_CHECKER: True} if relay_config_changed else {}
+        dhcprelayd._proceed_with_check_res(check_res, True)
+        if relay_config_changed:
+            mock_transition.assert_called_once_with()
+        else:
+            mock_transition.assert_not_called()
+        if local_relay_active:
+            mock_check.assert_not_called()
+        else:
+            mock_check.assert_called_once_with()
+
+
 @pytest.mark.parametrize("op", ["stop", "start", "starts"])
 @pytest.mark.parametrize("return_code", [0, -1])
 def test_execute_supervisor_dhcp_relay_process(mock_swsscommon_dbconnector_init, mock_swsscommon_table_init, op,
@@ -193,6 +508,20 @@ def test_execute_supervisor_dhcp_relay_process(mock_swsscommon_dbconnector_init,
             assert op == "starts" or return_code != 0
         else:
             mock_run.assert_called_once_with(["supervisorctl", op, "dhcpmon-Vlan1000"], check=True)
+
+
+@pytest.mark.parametrize("op", ["stop", "start"])
+def test_execute_grouped_sonic_dhcp_relay_process(mock_swsscommon_dbconnector_init, op):
+    with patch.object(subprocess, "run", return_value=MockSubprocessRes(0)) as mock_run, \
+         patch.object(DhcpRelayd, "dhcp_relay_supervisor_config",
+                      return_value={"dhcp4relay": ["/usr/sbin/dhcp4relay"]},
+                      new_callable=PropertyMock):
+        dhcp_db_connector = DhcpDbConnector()
+        dhcprelayd = DhcpRelayd(dhcp_db_connector, None)
+        dhcprelayd._execute_supervisor_dhcp_relay_process(op, ["dhcp4relay"])
+        mock_run.assert_called_once_with(
+            ["supervisorctl", op, "dhcp-relay:dhcp4relay"], check=True
+        )
 
 
 @pytest.mark.parametrize("iter_process", [
@@ -224,6 +553,24 @@ def test_check_dhcp_relay_process(mock_swsscommon_dbconnector_init, mock_swsscom
             assert any(process[0] == "dhcrelay" for process in iter_process)
 
 
+@pytest.mark.parametrize("running", [True, False])
+def test_check_sonic_dhcp_relay_process(mock_swsscommon_dbconnector_init, mock_swsscommon_table_init, running):
+    process_iter_ret = [MockProc("dhcp4relay")] if running else []
+    with patch.object(DhcpRelayd, "dhcp_relay_supervisor_config",
+                      return_value={"dhcp4relay": ["/usr/sbin/dhcp4relay"]},
+                      new_callable=PropertyMock), \
+         patch.object(sys, "exit", mock_exit_func), \
+         patch.object(psutil, "process_iter", return_value=process_iter_ret):
+        dhcp_db_connector = DhcpDbConnector()
+        dhcprelayd = DhcpRelayd(dhcp_db_connector, None)
+        try:
+            dhcprelayd._check_dhcp_relay_processes()
+        except SystemExit:
+            assert not running
+        else:
+            assert running
+
+
 def test_get_dhcp_relay_config(mock_swsscommon_dbconnector_init, mock_swsscommon_table_init):
     with patch.object(DhcpRelayd, "supervisord_conf_path", return_value="tests/test_data/supervisor.conf",
                       new_callable=PropertyMock):
@@ -239,7 +586,8 @@ def test_get_dhcp_relay_config(mock_swsscommon_dbconnector_init, mock_swsscommon
             "dhcpmon:dhcpmon-Vlan1000": [
                 "/usr/sbin/dhcpmon", "-id", "Vlan1000", "-iu", "PortChannel101", "-iu", "PortChannel102", "-iu",
                 "PortChannel103", "-iu", "PortChannel104", "-im", "eth0"
-            ]
+            ],
+            "dhcp4relay": ["/usr/sbin/dhcp4relay"]
         }
 
 

--- a/src/sonic-dhcp-utilities/tests/test_dhcprelayd.py
+++ b/src/sonic-dhcp-utilities/tests/test_dhcprelayd.py
@@ -439,15 +439,24 @@ def test_is_dhcp_server_enabled(mock_swsscommon_dbconnector_init, mock_swsscommo
             assert not res
 
 
-@pytest.mark.parametrize("relay_table, expected", [
-    ({}, False),
-    ({"Vlan1000": {"dhcpv4_servers": []}}, False),
-    ({"Vlan1000": {"dhcpv4_servers": [""]}}, False),
-    ({"Vlan1000": {"dhcpv4_servers": ["  "]}}, False),
-    ({"Vlan1000": {"dhcpv4_servers": ["192.0.0.1"]}}, True)
+@pytest.mark.parametrize("relay_table, vlan_interfaces, expected", [
+    ({}, ["Vlan1000"], False),
+    ({"Vlan1000": {"dhcpv4_servers": []}}, ["Vlan1000"], False),
+    ({"Vlan1000": {"dhcpv4_servers": [""]}}, ["Vlan1000"], False),
+    ({"Vlan1000": {"dhcpv4_servers": ["  "]}}, ["Vlan1000"], False),
+    ({"Vlan1000": {"dhcpv4_servers": ["192.0.0.1"]}}, [], False),
+    ({"Vlan1000": {"dhcpv4_servers": ["192.0.0.1"]}}, ["Vlan2000|192.168.0.1/24"], False),
+    ({"Vlan1000": {"dhcpv4_servers": ["192.0.0.1"]}}, ["Vlan1000|192.168.0.1/24"], True)
 ])
-def test_is_sonic_dhcpv4_relay_configured(mock_swsscommon_dbconnector_init, relay_table, expected):
-    with patch.object(DhcpDbConnector, "get_config_db_table", return_value=relay_table):
+def test_is_sonic_dhcpv4_relay_configured(mock_swsscommon_dbconnector_init, relay_table, vlan_interfaces, expected):
+    def get_config_db_table(table_name):
+        if table_name == "DHCPV4_RELAY":
+            return relay_table
+        if table_name == "VLAN_INTERFACE":
+            return {interface: {} for interface in vlan_interfaces}
+        return {}
+
+    with patch.object(DhcpDbConnector, "get_config_db_table", side_effect=get_config_db_table):
         dhcp_db_connector = DhcpDbConnector()
         dhcprelayd = DhcpRelayd(dhcp_db_connector, None)
         assert dhcprelayd._is_sonic_dhcpv4_relay_configured() == expected

--- a/src/sonic-dhcp-utilities/tests/test_dhcprelayd.py
+++ b/src/sonic-dhcp-utilities/tests/test_dhcprelayd.py
@@ -487,7 +487,8 @@ def test_sonic_dhcpv4_relay_config_transition(mock_swsscommon_dbconnector_init, 
 def test_dhcpv4_relay_config_change_is_checked(mock_swsscommon_dbconnector_init, local_relay_active,
                                                relay_config_changed):
     with patch.object(DhcpRelayd, "_check_sonic_dhcpv4_relay_config_transition") as mock_transition, \
-         patch.object(DhcpRelayd, "_check_dhcp_relay_processes") as mock_check:
+         patch.object(DhcpRelayd, "_check_dhcp_relay_processes") as mock_check, \
+         patch.object(DhcpRelayd, "_check_sonic_dhcp_server_relay_process") as mock_local_check:
         dhcp_db_connector = DhcpDbConnector()
         dhcprelayd = DhcpRelayd(dhcp_db_connector, None)
         dhcprelayd.has_sonic_dhcpv4_relay = True
@@ -501,8 +502,29 @@ def test_dhcpv4_relay_config_change_is_checked(mock_swsscommon_dbconnector_init,
             mock_transition.assert_not_called()
         if local_relay_active:
             mock_check.assert_not_called()
+            mock_local_check.assert_called_once_with()
         else:
             mock_check.assert_called_once_with()
+            mock_local_check.assert_not_called()
+
+
+@pytest.mark.parametrize("running", [True, False])
+def test_check_sonic_dhcp_server_relay_process(mock_swsscommon_dbconnector_init, running):
+    process_iter_ret = [MockProc("dhcp4relay")] if running else []
+    with patch.object(psutil, "process_iter", return_value=process_iter_ret), \
+         patch.object(sys, "exit", side_effect=mock_exit_func) as mock_exit:
+        dhcp_db_connector = DhcpDbConnector()
+        dhcprelayd = DhcpRelayd(dhcp_db_connector, None)
+        try:
+            dhcprelayd._check_sonic_dhcp_server_relay_process()
+        except SystemExit:
+            assert not running
+        else:
+            assert running
+        if running:
+            mock_exit.assert_not_called()
+        else:
+            mock_exit.assert_called_once_with(1)
 
 
 @pytest.mark.parametrize("op", ["stop", "start", "starts"])


### PR DESCRIPTION
#### Why I did it

With the SONiC DHCPv4 relay backend enabled, `dhcp4relay` is currently rendered even when there is no external `DHCPV4_RELAY` server configuration. Changing that default also has to preserve local DHCP-server forwarding, external configuration transitions, Dual-ToR arguments, DHCPv6, ISC relay, and `dhcpmon`.

This behavior is split from https://github.com/sonic-net/sonic-buildimage/pull/27277 so the monitor/startup correction can be reviewed independently.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Render supervisor-owned SONiC `dhcp4relay` only when at least one `DHCPV4_RELAY` row has non-empty `dhcpv4_servers`.
- Keep no relay process when neither external servers nor enabled local DHCP-server interfaces require one.
- Let `dhcprelayd` dynamically start `/usr/sbin/dhcp4relay` when `FEATURE.dhcp_server` is enabled with an enabled `DHCP_SERVER_IPV4` interface.
- Add `-u Loopback0` for Dual-ToR local mode.
- Stop only supervisor-owned `dhcp4relay` when local mode takes ownership, preserving DHCPv6 and `dhcpmon`.
- Return ownership to supervisor when local interfaces disappear or the DHCP-server feature is disabled.
- Watch `DHCPV4_RELAY` continuously and restart the container when configuration presence crosses zero/nonzero so the conditional supervisor configuration is regenerated. Nonzero-to-nonzero server updates remain dynamic.
- Preserve the external checker across local-mode transitions.
- Watch the dynamically-owned local `dhcp4relay` process during regular database cycles so a crash triggers container recovery.

#### How to verify it

- Dependency: https://github.com/sonic-net/sonic-buildimage/pull/27277
- Downstream process matrix: https://github.com/sonic-net/sonic-mgmt/pull/26657
- Azure build: https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1180453
- Public PR checks are the validation surface; no local SONiC build or functional test was run.

Expected matrix:

| External servers | Enabled local interfaces | Expected SONiC `dhcp4relay` |
|---|---|---|
| No | No | Absent |
| Yes | No | Supervisor-owned |
| No | Yes | Dynamically owned by `dhcprelayd` |
| Yes | Yes | Dynamically owned by `dhcprelayd` |

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] master - public PR checks pending on head `d7abc5545f`

#### Description for the changelog

Run SONiC DHCPv4 relay only for configured external servers or enabled local DHCP-server interfaces.

#### Link to config_db schema for YANG module changes

N/A - no schema change.

#### A picture of a cute animal (not mandatory but encouraged)

N/A
