### PR TITLE
[cache validation] platform/p4: add dpkg build-cache dependency tracking for the p4 from-source closure

### DIFF
--- a/platform/p4/libsaithrift-dev.dep
+++ b/platform/p4/libsaithrift-dev.dep
@@ -1,0 +1,19 @@
+#DPKG FRK
+# LIBSAITHRIFT_DEV_P4 is built from source at src/sonic-sairedis/SAI (a git
+# submodule) with further nested submodules test/ptf and test/saithrift/ctypesgen
+# that are part of the build and must be keyed explicitly (git ls-files does not
+# recurse into nested submodules). Mirrors the blessed broadcom/barefoot
+# libsaithrift-dev.dep pattern. LIBSAITHRIFT_DEV_P4 also depends on P4_SWITCH and
+# the thrift family; those are keyed by their own .dep files and fold in via
+# GET_MOD_DEP_SHA.
+SPATH       := $($(LIBSAITHRIFT_DEV_P4)_SRC_PATH)
+DEP_FILES   := $(SONIC_COMMON_FILES_LIST) $(PLATFORM_PATH)/libsaithrift-dev.mk $(PLATFORM_PATH)/libsaithrift-dev.dep
+DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
+SMDEP_PATHS := $(SPATH) $(SPATH)/test/ptf  $(SPATH)/test/saithrift/ctypesgen
+$(foreach path, $(SMDEP_PATHS), $(eval $(path) :=$(filter-out $(SMDEP_PATHS),$(addprefix $(path)/, $(shell cd $(path) &&  git ls-files | grep -Ev " " )))))
+
+$(LIBSAITHRIFT_DEV_P4)_CACHE_MODE  := GIT_CONTENT_SHA
+$(LIBSAITHRIFT_DEV_P4)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)
+$(LIBSAITHRIFT_DEV_P4)_DEP_FILES   := $(DEP_FILES)
+$(LIBSAITHRIFT_DEV_P4)_SMDEP_FILES := $(foreach path, $(SMDEP_PATHS), $($(path)))
+$(LIBSAITHRIFT_DEV_P4)_SMDEP_PATHS := $(SMDEP_PATHS)

--- a/platform/p4/p4-bmv.dep
+++ b/platform/p4/p4-bmv.dep
@@ -1,0 +1,18 @@
+#DPKG FRK
+# P4_BMV is built from source at platform/p4/SAI-P4-BM/p4-switch, a subdirectory
+# of the SAI-P4-BM git submodule. That subdirectory contains a further nested
+# submodule at p4-switch/behavioral-model, which is part of P4_BMV's source and
+# must be keyed explicitly (git ls-files does not recurse into nested
+# submodules). P4_BMV also depends on P4C_BM and the thrift family; those are
+# keyed by their own .dep files and fold in via GET_MOD_DEP_SHA.
+SPATH       := $($(P4_BMV)_SRC_PATH)
+DEP_FILES   := $(SONIC_COMMON_FILES_LIST) $(PLATFORM_PATH)/p4-bmv.mk $(PLATFORM_PATH)/p4-bmv.dep
+DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
+SMDEP_PATHS := $(SPATH) $(SPATH)/behavioral-model
+$(foreach path, $(SMDEP_PATHS), $(eval $(path) :=$(filter-out $(SMDEP_PATHS),$(addprefix $(path)/, $(shell cd $(path) &&  git ls-files | grep -Ev " " )))))
+
+$(P4_BMV)_CACHE_MODE  := GIT_CONTENT_SHA
+$(P4_BMV)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)
+$(P4_BMV)_DEP_FILES   := $(DEP_FILES)
+$(P4_BMV)_SMDEP_FILES := $(foreach path, $(SMDEP_PATHS), $($(path)))
+$(P4_BMV)_SMDEP_PATHS := $(SMDEP_PATHS)

