### PR TITLE
Move create-only to yang

### DIFF
--- a/src/sonic-yang-mgmt/sonic_yang.py
+++ b/src/sonic-yang-mgmt/sonic_yang.py
@@ -45,6 +45,9 @@ class SonicYang(SonicYangExtMixin, SonicYangPathMixin):
         # `self.yJson`. None means "not yet built"; the loader resets this back
         # to None whenever the schema set changes. See _build_yjson_compat().
         self._yJsonCache: Optional[List[Dict[str, Any]]] = None
+        # Lazy create-only pattern list from schema walk; None means not yet
+        # built. loadYangModel() resets this whenever the schema set changes.
+        self._create_only_fields_cache: Optional[List[List[str]]] = None
         # Lazy caching for must counts
         self.mustCache: Dict[Tuple[Any, bool], int] = dict()
         # Lazy caching for configdb to xpath

--- a/src/sonic-yang-mgmt/sonic_yang_ext.py
+++ b/src/sonic-yang-mgmt/sonic_yang_ext.py
@@ -61,6 +61,7 @@ class SonicYangExtMixin(SonicYangPathMixin):
         yangFiles: List[str]
         confDbYangMap: Dict[str, Any]
         _yJsonCache: Optional[List[Dict[str, Any]]]
+        _create_only_fields_cache: Optional[List[List[str]]]
         jIn: Dict[str, Any]
         xlateJson: Dict[str, Any]
         revXlateJson: Dict[str, Any]
@@ -81,8 +82,9 @@ class SonicYangExtMixin(SonicYangPathMixin):
     def loadYangModel(self):
 
         try:
-            # Invalidate any cached YIN-shape view from a previous load.
+            # Invalidate any cached YIN-shape view / create-only patterns from a previous load.
             self._yJsonCache = None
+            self._create_only_fields_cache = None
             # get all files
             self.yangFiles = glob(self.yang_dir +"/*.yang")
             # load yang modules
@@ -1038,5 +1040,56 @@ class SonicYangExtMixin(SonicYangPathMixin):
         self._revXlateYangtoConfigDB(yang_data, config_db_json)
         return config_db_json
 
+    def get_create_only_fields(self):
+        """
+        Discover ConfigDB path patterns for nodes annotated with sonic-extension
+        create-only. Returns a cached, de-duplicated list of patterns such as
+        ["PORT", "*", "lanes"] or ["MIRROR_SESSION", "*", "*"].
+        """
+        if self._create_only_fields_cache is not None:
+            return self._create_only_fields_cache
+
+        patterns = []
+        seen = set()
+        for table_name, mapping in self.confDbYangMap.items():
+            self._find_create_only_fields(table_name, mapping['container'], patterns, seen)
+
+        self._create_only_fields_cache = patterns
+        return patterns
+
+    def _find_create_only_fields(self, table_name, node, patterns, seen):
+        def is_create_only(snode):
+            for ext in snode.extensions():
+                if ext.name() == "create-only" and ext.module().name() == "sonic-extension":
+                    return True
+            return False
+
+        def add_pattern(pattern):
+            key = tuple(pattern)
+            if key not in seen:
+                seen.add(key)
+                patterns.append(pattern)
+
+        # If a container/list itself is create-only, the whole table is create-only
+        if isinstance(node, (ly.SContainer, ly.SList)) and is_create_only(node):
+            add_pattern([table_name, "*", "*"])
+            return
+
+        if isinstance(node, (ly.SContainer, ly.SList)):
+            for child in node.children():
+                self._find_create_only_fields(table_name, child, patterns, seen)
+        elif isinstance(node, (ly.SLeaf, ly.SLeafList)):
+            if is_create_only(node):
+                # Traverse upward to the first SList node to resolve accurate nested path depth
+                curr = node
+                path_segments = []
+                while curr is not None and not isinstance(curr, ly.SList):
+                    path_segments.insert(0, curr.name())
+                    curr = curr.parent()
+
+                if curr is not None:
+                    add_pattern([table_name, "*"] + path_segments)
+                else:
+                    add_pattern([table_name, "*", node.name()])
 
     # End of class sonic_yang

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/sample-yang-models/sonic-extension.yang
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/sample-yang-models/sonic-extension.yang
@@ -1,0 +1,19 @@
+module sonic-extension {
+
+    yang-version 1.1;
+
+    namespace "http://github.com/sonic-net/sonic-extension";
+    prefix sonic-extension;
+
+    description "Minimal sonic-extension for create-only discovery tests";
+
+    revision 2019-07-01 {
+        description "First Revision";
+    }
+
+    extension create-only {
+        description
+            "Test fixture copy of create-only. See sonic-yang-models template
+             for the full contract.";
+    }
+}

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/sample-yang-models/test-grouping.yang
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/sample-yang-models/test-grouping.yang
@@ -5,6 +5,10 @@ module test-grouping {
 
     yang-version 1.1;
 
+    import sonic-extension {
+        prefix ext;
+    }
+
     revision 2024-01-01 {
         description "Test uses compilation with container/list/uses in groupings";
     }
@@ -58,7 +62,18 @@ module test-grouping {
 
                 uses group-with-container;
                 uses group-with-list;
-                uses nested-uses-group;
+                // create-only via refine: must survive libyang refine→target
+                // extension copy so get_create_only_fields() sees it.
+                // description is nested (nested-uses-group → simple-fields);
+                // extra is declared directly on nested-uses-group (shipping shape).
+                uses nested-uses-group {
+                    refine description {
+                        ext:create-only;
+                    }
+                    refine extra {
+                        ext:create-only;
+                    }
+                }
             }
         }
     }

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/sample-yang-models/test-port.yang
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/sample-yang-models/test-port.yang
@@ -16,6 +16,10 @@ module test-port{
 		revision-date 2019-07-01;
 	}
 
