### PR TITLE
[docker-ptf] upgrade vulnerable msgpack and setuptools packages

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -162,7 +162,14 @@ RUN set -eux \
     && rm -rf "/tmp/influxdb3-core-${INFLUXDB_VERSION}" \
     && pip3 install --target /usr/local/lib/influxdb3-python/lib/python3.13/site-packages "pip>=26.1" \
     && NEWPIP=$(ls -d /usr/local/lib/influxdb3-python/lib/python3.13/site-packages/pip-*.dist-info | sort -V | tail -1) \
-    && find /usr/local/lib/influxdb3-python/lib/python3.13/site-packages -maxdepth 1 -name 'pip-*.dist-info' ! -path "$NEWPIP" -exec rm -rf {} +
+    && find /usr/local/lib/influxdb3-python/lib/python3.13/site-packages -maxdepth 1 -name 'pip-*.dist-info' ! -path "$NEWPIP" -exec rm -rf {} + \
+    && pip3 install --target /tmp/pip-vendored-msgpack "msgpack>=1.2.1" \
+    && MSGPACK_VERSION=$(PYTHONPATH=/tmp/pip-vendored-msgpack python3 -c 'import msgpack; print(msgpack.__version__)') \
+    && rm -rf /usr/local/lib/influxdb3-python/lib/python3.13/site-packages/pip/_vendor/msgpack \
+    && cp -a /tmp/pip-vendored-msgpack/msgpack /usr/local/lib/influxdb3-python/lib/python3.13/site-packages/pip/_vendor/msgpack \
+    && sed -i "s/^msgpack==.*/msgpack==${MSGPACK_VERSION}/" /usr/local/lib/influxdb3-python/lib/python3.13/site-packages/pip/_vendor/vendor.txt \
+    && rm -rf /tmp/pip-vendored-msgpack \
+    && /usr/local/lib/influxdb3-python/bin/python3 -m pip --version
 {% endif %}
 
 {% if PTF_ENV_PY_VER == "py3" %}
@@ -376,7 +383,7 @@ RUN set -e; \
 
 # Ensure setuptools >= 70.0.0 to address GHSA-cx63-2mw6-8hw5
 # Upgrade lxml to address GHSA-vfmq-68hx-4jfw
-RUN pip3 install "setuptools>=70.0.0" "lxml>=5.3.2"
+RUN pip3 install "setuptools>=83.0.0" "lxml>=5.3.2"
 
 ## Adjust sshd settings
 RUN mkdir -p /var/run/sshd \

--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -163,8 +163,8 @@ RUN set -eux \
     && pip3 install --target /usr/local/lib/influxdb3-python/lib/python3.13/site-packages "pip>=26.1" \
     && NEWPIP=$(ls -d /usr/local/lib/influxdb3-python/lib/python3.13/site-packages/pip-*.dist-info | sort -V | tail -1) \
     && find /usr/local/lib/influxdb3-python/lib/python3.13/site-packages -maxdepth 1 -name 'pip-*.dist-info' ! -path "$NEWPIP" -exec rm -rf {} + \
-    && pip3 install --target /tmp/pip-vendored-msgpack "msgpack>=1.2.1" \
-    && MSGPACK_VERSION=$(PYTHONPATH=/tmp/pip-vendored-msgpack python3 -c 'import msgpack; print(msgpack.__version__)') \
+    && /usr/local/lib/influxdb3-python/bin/python3 -m pip install --target /tmp/pip-vendored-msgpack "msgpack>=1.2.1" \
+    && MSGPACK_VERSION=$(PYTHONPATH=/tmp/pip-vendored-msgpack /usr/local/lib/influxdb3-python/bin/python3 -c 'from importlib.metadata import version; print(version("msgpack"))') \
     && rm -rf /usr/local/lib/influxdb3-python/lib/python3.13/site-packages/pip/_vendor/msgpack \
     && cp -a /tmp/pip-vendored-msgpack/msgpack /usr/local/lib/influxdb3-python/lib/python3.13/site-packages/pip/_vendor/msgpack \
     && sed -i "s/^msgpack==.*/msgpack==${MSGPACK_VERSION}/" /usr/local/lib/influxdb3-python/lib/python3.13/site-packages/pip/_vendor/vendor.txt \
@@ -381,7 +381,7 @@ RUN set -e; \
 {{ install_python_wheels(docker_ptf_whls.split(' ')) }}
 {% endif %}
 
-# Ensure setuptools >= 70.0.0 to address GHSA-cx63-2mw6-8hw5
+# Ensure setuptools >= 83.0.0 to address GHSA-h35f-9h28-mq5c
 # Upgrade lxml to address GHSA-vfmq-68hx-4jfw
 RUN pip3 install "setuptools>=83.0.0" "lxml>=5.3.2"
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The docker-ptf image contains vulnerable Python packages reported by the container security scan:

- `msgpack 1.1.2` is affected by GHSA-6v7p-g79w-8964.
- `setuptools 70.3.0` is affected by CVE-2025-47273 and CVE-2026-59890.

The vulnerable msgpack copy is vendored by pip in the Python runtime bundled with InfluxDB 3 Core. Installing msgpack into the main docker-ptf virtual environment does not replace this vendored copy.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Installed `msgpack>=1.2.1` into a temporary directory.
- Replaced only the vulnerable `pip._vendor.msgpack` copy in the InfluxDB embedded Python runtime.
- Updated pip's `vendor.txt` with the resolved msgpack version.
- Preserved the embedded pip installation so InfluxDB runtime plugin dependency installation remains supported.
- Raised the docker-ptf virtual environment setuptools floor to `83.0.0`.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
