### PR TITLE
fix(docker-ptf): backport grpc-go 1.82.1 to 202605

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -159,7 +159,7 @@ ENV PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
 RUN GRPCURL_VERSION=v1.9.3 \
     && git clone --depth 1 --branch "${GRPCURL_VERSION}" https://github.com/fullstorydev/grpcurl.git /tmp/grpcurl \
     && cd /tmp/grpcurl \
-    && go get google.golang.org/grpc@v1.79.3 \
+    && go get google.golang.org/grpc@v1.82.1 \
     && go get github.com/go-jose/go-jose/v4@latest \
     && go get golang.org/x/crypto@latest golang.org/x/net@latest golang.org/x/text@latest golang.org/x/sys@latest golang.org/x/oauth2@latest \
     && go mod tidy \


### PR DESCRIPTION
#### Why I did it

This is the 202605 backport of #28595. The grpcurl binary in docker-ptf uses google.golang.org/grpc v1.79.3, which is affected by [GHSA-hrxh-6v49-42gf](https://github.com/advisories/GHSA-hrxh-6v49-42gf). The first fixed release is v1.82.1.

The source PR also updates gnmic. The 202605 branch does not contain the earlier #27340 change that re-added gnmic, so that commit is not applicable to this release branch. Applying the conflicting hunk would introduce gnmic rather than update an existing binary.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

Cherry-picked the applicable grpcurl commit from #28595 onto 202605 and omitted the non-applicable gnmic commit while resolving the conflict.

#### How to verify it

Ran the grpcurl source-build commands from `dockers/docker-ptf/Dockerfile.j2` using Go 1.25.12. The build completed successfully, and `go version -m` reports:

```text
dep google.golang.org/grpc v1.82.1
```

#### Which release branch to backport (provide reason below if selected)

This PR directly targets 202605. No additional release backport is requested.

#### Tested branch (Please provide the tested image version)

- [x] 202605 - targeted grpcurl build with the branch's Go 1.25.12 toolchain; PR CI pending

#### Description for the changelog

[docker-ptf] Update grpcurl to grpc-go v1.82.1 to resolve GHSA-hrxh-6v49-42gf

#### Link to config_db schema for YANG module changes

N/A. No YANG or config_db schema changes.

#### A picture of a cute animal (not mandatory but encouraged)

N/A.