+	import sonic-extension {
+		prefix ext;
+	}
+
 	revision 2019-07-01 {
 		description "First Revision";
 	}
@@ -45,6 +49,7 @@ module test-port{
 					type string {
 						length 1..128;
 					}
+					ext:create-only;
 				}
 
 				leaf description {

--- a/src/sonic-yang-mgmt/tests/libyang-python-tests/test_sonic_yang.py
+++ b/src/sonic-yang-mgmt/tests/libyang-python-tests/test_sonic_yang.py
@@ -413,6 +413,75 @@ class Test_SonicYang(object):
 
         return sonic_yang_data
 
+    def test_get_create_only_fields_direct_and_refine(self):
+        """Pin create-only discovery for a direct leaf and refine-carried annotations.
+
+        Fourteen of the shipping create-only patterns come from refine on uses
+        sites; if libyang stopped copying refine extension instances onto the
+        refined node, those would silently drop. A direct leaf annotation
+        covers the non-refine path. Both must appear in get_create_only_fields().
+        """
+        data = _load_test_data()
+        yang_s = sy.SonicYang(str(data['yang_dir']))
+        yang_s.loadYangModel()
+        patterns = yang_s.get_create_only_fields()
+        # Direct ext:create-only on PORT/lanes in test-port.yang
+        assert ["PORT", "*", "lanes"] in patterns
+        # refine create-only on nested leaf (nested-uses-group → simple-fields)
+        assert ["TEST_GROUPING_TABLE", "*", "description"] in patterns
+        # refine create-only on a leaf nested-uses-group declares itself
+        # (matches shipping BGP refine placement)
+        assert ["TEST_GROUPING_TABLE", "*", "extra"] in patterns
+        # Cached on second call
+        assert yang_s.get_create_only_fields() is patterns
+
+    def test_get_create_only_fields_matches_expected_set(self, sonic_yang_data):
+        """Pin the shipping create-only pattern set produced by the schema walk.
+
+        CreateOnlyFilter unions discovery with a historical floor, but a partial
+        YANG result still means the producer drifted. This asserts the walk on
+        the installed models returns exactly the annotated set (26 patterns).
+        """
+        syc = sonic_yang_data['syc']
+
+        # Golden counterpart of sonic-utilities CreateOnlyFilter's
+        # _CREATE_ONLY_FIELDS_FALLBACK; update this when adding an annotation.
+        expected = [
+            ["PORT", "*", "lanes"],
+            ["LOOPBACK_INTERFACE", "*", "vrf_name"],
+            ["BGP_NEIGHBOR", "*", "asn"],
+            ["BGP_NEIGHBOR", "*", "holdtime"],
+            ["BGP_NEIGHBOR", "*", "keepalive"],
+            ["BGP_NEIGHBOR", "*", "local_addr"],
+            ["BGP_NEIGHBOR", "*", "name"],
+            ["BGP_NEIGHBOR", "*", "nhopself"],
+            ["BGP_NEIGHBOR", "*", "rrclient"],
+            ["BGP_PEER_RANGE", "*", "*"],
+            ["BGP_SENTINELS", "*", "*"],
+            ["BGP_MONITORS", "*", "asn"],
+            ["BGP_MONITORS", "*", "holdtime"],
+            ["BGP_MONITORS", "*", "keepalive"],
+            ["BGP_MONITORS", "*", "local_addr"],
+            ["BGP_MONITORS", "*", "name"],
+            ["BGP_MONITORS", "*", "nhopself"],
+            ["BGP_MONITORS", "*", "rrclient"],
+            ["MIRROR_SESSION", "*", "*"],
+            ["SCHEDULER", "*", "type"],
+            ["SCHEDULER", "*", "weight"],
+            ["SCHEDULER", "*", "meter_type"],
+            ["SCHEDULER", "*", "cir"],
+            ["SCHEDULER", "*", "cbs"],
+            ["SCHEDULER", "*", "pir"],
+            ["SCHEDULER", "*", "pbs"],
+        ]
+        actual = syc.get_create_only_fields()
+        assert sorted(tuple(p) for p in actual) == sorted(tuple(p) for p in expected)
+        # Sibling tables that share the BGP groupings must stay unannotated.
+        tables = {p[0] for p in actual}
+        assert "BGP_PEER_GROUP" not in tables
+        assert "BGP_INTERNAL_NEIGHBOR" not in tables
+        assert "BGP_VOQ_CHASSIS_NEIGHBOR" not in tables
+
     def test_validate_yang_models(self, sonic_yang_data):
         '''
         In this test, we validate yang models

--- a/src/sonic-yang-models/yang-models/sonic-bgp-monitor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-monitor.yang
@@ -11,6 +11,10 @@ module sonic-bgp-monitor {
         prefix bgpcmn;
     }
 
+    import sonic-extension {
+        prefix ext;
+    }
+
     organization
         "SONiC";
 
@@ -37,10 +41,29 @@ module sonic-bgp-monitor {
                 }
 
                 uses bgpcmn:sonic-bgp-cmn-neigh {
+                    refine asn {
+                        ext:create-only;
+                    }
+                    refine holdtime {
+                        ext:create-only;
+                    }
+                    refine keepalive {
+                        ext:create-only;
+                    }
+                    refine local_addr {
+                        ext:create-only;
+                    }
                     refine name {
                         must "current() = 'BGPMonitor'" {
                             error-message "Invalid BGP monitor name";
                         }
+                        ext:create-only;
+                    }
+                    refine nhopself {
+                        ext:create-only;
+                    }
+                    refine rrclient {
+                        ext:create-only;
                     }
                 }
             }

--- a/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
@@ -11,6 +11,10 @@ module sonic-bgp-neighbor {
         prefix bgpcmn;
     }
 
+    import sonic-extension {
+        prefix ext;
+    }
+
     import sonic-port {
         prefix port;
     }
@@ -62,6 +66,25 @@ module sonic-bgp-neighbor {
                         must ". >= 1" {
                             error-message "ASN must be greater than 0";
                         }
+                        ext:create-only;
+                    }
+                    refine holdtime {
+                        ext:create-only;
+                    }
+                    refine keepalive {
+                        ext:create-only;
+                    }
+                    refine local_addr {
+                        ext:create-only;
+                    }
+                    refine name {
+                        ext:create-only;
+                    }
+                    refine nhopself {
+                        ext:create-only;
+                    }
+                    refine rrclient {
+                        ext:create-only;
                     }
                 }
             }
@@ -105,7 +128,23 @@ module sonic-bgp-neighbor {
                     description "Peer group name";
                 }
 
-                uses bgpcmn:sonic-bgp-cmn;
+                uses bgpcmn:sonic-bgp-cmn {
+                    refine asn {
+                        ext:create-only;
+                    }
+                    refine holdtime {
+                        ext:create-only;
+                    }
+                    refine keepalive {
+                        ext:create-only;
+                    }
+                    refine local_addr {
+                        ext:create-only;
+                    }
+                    refine name {
+                        ext:create-only;
+                    }
+                }
             }
         }
 

--- a/src/sonic-yang-models/yang-models/sonic-bgp-peerrange.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-peerrange.yang
@@ -19,6 +19,10 @@ module sonic-bgp-peerrange {
         prefix svnet;
     }
 
+    import sonic-extension {
+        prefix ext;
+    }
+
     organization
         "SONiC";
 
@@ -35,6 +39,8 @@ module sonic-bgp-peerrange {
 
     container sonic-bgp-peerrange {
         container BGP_PEER_RANGE {
+            ext:create-only;
+
             list BGP_PEER_RANGE_LIST {
                 description "This list supports BGP_PEER_RANGE_TEMPLATE configurations with vnet and vrf support";
                 key "vrf_name peer_range_name";

--- a/src/sonic-yang-models/yang-models/sonic-bgp-sentinel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-sentinel.yang
@@ -11,6 +11,10 @@ module sonic-bgp-sentinel {
         prefix stypes;
     }
 
+    import sonic-extension {
+        prefix ext;
+    }
+
     organization
         "SONiC";
 
@@ -27,6 +31,8 @@ module sonic-bgp-sentinel {
 
     container sonic-bgp-sentinel {
         container BGP_SENTINELS {
+            ext:create-only;
+
             list BGP_SENTINELS_LIST {
                 key "sentinel_name";
 

--- a/src/sonic-yang-models/yang-models/sonic-loopback-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-loopback-interface.yang
@@ -13,6 +13,10 @@ module sonic-loopback-interface {
         prefix vrf;
     }
 
+    import sonic-extension {
+        prefix ext;
+    }
+
     description
         "Loopback interface configuration for virtual interfaces used as router IDs and service IPs";
 
@@ -41,10 +45,11 @@ module sonic-loopback-interface {
                 }
 
                 leaf vrf_name {
-                    description "VRF instance to which this loopback interface is bound";
                     type leafref {
                         path "/vrf:sonic-vrf/vrf:VRF/vrf:VRF_LIST/vrf:name";
                     }
+                    ext:create-only;
+                    description "VRF instance to which this loopback interface is bound";
                 }
 
                 leaf nat_zone {

--- a/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
+++ b/src/sonic-yang-models/yang-models/sonic-mirror-session.yang
@@ -17,6 +17,10 @@ module sonic-mirror-session {
         prefix policer;
     }
 
+    import sonic-extension {
+        prefix ext;
+    }
+
     description
         "SONiC Mirror session yang model";
 
@@ -59,6 +63,7 @@ module sonic-mirror-session {
     container sonic-mirror-session {
 
         container MIRROR_SESSION {
+            ext:create-only;
 
             list MIRROR_SESSION_LIST {
                 key "name";

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -17,7 +17,19 @@ module sonic-port{
 		prefix macsec;
 	}
 
+<<<<<<< HEAD
 	description "PORT yang Module for SONiC OS";
+=======
+	import ietf-inet-types {
+		prefix inet;
+	}
+
+	import sonic-extension {
+		prefix ext;
+	}
+
+	description "PORT configuration";
+>>>>>>> bed76681c (NOS-12728: move create only to yang (#7053))
 
 	revision 2019-07-01 {
 		description "First Revision";
@@ -81,6 +93,7 @@ module sonic-port{
 					type string {
 						length 1..128;
 					}
+					ext:create-only;
 				}
 
 				leaf mode {

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -17,19 +17,11 @@ module sonic-port{
 		prefix macsec;
 	}
 
-<<<<<<< HEAD
-	description "PORT yang Module for SONiC OS";
-=======
-	import ietf-inet-types {
-		prefix inet;
-	}
-
 	import sonic-extension {
 		prefix ext;
 	}
 
-	description "PORT configuration";
->>>>>>> bed76681c (NOS-12728: move create only to yang (#7053))
+	description "PORT yang Module for SONiC OS";
 
 	revision 2019-07-01 {
 		description "First Revision";

--- a/src/sonic-yang-models/yang-models/sonic-scheduler.yang
+++ b/src/sonic-yang-models/yang-models/sonic-scheduler.yang
@@ -6,6 +6,10 @@ module sonic-scheduler {
 
     prefix sch;
 
+    import sonic-extension {
+        prefix ext;
+    }
+
     organization
         "SONiC";
 
@@ -49,6 +53,7 @@ module sonic-scheduler {
                             description "Strict Scheduling";
                         }
                     }
+                    ext:create-only;
                     default WRR;
                     description "Scheduling algorithm type";
                 }
@@ -57,6 +62,7 @@ module sonic-scheduler {
                     type uint8 {
                         range "1..100";
                     }
+                    ext:create-only;
                     default 1;
                     description "Scheduling algorithm weight";
                 }
@@ -77,12 +83,14 @@ module sonic-scheduler {
                             description "Metering is based on bytes";
                         }
                     }
+                    ext:create-only;
                     default bytes;
                     description "Metering unit for shaping rates (packets or bytes).";
                 }
 
                 leaf cir {
                     type uint64;
+                    ext:create-only;
                     description
                         "Committed information rate for the dual-rate token
                         bucket policer.This value represents the rate at which
@@ -99,6 +107,7 @@ module sonic-scheduler {
                         error-message "pir must be greater than or equal to cir";
                     }
                     type uint64;
+                    ext:create-only;
                     description
                         "Peak information rate for the dual-rate token bucket
                         policer.This value represents the rate at which tokens
@@ -114,6 +123,7 @@ module sonic-scheduler {
                     }
 
                     type uint32;
+                    ext:create-only;
                     description
                         "Committed burst size for the dual-rate token bucket
                         policer.This value represents the depth of the token
@@ -131,6 +141,7 @@ module sonic-scheduler {
                     }
 
                     type uint32;
+                    ext:create-only;
                     description
                         "Excess burst size for the dual-rate token bucket policer.
                         This value represents the depth of the secondary bucket.

--- a/src/sonic-yang-models/yang-templates/sonic-extension.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-extension.yang.j2
@@ -20,6 +20,25 @@ module sonic-extension {
         argument "value";
     }
 
+    extension create-only {
+        description
+            "During an apply-patch operation, indicates that a node can only be created
+             or re-created (i.e., deleted and re-added) but cannot be updated in-place.
+             Any update to a node carrying this extension is realized as a deletion and
+             recreation of the corresponding object.
+
+             This extension can be defined under:
+             - leaf or leaf-list: The immutability restriction applies specifically to this field.
+             - container or list: The restriction applies to the entire container/list, meaning
+               a change to any field within it triggers a deletion and recreation of the entire entry
+               (e.g., [table, '*', '*']).
+             - refine on a uses site: The restriction applies only to the refined node at that
+               uses expansion (preferred for shared groupings so sibling consumers are not widened).
+             - grouping: The restriction applies to the target leaf/leaf-list at every 'uses' site
+               where the grouping is expanded — including consumers that should not be create-only —
+               so prefer refine at the intended uses site instead.";
+    }
+
     {% if yang_model_type == "cvl" %}
     extension custom-validation-cvl {
         description "Extension for registering cvl based custom validation handler.";


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Currently, the Generic Config Updater (GCU) in `sonic-utilities` (specifically inside `patch_sorter.py`) relies on a static, hardcoded list of `create-only` fields to prevent users from modifying immutable attributes. This approach is rigid, hard to scale, and divorces schema properties from the actual YANG validation layer. 

To resolve this, we are transitioning to a declarative, schema-driven approach by moving the create-only configuration metadata out of hardcoded scripts and directly into YANG models as declarative annotations (`ext:create-only`, see https://github.com/sonic-net/sonic-mgmt-common/pull/234 and https://github.com/sonic-net/sonic-utilities/pull/4733).

#### How I did it

* Updated the custom YANG extension template `sonic-extension.yang.j2` (and sample test models) to declare the `ext:create-only` extension.
* Annotated the relevant leaves/containers across 8 YANG models with the `ext:create-only` decorator:
  * `sonic-port.yang` (leaf `lanes`)
  * `sonic-loopback-interface.yang` (leaf `vrf_name`)
  * `sonic-scheduler.yang` (leaves: `type`, `weight`, `cir`, `pir`, `cbs`, `pbs`, `meter_type`)
  * `sonic-mirror-session.yang` (container `MIRROR_SESSION`)
  * `sonic-bgp-neighbor.yang` (leaves on `BGP_NEIGHBOR_LIST` uses sites)
  * `sonic-bgp-monitor.yang` (leaves on `BGP_MONITORS_LIST` uses sites)
  * `sonic-bgp-peerrange.yang` (container `BGP_PEER_RANGE`)
  * `sonic-bgp-sentinel.yang` (container `BGP_SENTINELS`)
  * *Note*: BGP-related annotations are attached via `refine` at individual `uses` sites rather than on the shared groupings in `sonic-bgp-common.yang`. This ensures that unrelated tables like `BGP_PEER_GROUP`, `BGP_INTERNAL_NEIGHBOR`, and `BGP_VOQ_CHASSIS_NEIGHBOR` do not inherit these constraints.
* Added `get_create_only_fields()` method to `sonic_yang_ext.py` in `sonic-yang-mgmt` to dynamically walk the compiled YANG models using the libyang schema tree and discover the annotated elements, replacing the static GCU list.
* Implemented unit tests in `src/sonic-yang-mgmt/tests/libyang-python-tests/test_sonic_yang.py`:
  * `test_get_create_only_fields_matches_expected_set`: Asserts that `get_create_only_fields()` on the installed models produces exactly the 26 expected patterns matching the original hardcoded fallback list.
  * `test_get_create_only_fields_direct_and_refine`: Tests discovery mechanism on fixture models covering both direct leaf annotations and `refine`-carried annotations.

#### How to verify it

* Run the newly added unit tests inside the `sonic-yang-mgmt` test suite during image build or manually:
  ```bash
  pytest src/sonic-yang-mgmt/tests/libyang-python-tests/test_sonic_yang.py
  ```
  Ensure all 26 patterns are dynamically discovered and match the expected golden set exactly.

#### Which release branch to backport (provide reason below if selected)

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608