### PR TITLE
[bgpcfgd]: Add downstream constants overlay support

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -28,6 +28,17 @@ ip prefix-list PL_LoopbackV4 permit {{ lo0_ipv4 }}/32
 {% set disagg_rh = "true" %}
 {% endif%}
 {% endif %}
+{% set device_type = DEVICE_METADATA['localhost']['type'] | default("") | lower %}
+{% set extra_confederation_device_types = constants.bgp.extra_confederation_device_types | default([]) %}
+{% set loopback_route_map = constants.bgp.loopback_advertisement_route_map | default({}) %}
+{% set loopback_route_map_device_types = loopback_route_map.device_types | default([]) %}
+{% set use_loopback_route_map = loopback_route_map.name is defined and loopback_route_map.community is defined and device_type in loopback_route_map_device_types %}
+{% set suppress_storage_backend_loopback = false %}
+{% if constants.bgp.suppress_storage_backend_loopback | default(false) %}
+{% if DEVICE_METADATA['localhost']['storage_device'] | default("false") | string | lower == "true" and "backend" in device_type %}
+{% set suppress_storage_backend_loopback = true %}
+{% endif %}
+{% endif %}
 {% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") != 'None' %}
 {% if ( ('localhost' in DEVICE_METADATA) and ('bgp_adv_lo_prefix_as_128' in  DEVICE_METADATA['localhost']) and
         (DEVICE_METADATA['localhost']['bgp_adv_lo_prefix_as_128'] == 'true') ) %}
@@ -91,10 +102,15 @@ route-map HIDE_INTERNAL permit 20
 !
 {% endif %}
 !
+{% if use_loopback_route_map %}
+route-map {{ loopback_route_map.name }} permit 100
+  set community {{ loopback_route_map.community }}
+!
+{% endif %}
 {% if (DEVICE_METADATA is defined) and ('localhost' in DEVICE_METADATA) and ('bgp_asn' in DEVICE_METADATA['localhost']) and (DEVICE_METADATA['localhost']['bgp_asn'].lower() != 'none') and (DEVICE_METADATA['localhost']['bgp_asn'].lower() != 'null') %}
 router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 !
-{% if disagg_t2  == "true" or disagg_rh == "true" %}
+{% if disagg_t2 == "true" or disagg_rh == "true" or device_type in extra_confederation_device_types %}
 {% if (BGP_DEVICE_GLOBAL is defined) and ('CONFED' in BGP_DEVICE_GLOBAL) and ('asn' in BGP_DEVICE_GLOBAL['CONFED'] )  %}
   bgp confederation identifier {{ BGP_DEVICE_GLOBAL['CONFED']['asn'] }}
 {% endif %}
@@ -157,25 +173,35 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% endif %}
 !
 {# advertise loopback #}
-{% if lo0_ipv4 is not none %}
+{% if lo0_ipv4 is not none and not suppress_storage_backend_loopback %}
+{% if use_loopback_route_map %}
+  network {{ lo0_ipv4 }}/32 route-map {{ loopback_route_map.name }}
+{% else %}
   network {{ lo0_ipv4 }}/32
+{% endif %}
 {% endif %}
 {% if lo4096_ipv4 is not none and ((multi_asic is defined and DEVICE_METADATA['localhost']['switch_type'] != 'chassis-packet') or (voq_chassis is defined)) %}
   network {{ lo4096_ipv4 }}/32 route-map HIDE_INTERNAL
 {% endif %}
 !
+{% if not suppress_storage_backend_loopback %}
 {% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") != 'None' %}
   address-family ipv6
 {% if ( ('localhost' in DEVICE_METADATA) and ('bgp_adv_lo_prefix_as_128' in  DEVICE_METADATA['localhost']) and
         (DEVICE_METADATA['localhost']['bgp_adv_lo_prefix_as_128'] == 'true') ) %}
     network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/128
 {% else %}
+{% if use_loopback_route_map %}
+    network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/64 route-map {{ loopback_route_map.name }}
+{% else %}
     network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/64
+{% endif %}
 {% if voq_chassis is defined or DEVICE_METADATA['localhost']['switch_type'] == 'chassis-packet' %}
     network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/128 route-map HIDE_INTERNAL
 {% endif %}
 {% endif %}
   exit-address-family
+{% endif %}
 {% endif %}
 {% if ((multi_asic is defined and DEVICE_METADATA['localhost']['switch_type'] != 'chassis-packet') or (voq_chassis is defined)) %}
 {% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") != 'None' %}

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -809,7 +809,10 @@ sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/rps.py
 sudo cp $IMAGE_CONFIGS/snmp/snmp.yml $FILESYSTEM_ROOT/etc/sonic/
 
 # Copy ASN configuration files
-j2 files/build_templates/constants.yml.j2 | sudo tee $FILESYSTEM_ROOT/etc/sonic/constants.yml > /dev/null
+constants_tmp=$(mktemp)
+python3 scripts/render_constants.py files/build_templates/constants.yml.j2 > "$constants_tmp"
+sudo install -m 644 "$constants_tmp" $FILESYSTEM_ROOT/etc/sonic/constants.yml
+rm -f "$constants_tmp"
 
 # Copy BMC network configuration file to share templates
 sudo cp $IMAGE_CONFIGS/constants/bmc.json $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/
@@ -1409,4 +1412,3 @@ sudo cp $IMAGE_CONFIGS/set-vrf-strict-mode/set-vrf-strict-mode.service $FILESYST
 # Install set-vrf-strict-mode service
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable set-vrf-strict-mode
 {% endif %}
-

--- a/platform/vs/docker-sonic-vs.mk
+++ b/platform/vs/docker-sonic-vs.mk
@@ -67,8 +67,9 @@ SONIC_BOOKWORM_DOCKERS += $(DOCKER_SONIC_VS)
 # which is the same source used to generate /etc/sonic/constants.yml for real
 # images (see files/build_templates/sonic_debian_extension.j2).
 DOCKER_SONIC_VS_CONSTANTS = $(PLATFORM_PATH)/docker-sonic-vs/constants.yml
-$(DOCKER_SONIC_VS_CONSTANTS): files/build_templates/constants.yml.j2
-	ENABLE_FRR_SNMP_AGENT="$(ENABLE_FRR_SNMP_AGENT)" j2 $< > $@
+$(DOCKER_SONIC_VS_CONSTANTS): files/build_templates/constants.yml.j2 $(SONIC_CONSTANTS_OVERLAY)
+	ENABLE_FRR_SNMP_AGENT="$(ENABLE_FRR_SNMP_AGENT)" \
+	SONIC_CONSTANTS_OVERLAY="$(SONIC_CONSTANTS_OVERLAY)" \
+		python3 scripts/render_constants.py $< > $@
 
 $(TARGET_PATH)/docker-sonic-vs.gz : $(DOCKER_SONIC_VS_CONSTANTS)
-

--- a/scripts/render_constants.py
+++ b/scripts/render_constants.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+import argparse
+import copy
+import os
+import sys
+
+import yaml
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+
+REPLACE_KEY = "__replace__"
+
+
+def render_yaml(path):
+    template_path = os.path.abspath(path)
+    environment = Environment(
+        loader=FileSystemLoader(os.path.dirname(template_path)),
+        undefined=StrictUndefined,
+    )
+    template = environment.get_template(os.path.basename(template_path))
+    rendered = template.render(**os.environ)
+    return yaml.safe_load(rendered) or {}
+
+
+def merge(base, override):
+    if isinstance(override, dict) and override.get(REPLACE_KEY) is True:
+        return {
+            key: merge({}, value)
+            for key, value in override.items()
+            if key != REPLACE_KEY
+        }
+
+    if isinstance(base, dict) and isinstance(override, dict):
+        result = copy.deepcopy(base)
+        for key, value in override.items():
+            if key in result:
+                result[key] = merge(result[key], value)
+            else:
+                result[key] = copy.deepcopy(value)
+        return result
+
+    return copy.deepcopy(override)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Render constants YAML with optional downstream overlays."
+    )
+    parser.add_argument("template", help="Base constants Jinja template")
+    parser.add_argument(
+        "--overlay",
+        action="append",
+        default=[],
+        help="Optional overlay template; may be specified multiple times",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    overlays = list(args.overlay)
+    env_overlay = os.environ.get("SONIC_CONSTANTS_OVERLAY")
+    if env_overlay:
+        overlays.extend(path for path in env_overlay.split(os.pathsep) if path)
+
+    constants = render_yaml(args.template)
+    for overlay in overlays:
+        constants = merge(constants, render_yaml(overlay))
+
+    yaml.safe_dump(constants, sys.stdout, sort_keys=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_lrh_route_map.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_lrh_route_map.conf
@@ -1,0 +1,29 @@
+!
+! template: bgpd/bgpd.main.conf.j2
+!
+! bgp multiple-instance
+!
+! BGP configuration
+!
+! TSA configuration
+!
+ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
+!
+route-map LOOPBACK_ROUTE_MAP permit 100
+  set community 12345:8888
+!
+router bgp 65001
+!
+  bgp confederation identifier 65000
+  bgp confederation peers 65001 65002
+  bgp log-neighbor-changes
+  bgp suppress-fib-pending
+  no bgp default ipv4-unicast
+  no bgp ebgp-requires-policy
+!
+  bgp router-id 55.55.55.55
+!
+  network 55.55.55.55/32 route-map LOOPBACK_ROUTE_MAP
+!
+! end of template: bgpd/bgpd.main.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_lrh_route_map.json
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_lrh_route_map.json
@@ -1,0 +1,32 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "bgp_asn": "65001",
+            "type": "LowerRegionalHub"
+        }
+    },
+    "BGP_DEVICE_GLOBAL": {
+        "CONFED" : {
+            "asn": "65000",
+            "peers": "65001;65002"
+        }
+    },
+    "LOOPBACK_INTERFACE": {
+        "Loopback0|55.55.55.55/32": {},
+        "Loopback1|fc00::1/128": {}
+    },
+    "constants": {
+        "bgp": {
+            "loopback_advertisement_route_map": {
+                "name": "LOOPBACK_ROUTE_MAP",
+                "community": "12345:8888",
+                "device_types": [
+                    "lowerregionalhub"
+                ]
+            },
+            "multipath_relax": {},
+            "graceful_restart": {},
+            "maximum_paths": {}
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_ma_confed.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_ma_confed.conf
@@ -1,0 +1,26 @@
+!
+! template: bgpd/bgpd.main.conf.j2
+!
+! bgp multiple-instance
+!
+! BGP configuration
+!
+! TSA configuration
+!
+ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
+!
+router bgp 65001
+!
+  bgp confederation identifier 65000
+  bgp confederation peers 65001 65002
+  bgp log-neighbor-changes
+  bgp suppress-fib-pending
+  no bgp default ipv4-unicast
+  no bgp ebgp-requires-policy
+!
+  bgp router-id 55.55.55.55
+!
+  network 55.55.55.55/32
+!
+! end of template: bgpd/bgpd.main.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_ma_confed.json
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_ma_confed.json
@@ -1,0 +1,28 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "bgp_asn": "65001",
+            "type": "UpperMgmtAggregator"
+        }
+    },
+    "BGP_DEVICE_GLOBAL": {
+        "CONFED" : {
+            "asn": "65000",
+            "peers": "65001;65002"
+        }
+    },
+    "LOOPBACK_INTERFACE": {
+        "Loopback0|55.55.55.55/32": {},
+        "Loopback1|fc00::1/128": {}
+    },
+    "constants": {
+        "bgp": {
+            "extra_confederation_device_types": [
+                "uppermgmtaggregator"
+            ],
+            "multipath_relax": {},
+            "graceful_restart": {},
+            "maximum_paths": {}
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/storage_backend.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/storage_backend.conf
@@ -1,0 +1,43 @@
+!
+! template: bgpd/bgpd.main.conf.j2
+!
+! bgp multiple-instance
+!
+! BGP configuration
+!
+! TSA configuration
+!
+ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
+!
+!
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 10.10.10.0/24
+!
+!
+!
+!
+router bgp 55555
+!
+  bgp log-neighbor-changes
+  bgp suppress-fib-pending
+  no bgp default ipv4-unicast
+  no bgp ebgp-requires-policy
+!
+!
+!
+  bgp router-id 55.55.55.55
+!
+!
+!
+  network 10.10.10.1/24
+!
+!
+!
+  address-family ipv4
+    maximum-paths 64
+  exit-address-family
+  address-family ipv6
+    maximum-paths 64
+  exit-address-family
+!
+! end of template: bgpd/bgpd.main.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/storage_backend.json
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/storage_backend.json
@@ -1,0 +1,28 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "bgp_asn": "55555",
+            "type": "BackEndToRRouter",
+            "storage_device": "true"
+        }
+    },
+    "LOOPBACK_INTERFACE": {
+        "Loopback0|55.55.55.55/32": {}
+    },
+    "VLAN_INTERFACE": {
+        "Vlan10|10.10.10.1/24": {}
+    },
+    "constants": {
+        "bgp": {
+            "suppress_storage_backend_loopback": true,
+            "multipath_relax": {},
+            "graceful_restart": {
+                "enabled": true,
+                "restart_time": 480
+            },
+            "maximum_paths": {
+                "enabled": true
+            }
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/test_constants_renderer.py
+++ b/src/sonic-bgpcfgd/tests/test_constants_renderer.py
@@ -1,0 +1,92 @@
+import os
+import subprocess
+
+import yaml
+
+
+REPOSITORY_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', '..', '..')
+)
+RENDERER = os.path.join(REPOSITORY_ROOT, 'scripts', 'render_constants.py')
+BASE_TEMPLATE = os.path.join(
+    REPOSITORY_ROOT,
+    'files',
+    'build_templates',
+    'constants.yml.j2',
+)
+
+
+def render_constants(overlay=None, env_overlay=None):
+    env = os.environ.copy()
+    env['ENABLE_FRR_SNMP_AGENT'] = 'y'
+    env.pop('SONIC_CONSTANTS_OVERLAY', None)
+    if env_overlay:
+        env['SONIC_CONSTANTS_OVERLAY'] = str(env_overlay)
+    command = ['python3', RENDERER, BASE_TEMPLATE]
+    if overlay:
+        command.extend(['--overlay', str(overlay)])
+    result = subprocess.run(
+        command,
+        check=True,
+        env=env,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    return yaml.safe_load(result.stdout)
+
+
+def test_constants_overlay_merges_nested_values(tmp_path):
+    overlay = tmp_path / 'overlay.yml'
+    overlay.write_text(
+        'constants:\n'
+        '  bgp:\n'
+        '    loopback_advertisement_route_map:\n'
+        '      name: TEST_ROUTE_MAP\n'
+        '      community: "12345:8888"\n'
+    )
+
+    constants = render_constants(overlay)['constants']
+
+    assert constants['bgp']['traffic_shift_community'] == '12345:12345'
+    assert constants['bgp']['loopback_advertisement_route_map'] == {
+        'name': 'TEST_ROUTE_MAP',
+        'community': '12345:8888',
+    }
+
+
+def test_constants_overlay_can_replace_mapping(tmp_path):
+    overlay = tmp_path / 'overlay.yml'
+    overlay.write_text(
+        'constants:\n'
+        '  bgp:\n'
+        '    peers:\n'
+        '      __replace__: true\n'
+        '      custom:\n'
+        '        template_dir: custom\n'
+    )
+
+    peers = render_constants(overlay)['constants']['bgp']['peers']
+
+    assert peers == {
+        'custom': {
+            'template_dir': 'custom',
+        },
+    }
+
+
+def test_constants_environment_overlay_can_replace_root(tmp_path):
+    overlay = tmp_path / 'overlay.yml'
+    overlay.write_text(
+        'constants:\n'
+        '  __replace__: true\n'
+        '  custom:\n'
+        '    enabled: true\n'
+    )
+
+    constants = render_constants(env_overlay=overlay)['constants']
+
+    assert constants == {
+        'custom': {
+            'enabled': True,
+        },
+    }

--- a/src/sonic-bgpcfgd/tests/test_sonic-cfggen.py
+++ b/src/sonic-bgpcfgd/tests/test_sonic-cfggen.py
@@ -260,6 +260,24 @@ def test_bgp_confed_urh_single_asic():
              "bgpd.main.conf.j2/single_asic_urh.json",
              "bgpd.main.conf.j2/single_asic_urh.conf")
 
+def test_bgp_loopback_advertisement_route_map():
+    run_test("BGP loopback advertisement route-map",
+             "bgpd/bgpd.main.conf.j2",
+             "bgpd.main.conf.j2/single_asic_lrh_route_map.json",
+             "bgpd.main.conf.j2/single_asic_lrh_route_map.conf")
+
+def test_bgp_storage_backend_loopback_suppression():
+    run_test("BGP storage backend loopback suppression",
+             "bgpd/bgpd.main.conf.j2",
+             "bgpd.main.conf.j2/storage_backend.json",
+             "bgpd.main.conf.j2/storage_backend.conf")
+
+def test_bgp_extra_confederation_device_type():
+    run_test("BGP extra confederation device type",
+             "bgpd/bgpd.main.conf.j2",
+             "bgpd.main.conf.j2/single_asic_ma_confed.json",
+             "bgpd.main.conf.j2/single_asic_ma_confed.conf")
+
 def _render_bgpd_main(json_path):
     template_path = os.path.join(TEMPLATE_PATH, "bgpd/bgpd.main.conf.j2")
     json_full_path = os.path.join(DATA_PATH, json_path)

--- a/src/sonic-bgpcfgd/tests/util.py
+++ b/src/sonic-bgpcfgd/tests/util.py
@@ -1,7 +1,7 @@
 import os
+import subprocess
 import tempfile
 import yaml
-from jinja2 import Template
 
 # The production constants are owned by the shared build template
 # files/build_templates/constants.yml.j2 (the same source used to generate
@@ -14,15 +14,23 @@ CONSTANTS_TEMPLATE_PATH = os.path.abspath(
 def render_constants(template_path=CONSTANTS_TEMPLATE_PATH):
     """Render constants.yml.j2 into a temp file and return its path.
 
-    The template only references ENABLE_FRR_SNMP_AGENT (defaults to 'y', the
-    same default as rules/config); everything else is static YAML.
+    Optional downstream constants are applied by the same renderer used by the
+    image build.
     """
-    with open(template_path) as f:
-        rendered = Template(f.read()).render(
-            ENABLE_FRR_SNMP_AGENT=os.environ.get('ENABLE_FRR_SNMP_AGENT', 'y'))
     fd, path = tempfile.mkstemp(prefix='constants', suffix='.yml')
-    with os.fdopen(fd, 'w') as f:
-        f.write(rendered)
+    os.close(fd)
+    repository_root = os.path.abspath(os.path.join(
+        os.path.dirname(__file__), '..', '..', '..'))
+    renderer = os.path.join(repository_root, 'scripts', 'render_constants.py')
+    env = os.environ.copy()
+    env.setdefault('ENABLE_FRR_SNMP_AGENT', 'y')
+    with open(path, 'w') as output:
+        subprocess.run(
+            ['python3', renderer, template_path],
+            check=True,
+            env=env,
+            stdout=output,
+        )
     return path
 
 


### PR DESCRIPTION
#### Why I did it

Downstream deployments currently modify shared constants and BGP templates, creating recurring public-to-downstream sync conflicts.

#### How I did it

- Added a generic constants renderer with optional deep-merge/replacement overlays.
- Added data-driven BGP main-template options for loopback route maps, storage-backend suppression, and extra confederation device types.
- Preserved existing public defaults when no overlay is configured.
- Added renderer and template fixture coverage.

#### How to verify it

```bash
python3 -m pytest -q -o addopts= src/sonic-bgpcfgd/tests/test_constants_renderer.py
pytest -q src/sonic-bgpcfgd/tests/test_sonic-cfggen.py
```

#### Which release branch to backport

- [ ] 202505
- [ ] 202411
- [ ] 202405

#### Tested branch

master

#### Description for the changelog

Add generic downstream constants overlays and configurable BGP main-template behavior.

#### Link to config_db schema for YANG module changes

Not applicable.