### PR TITLE
[202505][build] Fix bullseye target guard variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ endif
 
 bullseye:
 	@echo "+++ Making $@ +++"
-ifeq ($(NOBUSTER), 0)
+ifeq ($(NOBULLSEYE), 0)
 	$(MAKE) -f Makefile.work bullseye
 endif
 


### PR DESCRIPTION
#### Why I did it

The named `bullseye` target on the `202505` branch is incorrectly gated by `NOBUSTER` instead of `NOBULLSEYE`.

As a result:

- `NOBULLSEYE=1 NOBUSTER=0 make bullseye` incorrectly invokes the bullseye build.
- `NOBULLSEYE=0 NOBUSTER=1 make bullseye` incorrectly skips the bullseye build.

This backports the corresponding fix from #26409.

Fixes #28649

##### Work item tracking

- Microsoft ADO **(number only)**: N/A

#### How I did it

Changed the conditional guard for the named `bullseye` target from `NOBUSTER` to `NOBULLSEYE`.

#### How to verify it

Before the change:

```bash
NOBULLSEYE=1 NOBUSTER=0 make -n bullseye
```

incorrectly attempted to invoke `Makefile.work`.

```bash
NOBULLSEYE=0 NOBUSTER=1 make -n bullseye
```

incorrectly skipped that invocation.

After the change, verified without requiring a Docker build:

```bash
NOBULLSEYE=1 NOBUSTER=0 make -n MAKE=/bin/echo bullseye
```

Only prints the top-level target message and skips the bullseye invocation.

```bash
NOBULLSEYE=0 NOBUSTER=1 make -n MAKE=/bin/echo bullseye
```

prints:

```text
/bin/echo -f Makefile.work bullseye
```

Also verified:

```bash
git diff --check
```

#### Which release branch to backport

- [x] 202505 — this PR directly backports the fix from #26409.

#### Tested branch

- [x] 202505 — Makefile dry-run verification; no SONiC image build was performed.

#### Description for the changelog

Fix the named bullseye target to use the NOBULLSEYE guard instead of NOBUSTER.

#### Link to config_db schema for YANG module changes

N/A