--- a/platform/p4/p4-hlir.dep
+++ b/platform/p4/p4-hlir.dep
@@ -1,0 +1,30 @@
+#DPKG FRK
+# p4-hlir.mk defines two from-source packages, each built from its own git
+# submodule. Key each submodule's tracked source tree so changes invalidate the
+# cache for the package and its cached consumers (P4C_BM -> P4_BMV -> ...).
+
+# --- P4_HLIR (platform/p4/p4-hlir/p4-hlir) ---
+HLIR_SPATH   := $($(P4_HLIR)_SRC_PATH)
+HLIR_DFILES  := $(SONIC_COMMON_FILES_LIST) $(PLATFORM_PATH)/p4-hlir.mk $(PLATFORM_PATH)/p4-hlir.dep
+HLIR_DFILES  += $(SONIC_COMMON_BASE_FILES_LIST)
+HLIR_SMPATHS := $(HLIR_SPATH)
+$(foreach path, $(HLIR_SMPATHS), $(eval $(path) :=$(filter-out $(HLIR_SMPATHS),$(addprefix $(path)/, $(shell cd $(path) &&  git ls-files | grep -Ev " " )))))
+
+$(P4_HLIR)_CACHE_MODE  := GIT_CONTENT_SHA
+$(P4_HLIR)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)
+$(P4_HLIR)_DEP_FILES   := $(HLIR_DFILES)
+$(P4_HLIR)_SMDEP_FILES := $(foreach path, $(HLIR_SMPATHS), $($(path)))
+$(P4_HLIR)_SMDEP_PATHS := $(HLIR_SMPATHS)
+
+# --- P4_HLIR_V1_1 (platform/p4/p4-hlir/p4-hlir-v1.1) ---
+HLIRV_SPATH   := $($(P4_HLIR_V1_1)_SRC_PATH)
+HLIRV_DFILES  := $(SONIC_COMMON_FILES_LIST) $(PLATFORM_PATH)/p4-hlir.mk $(PLATFORM_PATH)/p4-hlir.dep
+HLIRV_DFILES  += $(SONIC_COMMON_BASE_FILES_LIST)
+HLIRV_SMPATHS := $(HLIRV_SPATH)
+$(foreach path, $(HLIRV_SMPATHS), $(eval $(path) :=$(filter-out $(HLIRV_SMPATHS),$(addprefix $(path)/, $(shell cd $(path) &&  git ls-files | grep -Ev " " )))))
+
+$(P4_HLIR_V1_1)_CACHE_MODE  := GIT_CONTENT_SHA
+$(P4_HLIR_V1_1)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)
+$(P4_HLIR_V1_1)_DEP_FILES   := $(HLIRV_DFILES)
+$(P4_HLIR_V1_1)_SMDEP_FILES := $(foreach path, $(HLIRV_SMPATHS), $($(path)))
+$(P4_HLIR_V1_1)_SMDEP_PATHS := $(HLIRV_SMPATHS)

--- a/platform/p4/p4-switch.dep
+++ b/platform/p4/p4-switch.dep
@@ -1,0 +1,18 @@
+#DPKG FRK
+# P4_SWITCH is built from source at platform/p4/SAI-P4-BM/sai_adapter, a
+# subdirectory of the SAI-P4-BM git submodule. Key the sai_adapter source tree.
+# The SAI-P4-BM/p4-switch/behavioral-model nested submodule is OUTSIDE
+# sai_adapter and belongs to P4_BMV (keyed in p4-bmv.dep), so it is not listed
+# here. P4_SWITCH also depends on P4_BMV and the thrift family; those are keyed
+# by their own .dep files and fold in via GET_MOD_DEP_SHA.
+SPATH       := $($(P4_SWITCH)_SRC_PATH)
+DEP_FILES   := $(SONIC_COMMON_FILES_LIST) $(PLATFORM_PATH)/p4-switch.mk $(PLATFORM_PATH)/p4-switch.dep
+DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
+SMDEP_PATHS := $(SPATH)
+$(foreach path, $(SMDEP_PATHS), $(eval $(path) :=$(filter-out $(SMDEP_PATHS),$(addprefix $(path)/, $(shell cd $(path) &&  git ls-files | grep -Ev " " )))))
+
+$(P4_SWITCH)_CACHE_MODE  := GIT_CONTENT_SHA
+$(P4_SWITCH)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)
+$(P4_SWITCH)_DEP_FILES   := $(DEP_FILES)
+$(P4_SWITCH)_SMDEP_FILES := $(foreach path, $(SMDEP_PATHS), $($(path)))
+$(P4_SWITCH)_SMDEP_PATHS := $(SMDEP_PATHS)

