### PR TITLE
[docker-sonic-mgmt]: Fix invalid job dependency in SecurityScan stage

### DIFF
--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -94,7 +94,6 @@ stages:
     pool: sonicso1ES-amd64
     continueOnError: true
     timeoutInMinutes: 60
-    dependsOn: Build
     steps:
     - download: current
       artifact: 'docker-sonic-mgmt'


### PR DESCRIPTION
#### Why I did it

The `docker-sonic-mgmt` pipeline on 202511 fails to compile with:

```
Stage SecurityScan must contain at least one job with no dependencies.
```

The `trivy_scan` job declares a job level `dependsOn: Build`. In Azure Pipelines a job level `dependsOn` can only reference another job **within the same stage**, and `Build` is a stage, not a job of `SecurityScan`. As a result the stage is left without any job that can start it, and the whole pipeline is rejected before anything runs.

#### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Removed the job level `dependsOn: Build`. The stage level `dependsOn: Build` that is already present orders `SecurityScan` after the build, which is the intended behaviour, so nothing else has to change.

#### How to verify it

Queue the `docker-sonic-mgmt` pipeline on this branch. It now compiles and `SecurityScan` runs after `Build`, whereas before the change the run was rejected at compile time.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

- [ ] <!-- Image version 1 -->
- [ ] <!-- Image version 2 -->

#### Description for the changelog

Fix invalid job dependency in the SecurityScan stage of the docker-sonic-mgmt pipeline

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should have a format 'https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#<table_name>'
-->

#### A picture of a cute animal (not mandatory but encouraged)
