### PR TITLE
[Nexthop] NH-4210 Enabling missing sai stats

### DIFF
--- a/device/nexthop/x86_64-nexthop_4210-r0021/NH-4210-F-O256/nh4210-r0021-F-O256.yaml
+++ b/device/nexthop/x86_64-nexthop_4210-r0021/NH-4210-F-O256/nh4210-r0021-F-O256.yaml
@@ -4680,7 +4680,7 @@ bcm_device:
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 32768
             #enable port queue drop stats
-            sai_stats_support_mask: 0x80
+            sai_stats_support_mask: 0x884
             #disable vxlan tunnel stats
             sai_stats_disable_mask: 0x200
             #For PPIU Mode, Set resources for counters in global mode counters like ACL, etc

--- a/device/nexthop/x86_64-nexthop_4210-r0021/NH-4210-F-P128/nh4210-r0021-F-P128.yaml
+++ b/device/nexthop/x86_64-nexthop_4210-r0021/NH-4210-F-P128/nh4210-r0021-F-P128.yaml
@@ -3144,7 +3144,7 @@ bcm_device:
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 32768
             #enable port queue drop stats
-            sai_stats_support_mask: 0x80
+            sai_stats_support_mask: 0x884
             #disable vxlan tunnel stats
             sai_stats_disable_mask: 0x200
             #For PPIU Mode, Set resources for counters in global mode counters like ACL, etc


### PR DESCRIPTION
#### Why I did it

Bit 11 (0x800):
Rx PFC pause frames were being counted as priority-group drops / RX_DRP.
Enabling bit 11 (0x800) of sai_stats_support_mask tells the Broadcom SDK not to count Rx PFC frames as PG/RX drops.

Causes `pfcwd/test_xon_not_counted.py` failures

Bit 2 (0x4):
The pfcwd drop counters (tx_drop_count / interface-fallback intf_tx_drp) do not increment during a PFC storm, failing test_pfcwd_storm_during_traffic and test_pfcwd_show_stat. The sai_stats_support_mask was missing the 0x4 (egress queue drop stats) bit the watchdog reads.

Causes `pfcwd/test_pfcwd_function.py` failures

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

Bit 11 (0x800)
On a 2-DUT PFC setup with VLAN-configured ingress ports, send lossless traffic in PG3 and generate Rx PFC frames. Confirm `show pfc counters` increments while `show priority-group drop counters` / `show dropcounters` counts no longer report RX_DRP matching the PFC frame count.

Before:
```
+-------------------------------------+-------------------------------------+--------+----------+------------------------------------------------------------------------+
| Test                                | Description                         | Result | Duration | Error                                                                  |
+-------------------------------------+-------------------------------------+--------+----------+------------------------------------------------------------------------+
| tests/pfcwd/test_xon_not_counted.py | skipped 0 errors 0 failed 1 total 1 | FAIL   | 163.22   | AssertionError: RX_DROP increased on Ethernet256: before=25 after=1025 |
+-------------------------------------+-------------------------------------+--------+----------+————————————————————————————————————+
```

After:
```
+-------------------------------------+-------------------------------------+--------+----------+-------+
| Test                                | Description                         | Result | Duration | Error |
+-------------------------------------+-------------------------------------+--------+----------+-------+
| tests/pfcwd/test_xon_not_counted.py | skipped 0 errors 0 failed 0 total 1 | PASS   | 205.13   |       |
+-------------------------------------+-------------------------------------+--------+----------+-------+
```

Bit 2 (0x4)
Before:
```
FAILED pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_storm_during_traffic[IPv4|6]: tx_drop_count not incrementing after storm on port Ethernet260 queue 4
```

After:
```
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[IPv6] PASSED [ 10%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[IPv6] SKIPPED [ 20%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[IPv6] PASSED [ 30%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[IPv6] PASSED [ 40%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic[IPv6] SKIPPED [ 50%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_actions[IPv4] PASSED [ 60%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_multi_port[IPv4] SKIPPED [ 70%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_mmu_change[IPv4] PASSED [ 80%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_port_toggle[IPv4] PASSED [ 90%]
pfcwd/test_pfcwd_function.py::TestPfcwdFunc::test_pfcwd_no_traffic[IPv4] SKIPPED [100%]
```


#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master: See above
- 202512: See above (run on master + 202512)

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