--- a/platform/p4/p4c-bm.dep
+++ b/platform/p4/p4c-bm.dep
@@ -1,0 +1,17 @@
+#DPKG FRK
+# P4C_BM is built from source at platform/p4/p4c-bm/p4c-bm (a git submodule).
+# Key the submodule's tracked source tree. P4C_BM also depends on TENJIN,
+# P4_HLIR and P4_HLIR_V1_1 (see p4c-bm.mk); those are keyed by their own .dep
+# files and fold in via GET_MOD_DEP_SHA, so only this package's own source is
+# listed here.
+SPATH       := $($(P4C_BM)_SRC_PATH)
+DEP_FILES   := $(SONIC_COMMON_FILES_LIST) $(PLATFORM_PATH)/p4c-bm.mk $(PLATFORM_PATH)/p4c-bm.dep
+DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
+SMDEP_PATHS := $(SPATH)
+$(foreach path, $(SMDEP_PATHS), $(eval $(path) :=$(filter-out $(SMDEP_PATHS),$(addprefix $(path)/, $(shell cd $(path) &&  git ls-files | grep -Ev " " )))))
+
+$(P4C_BM)_CACHE_MODE  := GIT_CONTENT_SHA
+$(P4C_BM)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)
+$(P4C_BM)_DEP_FILES   := $(DEP_FILES)
+$(P4C_BM)_SMDEP_FILES := $(foreach path, $(SMDEP_PATHS), $($(path)))
+$(P4C_BM)_SMDEP_PATHS := $(SMDEP_PATHS)

--- a/platform/p4/rules.dep
+++ b/platform/p4/rules.dep
@@ -1,0 +1,6 @@
+include $(PLATFORM_PATH)/tenjin.dep
+include $(PLATFORM_PATH)/p4-hlir.dep
+include $(PLATFORM_PATH)/p4c-bm.dep
+include $(PLATFORM_PATH)/p4-bmv.dep
+include $(PLATFORM_PATH)/p4-switch.dep
+include $(PLATFORM_PATH)/libsaithrift-dev.dep

--- a/platform/p4/tenjin.dep
+++ b/platform/p4/tenjin.dep
@@ -1,0 +1,11 @@
+# tenjin is built from source at platform/p4/tenjin (a regular tracked directory).
+# Key the source tree so any change to the tenjin recipe/sources invalidates the
+# cache for this package and its cached p4 consumers (P4C_BM -> P4_BMV -> ...).
+SPATH       := $($(TENJIN)_SRC_PATH)
+DEP_FILES   := $(SONIC_COMMON_FILES_LIST) $(PLATFORM_PATH)/tenjin.mk $(PLATFORM_PATH)/tenjin.dep
+DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
+DEP_FILES   += $(shell git ls-files $(SPATH))
+
+$(TENJIN)_CACHE_MODE  := GIT_CONTENT_SHA
+$(TENJIN)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)
+$(TENJIN)_DEP_FILES   := $(DEP_FILES)


### PR DESCRIPTION
#### Why I did it

The p4 platform (`platform/p4`) had **no dpkg build-cache dependency tracking** — none of its
from-source packages carried a `.dep` file, and the platform had no `platform/p4/rules.dep`.

