### PR TITLE
[cache validation] [rules/libnl3]: Register LIBNL_NF3_DBG against the top-level LIBNL3

### DIFF
--- a/rules/libnl3.mk
+++ b/rules/libnl3.mk
@@ -55,7 +55,7 @@ $(eval $(call add_derived_package,$(LIBNL3),$(LIBNL_NF3)))
 LIBNL_NF3_DBG = libnl-nf-3-200-dbgsym_$(LIBNL3_VERSION_SONIC)_$(CONFIGURED_ARCH).deb
 $(LIBNL_NF3_DBG)_DEPENDS += $(LIBNL_NF3)
 $(LIBNL_NF3_DBG)_RDEPENDS += $(LIBNL_NF3)
-$(eval $(call add_derived_package,$(LIBNL_NF3),$(LIBNL_NF3_DBG)))
+$(eval $(call add_derived_package,$(LIBNL3),$(LIBNL_NF3_DBG)))
 
 LIBNL_NF3_DEV = libnl-nf-3-dev_$(LIBNL3_VERSION_SONIC)_$(CONFIGURED_ARCH).deb
 $(LIBNL_NF3_DEV)_DEPENDS += $(LIBNL_NF3)


### PR DESCRIPTION
#### Why I did it

In `rules/libnl3.mk` every derived debian package is registered against the buildable top-level package `$(LIBNL3)` via `add_derived_package` — **except** `LIBNL_NF3_DBG`, which was registered against `$(LIBNL_NF3)`:

```make
$(eval $(call add_derived_package,$(LIBNL_NF3),$(LIBNL_NF3_DBG)))
```

But `LIBNL_NF3` is itself only a *derived* deb of `LIBNL3` (`add_derived_package($(LIBNL3),$(LIBNL_NF3))`), never a buildable target. `add_derived_package(M,D)` does `M_DERIVED_DEBS += D`, so `LIBNL_NF3_DBG` landed in `LIBNL_NF3_DERIVED_DEBS` instead of `LIBNL3_DERIVED_DEBS`.

The DPKG cache only tars/restores a main package plus its **own** `_DERIVED_DEBS` (`Makefile.cache` `SAVE_CACHE`/`LOAD`), and `SAVE_CACHE` runs only from a buildable main-deb recipe. `LIBNL_NF3` (derived) never runs `SAVE_CACHE`, and the generic derived-deb recipe is a no-op (`[ -f $@ ] && touch $@`) that succeeds even when the file is absent. So on a `LIBNL3` **cache hit**, `libnl-nf-3-200-dbgsym` is never restored and never rebuilt — it is **silently dropped** from the produced artifact set, diverging from a from-source build.

#### How I did it

Register `LIBNL_NF3_DBG` against `$(LIBNL3)`, consistent with every other dbg package (`LIBNL_ROUTE3_DBG`, `LIBNL_CLI_DBG`, `LIBNL_GENL3_DBG`, …), so it is tarred on save and restored on a `LIBNL3` cache hit:

```diff
-$(eval $(call add_derived_package,$(LIBNL_NF3),$(LIBNL_NF3_DBG)))
+$(eval $(call add_derived_package,$(LIBNL3),$(LIBNL_NF3_DBG)))
```

The explicit `$(LIBNL_NF3_DBG)_DEPENDS/_RDEPENDS += $(LIBNL_NF3)` lines above are kept, preserving build ordering. This is the **only** nested `add_derived_package` call in the repo (verified across all 224 calls).

#### How to verify it

- Make expansion: before, `LIBNL3_DERIVED_DEBS` excludes `libnl-nf-3-200-dbgsym`; after, it includes it (and `LIBNL_NF3_DERIVED_DEBS` becomes empty).
- On a `LIBNL3` cache hit, the restored tarball now contains `libnl-nf-3-200-dbgsym`, matching a from-source build.

#### Which release branch to backport (provide reason below if selected)

<!-- - [ ] 202305 etc -->

#### Tested branch (Please provide the tested image version)

<!-- master -->

#### Description for the changelog

Register the `libnl-nf-3-200-dbgsym` derived package against the buildable top-level `LIBNL3` (not the intermediate derived `LIBNL_NF3`), so it is saved to and restored from the DPKG cache instead of being silently dropped on a cache hit.

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
