### PR TITLE
[swss] Skip stopping peer service when it is not active

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -378,6 +378,18 @@ stop_peer_and_dependent_services() {
             /bin/systemctl stop ${dep}
         done
         for peer in ${PEER}; do
+            # Skip stopping the peer service if it is not active. When syncd
+            # exits unexpectedly, docker-wait-any-rs causes swss to restart.
+            # This function would otherwise call 'systemctl stop syncd' while
+            # syncd's ExecStartPre is already in progress, killing it with
+            # SIGTERM and producing 'Failed with result signal', which delays
+            # recovery by forcing syncd through a rate-limit gap before the
+            # next restart attempt.
+            local peer_service="${peer}${DEV:+@$DEV}"
+            if ! /bin/systemctl is-active --quiet "${peer_service}"; then
+                debug "Skipping stop of ${peer_service}: service not active"
+                continue
+            fi
             if [[ ! -z $DEV ]]; then
                 /bin/systemctl stop ${peer}@$DEV
             else


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When a peer service (e.g. syncd) exits unexpectedly, docker-wait-any-rs causes swss to restart. swss ExecStop calls stop_peer_and_dependent_services() which unconditionally calls 'systemctl stop <peer>' regardless of whether the peer is still running.

If the peer's Restart=always has already scheduled or started its ExecStartPre, the 'systemctl stop' arrives while ExecStartPre is in progress and kills it with SIGTERM, producing 'Failed with result signal'. This causes an unnecessary failed restart attempt that should not happen.

The root cause is that stop_peer_and_dependent_services() does not distinguish between two situations:
  - swss was intentionally stopped and should bring its peer down too
  - the peer exited first and triggered this swss restart cycle, so there is nothing to stop


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Before calling 'systemctl stop <peer>', check whether the peer service is active. If it is not active (inactive, activating, or failed) the peer triggered this restart cycle and its own Restart=always will handle recovery — skip the stop call to avoid killing its ExecStartPre.

systemctl is-active is preferred over a docker container check because it correctly handles all relevant states: inactive (container gone), activating (ExecStartPre in progress), and failed (process died inside the container without recovery).

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