In `Makefile.cache`, a from-source package with a `.mk` but no `.dep` gets an empty
`_DEP_FILES`/`_SMDEP_FILES` list, so its `_MOD_HASH` is a **constant**. Cached consumers fold that
constant via `_DEPENDS` → `GET_MOD_DEP_SHA`, so they stay cache-HIT even when the dependency's
source actually changed → **stale cached artifact**. Because these packages form an internal
dependency chain, keying any subset while leaving the rest unkeyed would itself be a partial-keying
stale-cache hazard. This PR closes the whole p4 from-source closure atomically.

This is part of an ongoing dpkg build-cache correctness hardening effort (companion PRs added the
same tracking for barefoot, grpc, iproute2, marvell-teralynx, and nephos).

#### How I did it

Added a `.dep` for each of the 7 from-source packages in the p4 closure and a new
`platform/p4/rules.dep` to wire them in (loaded only when the p4 platform is selected, via
`Makefile.cache`'s `-include $(PLATFORM_PATH)/rules.dep`, so it is additive and cannot affect any
other platform):

| Package | var | source type | keyed via |
|---|---|---|---|
| tenjin | `TENJIN` | regular tracked dir | `git ls-files` in `DEP_FILES` |
| p4-hlir | `P4_HLIR`, `P4_HLIR_V1_1` | git submodules | single-path `SMDEP` each |
| p4c-bm | `P4C_BM` | git submodule | single-path `SMDEP` |
| p4-bmv | `P4_BMV` | submodule subdir + nested `behavioral-model` submodule | multi-path `SMDEP` |
| p4-switch | `P4_SWITCH` | submodule subdir | single-path `SMDEP` |
| libsaithrift-dev | `LIBSAITHRIFT_DEV_P4` | `src/sonic-sairedis/SAI` submodule + nested `test/ptf`, `test/saithrift/ctypesgen` | multi-path `SMDEP` (mirrors broadcom/barefoot) |

The closure's dependency chain is
`LIBSAITHRIFT_DEV_P4 → P4_SWITCH → P4_BMV → P4C_BM → {TENJIN, P4_HLIR, P4_HLIR_V1_1}`. Every internal
from-source edge is now keyed, so no cached p4 package can fold a constant hash for a source that
changed. The external thrift family (`LIBTHRIFT`, `LIBTHRIFT_DEV`, `THRIFT_COMPILER`,
`PYTHON_THRIFT`) is already keyed by `rules/thrift.dep`.

Nested submodules are listed explicitly in `SMDEP_PATHS` because `git ls-files` does not recurse
into nested submodules — the same blessed pattern used by `platform/broadcom/libsaithrift-dev.dep`.

**Deliberate scope boundary:** `docker-sonic-p4` is intentionally left uncached. It is a terminal
`SONIC_DOCKER_IMAGES` target with no cached downstream consumer, and it pulls in a large set of
packages. Making the image cacheable would require auditing that entire set and would be a
partial-keying regression if any transitive from-source dependency were still unkeyed. Leaving it
uncached means it always rebuilds — never stale — which preserves the status quo. This PR keeps the
scope to the p4 from-source `.deb` closure only.

#### How to verify it

- A make harness that includes the real `.mk` files plus `platform/p4/rules.dep` confirms all 7
  packages get `CACHE_MODE=GIT_CONTENT_SHA` with the expected file counts (TENJIN incl. its
  Makefile; P4_HLIR/P4_HLIR_V1_1/P4C_BM submodule trees; P4_BMV incl. the 443-file
  `behavioral-model` nested submodule; LIBSAITHRIFT_DEV_P4 SMDEP count matches the blessed barefoot
  result).
- Touch a source file in any p4 package and confirm the package **and** its cached consumers
  recompute their module hash (cache miss) instead of staying HIT.

#### Which release branch to backport (provide reason below if selected)

<!-- - 202xxx -->

#### Description for the changelog

`[cache] platform/p4: add dpkg build-cache dependency tracking for the full p4 from-source closure`

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
