### PR TITLE
[nexthop]: Fix NH-4210 PFC discard statistics mask

### DIFF
--- a/device/nexthop/x86_64-nexthop_4210-r0021/NH-4210-F-O256/nh4210-r0021-F-O256.yaml
+++ b/device/nexthop/x86_64-nexthop_4210-r0021/NH-4210-F-O256/nh4210-r0021-F-O256.yaml
@@ -4680,7 +4680,7 @@ bcm_device:
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 32768
             #enable port queue drop stats
-            sai_stats_support_mask: 0x80
+            sai_stats_support_mask: 0x880
             #disable vxlan tunnel stats
             sai_stats_disable_mask: 0x200
             #For PPIU Mode, Set resources for counters in global mode counters like ACL, etc


### PR DESCRIPTION
#### Why I did it

On NH-4210-F-O256, PFC XON/XOFF frames were counted in
`SAI_PORT_STAT_IF_IN_DISCARDS`, causing
`pfcwd/test_xon_not_counted.py` to report an RX_DROP increase of 1000.

#### How I did it

Updated `sai_stats_support_mask` from `0x80` to `0x880` for
NH-4210-F-O256 so PFC pause frames are excluded from RX discard statistics.

#### How to verify it

Cold-reboot the DUT so syncd reloads the SAI profile, then run:

```text
pytest pfcwd/test_xon_not_counted.py \
  --inventory ../ansible/veos,../ansible/str4 \
  --host-pattern all \
  --testbed_file ../ansible/testbed.yaml \
  --testbed vms13-lt2-nh4210-1 \
  --skip_sanity --disable_loganalyzer -rav
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: day-one issue

#### Tested branch

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- 202512: `SONiC.20251210.10` — `pfcwd/test_xon_not_counted.py`:
  **1 passed** after applying `0x880` and cold rebooting.

#### Description for the changelog

Fix NH-4210-F-O256 PFC pause frames being counted as RX discards.

#### Link to config_db schema for YANG module changes


