### PR TITLE
[ci] cherry-pick master docker-ptf pipeline changes to 202605

### DIFF
--- a/.azure-pipelines/docker-ptf.yml
+++ b/.azure-pipelines/docker-ptf.yml
@@ -12,7 +12,6 @@ pr:
     - 202???
   paths:
     include:
-    - dockers/docker-ptf
     - .azure-pipelines/docker-ptf.yml
 
 resources:
@@ -30,6 +29,10 @@ parameters:
 - name: registry_conn
   type: string
   default: sonicdev
+- name: use_frozen_versions
+  type: boolean
+  default: false
+  displayName: 'Use pinned versions from dockers/docker-ptf/files'
 
 stages:
 - stage: Prepare
@@ -57,6 +60,11 @@ stages:
     value: 'y'
   - name: BUILD_BRANCH
     value: $[ coalesce(variables['System.PullRequest.TargetBranchName'], variables['Build.SourceBranchName']) ]
+  - name: VERSION_CONTROL_OPTIONS
+    ${{ if parameters.use_frozen_versions }}:
+      value: 'SONIC_VERSION_CONTROL_COMPONENTS=py2,py3,web,git,docker'
+    ${{ else }}:
+      value: 'SONIC_VERSION_CONTROL_COMPONENTS='
   jobs:
   - job: Build
     pool: sonicso1ES-amd64
@@ -83,22 +91,31 @@ stages:
         allowPartiallySucceededBuilds: true
         targetPath: $(Pipeline.Workspace)/vs-images
 
-    - script: |
-        echo "DEBIAN_TIMESTAMP=$DEBIAN_TIMESTAMP, DEBIAN_SECURITY_TIMESTAMP=$DEBIAN_SECURITY_TIMESTAMP"
-        if [ "$MIRROR_SNAPSHOT" == y ]; then
-          mkdir -p target/versions/default/
-          echo "debian==$DEBIAN_TIMESTAMP" > target/versions/default/versions-mirror
-          echo "debian-security==$DEBIAN_SECURITY_TIMESTAMP" >> target/versions/default/versions-mirror
-          cat target/versions/default/versions-mirror
-        fi
-      displayName: 'Set snapshot versions'
+    - ${{ if not(parameters.use_frozen_versions) }}:
+      - script: |
+          echo "DEBIAN_TIMESTAMP=$DEBIAN_TIMESTAMP, DEBIAN_SECURITY_TIMESTAMP=$DEBIAN_SECURITY_TIMESTAMP"
+          if [ "$MIRROR_SNAPSHOT" == y ]; then
+            mkdir -p target/versions/default/
+            echo "debian==$DEBIAN_TIMESTAMP" > target/versions/default/versions-mirror
+            echo "debian-security==$DEBIAN_SECURITY_TIMESTAMP" >> target/versions/default/versions-mirror
+            cat target/versions/default/versions-mirror
+          fi
+        displayName: 'Set snapshot versions'
+
+    - ${{ if parameters.use_frozen_versions }}:
+      - bash: |
+          set -ex
+          # Restore all frozen version files from dockers/docker-ptf/files/ back into
+          # files/build/versions/ so versions_manager can find them during the build.
+          rsync -av dockers/docker-ptf/files/ files/build/versions/
+        displayName: 'Apply frozen versions for docker-ptf'
 
     - bash: |
         set -xe
-        git submodule update --init --recursive -- src/ptf src/ptf-py3 src/sonic-sairedis src/sonic-frr/frr src/sonic-swss-common
+        git submodule update --init --recursive -- src/ptf src/ptf-py3 src/scapy src/sonic-sairedis src/sonic-frr/frr src/sonic-swss-common
         # TODO: ENABLE_SBOM=y
         BUILD_OPTIONS="SONIC_BUILD_JOBS=$(nproc) DEFAULT_CONTAINER_REGISTRY=publicmirror.azurecr.io ENABLE_DOCKER_BASE_PULL=y MIRROR_SNAPSHOT=$MIRROR_SNAPSHOT 
-                      SONIC_BUILD_RETRY_COUNT=3 SONIC_BUILD_RETRY_INTERVAL=600 DOCKER_BUILDKIT=0 SONIC_VERSION_CONTROL_COMPONENTS="
+                      SONIC_BUILD_RETRY_COUNT=3 SONIC_BUILD_RETRY_INTERVAL=600 DOCKER_BUILDKIT=0 $(VERSION_CONTROL_OPTIONS)"
 
         make NOBUSTER=1 NOBULLSEYE=1 $BUILD_OPTIONS configure PLATFORM=vs NOTRIXIE=1 # docker-ptf is built for bookworm, disable trixie currently to save build time. will enable it after migrating to trixie.
         make -f Makefile.work BLDENV=bookworm $BUILD_OPTIONS target/docker-ptf.gz
@@ -209,3 +226,93 @@ stages:
         repository: docker-ptf
         command: push
         tags: $(DOCKER_TAG)
