### PR TITLE
[docker-macsec]: Require Type-7 decimal salt prefix on MACsec CAK

### DIFF
--- a/dockers/docker-macsec/cli-plugin-tests/test_config_macsec.py
+++ b/dockers/docker-macsec/cli-plugin-tests/test_config_macsec.py
@@ -103,6 +103,12 @@ class TestConfigMACsec(object):
                 "--cipher_suite=GCM-AES-256"], obj=cfgdb)
         assert result.exit_code != 0
 
+        # Invalid primary cak Type-7 salt prefix
+        result = runner.invoke(macsec.macsec, ["profile", "add", "test",
+                "--primary_cak=B063647040534355560e000802065d574d400e000e030307075f0e5050000e5541","--primary_ckn=01234567890123456789012345678912",
+                "--cipher_suite=GCM-AES-128"], obj=cfgdb)
+        assert result.exit_code != 0
+
 
     def test_macsec_port(self, mock_cfgdb):
         cfgdb = mock_cfgdb

--- a/dockers/docker-macsec/cli/config/plugins/macsec.py
+++ b/dockers/docker-macsec/cli/config/plugins/macsec.py
@@ -106,6 +106,11 @@ def is_hexstring(hexstring: str):
         return False
 
 
+def has_type7_salt(cak: str):
+    # A Type-7 encoded key is prefixed with a two digit decimal salt.
+    return len(cak) >= 2 and all('0' <= c <= '9' for c in cak[:2])
+
+
 #
 # 'add' command ('config macsec profile add ...')
 #
@@ -145,6 +150,8 @@ def add_profile(profile, priority, cipher_suite, primary_cak, primary_ckn, polic
             ctx.fail("Expect the length of CAK is 130, but got {}".format(len(primary_cak)))
     if not is_hexstring(primary_cak):
         ctx.fail("Expect the primary_cak is valid hex string")
+    if not has_type7_salt(primary_cak):
+        ctx.fail("Expect the primary_cak to start with a two digit decimal Type-7 salt, but got {}".format(primary_cak[:2]))
     if not is_hexstring(primary_ckn):
         ctx.fail("Expect the primary_ckn is valid hex string")
     profile_table["primary_cak"] = primary_cak

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/macsec.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/macsec.json
@@ -14,6 +14,10 @@
         "desc": "Invalid CAK character",
         "eStrKey": "Pattern"
     },
+    "INVALID_CAK_SALT_PREFIX": {
+        "desc": "Invalid Type-7 CAK salt prefix (first two chars must be digits)",
+        "eStrKey": "Pattern"
+    },
     "INVALID_CIPHER_LOWERCASE": {
         "desc": "Invalid cipher with lowercase",
         "eStrKey": "Pattern"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/macsec.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/macsec.json
@@ -121,6 +121,20 @@
             }
         }
     },
