### PR TITLE
[build]: Include DOCKER_DEFAULT_PLATFORM in the build cache key

### DIFF
--- a/Makefile.cache
+++ b/Makefile.cache
@@ -109,13 +109,16 @@ endif
 # NOTE: slave.mk is intentionally NOT included here; see SONIC_CACHE_RECIPE_VER above.
 SONIC_COMMON_FILES_LIST :=  $(if $(wildcard cache.skip.common),, .platform rules/functions Makefile.cache)
 SONIC_DEVICE_FILES_LIST := $(shell git ls-files -s device | grep -v ^120000 | grep -Eo device.*)
+# NOTE: DOCKER_DEFAULT_PLATFORM changes the architecture recorded in every docker
+# image produced, so images cached under a different value must not be reused.
 SONIC_COMMON_FLAGS_LIST :=  $(SONIC_CACHE_RECIPE_VER) \
                             $(CONFIGURED_PLATFORM) \
                             $(CONFIGURED_ARCH) \
                             $(BLDENV) \
                             $(MIRROR_URLS) $(MIRROR_SECURITY_URLS) \
                             $(SONIC_DEBUGGING_ON) \
-                            $(SONIC_PROFILING_ON)
+                            $(SONIC_PROFILING_ON) \
+                            $(DOCKER_DEFAULT_PLATFORM)
 SONIC_COMMON_DPKG_LIST  :=  debian/control debian/changelog debian/rules \
                             debian/compat debian/install debian/copyright
 SONIC_COMMON_BASE_FILES_LIST  := sonic-slave-jessie/Dockerfile.j2 \


### PR DESCRIPTION
#### Why I did it

`DOCKER_DEFAULT_PLATFORM` is exported from `slave.mk`, so it applies a platform filter to *every* `docker build` / `docker run` / image-name resolution in the build, and it determines the architecture recorded in each image the build produces.

It is not part of `SONIC_COMMON_FLAGS_LIST`, so changing it does not invalidate any cache entry. When a build starts setting (or changing) the variable, the docker base image is still served from the cache — but that cached image was stamped for a different platform. The daemon then declines to resolve it locally and falls back to pulling the intermediate image from a registry where it was never published:

```
[ building ] [ target/docker-base-bookworm.gz ]
[ cached ]   [ target/docker-base-bookworm.gz ]
[ cached ]   [ target/docker-base-bookworm.gz-load ]
[ building ] [ target/docker-config-engine-bookworm.gz ]
...
Unable to find image 'docker-base-bookworm-sonic:latest' locally
docker: Error response from daemon: pull access denied for docker-base-bookworm-sonic,
repository does not exist or may require 'docker login'
...
#3 [internal] load metadata for docker.io/library/docker-base-bookworm-sonic:latest
#3 ERROR: pull access denied, repository does not exist or may require authorization:
   server message: insufficient_scope: authorization failed
------
ERROR: failed to solve: docker-base-bookworm-sonic:latest: pull access denied,
repository does not exist or may require authorization
```

The `pull access denied` wording makes this look like a credential or mirror problem, but it is not. The `docker info` dump in the same failure log reports `Images: 1` — the image *is* present locally and is only being filtered out by the platform mismatch. ARM variant matching is also one-directional, so an image stamped `linux/arm/v8` is not usable when `linux/arm/v7` is requested.

Retries do not recover: once `target/docker-base-*.gz` exists, make skips that target entirely and just re-loads the same mismatched image, so every attempt fails identically.

This affects any build that reuses a docker base image produced before the platform target took effect — whether it comes from `rcache` or from a plain local incremental rebuild. `slave.mk` is deliberately excluded from every target's `DEP_FILES`, so nothing else invalidates these entries.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Add `$(DOCKER_DEFAULT_PLATFORM)` to `SONIC_COMMON_FLAGS_LIST` in `Makefile.cache`, so the value is written into every `target/<pkg>.flags` file and therefore becomes part of the cache key.

Where the variable is empty there is no effect: `Makefile.cache` collapses and strips whitespace when writing `.flags`, so empty variables do not change the key. `SONIC_DEBUGGING_ON` and `SONIC_PROFILING_ON` are already in the list under exactly that condition.

Resulting `.flags` content:

| build | `.flags` | cache impact |
| --- | --- | --- |
| amd64 (native or qemu) | `1 generic amd64 <bldenv>` | unchanged |
| arm64 native | `1 generic arm64 <bldenv>` | unchanged |
| arm64 qemu / cross | `... <bldenv> linux/arm64` | one-time invalidation |
| armhf | `... <bldenv> linux/arm/v7` | one-time invalidation |

`DOCKER_DEFAULT_PLATFORM` is assigned in `slave.mk` before `include Makefile.cache`, so the value is available when the list is expanded.

#### How to verify it

For a target where `DOCKER_DEFAULT_PLATFORM` is set (armhf, or arm64 with `MULTIARCH_QEMU_ENVIRON` / `CROSS_BUILD_ENVIRON`):

```
make configure PLATFORM=marvell-prestera PLATFORM_ARCH=armhf
cat target/docker-base-bookworm.gz.flags
```

The flags file now ends with the platform value, so the cache key differs from the one generated without it and the docker base image is rebuilt rather than restored from a cache entry stamped for a different platform. Subsequent builds hit the cache normally.

For amd64 and native arm64 the flags file is byte-identical to before, so existing cache entries stay valid.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: regression

#### Tested branch

- [x] master

#### Test result

Verified the expansion of `SONIC_COMMON_FLAGS_LIST` for each architecture and build mode using an equivalent makefile fragment, confirming that the `.flags` content is unchanged for amd64 and native arm64, and gains the platform value only where `DOCKER_DEFAULT_PLATFORM` is actually set. Makefile-only change with no runtime impact on the produced image.

#### Description for the changelog

Include `DOCKER_DEFAULT_PLATFORM` in the build cache key so docker images cached under a different platform target are not reused.

#### Link to config_db schema for YANG module changes

N/A
