### PR TITLE
[p4lang]: Fix flaky bmv2 CLI tests caused by device id collision

### DIFF
--- a/.azure-pipelines/docker-ptf.yml
+++ b/.azure-pipelines/docker-ptf.yml
@@ -12,6 +12,9 @@ pr:
     - 202???
   paths:
     include:
+    # Package sources that end up in the image (src/p4lang, src/ptf, ...) are
+    # not listed here, so a change to one of them has to touch this file as
+    # well to get the docker-ptf build exercised on a pull request.
     - .azure-pipelines/docker-ptf.yml
 
 resources:

--- a/src/p4lang/Makefile
+++ b/src/p4lang/Makefile
@@ -29,6 +29,7 @@ $(addprefix $(DEST)/, $(P4LANG_BMV2_TARGET)): $(DEST)/% :
 	pushd p4lang-bmv2-$(P4LANG_BMV2_VERSION)
 	patch -p1 -i ../p4lang-bmv2.patch/use-boost-1.83.patch
 	patch -p1 -i ../p4lang-bmv2.patch/remove-unnecessary-dependencies.patch
+	patch -p1 -i ../p4lang-bmv2.patch/fix-cli-tests-device-id-race.patch
 ifeq ($(CROSS_BUILD_ENVIRON), y)
 	dpkg-buildpackage -us -uc -b -a$(CONFIGURED_ARCH) -Pcross,nocheck -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)
 else

--- a/src/p4lang/p4lang-bmv2.patch/fix-cli-tests-device-id-race.patch
+++ b/src/p4lang/p4lang-bmv2.patch/fix-cli-tests-device-id-race.patch
@@ -1,0 +1,52 @@
+Index: p4lang-bmv2-1.15.0/targets/simple_switch/tests/CLI_tests/run_one_test.py.in
+===================================================================
+--- p4lang-bmv2-1.15.0.orig/targets/simple_switch/tests/CLI_tests/run_one_test.py.in
++++ p4lang-bmv2-1.15.0/targets/simple_switch/tests/CLI_tests/run_one_test.py.in
+@@ -24,6 +24,10 @@
+ # Class written by Mihai Budiu, for Barefoot Networks, Inc.
+ 
+ 
++# TODO(antonin): fragile if the name changes in the bmv2 code
++RPC_PATH_TEMPLATE = "/tmp/bmv2-{}-notifications.ipc"
++
++
+ class ConcurrentInteger(object):
+     # Generates exclusive integers in a range 0-max
+     # in a way which is safe across multiple processes.
+@@ -45,10 +49,14 @@
+         # try 10 times
+         for i in range(0, 10):
+             index = random.randint(0, self.max)
++            # A leftover notification socket means the id is either in use by
++            # a concurrent instance or was orphaned by a crashed one; binding
++            # to it would fail with "Address already in use".
++            if os.path.exists(RPC_PATH_TEMPLATE.format(index)):
++                continue
+             file = self.lockName(index)
+             try:
+                 os.makedirs(file)
+-                os.rmdir(file)
+                 return index
+             except:
+                 time.sleep(1)
+@@ -74,8 +82,7 @@
+         sys.exit(2)
+     thrift_port = str(9090 + rand)
+     device_id = str(rand)
+-    # TODO(antonin): fragile if the name changes in the bmv2 code
+-    rpc_path = "/tmp/bmv2-{}-notifications.ipc".format(device_id)
++    rpc_path = RPC_PATH_TEMPLATE.format(device_id)
+ 
+     # makes sure that the switch will start right away
+     simple_switch_p = subprocess.Popen(
+@@ -101,6 +108,10 @@
+             os.remove(rpc_path)
+         except:
+             pass
++        try:
++            concurrent.release(rand)
++        except:
++            pass
+ 
+     cmd = ["@abs_top_srcdir@/tools/runtime_CLI.py",
+            "--thrift-port", thrift_port]


### PR DESCRIPTION
#### Why I did it

Building `p4lang-bmv2` intermittently fails the `docker-ptf` job:

```
Nanomsg returned a exception when trying to bind to address 'ipc:///tmp/bmv2-227-notifications.ipc'.
The exception is: Address already in use
...
FAIL: table_dump.test
```

`dh_auto_test` propagates the failure and the whole package build aborts, taking `target/docker-ptf.gz` with it.

The id in that path is handed out by `ConcurrentInteger` in `targets/simple_switch/tests/CLI_tests/run_one_test.py.in`. It exists so that concurrently running switches get distinct `--device-id` and `--thrift-port` values, but its lock does not lock:

```python
def generate(self):
    for i in range(0, 10):
        index = random.randint(0, self.max)
        file = self.lockName(index)
        try:
            os.makedirs(file)
            os.rmdir(file)      # released before the id is even returned
            return index
```

The lock directory is removed before `generate()` returns, so the "exclusive" id is already free when the caller receives it, and the `release()` method sitting right above it is never called from anywhere. `make check` runs the five CLI tests in parallel, so two of them can draw the same number.

The way it then fails is misleading, because the script never verifies that the switch came up:

1. test A wins the race and owns device id 227 and thrift port 9317
2. test B's switch fails to bind the notification socket and logs the error above
3. the script sleeps one second and runs the CLI regardless
4. the CLI connects to port 9317, which is test A's switch, loaded with a different P4 program
5. the lookup fails with `Invalid table name (ecmp_group)` and the test is reported as an output mismatch

So the visible symptom points at table contents while the actual cause is id allocation.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added a patch for the upstream test helper:

- keep the lock directory until `cleanup()` releases it, so the id is genuinely exclusive for the lifetime of the switch
- skip ids whose notification socket is still on disk, left behind by an instance that died before it could clean up; bmv2 itself lists this as a bind failure cause ("the file already exists")
- hoist the socket path into a module level constant so the allocator and `main()` cannot drift apart

`run_one_test.py` is generated through `AC_CONFIG_FILES`, so patching the `.in` template needs no autoreconf. No test suite is disabled and no build option is changed: all 49 tests still run.

Known limitation: this fixes the coordination bug but not the design around it. The script still trusts the allocation rather than verifying it, because the startup check is commented out upstream in favour of a fixed one second sleep, so a bind failure is never noticed and never retried. Restoring that check and retrying with a fresh id would make this robust against any occupant, including unrelated processes on the build host, but that is a much larger change to `main()` and is deliberately left alone here.

#### How to verify it

Build the package:

```
make target/debs/trixie/p4lang-bmv2_1.15.0-9_amd64.deb
```

Verified locally against the real `p4lang-bmv2_1.15.0-9.dsc` fetched from the packaging source:

- the three patches apply in Makefile order with no conflict, and the patched file compiles
- the file in the tarball is byte identical to the upstream revision the patch was written against
- allocator behaviour, exercised through the patched source itself, 6 workers competing for 6 slots, 3 rounds: unpatched produced 2 to 3 duplicate allocations per round, patched produced none and filled every slot
- stale socket avoidance: unpatched picked a blocked id 105 times out of 300, patched 0 times out of 300
- the real script driven end to end against stub binaries that create a notification socket: on all three exit paths (success, CLI non-zero, output mismatch) the lock is released and the socket removed, so a failing test cannot poison the ones after it

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type:

#### Tested branch

- [x] master

#### Test result

master: patch application, allocator behaviour and end to end lock release verified locally as described above. Full package build to be confirmed by CI.

#### Description for the changelog

Fix flaky p4lang-bmv2 CLI tests caused by a non-exclusive id allocator in the upstream test helper

#### Link to config_db schema for YANG module changes

N/A