+    "INVALID_CAK_SALT_PREFIX": {
+        "sonic-macsec:sonic-macsec": {
+            "sonic-macsec:MACSEC_PROFILE": {
+                "MACSEC_PROFILE_LIST": [
+                    {
+                        "name": "test",
+                        "cipher_suite": "GCM-AES-256",
+                        "primary_cak": "B007554155500e5d5157786d6c2a3d2031425a5e577e7e727f6b6c03312432262706080a00005b554f4e007975707670725b0a54540c0252445e5d7a29252b046a",
+                        "primary_ckn": "6162636465666768696A6B6C6D6E6F706162636465666768696A6B6C6D6E6F70"
+                    }
+                ]
+            }
+        }
+    },
     "MISMATCH_LENGTH_PRIMARY_FALLBACK": {
         "sonic-macsec:sonic-macsec": {
             "sonic-macsec:MACSEC_PROFILE": {

--- a/src/sonic-yang-models/yang-models/sonic-macsec.yang
+++ b/src/sonic-yang-models/yang-models/sonic-macsec.yang
@@ -12,6 +12,10 @@ module sonic-macsec {
 
     description "IEEE 802.1AE MACsec link-layer encryption YANG module for SONiC OS.";
 
+    revision 2026-08-05 {
+        description "Require Type-7 decimal salt prefix on encoded CAK fields.";
+    }
+
     revision 2022-04-12 {
         description "First Revision";
     }
@@ -50,10 +54,11 @@ module sonic-macsec {
 
                 leaf primary_cak {
                     type string {
-                        pattern "[0-9a-fA-F]{66}|[0-9a-fA-F]{130}";
+                        /* Type-7: 2 decimal salt digits + hex-encoded key (64 or 128 hex chars). */
+                        pattern "[0-9]{2}[0-9a-fA-F]{64}|[0-9]{2}[0-9a-fA-F]{128}";
                     }
                     mandatory true;
-                    description "Primary Connectivity Association Key (CAK) in hex.";
+                    description "Primary Connectivity Association Key (CAK) in Type-7 encoded hex; the first two characters must be decimal digits.";
                 }
 
                 leaf primary_ckn {
@@ -66,9 +71,10 @@ module sonic-macsec {
 
                 leaf fallback_cak {
                     type string {
-                        pattern "[0-9a-fA-F]{66}|[0-9a-fA-F]{130}";
+                        /* Type-7: 2 decimal salt digits + hex-encoded key (64 or 128 hex chars). */
+                        pattern "[0-9]{2}[0-9a-fA-F]{64}|[0-9]{2}[0-9a-fA-F]{128}";
                     }
-                    description "Fallback CAK used when the primary key fails, in hex.";
+                    description "Fallback CAK used when the primary key fails, in Type-7 encoded hex; the first two characters must be decimal digits.";
                 }
 
                 leaf fallback_ckn {


### PR DESCRIPTION
#### Why I did it

`sonic-macsec.yang` validated `primary_cak` and `fallback_cak` as plain hex strings of length 66 or 130. In practice these fields hold Cisco Type-7 encoded values (see sonic-net/sonic-swss#2892): the first two characters are a **decimal** salt index and the remaining 64 or 128 characters are the encoded key.

Because the pattern `[0-9a-fA-F]{66}|[0-9a-fA-F]{130}` allowed any hex character in the salt position, a malformed value such as `B007554155...` passed YANG validation. The `config macsec profile add` CLI had the same gap — it checked length and `int(x, 16)`, both of which a `B0`-prefixed value satisfies — so nothing on the write path rejected it.

That value is not harmless once it lands in CONFIG_DB. `macsecmgr` decodes the salt with `stoi(cipher_str.substr(0,2))` in `decodeKey()`, which throws `std::invalid_argument` on a non-decimal prefix. We hit this in production on a Cisco 8223 with 32 MACsec sessions:

```
2026 Jul  2 17:33:50.553619 ERR  macsec#macsecmgrd: :- main: Runtime error: stoi
2026 Jul  2 17:33:50.555366 INFO macsec#supervisord WARN exited: macsecmgrd (exit status 255; not expected)
```

`macsecmgrd` exited, and because `MACsecMgr` is a stack object inside `main()`'s `try`, unwinding ran `~MACsecMgr()` and tore down MACsec on **all** ports before the error was even logged. The daemon-side hardening for that is in sonic-net/sonic-swss#4762; this PR closes the validation gap that let the value through in the first place.

##### Work item tracking
* Microsoft ADO **(number only)**:

#### How I did it

**YANG model** — tightened the pattern on both `primary_cak` and `fallback_cak`:

- from `[0-9a-fA-F]{66}|[0-9a-fA-F]{130}`
- to `[0-9]{2}[0-9a-fA-F]{64}|[0-9]{2}[0-9a-fA-F]{128}`

Total accepted lengths are unchanged at 66 and 130; only the two leading salt characters are newly constrained to decimal digits. Leaf descriptions now state the Type-7 requirement, and a `2026-08-05` revision statement was added to the module.

**CLI plugin** — added the equivalent check to `config macsec profile add` so the CLI and the model agree, placed alongside the existing length and hex checks:

```python
def has_type7_salt(cak: str):
    # A Type-7 encoded key is prefixed with a two digit decimal salt.
    return len(cak) >= 2 and all('0' <= c <= '9' for c in cak[:2])
```

The explicit ASCII range test is deliberate: `str.isdigit()` accepts non-ASCII digit characters such as superscripts and Arabic-Indic digits, which `stoi` would still reject.

**Fixtures** — audited every CAK value in the repo against the new pattern. All existing fixtures already begin with decimal digits (`11`, `00`, `23`, `39`, `52`), so no other fixture required changes.

**Backwards compatibility** — every currently valid Type-7 CAK continues to validate, since a correctly encoded value always carries a decimal salt. The only configurations newly rejected are ones that crash `macsecmgrd` today, so a device holding such a value will now fail `config reload`/`config apply-patch` validation instead of silently loading a profile that takes the container down at port-bind time. That trade is intentional, but it is a behaviour change on upgrade and worth calling out.

**Relationship to #28712** — sonic-net/sonic-buildimage#28712 is in flight and also adds a decimal-salt check to `add_profile`, as part of a larger change that additionally accepts raw hex CAKs and tightens `is_hexstring`. The CLI hunk here is a subset of that. The YANG change is not covered by #28712 (which is explicitly YANG-neutral) and is the part that closes `config apply-patch`/GCU and gNMI. Happy to drop the CLI hunk from this PR and keep it purely the YANG layer if #28712 lands first — whichever ordering reviewers prefer.

#### How to verify it

YANG model tests — added the negative case `INVALID_CAK_SALT_PREFIX`, which reuses the existing `5207554155...` fixture with the salt changed to `B0` and expects a `Pattern` violation:

```
cd src/sonic-yang-models
pytest tests/yang_model_tests
```

CLI plugin tests — added a negative case to `test_macsec_invalid_profile` using a 66-character, valid-hex CAK with a `B0` prefix, so it fails specifically on the new salt check rather than on length or hex:

```
pytest dockers/docker-macsec/cli-plugin-tests/
```

On-device, by dropping the updated model into `/usr/local/yang-models/sonic-macsec.yang` and the updated plugin over `/usr/local/lib/python3.13/dist-packages/config/plugins/macsec.py`. See Test result for the transcripts.

#### Which release branch to backport (provide reason below if selected)
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type:

#### Tested branch
- [x] 202511

#### Test result

Unit tests:

On-device, YANG validation with the updated model (SONiC 202511-based, Cisco 8223). The `B0`-prefixed CAK is now rejected by the model:

```
root@sonic:/usr/local/yang-models# python3 - <<'EOF'
import sonic_yang
sy = sonic_yang.SonicYang("/usr/local/yang-models")
sy.loadYangModel()
cfg = {"MACSEC_PROFILE": {"test": {
  "cipher_suite": "GCM-AES-256",
  "primary_cak": "B007554155500e5d5157786d6c2a3d2031425a5e577e7e727f6b6c03312432262706080a00005b554f4e007975707670725b0a54540c0252445e5d7a29252b046a",
  "primary_ckn": "6162636465666768696A6B6C6D6E6F706162636465666768696A6B6C6D6E6F70"}}}
sy.loadData(configdbJson=cfg)
sy.validate_data_tree()
print("NOT OK - bad salt was accepted")
EOF

libyang[0]: Value "B007554155500e5d...29252b046a" does not satisfy the constraint
"[0-9]{2}[0-9a-fA-F]{64}|[0-9]{2}[0-9a-fA-F]{128}" (range, length, or pattern).
(path: /sonic-macsec:sonic-macsec/MACSEC_PROFILE/MACSEC_PROFILE_LIST[name='test']/primary_cak)
sonic_yang_ext.SonicYangException: Data Loading Failed
```

On-device CLI, before — a `B0`-prefixed CAK is accepted and written to CONFIG_DB:

```
root@sonic:~# sudo config macsec profile add --cipher_suite GCM-AES-256 --policy security \
    --primary_cak B06D2A3A263431282F270908070B1016013024352022757A7B70772D203B357A7B7470717677287825247B74273025277828252C026F6D2A3A263431282F270908 \
    --primary_ckn CCC256 --priority 64 --rekey_period 1800 --send_sci MSP1-AES-256-KEYMISMATCH-1
root@sonic:~#          # no error; profile created
```

On-device CLI, after  — rejected, and for the right reason:

```
root@sonic:~# sudo config macsec profile add \
    --cipher_suite GCM-AES-128 \
    --primary_cak B063647040534355560e000802065d574d400e000e030307075f0e5050000e5541 \
    --primary_ckn 01234567890123456789012345678912 \
    test
Usage: config macsec profile add [OPTIONS] <profile_name>
Try 'config macsec profile add -h' for help.

Error: Expect the primary_cak to start with a two digit decimal Type-7 salt, but got B0
```

The pre-existing length check is unchanged — a 64-character CAK still fails on length rather than on the new salt rule, so the two checks stay distinguishable:

```
root@sonic:~# sudo config macsec profile add --cipher_suite GCM-AES-128 \
    --primary_cak 63647040534355560e000802065d574d400e000e030307075f0e5050000e5541 \
    --primary_ckn 01234567890123456789012345678912 test
Error: Expect the length of CAK is 66, but got 64
```

The positive path is covered by the existing fixtures, which are unchanged: `test_config_macsec.py` configures `2363647040...` (salt `23`) and asserts it is stored verbatim, and the `cli-plugin-tests/config_db.json` profile uses `5207554155...` (salt `52`).

#### Description for the changelog

Require the Type-7 decimal salt prefix on MACsec `primary_cak` and `fallback_cak` in `sonic-macsec.yang`, and enforce the same rule in `config macsec profile add`.

#### Link to config_db schema for YANG module changes

No CONFIG_DB schema change. The fields, their table, and their accepted lengths (66/130) are unchanged; only the character class of the two leading salt characters is constrained, matching the Type-7 format `macsecmgr` already requires.
