### PR TITLE
Add Adjust TX Counters Flag for TD3 to SDK Config

### DIFF
--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C28S16/config.bcm.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C28S16/config.bcm.j2
@@ -421,6 +421,7 @@ robust_hash_disable_egress_vlan=1
 robust_hash_disable_mpls=1
 robust_hash_disable_vlan=1
 sai_adjust_acl_drop_in_rx_drop=1
+sai_adjust_acl_drop_out_tx_drop=1
 sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_premium_issu/b870.6.4.1/
 sai_optimized_mmu=1
 sai_pfc_dlr_init_capability=1' -%}

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C28S4/config.bcm.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C28S4/config.bcm.j2
@@ -16,6 +16,7 @@ sai_pfc_dlr_init_capability=1' -%}
 sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_premium_issu/b870.6.4.1/
 l3_alpm_hit_skip=1
 sai_adjust_acl_drop_in_rx_drop=1
+sai_adjust_acl_drop_out_tx_drop=1
 sai_verify_incoming_chksum=0
 {{ map_prio }}
 {{ pfcwd_sock }}

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/config.bcm.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/config.bcm.j2
@@ -16,6 +16,7 @@ sai_pfc_dlr_init_capability=1' -%}
 sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_premium_issu/b870.6.4.1/
 l3_alpm_hit_skip=1
 sai_adjust_acl_drop_in_rx_drop=1
+sai_adjust_acl_drop_out_tx_drop=1
 sai_verify_incoming_chksum=0
 {{ map_prio }}
 {{ pfcwd_sock }}

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C6S104/td3-a7050cx3-32s-6x100g-104x10g.config.bcm
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C6S104/td3-a7050cx3-32s-6x100g-104x10g.config.bcm
@@ -44,6 +44,7 @@ robust_hash_disable_egress_vlan=1
 robust_hash_disable_mpls=1
 robust_hash_disable_vlan=1
 sai_adjust_acl_drop_in_rx_drop=1
+sai_adjust_acl_drop_out_tx_drop=1
 sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_premium_issu/b870.6.4.1/
 sai_optimized_mmu=1
 sai_pfc_dlr_init_capability=1' -%}

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/config.bcm.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/config.bcm.j2
@@ -16,6 +16,7 @@ sai_pfc_dlr_init_capability=1' -%}
 sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_premium_issu/b870.6.4.1/
 l3_alpm_hit_skip=1
 sai_adjust_acl_drop_in_rx_drop=1
+sai_adjust_acl_drop_out_tx_drop=1
 sai_verify_incoming_chksum=0
 {{ map_prio }}
 {{ pfcwd_sock }}

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-S128/td3-a7050cx3-32s-128x10g.config.bcm
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-S128/td3-a7050cx3-32s-128x10g.config.bcm
@@ -43,6 +43,7 @@ robust_hash_disable_egress_vlan=1
 robust_hash_disable_mpls=1
 robust_hash_disable_vlan=1
 sai_adjust_acl_drop_in_rx_drop=1
+sai_adjust_acl_drop_out_tx_drop=1
 sai_load_hw_config=/etc/bcm/flex/bcm56870_a0_premium_issu/b870.6.4.1/
 sai_optimized_mmu=1
 sai_pfc_dlr_init_capability=1' -%}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

SAI events have been causing packets dropped by Everflow policer to show up as dropped dataplane packets in interface counters. This SAI flag should adjust the reported number of interface drops to not show these policer-dropped packets.

#### How I did it

Enabled flag after consulting with Broadcom.

#### How to verify it

1. Enable Erpsan session with policer
2. Mirror traffic at a higher rate than policer allows
3. Observe that no drops are shown in `show int counters`

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

Test log is below for 7050cx3. Not that the DSCP policer test is still failing. This is because the packet drops are still being incorrectly registered in the queue drop counters. This issue is being separately tracked with Broadcom. However, encountering this new error means we are no longer observing the issue in interface counters.

[sonic_test.log](https://github.com/user-attachments/files/30761536/sonic_test.log)


#### Description for the changelog

Adds tag to adjust TX drop counters based on erspan policer drops.