+
+- stage: UpdateVersions
+  dependsOn: Publish
+  condition: and(not(canceled()), ne(variables['Build.Reason'], 'PullRequest'), in(dependencies.Publish.result, 'Succeeded'))
+  jobs:
+  - job: UpdateVersions
+    pool:
+      vmImage: 'ubuntu-22.04'
+    variables:
+      - group: sonicbld
+    steps:
+    - script: |
+        if [ -z "$(which gh)" ]; then
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+          sudo apt-add-repository -y https://cli.github.com/packages
+          sudo apt update
+          sudo apt install -y gh
+        fi
+
+        echo $TOKEN | gh auth login --with-token
+      env:
+        TOKEN: $(GITHUB-TOKEN)
+      displayName: 'Install gh'
+
+    - checkout: self
+      displayName: 'Checkout code'
+
+    - download: current
+      artifact: 'sonic-buildimage.vs'
+      patterns: '**/versions-*'
+      displayName: 'Download build artifact'
+
+    - script: |
+        set -ex
+        # Copy all version files produced by the build into dockers/docker-ptf/files/,
+        # preserving the subdirectory structure (dockers/docker-ptf/, default/, etc.).
+        # This keeps them separate from the global files/build/versions tree so the
+        # UpgradeVersion pipeline does not overwrite them.
+        mkdir -p target
+        cp -r $(Pipeline.Workspace)/sonic-buildimage.vs/target/versions target/
+        FREEZE_TMPDIR=$(mktemp -d)
+        make freeze FREEZE_VERSION_OPTIONS="-r -s $FREEZE_TMPDIR"
+
+        mkdir -p dockers/docker-ptf/files
+        rsync -av --delete "$FREEZE_TMPDIR/files/build/versions/" dockers/docker-ptf/files/
+        rm -rf "$FREEZE_TMPDIR"
+        git diff dockers/docker-ptf/files
+      displayName: 'Update docker-ptf version files'
+
+    - script: |
+        GIT_STATUS=$(git status --porcelain dockers/docker-ptf/files)
+        if [ -z "$GIT_STATUS" ]; then
+          echo "Skipped to send the pull request, no version change in docker-ptf versions"
+          exit 0
+        fi
+        if [ ! -d "$HOME" ]; then
+          sudo mkdir -p $HOME
+          sudo chown -R $(id -un):$(id -gn) $HOME
+        fi
+        SOURCE_BRANCH=$(Build.SourceBranch)
+        REPO_NAME=$(Build.Repository.Name)
+        [ -z "$GIT_REPO" ] && GIT_REPO=${REPO_NAME#*/}
+        BRANCH_NAME=repd/docker-ptf-versions/${SOURCE_BRANCH#refs/heads/}
+
+        gh auth setup-git
+        git config user.name "Sonic Build Admin"
+        git config user.email "sonicbld@microsoft.com"
+        git add dockers/docker-ptf/files
+        git commit -s -m "[docker-ptf] Upgrade docker-ptf package versions"
+        git checkout -b $BRANCH_NAME
+        git push origin HEAD:refs/heads/$BRANCH_NAME -f
+
+        TITLE="[${SOURCE_BRANCH#refs/heads/}] Upgrade docker-ptf package versions"
+        # The branch was already force pushed above, so an open pull request
+        # picks up the new commit and does not need to be recreated.
+        PR_URL=$(gh pr list -R $REPO_NAME -H $BRANCH_NAME -B ${SOURCE_BRANCH#refs/heads/} --state open --json url --jq '.[].url' | head -1)
+        if [ -n "$PR_URL" ]; then
+          echo "Skipped to send the pull request, an open pull request was updated: $PR_URL"
+          exit 0
+        fi
+
+        RET=0
+        if ! gh pr create -t "$TITLE" -b "$TITLE" -B $(Build.SourceBranch) -R $(Build.Repository.Name) > pr.log 2>&1; then
+          if ! grep -q "already exists" pr.log; then
+            RET=1
+          fi
+        fi
+        cat pr.log
+        exit $RET
+      displayName: 'Send Pull Request'


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
cherry-pick: https://github.com/sonic-net/sonic-buildimage/pull/28399
#### Why I did it
The docker-ptf pipeline builds with version control disabled. That makes docker-ptf builds non-reproducible.

This change brings docker-ptf in line with the main sonic-buildimage build's version-freeze workflow: pin the build to a set of tracked version files, and auto-generate a PR to refresh those files when new versions are validated.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
1. Opt-in version pinning. Added a `use_frozen_versions` pipeline parameter (default `false`) that selects `VERSION_CONTROL_OPTIONS`. The build now passes `$(VERSION_CONTROL_OPTIONS)`  instead of the hard-coded empty value.
2. Apply frozen versions before build. When `use_frozen_versions` is set, an added step `rsync`s the tracked version files from `dockers/docker-ptf/files/` into `files/build/versions/` so `versions_manager` picks them up during the build. Keeping them under `dockers/docker-ptf/files/` (rather than the global `files/build/versions/` tree) isolates the docker-ptf pins so the repo-wide UpgradeVersion pipeline won't overwrite them.
3. Auto-refresh version files. Added an `UpdateVersions` stage that runs only on non-PR builds after publish step succeeds. It downloads the `versions-*` artifacts produced by the build, copies them into `dockers/docker-ptf/files/`, and — if anything changed — opens a PR to update the versions.
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

