### PR TITLE
[logrotate] Decouple configuration generation from Config DB

### DIFF
--- a/files/image_config/logrotate/logrotate-config.service
+++ b/files/image_config/logrotate/logrotate-config.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=Update logrotate configuration
-Requires=config-setup.service
-After=config-setup.service
 
 [Service]
 Type=oneshot
@@ -10,4 +8,3 @@ RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target
-

--- a/files/image_config/logrotate/logrotate-config.sh
+++ b/files/image_config/logrotate/logrotate-config.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-sonic-cfggen -d -t  /usr/share/sonic/templates/rsyslog.j2 -a "{\"var_log_kb\":$(df -k /var/log | sed -n 2p | awk '{ print $2 }') }" > /etc/logrotate.d/rsyslog
-
+sonic-cfggen -t  /usr/share/sonic/templates/rsyslog.j2 -a "{\"var_log_kb\":$(df -k /var/log | sed -n 2p | awk '{ print $2 }') }" > /etc/logrotate.d/rsyslog

--- a/files/image_config/logrotate/logrotateOverride.conf
+++ b/files/image_config/logrotate/logrotateOverride.conf
@@ -1,5 +1,6 @@
 [Unit]
 Requires=logrotate-config.service
+After=logrotate-config.service
 
 [Service]
 ExecStart=


### PR DESCRIPTION
#### Why I did it

`logrotate.service` currently reaches Config DB, database, and Docker through
the following transitive dependency chain:

```text
logrotate.service
  -> logrotate-config.service
  -> config-setup.service
  -> database.service
  -> docker.service
```

If logrotate is triggered while database and Docker are intentionally stopped,
systemd can start those services again. This can interfere with workflows that
require them to remain stopped, including reboot shutdown windows.

`rsyslog.j2` does not require Config DB data for this operation. Its log-size
input, `var_log_kb`, is already supplied explicitly through `sonic-cfggen -a`.

Fixes #28755

##### Work item tracking

- GitHub issue: #28755

#### How I did it

- Removed `-d` from the `sonic-cfggen` invocation in
  `logrotate-config.sh`.
- Removed the `config-setup.service` requirement and ordering from
  `logrotate-config.service`.
- Added `After=logrotate-config.service` to the logrotate systemd override.
- Retained `Requires=logrotate-config.service` so configuration-generation
  failures continue to propagate to logrotate.

The resulting dependency path is:

```text
logrotate.service
  -> logrotate-config.service
```

#### How to verify it

Static validation on this public `master` branch:

```text
bash -n files/image_config/logrotate/logrotate-config.sh: PASS
git diff --check: PASS
```

Lifecycle validation was also completed on a downstream 202405-derived image
containing the same three-file change:

```text
test_logrotate_service_boot_startup: PASS
test_logrotate_config_render_without_db: PASS
test_logrotate_service_cli_restart: PASS
test_logrotate_service_config_reload: PASS
test_logrotate_service_timer_trigger: PASS
test_logrotate_service_after_reboot: PASS
```

Final lifecycle result: **6/6 passed**.

A companion `sonic-mgmt` PR containing this lifecycle coverage will follow.
Public `master` image-build and runtime validation remain to be completed before
this draft is marked ready for review.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

No release backport is requested in this draft. A 202405 backport can be
requested after public branch-specific image validation is available.

Tracking issue/work item for backport/cherry-pick request: #28755

Failure type: other

#### Tested branch

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- Public `master`: static validation passed; image-build/runtime validation is
  pending.
- Downstream 202405-derived image: logrotate lifecycle suite 6/6 passed.

#### Description for the changelog

Decouple logrotate configuration generation from Config DB, database, and
Docker startup.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

N/A
