### PR TITLE
[Nexthop] warmboot-finalizer: re-enable FLOW_CNT_TRAP after warm-boot reconcile

### DIFF
--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -221,6 +221,7 @@ function restore_counters_folder()
     fi
 }
 
+<<<<<<< HEAD
 function check_warm_boot_and_fast_boot_or_exit()
 {
     check_fast_reboot
@@ -260,6 +261,39 @@ function wait_for_components_to_reconcile() {
 
 wait_for_database_service
 check_warm_boot_and_fast_boot_or_exit
+=======
+FLOW_CNT_TRAP_MARKER="/host/warmboot/flow_cnt_trap_need_re_enable"
+
+# Re-enable FLOW_CNT_TRAP if /usr/local/bin/fast-reboot disabled it
+# pre-warmboot. The marker is written only when re-enable is needed.
+function restore_flow_cnt_trap()
+{
+    if [[ ! -f "$FLOW_CNT_TRAP_MARKER" ]]; then
+        return
+    fi
+    debug "Restoring FLOW_CNT_TRAP=enable after warmboot reconcile"
+    sonic-db-cli CONFIG_DB HSET "FLEX_COUNTER_TABLE|FLOW_CNT_TRAP" FLEX_COUNTER_STATUS enable > /dev/null
+    rm -f "$FLOW_CNT_TRAP_MARKER"
+}
+
+
+wait_for_database_service
+
+check_fast_reboot
+check_warm_boot
+
+if [[ x"${WARM_BOOT}" != x"true" ]]; then
+    debug "warmboot is not enabled ..."
+    # Drop a stale marker from a prior aborted warm-reboot. Only warm-reboot
+    # writes/honors it; on any other boot path it would falsely re-enable a
+    # counter the user may have disabled.
+    rm -f "$FLOW_CNT_TRAP_MARKER"
+    if [[ x"${FAST_REBOOT}" != x"true" ]]; then
+	    debug "fastboot is not enabled ..."
+	    exit 0
+    fi
+fi
+>>>>>>> ea14cde72 (NOS-6934: re-enable FLOW_CNT_TRAP after warm-boot reconcile (#4938))
 
 if [[ (x"${WARM_BOOT}" == x"true") && (x"${FAST_REBOOT}" != x"true") ]]; then
     restore_counters_folder
@@ -304,6 +338,8 @@ finalize_global
 if [[ (x"${WARM_BOOT}" == x"true") && (x"${FAST_REBOOT}" != x"true") ]]; then
     stop_control_plane_assistant
 fi
+
+restore_flow_cnt_trap
 
 # Save DB after stopped control plane assistant to avoid extra entries
 debug "Save in-memory database after warm/fast reboot ..."


### PR DESCRIPTION
#### Why I did it

Resolves #28895

Pairs with sonic-utilities PR https://github.com/sonic-net/sonic-utilities/pull/4756: with trap flow counters enabled, warm reboot crash-loops orchagent (Broadcom SAI fails the HOSTIF trap counter replay during APPLY_VIEW), so the warm-reboot script disables `FLOW_CNT_TRAP` before the warm shutdown. Something then has to re-enable the group once reconcile completes, or trap flow counters silently stay off after every warm reboot.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

- `finalize-warmboot.sh` re-enables `FLEX_COUNTER_TABLE|FLOW_CNT_TRAP` after reconcile if — and only if — the reboot script left the marker `/host/warmboot/flow_cnt_trap_need_re_enable`, then removes the marker. The marker distinguishes "the reboot script disabled this on the user's behalf" from "the user had it disabled".
- On non-warm boot paths, a stale marker from a prior aborted warm-reboot is dropped without touching user configuration.

#### How to verify it

1. Enable `FLOW_CNT_TRAP` in CONFIG_DB, `sudo warm-reboot` with the paired sonic-utilities change.
2. After the finalizer completes: `FLEX_COUNTER_TABLE|FLOW_CNT_TRAP` is back to `enable`, the marker is gone, and `show flowcnt-trap stats` works.
3. Cold boot with a stale marker present: marker is removed and the counter group is left untouched.

Verified on Broadcom Tomahawk-based platforms together with the paired sonic-utilities change.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605
- [ ] 202608

Backport reason: required for warm reboot support on Broadcom Tomahawk platforms in 202512 (warm reboot fails with trap flow counters enabled without this fix + the paired sonic-utilities change).

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://github.com/sonic-net/sonic-buildimage/issues/28895
Failure type: day-one issue

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
